### PR TITLE
fix(jans-auth-server): don't fail registration without custom script (#710)

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalDynamicClientRegistrationService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalDynamicClientRegistrationService.java
@@ -127,8 +127,12 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
     }
 
     public JSONObject getSoftwareStatementJwks(HttpServletRequest httpRequest, JSONObject registerRequest, Jwt softwareStatement) {
+        if (defaultExternalCustomScript == null) {
+            return null;
+        }
+
         try {
-            log.info("Executing python 'getSoftwareStatementJwks' method, script name:" + defaultExternalCustomScript.getName());
+            log.info("Executing python 'getSoftwareStatementJwks' method, script name: {}", defaultExternalCustomScript.getName());
 
             DynamicClientRegistrationContext context = new DynamicClientRegistrationContext(httpRequest, registerRequest, defaultExternalCustomScript);
             context.setSoftwareStatement(softwareStatement);
@@ -137,7 +141,7 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
             ClientRegistrationType externalType = (ClientRegistrationType) defaultExternalCustomScript.getExternalType();
             final String result = externalType.getSoftwareStatementJwks(context);
             context.throwWebApplicationExceptionIfSet();
-            log.info("Result of python 'getSoftwareStatementJwks' method: " + result);
+            log.info("Result of python 'getSoftwareStatementJwks' method: {}", result);
             return new JSONObject(result);
         } catch (WebApplicationException e) {
             throw e;
@@ -149,6 +153,10 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
     }
 
     public String getSoftwareStatementHmacSecret(HttpServletRequest httpRequest, JSONObject registerRequest, Jwt softwareStatement) {
+        if (defaultExternalCustomScript == null) {
+            return "";
+        }
+
         try {
             log.trace("Executing python 'getSoftwareStatementHmacSecret' method");
 
@@ -159,7 +167,7 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
             ClientRegistrationType externalType = (ClientRegistrationType) defaultExternalCustomScript.getExternalType();
             final String result = externalType.getSoftwareStatementHmacSecret(context);
             context.throwWebApplicationExceptionIfSet();
-            log.trace("Result of python 'getSoftwareStatementHmacSecret' method: " + result);
+            log.trace("Result of python 'getSoftwareStatementHmacSecret' method: {}", result);
             return result;
         } catch (WebApplicationException e) {
             throw e;
@@ -171,6 +179,10 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
     }
 
     public JSONObject getDcrJwks(HttpServletRequest httpRequest, Jwt dcr) {
+        if (defaultExternalCustomScript == null) {
+            return null;
+        }
+
         try {
             log.trace("Executing python 'getDcrJwks' method");
 
@@ -181,7 +193,7 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
             ClientRegistrationType externalType = (ClientRegistrationType) defaultExternalCustomScript.getExternalType();
             final String result = externalType.getDcrJwks(context);
             context.throwWebApplicationExceptionIfSet();
-            log.trace("Result of python 'getDcrJwks' method: " + result);
+            log.trace("Result of python 'getDcrJwks' method: {}", result);
             return new JSONObject(result);
         } catch (WebApplicationException e) {
             throw e;
@@ -193,6 +205,10 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
     }
 
     public String getDcrHmacSecret(HttpServletRequest httpRequest, Jwt dcr) {
+        if (defaultExternalCustomScript == null) {
+            return "";
+        }
+
         try {
             log.trace("Executing python 'getDcrHmacSecret' method");
 
@@ -203,7 +219,7 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
             ClientRegistrationType externalType = (ClientRegistrationType) defaultExternalCustomScript.getExternalType();
             final String result = externalType.getDcrHmacSecret(context);
             context.throwWebApplicationExceptionIfSet();
-            log.trace("Result of python 'getDcrHmacSecret' method: " + result);
+            log.trace("Result of python 'getDcrHmacSecret' method: {}", result);
             return result;
         } catch (WebApplicationException e) {
             throw e;
@@ -215,6 +231,10 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
     }
 
     public boolean isCertValidForClient(X509Certificate cert, DynamicClientRegistrationContext context) {
+        if (defaultExternalCustomScript == null) {
+            return true;
+        }
+
         try {
             log.trace("Executing python 'isCertValidForClient' method");
             context.setScript(defaultExternalCustomScript);
@@ -222,7 +242,7 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
             ClientRegistrationType externalType = (ClientRegistrationType) defaultExternalCustomScript.getExternalType();
             final boolean result = externalType.isCertValidForClient(cert, context);
             context.throwWebApplicationExceptionIfSet();
-            log.trace("Result of python 'isCertValidForClient' method: " + result);
+            log.trace("Result of python 'isCertValidForClient' method: {}", result);
             return result;
         } catch (WebApplicationException e) {
             throw e;
@@ -234,6 +254,10 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
     }
 
     public boolean modifyPostResponse(JSONObject responseAsJsonObject, ExecutionContext context) {
+        if (defaultExternalCustomScript == null) {
+            return false;
+        }
+
         CustomScriptConfiguration script = defaultExternalCustomScript;
 
         try {
@@ -257,6 +281,10 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
     }
 
     public boolean modifyPutResponse(JSONObject responseAsJsonObject, ExecutionContext context) {
+        if (defaultExternalCustomScript == null) {
+            return false;
+        }
+
         CustomScriptConfiguration script = defaultExternalCustomScript;
 
         try {
@@ -280,6 +308,10 @@ public class ExternalDynamicClientRegistrationService extends ExternalScriptServ
     }
 
     public boolean modifyReadResponse(JSONObject responseAsJsonObject, ExecutionContext context) {
+        if (defaultExternalCustomScript == null) {
+            return false;
+        }
+
         CustomScriptConfiguration script = defaultExternalCustomScript;
 
         try {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/external/ExternalDynamicClientRegistrationServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/external/ExternalDynamicClientRegistrationServiceTest.java
@@ -1,0 +1,85 @@
+package io.jans.as.server.service.external;
+
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.jwt.Jwt;
+import io.jans.as.server.model.common.ExecutionContext;
+import org.json.JSONObject;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Zabrovarnyy
+ */
+@Listeners(MockitoTestNGListener.class)
+public class ExternalDynamicClientRegistrationServiceTest {
+
+    @InjectMocks
+    private ExternalDynamicClientRegistrationService externalDynamicClientRegistrationService;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Test
+    public void modifyPostResponse_whenDefaultExternalCustomScriptIsNull_shouldReturnFalseWithoutNpe() {
+        final boolean result = externalDynamicClientRegistrationService.modifyPostResponse(new JSONObject(), new ExecutionContext());
+        assertFalse(result);
+    }
+
+    @Test
+    public void modifyPutResponse_whenDefaultExternalCustomScriptIsNull_shouldReturnFalseWithoutNpe() {
+        final boolean result = externalDynamicClientRegistrationService.modifyPutResponse(new JSONObject(), new ExecutionContext());
+        assertFalse(result);
+    }
+
+    @Test
+    public void modifyReadResponse_whenDefaultExternalCustomScriptIsNull_shouldReturnFalseWithoutNpe() {
+        final boolean result = externalDynamicClientRegistrationService.modifyReadResponse(new JSONObject(), new ExecutionContext());
+        assertFalse(result);
+    }
+
+    @Test
+    public void isCertValidForClient_whenDefaultExternalCustomScriptIsNull_shouldReturnTrueWithoutNpe() {
+        final boolean result = externalDynamicClientRegistrationService.isCertValidForClient(null, null);
+        assertTrue(result);
+    }
+
+    @Test
+    public void getDcrHmacSecret_whenDefaultExternalCustomScriptIsNull_shouldReturnEmptyStringWithoutNpe() {
+        final String result = externalDynamicClientRegistrationService.getDcrHmacSecret(null, new Jwt());
+        assertEquals(result, "");
+    }
+
+    @Test
+    public void getDcrJwks_whenDefaultExternalCustomScriptIsNull_shouldReturnNullWithoutNpe() {
+        JSONObject result = externalDynamicClientRegistrationService.getDcrJwks(null, new Jwt());
+        assertNull(result);
+    }
+
+    @Test
+    public void getSoftwareStatementHmacSecret_whenDefaultExternalCustomScriptIsNull_shouldReturnEmptyStringWithoutNpe() {
+        String result = externalDynamicClientRegistrationService.getSoftwareStatementHmacSecret(null, new JSONObject(), new Jwt());
+        assertEquals(result, "");
+    }
+
+    @Test
+    public void getSoftwareStatementJwks_whenDefaultExternalCustomScriptIsNull_shouldReturnNullWithoutNpe() {
+        JSONObject result = externalDynamicClientRegistrationService.getSoftwareStatementJwks(null, new JSONObject(), new Jwt());
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
If there no any custom script for dynamic registration we should not fail entire call (avoid npe).

https://github.com/JanssenProject/jans/issues/710