### PR TITLE
feat: update base images #672

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.13.6
+FROM bellsoft/liberica-openjre-alpine:11
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache openssl py3-pip tini curl bash openjdk11-jre-headless py3-cryptography py3-grpcio py3-psycopg2 \
+    && apk add --no-cache openssl py3-pip tini curl bash py3-cryptography py3-psycopg2 \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git \
     && mkdir -p /usr/java/latest \
-    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
+    && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
 # =====
 # Jetty
@@ -98,8 +99,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV
@@ -229,7 +229,7 @@ RUN chown -R 1000:1000 /opt/jans/jetty \
     && chgrp -R 0 /deploy && chmod -R g=u /deploy \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chmod -R +w /etc/ssl/certs/java/cacerts && chgrp -R 0 /etc/ssl/certs/java/cacerts && chmod -R g=u /etc/ssl/certs/java/cacerts \
+    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml
 

--- a/docker-jans-auth-server/conf/jans-sql.properties.tmpl
+++ b/docker-jans-auth-server/conf/jans-sql.properties.tmpl
@@ -1,6 +1,6 @@
 db.schema.name=%(rdbm_db)s
 
-connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s
+connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s?enabledTLSProtocols=TLSv1.2
 
 connection.driver-property.serverTimezone=%(server_time_zone)s
 # Prefix connection.driver-property.key=value will be coverterd to key=value JDBC driver properties

--- a/docker-jans-auth-server/scripts/bootstrap.py
+++ b/docker-jans-auth-server/scripts/bootstrap.py
@@ -113,7 +113,7 @@ def main():
     cert_to_truststore(
         "web_https",
         "/etc/certs/web_https.crt",
-        "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+        "/usr/java/latest/jre/lib/security/cacerts",
         "changeit",
     )
 
@@ -160,14 +160,14 @@ def main():
         cert_to_truststore(
             "OpenBankingJwksUri",
             "/etc/certs/obextjwksuri.crt",
-            "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+            "/usr/java/latest/jre/lib/security/cacerts",
             "changeit",
         )
 
         cert_to_truststore(
             ob_ext_alias,
             ext_cert,
-            "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+            "/usr/java/latest/jre/lib/security/cacerts",
             "changeit",
         )
 
@@ -191,7 +191,7 @@ def main():
             cert_to_truststore(
                 ob_transport_alias,
                 ob_transport_cert,
-                "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+                "/usr/java/latest/jre/lib/security/cacerts",
                 "changeit",
             )
 

--- a/docker-jans-certmanager/Dockerfile
+++ b/docker-jans-certmanager/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.13.6
+FROM bellsoft/liberica-openjre-alpine:11
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache openssl py3-pip curl tini openjdk11-jre-headless py3-cryptography py3-grpcio py3-psycopg2 \
+    && apk add --no-cache openssl py3-pip curl tini py3-cryptography py3-psycopg2 \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git \
     && mkdir -p /usr/java/latest \
-    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
+    && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
 # ===========
 # Auth client
@@ -51,8 +52,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV

--- a/docker-jans-client-api/Dockerfile
+++ b/docker-jans-client-api/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.13.6
+FROM bellsoft/liberica-openjre-alpine:11
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache openssl py3-pip tini curl openjdk11-jre-headless py3-cryptography py3-grpcio py3-psycopg2 \
+    && apk add --no-cache openssl py3-pip tini curl py3-cryptography py3-psycopg2 \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps unzip wget git \
     && mkdir -p /usr/java/latest \
-    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
+    && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
 # ==========
 # Client API
@@ -45,8 +46,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV
@@ -161,7 +161,7 @@ RUN chown -R 1000:1000 /app/templates \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
     && chgrp -R 0 /opt/client-api && chmod -R g=u /opt/client-api \
-    && chmod -R +w /etc/ssl/certs/java/cacerts && chgrp -R 0 /etc/ssl/certs/java/cacerts && chmod -R g=u /etc/ssl/certs/java/cacerts
+    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts
 
 USER 1000
 

