### PR TITLE
fix(jans-auth-server): if consent is off then check whether response already have access_token

### DIFF
--- a/jans-auth-server/client/src/test/java/io/jans/as/client/BaseTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/BaseTest.java
@@ -483,10 +483,10 @@ public abstract class BaseTest {
                 authorizationResponseStr = waitForPageSwitch(currentDriver, authorizationResponseStr);
             }
         } else {
-            if (authorizationResponseStr.contains("#code=")) {
+            if (authorizationResponseStr.contains("code=") || authorizationResponseStr.contains("access_token=")) {
                 return authorizationResponseStr;
             }
-            fail("The authorization form was expected to be shown.");
+            fail("The authorization form was expected to be shown. authorizationResponseStr:" + authorizationResponseStr);
         }
 
         return authorizationResponseStr;


### PR DESCRIPTION
fix(jans-auth-server): if consent is off then check whether response already have access_token

https://github.com/JanssenProject/jans/issues/736