### PR TITLE
ci: add codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,5 +21,5 @@
 /jans-client-api/ @duttarnab @yuriyz
 /jans-config-api/ @pujavs @yuriyz
 /jans-cli/ @mbaser
-/jans-ce-setup/ @mbaser @smansoft
+/jans-ce-setup/ @mbaser @smansoft @yuriyz
 /jans-ce-setup/static/scripts/admin_ui_plugin.py @mbaser @duttarnab


### PR DESCRIPTION
This adds @yuriyz as a codeowner to the `jans-ce-setup` project.