### PR TITLE
chore(Dockerfiles): updated janspycloud build in dependabot/maven/jans-auth-server/org.eclipse.jetty-jetty-webapp-9.4.44.v20210927

### DIFF
--- a/docker-jans-auth-server/requirements.txt
+++ b/docker-jans-auth-server/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@7c70dd7174fbc96865a26aa8ba567c5827115329#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-certmanager/requirements.txt
+++ b/docker-jans-certmanager/requirements.txt
@@ -1,2 +1,2 @@
 click==6.7
-git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@7c70dd7174fbc96865a26aa8ba567c5827115329#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-client-api/requirements.txt
+++ b/docker-jans-client-api/requirements.txt
@@ -1,2 +1,2 @@
 ruamel.yaml==0.16.10
-git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@7c70dd7174fbc96865a26aa8ba567c5827115329#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-config-api/requirements.txt
+++ b/docker-jans-config-api/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@7c70dd7174fbc96865a26aa8ba567c5827115329#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-configurator/requirements.txt
+++ b/docker-jans-configurator/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
 marshmallow==3.10.0
 fqdn==1.4.0
-git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@7c70dd7174fbc96865a26aa8ba567c5827115329#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-fido2/requirements.txt
+++ b/docker-jans-fido2/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@7c70dd7174fbc96865a26aa8ba567c5827115329#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-persistence-loader/requirements.txt
+++ b/docker-jans-persistence-loader/requirements.txt
@@ -1,2 +1,2 @@
 ldif==4.1.1
-git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@7c70dd7174fbc96865a26aa8ba567c5827115329#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-scim/requirements.txt
+++ b/docker-jans-scim/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@7c70dd7174fbc96865a26aa8ba567c5827115329#egg=jans-pycloudlib&subdirectory=jans-pycloudlib


### PR DESCRIPTION
- This PR will automerge
- Updated unstable build
- Auto-generated.