### PR TITLE
fix(certmanager): bug fixes for patch auth command

### DIFF
--- a/docker-jans-certmanager/Dockerfile
+++ b/docker-jans-certmanager/Dockerfile
@@ -37,9 +37,8 @@ RUN wget -q ${CN_SOURCE_URL} -P /app/javalibs/
 # ======
 
 COPY requirements.txt /app/requirements.txt
-RUN pip3 install --no-cache-dir -U pip \
-    && pip3 install --no-cache-dir -r /app/requirements.txt \
-    && rm -rf /src/jans-pycloudlib/.git
+RUN pip3 install --no-cache-dir -U pip wheel \
+    && pip3 install --no-cache-dir -r /app/requirements.txt
 
 # =======
 # Cleanup

--- a/docker-jans-certmanager/requirements.txt
+++ b/docker-jans-certmanager/requirements.txt
@@ -1,2 +1,3 @@
 click==6.7
+libcst<0.4
 git+https://github.com/JanssenProject/jans-cloud-native@f415213cfd992363f3fb85005df16e963a6ed8ff#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -434,6 +434,8 @@ class AuthHandler(BaseHandler):
                 logger.info(f"Waiting for private key push delay ({int(self.privkey_push_delay)} seconds) ...")
                 time.sleep(int(self.privkey_push_delay))
                 for container in auth_containers:
+                    logger.info(f"creating backup of {name}:{jks_fn}")
+                    self.meta_client.exec_cmd(container, f"cp {jks_fn} {jks_fn}.backup")
                     logger.info(f"creating new {name}:{jks_fn}")
                     self.meta_client.copy_to_container(container, jks_fn)
 

--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -439,9 +439,11 @@ class AuthHandler(BaseHandler):
                     logger.info(f"creating new {name}:{jks_fn}")
                     self.meta_client.copy_to_container(container, jks_fn)
 
-                # key selection is changed
-                if self.privkey_push_strategy != self.key_strategy:
-                    rev = rev + 1
+                    # as new JKS pushed to container, we need to tell auth-server to reload the private keys
+                    # by increasing jansRevision again; note that as jansRevision may have been modified externally
+                    # we need to ensure we have fresh jansRevision value to increase to
+                    config = self.backend.get_auth_config()
+                    rev = int(config["jansRevision"]) + 1
                     conf_dynamic.update({
                         "keySelectionStrategy": self.privkey_push_strategy,
                     })


### PR DESCRIPTION
Overview:

- added patch to address issue where backup file (`/etc/certs/auth-keys.jks.backup`) is missing/not updated
- added patch to address issue where `jansRevision` isn't updated