### PR TITLE
ci: consolidate home and .gitHub repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/development-item.md
+++ b/.github/ISSUE_TEMPLATE/development-item.md
@@ -1,0 +1,61 @@
+---
+name: Development item
+about: Create this issue if you are a developer who is contributing code for a feature or bug, and you want to track or co-ordinate development work
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- 
+If a section or line item is not applicable, please put `NA` at the end of the line 
+We recommend tracking each non-trivial task as separate issue. 
+To quickly do that,
+- list your task titles in the list below (it'll become title of the issue later)
+- after you submit this issue, you can quickly create issues for each task below from description of this issue.
+Refer to the link below for help.
+(https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-task-list-item)
+-->
+
+-------------------
+
+### Description
+
+- Development target issue
+  <!-- Mention original Github `feature request` or `bug` ID which is being addressed -->
+
+- Implementation Details
+  <!-- Communicate high level analysis and implementation approach -->
+
+-------------------
+
+### Prepare
+
+- [ ] Read contribution guidelines
+- [ ] Read license information
+
+------------------
+
+### Identified code changes
+
+
+- [ ] task 1
+- [ ] task 2
+- [ ] task 3
+
+-------------------
+
+### Test cases and code coverage
+
+- [ ] Write unit test to cover added/changed code
+- [ ] Update integration tests to cover added/changed code
+
+-------------------
+
+### Document the changes
+
+- [ ] task for updating user guides if needed
+- [ ] task for updating installation and configuration guides if needed 
+- [ ] task for updating developer documentation if needed
+- [ ] task for updating technical documentation if needed
+

--- a/.github/ISSUE_TEMPLATE/failing-tests.md
+++ b/.github/ISSUE_TEMPLATE/failing-tests.md
@@ -1,0 +1,20 @@
+---
+name: Failing tests
+about: You noticed a flaky test or a problem with a build? This is the kind of issue to triage that!
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### What is failing?
+<!-- Mention the type of failure like build, test etc -->
+
+### Where is it failing?
+<!-- Mention the environment where you are seeing the failure. If possible, give the link where failure can be seen. e.g Link to Jenkins build -->
+
+### Relevent logs
+<!-- Paste relevent logs if you have any -->
+
+### Possible root cause
+<!-- Mention if you have a guess about what may be causing this failure. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+The **JanssenProject** team and community take security bugs seriously.
+
+We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+## Supported versions
+
+Security updates will typically only be applied to the latest release (at least until **Janssen** reaches first stable major version).
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| >=0.1 | :white_check_mark: |
+
+## Reporting a vulnerability
+
+To report a security issue, email [security@jans.io](mailto:security@jans.io?subject=SECURITY)
+and include the word "SECURITY" in the subject line.
+
+The **Janssen** team will send a response indicating the next steps in handling your report.
+After the initial reply to your report, the team will keep you informed of the progress towards a fix and full announcement,
+and may ask for additional information or guidance.
+
+Note also that the team can use [GitHub Security Advisories](https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories)
+to disclose, fix, and publish information about the vulnerability you responsibly reported to us.

--- a/docs/community/CONTRIBUTING.md
+++ b/docs/community/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+---
+layout: default
+---
+
+# Join the community
+
+* Chat: We have an active [community chat on Gitter](https://gitter.im/JanssenProject/Lobby). You can register for free their with your Github identity.
+* Tweet: Janssen is on [Twitter](https://twitter.com/janssen_project) too. Follow us there to stay up to date on release announcements and news around Janssen.
+* Email: We have an active mailing list also.
+* Google group : You can subscribe to the [Janssen Google Group](https://groups.google.com/u/2/g/janssen_project)
+  and post messages there.
+
+# Contribute
+
+Please go through our [contribution guidelines](#contribution-guidelines) so it'll be easy for you to make successful contributions.
+
+In case you are _**first-time**_ contributor, then you can start with our [good first issues list](https://github.com/JanssenProject/home/labels/good%20first%20issue) These are issues where you can easily contribute and community members will guide and support your contribution as always.
+
+If you need Janssen installation to test out your fix, here are the [steps](#janssen-quick-install).
+
+There are many ways of contributing to Janssen. And it is not just limited to fixing issues and raising pull requests. Janssen welcomes you to [raise issues](#issues), respond to queries, suggest new features, tell us your experience with Janssen, be it good or bad. All these are contributions towards making Janssen better.
+
+# Contribution guidelines
+
+We are really glad you are reading this, because we need volunteer developers to help this project come to fruition.
+
+- [Code of Conduct](#code-of-conduct)
+- [Community](#community)
+- [Issues](#issues)
+- [Triaging](#triaging)
+- [Commit convention](#commit-convention)
+- [Developer Certificate Of Origin](#developer-certificate-of-origin)
+
+## Code of Conduct
+
+Janssen project has a
+[Code of Conduct](code-of-conduct.md)
+to which all contributors must adhere, please read it before interacting with the repository or the community in any way.
+
+## Community
+
+We have setup a [community chat on Gitter](https://gitter.im/JanssenProject/Lobby). Please raise discussion and **support requests** here first.
+
+Join the [google group mailing list](https://groups.google.com/u/2/g/janssen_project) for news, announcements, and a Google calendar invite for our community open source meetings.
+
+We also run monthly **community calls** which are open calls to discuss Janssen projects from an user perspective. In case you want to discuss a topic during those calls you can simply propose it opening an issue in the [community](https://github.com/JanssenProject/community) repository and join the call!
+
+## Issues
+
+There are four kinds of issues you can open:
+
+- Bug report: you believe you found a problem in a project and you want to discuss and get it fixed,
+  creating an issue with the **bug report template** is the best way to do so.
+- Enhancement: any kind of new feature need to be discussed in this kind of issue, do you want a new rule or a new feature? This is the kind of issue you want to open. Be very good at explaining your intent, it's always important that others can understand what you mean in order to discuss, be open and collaborative in letting others help you getting this done!
+- Vulnerability: If you identify a security problem, please report it immediately, providing details about the nature, and if applicable, how to reproduce it. If you want to report an issue privately, you can email security@gluu.org
+- Failing tests: you noticed a flaky test or a problem with a build? This is the kind of issue to triage that!
+
+The best way to get **involved** in the project is through issues, you can help in many ways:
+
+- Issues triaging: participating in the discussion and adding details to open issues is always a good thing,
+  sometimes issues need to be verified, you could be the one writing a test case to fix a bug!
+- Helping to resolve the issue: you can help in getting it fixed in many ways, more often by opening a pull request. In case you are _**first-time**_ contributor, then you can start with our [good first issues list](https://github.com/JanssenProject/home/labels/good%20first%20issue) These are issues where you can easily contribute and community members will guide and support your contribution as always.
+
+## Triaging
+
+Triage is a process of evaluating issues and PRs in order to determine their characteristics and take quick actions if possible.
+
+When you triage an issue, you:
+
+* assess whether it has merit or not
+
+* quickly close it by correctly answering a question
+
+* point the reporter to a resource or documentation answering the issue
+
+* tag it via labels, projects, or milestones
+
+* take ownership submitting a PR for it, in case you want 😇
+
+Here is how we [continously triage](triage.md) new issues and PRs so that contributors can contribute faster and better.
+
+
+## Commit convention
+
+As commit convention, we adopt [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/), we have an history
+of commits that do not adopt the convention but any new commit must follow it to be eligible for merge.
+
+## Developer Certificate Of Origin
+
+The [Developer Certificate of Origin (DCO)](https://developercertificate.org/) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.
+
+Contributors to the Janssen project sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
+
+```
+This is a commit message
+
+Signed-off-by: Foo Bar <foobar@spam.org>
+```
+
+Git even has a `-s` command line option to append this automatically to your commit message:
+
+```
+$ git commit -s -m 'This is my commit message'
+```

--- a/docs/community/testing.md
+++ b/docs/community/testing.md
@@ -1,0 +1,24 @@
+# Test Driven development
+
+The Janssen Project is a large, complex project with tons of inter-dependency.  If we aren't test-driven, anarchy will ensue.
+
+### Unit testing
+Do not submit any code without a corresponding unit test. Also, any bug fixes should increment unit test coverage. All unit tests are executed with any subsequent Jenkins build.
+
+### Component testing
+Component testing uses real world use cases to exercise a portion of the software, using typical data inputs. Developers should document component stories and submit them to the component test library for the respective repository. A tester should be able to run component tests manually. Component tests should run automatically with each Jenkins build.
+
+The OpenID Foundation [certification tests](https://openid.net/certification) supplement the component testing library, and should be run for each major release of the software for which they are available.
+
+### Performance testing
+Performance tests are critical to optimization of the persistence and caching implementation. All major releases of the software should be tested for performance with all supported database and cache configurations using the Cloud Native distribution. The VM distribution will not be performance tested, as the main goal for this distribution is development and small deployments. The JMeter test tool should be used to generate the load. These tests are published so community members can run their own bench-marking analysis.
+
+## HA Tests
+HA tests should be run against the Cloud Native distribution, which by design is active-active with no single point of failure. The HA testing should simulate taking down various pieces of infrastructure, to see if authentications can still proceed. Also, what happens to transactions that were in progress during the crash?
+
+# Penetration tests
+Penetration testing is highly deployment specific. Depending on different implementations of the Janssen Project software, you may achieve different levels of risk mitigation. Thus it is important that organizations that operate their own IAM platform based on Janssen perform their own penetration
+testing.
+
+# Dependency Vulnerabilities
+Dependency vulnerabilities are monitored by Gihub. In addition we plan to use the [Linux Foundation Community Bridge](https://security.communitybridge.org) vulnerability detection platform.

--- a/docs/community/triage.md
+++ b/docs/community/triage.md
@@ -1,0 +1,71 @@
+# Janssen Triage Process and labels
+
+Triage process is used to quickly screen and categorise new issues and PRs. Aim is to determine characteristics of new PRs/issues and take quick actions if possible. 
+
+Triage process is a contineous process. As new issues/PRs come in, the community initiates discussions, add labels, ask for more details. This process does not wait for triage call or a meeting to be called. <br/><br/>Community holds triage calls at a regular cadence. Triage calls are mainly utilised to discuss issue/PR where concensus is not yet reached and to pick up anything which is not yet triaged. It is encouraged to complete triage outside of triage call to improve velocity. 
+
+### Stages in triage process:
+
+|Name|Description|
+| --- | --- |
+|Needs triage|When a new issue or PR is created, it is automatically <br/>labeled as `needs-triage`|
+|Ready for triage|For all issues/PRs with `needs-triage` label, Maintainers/committers<br/> will assign a suitable active community member as owner to <br/>start evaluating issue/PR . Owner and community will evaluate <br/>merit and characteristics of issue/PR asynchronously and assign approapriate [labels](#labels). <br/>When owner believes that sufficient details have been added <br/>and there is concensus, the owner would remove <br/>`needs-triage` label and apply label `ready-for-triage`.|
+|Triaged|All issues/PRs with label `ready-for-triage` will <br/>be reviewed by core members of the community who have<br/> permission to add `triaged` label. Reviewer reviews <br/>issue/PR to check if the issue/PR is fully triaged and can <br/>be added to backlog without discussion on triage call. <br/>At this point, label `triaged` is added and label <br/>`ready-for-triage` is removed.|
+
+We expect most of the isseus and PRs will be able to follow above path and quickly move out of triage process without waiting for triage call. Issues/PRs which still doesn't have `triaged` label, or has `needs-discussion` label, will be discussed during triage call.
+
+
+## Labels
+
+Github labels help us annotate issues/PRs with additional data. Janssen community uses labels, as detailed below, to communicate information and help making decisions about issues/PRs.
+
+### Communication labels
+
+These labels communicate status of current triage process for an issue/PR or indicate where community contribution is required. Most of communication labels would be replaced by other labels as triage process progresses and issue enters active development. For example, `help wanted` label would be removed once issue gets under active development and a community members takes ownership of the issue. Below is the list of labels which fall under this category:
+
+|Label|Indicates That|
+| --- | --- |
+|`needs-triage`|issue/PR needs triaging|
+|`ready-for-triage`|that sufficient details has been added to <br/>the issue/PR in form of labels and is ready for triage review|
+|`triaged`|Issue/PR is fully triaged|
+|`needs-information`|Indicates that creator needs to add more information <br/>to issue/PR in order to be meaningfully triaged. When adding this label, also comment on the issue about what information is needed  |
+|`needs-discussion`|Indicates that issue needs discussion during triage meeting. When adding this label, also comment on the issue about what is it that demands discussion on this issue|
+|`good first issue`|Indicates to the community that this issue suitable for first time contributor|
+|`help wanted`|Indicates to the community that this issue has complexity <br/>which is suitable for contribution from any external contributor|
+
+### Metadata labels
+
+These labels enrich issue/PR with metadata that will help during triage process and active development. These labels may not be removed from issue/PR, though value of labels may change as development progresses. For example, `effort` label may change from `effort-3` to `effort-8` as we understand issue in more detail. Below is the list of labels in this category:
+
+|Label|Indicates That|Details|
+| --- | --- | --- |
+|`comp-<module>`|Major Janssen components needing change in order to fix this issue/PR|e.g `comp-jans-auth-server`,`comp-jans-fido2`,|
+|`area-<concern>`|Cross-cutting concerns involved in fixing this issue/PR|e.g `area-documentation`, `area-release-notes`, `area-CI`|
+|`kind-bug`|Issue/PR is a bug in existing functionality||
+|`kind-enhancement`|Issue/PR is an enhancement to an existing functionality||
+|`kind-feature`|Issue/PR is new feature request||
+|`kind-question`|Issue/PR is a question that can be addressed via pointers to documentation or user education||
+|`kind-duplicate`|Issue/PR is a duplicate of existing issue/PR. Original issue should be mentioned in the comments using [Duplicate of](https://docs.github.com/en/issues/tracking-your-work-with-issues/marking-issues-or-pull-requests-as-a-duplicate) reply||
+|`kind-dependencies`|Fix for Issue/PR pertains to external dependencies||
+|`effort-1`|Relative effort required for completion||
+|`effort-2`|Relative effort required for completion||
+|`effort-3`|Relative effort required for completion||
+|`effort-5`|Relative effort required for completion||
+|`effort-8`|Relative effort required for completion||
+|`effort-13`|Relative effort required for completion||
+|`effort-21`|Relative effort required for completion||
+|`priority-0`|An issue that causes a full outage, breakage, or major function unavailability for everyone, without any known workaround. The issue must be fixed immediately, taking precedence over all other work. Should receive updates at least once per day.||
+|`priority-1`|An issue that significantly impacts a large percentage of users; if there is a workaround it is partial or overly painful. The issue should be resolved before the next release.||
+|`priority-2`|The issue is important to a large percentage of users, with a workaround. Issues that are significantly ugly or painful (especially first-use or install-time issues). Issues with workarounds that would otherwise be P0 or P1.||
+|`priority-3`|An issue that is relevant to core functions, but does not impede progress. Important, but not urgent.||
+|`priority-4`|A relatively minor issue that is not relevant to core functions, or relates only to the attractiveness or pleasantness of use of the system. Good to have but not necessary changes/fixes.||
+|`priority-5`|The team acknowledges the request but (due to any number of reasons) does not plan to work on or accept contributions for this request. The issue remains open for discussion.||
+
+
+### Status labels
+
+These labels will help in planing and tracking active development activities for a issue/PR.
+
+|Label|Indicates That|Details|
+| --- | --- | --- |
+|TBD|TBD|TBD|


### PR DESCRIPTION
Consolidate `docs`, `home` and `.github` repo into `jans` monorepo

- `docs` repo: 
  Not moving content from this repo into `jans`. This repo has lot of `work-in-progress` or placeholder content. Not suitable for moving into `jans` at this point in one go. Right approach would be to take work from this repo, finish it and then incrementally add it to `jans/docs`.

- `home` repo:
   Can be archived as most of the content from this repo is now moved to appropriate places in `jans`. 

- `.github`
  Can be archived. Moved all content to `jans`.