--- a/docker-jans-client-api/scripts/bootstrap.py
+++ b/docker-jans-client-api/scripts/bootstrap.py
@@ -34,7 +34,7 @@ def get_web_cert():
     cert_to_truststore(
         "web_https",
         "/etc/certs/web_https.crt",
-        "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+        "/usr/java/latest/jre/lib/security/cacerts",
         "changeit",
     )
 

--- a/docker-jans-client-api/templates/jans-sql.properties.tmpl
+++ b/docker-jans-client-api/templates/jans-sql.properties.tmpl
@@ -1,6 +1,6 @@
 db.schema.name=%(rdbm_db)s
 
-connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s
+connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s?enabledTLSProtocols=TLSv1.2
 
 connection.driver-property.serverTimezone=%(server_time_zone)s
 # Prefix connection.driver-property.key=value will be coverterd to key=value JDBC driver properties

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.13.6
+FROM bellsoft/liberica-openjre-alpine:11
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache openssl py3-pip tini curl openjdk11-jre-headless py3-cryptography py3-grpcio py3-psycopg2 \
+    && apk add --no-cache openssl py3-pip tini curl py3-cryptography py3-psycopg2 \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git \
     && mkdir -p /usr/java/latest \
-    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
+    && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
 # =====
 # Jetty
@@ -78,8 +79,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV
@@ -195,7 +195,7 @@ RUN chown -R 1000:1000 /opt/jans/jetty \
     && chgrp -R 0 /deploy && chmod -R g=u /deploy \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chmod -R +w /etc/ssl/certs/java/cacerts && chgrp -R 0 /etc/ssl/certs/java/cacerts && chmod -R g=u /etc/ssl/certs/java/cacerts \
+    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml
 

--- a/docker-jans-config-api/conf/jans-sql.properties.tmpl
+++ b/docker-jans-config-api/conf/jans-sql.properties.tmpl
@@ -1,6 +1,6 @@
 db.schema.name=%(rdbm_db)s
 
-connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s
+connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s?enabledTLSProtocols=TLSv1.2
 
 connection.driver-property.serverTimezone=%(server_time_zone)s
 # Prefix connection.driver-property.key=value will be coverterd to key=value JDBC driver properties

--- a/docker-jans-config-api/scripts/bootstrap.py
+++ b/docker-jans-config-api/scripts/bootstrap.py
@@ -75,7 +75,7 @@ def main():
     cert_to_truststore(
         "web_https",
         "/etc/certs/web_https.crt",
-        "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+        "/usr/java/latest/jre/lib/security/cacerts",
         "changeit",
     )
 

--- a/docker-jans-config-api/scripts/plugins.py
+++ b/docker-jans-config-api/scripts/plugins.py
@@ -131,6 +131,6 @@ class AdminUiPlugin:
         cert_to_truststore(
             "token_server",
             cert_file,
-            "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+            "/usr/java/latest/jre/lib/security/cacerts",
             "changeit",
         )

--- a/docker-jans-configurator/Dockerfile
+++ b/docker-jans-configurator/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.13.6
+FROM bellsoft/liberica-openjre-alpine:11
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache openssl py3-pip curl tini openjdk11-jre-headless py3-cryptography py3-grpcio py3-psycopg2 \
+    && apk add --no-cache openssl py3-pip curl tini py3-cryptography py3-psycopg2 \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git \
     && mkdir -p /usr/java/latest \
-    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
+    && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
 # ===========
 # Auth client
@@ -50,8 +51,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV
@@ -131,7 +131,7 @@ RUN chown -R 1000:1000 /tmp \
     && chgrp -R 0 /app/db && chmod -R g=u /app/db \
     && chgrp -R 0 /tmp && chmod -R g=u /tmp \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
-    && chmod -R +w /etc/ssl/certs/java/cacerts && chgrp -R 0 /etc/ssl/certs/java/cacerts && chmod -R g=u /etc/ssl/certs/java/cacerts
+    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts
 
 USER 1000
 

--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.13.6
+FROM bellsoft/liberica-openjre-alpine:11
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache openssl py3-pip tini curl openjdk11-jre-headless py3-cryptography py3-grpcio py3-psycopg2 \
+    && apk add --no-cache openssl py3-pip tini curl py3-cryptography py3-psycopg2 \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git \
     && mkdir -p /usr/java/latest \
