### PR TITLE
ci: add codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,3 +22,4 @@
 /jans-config-api/ @pujavs @yuriyz
 /jans-cli/ @mbaser
 /jans-ce-setup/ @mbaser @smansoft
+/jans-ce-setup/static/scripts/admin_ui_plugin.py @mbaser @duttarnab


### PR DESCRIPTION
Adding @duttarnab as a code owner to /jans-ce-setup/static/scripts/admin_ui_plugin.py