### PR TITLE
fix(certmanager): patches for auth handler

### DIFF
--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -433,7 +433,10 @@ class AuthHandler(BaseHandler):
             if int(self.privkey_push_delay) > 0:
                 logger.info(f"Waiting for private key push delay ({int(self.privkey_push_delay)} seconds) ...")
                 time.sleep(int(self.privkey_push_delay))
+
                 for container in auth_containers:
+                    logger.info(f"creating backup of {name}:{jks_fn}")
+                    self.meta_client.exec_cmd(container, f"cp {jks_fn} {jks_fn}.backup")
                     logger.info(f"creating new {name}:{jks_fn}")
                     self.meta_client.copy_to_container(container, jks_fn)
 

--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -437,9 +437,11 @@ class AuthHandler(BaseHandler):
                     logger.info(f"creating new {name}:{jks_fn}")
                     self.meta_client.copy_to_container(container, jks_fn)
 
-                # key selection is changed
-                if self.privkey_push_strategy != self.key_strategy:
-                    rev = rev + 1
+                    # as new JKS pushed to container, we need to tell auth-server to reload the private keys
+                    # by increasing jansRevision again; note that as jansRevision may have been modified externally
+                    # we need to ensure we have fresh jansRevision value to increase to
+                    config = self.backend.get_auth_config()
+                    rev = int(config["jansRevision"]) + 1
                     conf_dynamic.update({
                         "keySelectionStrategy": self.privkey_push_strategy,
                     })


### PR DESCRIPTION
Overview:

- added patch to address issue where backup file (`/etc/certs/auth-keys.jks.backup`) is missing/not updated
- added patch to address issue where `jansRevision` isn't updated