-    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
+    && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
 # =====
 # Jetty
@@ -64,8 +65,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV
@@ -184,7 +184,7 @@ RUN chown -R 1000:1000 /opt/jans/jetty \
     && chgrp -R 0 /deploy && chmod -R g=u /deploy \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chmod -R +w /etc/ssl/certs/java/cacerts && chgrp -R 0 /etc/ssl/certs/java/cacerts && chmod -R g=u /etc/ssl/certs/java/cacerts \
+    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml
 

--- a/docker-jans-fido2/conf/jans-sql.properties.tmpl
+++ b/docker-jans-fido2/conf/jans-sql.properties.tmpl
@@ -1,6 +1,6 @@
 db.schema.name=%(rdbm_db)s
 
-connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s
+connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s?enabledTLSProtocols=TLSv1.2
 
 connection.driver-property.serverTimezone=%(server_time_zone)s
 # Prefix connection.driver-property.key=value will be coverterd to key=value JDBC driver properties

--- a/docker-jans-fido2/scripts/bootstrap.py
+++ b/docker-jans-fido2/scripts/bootstrap.py
@@ -103,7 +103,7 @@ def main():
     cert_to_truststore(
         "web_https",
         "/etc/certs/web_https.crt",
-        "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+        "/usr/java/latest/jre/lib/security/cacerts",
         "changeit",
     )
 

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -1,11 +1,12 @@
-FROM alpine:3.13.6
+FROM alpine:3.14.3
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache py3-pip curl tini py3-cryptography py3-grpcio py3-psycopg2 \
+    && apk add --no-cache py3-pip curl tini py3-cryptography py3-psycopg2 \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps git
 
 # ======
@@ -27,8 +28,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV

--- a/docker-jans-scim/Dockerfile
+++ b/docker-jans-scim/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.13.6
+FROM bellsoft/liberica-openjre-alpine:11
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache openssl py3-pip tini curl bash openjdk11-jre-headless py3-cryptography py3-grpcio py3-psycopg2 \
+    && apk add --no-cache openssl py3-pip tini curl bash py3-cryptography py3-psycopg2 \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git \
     && mkdir -p /usr/java/latest \
-    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
+    && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
 # =====
 # Jetty
@@ -74,8 +75,7 @@ RUN apk del build-deps \
 # License
 # =======
 
-RUN mkdir -p /licenses
-COPY LICENSE /licenses/
+COPY LICENSE /licenses/LICENSE
 
 # ==========
 # Config ENV
@@ -190,7 +190,7 @@ RUN chown -R 1000:1000 /opt/jans/jetty \
     && chgrp -R 0 /deploy && chmod -R g=u /deploy \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chmod -R +w /etc/ssl/certs/java/cacerts && chgrp -R 0 /etc/ssl/certs/java/cacerts && chmod -R g=u /etc/ssl/certs/java/cacerts \
+    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml
 

--- a/docker-jans-scim/conf/jans-sql.properties.tmpl
+++ b/docker-jans-scim/conf/jans-sql.properties.tmpl
@@ -1,6 +1,6 @@
 db.schema.name=%(rdbm_db)s
 
-connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s
+connection.uri=jdbc:%(rdbm_type)s://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s?enabledTLSProtocols=TLSv1.2
 
 connection.driver-property.serverTimezone=%(server_time_zone)s
 # Prefix connection.driver-property.key=value will be coverterd to key=value JDBC driver properties

--- a/docker-jans-scim/scripts/bootstrap.py
+++ b/docker-jans-scim/scripts/bootstrap.py
@@ -103,7 +103,7 @@ def main():
     cert_to_truststore(
         "web_https",
         "/etc/certs/web_https.crt",
-        "/usr/lib/jvm/default-jvm/jre/lib/security/cacerts",
+        "/usr/java/latest/jre/lib/security/cacerts",
         "changeit",
     )
 


### PR DESCRIPTION
Overview:
- all Java-centric images are based on `bellsoft/liberica-openjre-alpine:11` image (for Java gRPC compatibility)
- add `enabledTLSProtocols=TLSv1.2` option to SQL connection URI
- install `py3-grpcio 1.41` from Alpine v3.15 repo