### PR TITLE
fix(jans-auth-server): corrected 500 error if absent redirect_uri in object for fapi

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidator.java
@@ -18,7 +18,6 @@ import io.jans.as.server.model.authorize.AuthorizeParamsValidator;
 import io.jans.as.server.model.authorize.JwtAuthorizationRequest;
 import io.jans.as.server.model.common.DeviceAuthorizationCacheControl;
 import io.jans.as.server.model.common.SessionId;
-import io.jans.as.server.model.exception.InvalidRedirectUrlException;
 import io.jans.as.server.service.ClientService;
 import io.jans.as.server.service.DeviceAuthorizationService;
 import io.jans.as.server.service.RedirectUriResponse;
@@ -216,7 +215,10 @@ public class AuthorizeRestWebServiceValidator {
             if (redirectUriResponse.getRedirectUri().getBaseRedirectUri() != null) {
                 throw redirectUriResponse.createWebException(AuthorizeErrorResponseType.INVALID_REQUEST_OBJECT);
             } else {
-                throw new InvalidRedirectUrlException("Request object and Authorization request does not have redirect_uri claim.");
+                throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                        .entity(errorResponseFactory.getErrorAsJson(AuthorizeErrorResponseType.INVALID_REQUEST_REDIRECT_URI,
+                                jwtRequest.getState(), "Request object does not have redirect_uri claim."))
+                        .type(MediaType.APPLICATION_JSON_TYPE).build());
             }
         }
     }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectUriResponse.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectUriResponse.java
@@ -43,7 +43,7 @@ public class RedirectUriResponse {
 
     public WebApplicationException createWebException(IErrorType errorType, String reason) {
         if (fapiCompatible) {
-            log.trace("Reason: " + reason); // print reason and set it to null since FAPI does not allow unknown fields in response
+            log.trace("Reason: {}", reason); // print reason and set it to null since FAPI does not allow unknown fields in response
             reason = null;
         }
         redirectUri.parseQueryString(errorFactory.getErrorAsQueryString(errorType, state, reason));

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/util/RedirectUtil.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/util/RedirectUtil.java
@@ -31,11 +31,14 @@ import static io.jans.as.client.AuthorizationRequest.NO_REDIRECT_HEADER;
  */
 public class RedirectUtil {
 
-    private final static Logger log = LoggerFactory.getLogger(RedirectUtil.class);
+    private static final Logger log = LoggerFactory.getLogger(RedirectUtil.class);
 
-    static String JSON_REDIRECT_PROPNAME = "redirect";
+    public static final String JSON_REDIRECT_PROPNAME = "redirect";
 
-    static int HTTP_REDIRECT = 302;
+    public static final int HTTP_REDIRECT = 302;
+
+    private RedirectUtil() {
+    }
 
     public static ResponseBuilder getRedirectResponseBuilder(RedirectUri redirectUriResponse, HttpServletRequest httpRequest) {
         ResponseBuilder builder;
@@ -48,14 +51,11 @@ public class RedirectUtil {
                 String jsonResp = jsonObject.toString();
                 jsonResp = jsonResp.replace("\\/", "/");
                 builder = Response.ok(
-                        new GenericEntity<String>(jsonResp, String.class),
+                        new GenericEntity<>(jsonResp, String.class),
                         MediaType.APPLICATION_JSON_TYPE
                 );
 
-            } catch (MalformedURLException e) {
-                builder = Response.serverError();
-                log.debug(e.getMessage(), e);
-            } catch (JSONException e) {
+            } catch (MalformedURLException | JSONException e) {
                 builder = Response.serverError();
                 log.debug(e.getMessage(), e);
             }


### PR DESCRIPTION
fix(jans-auth-server): corrected 500 error if absent redirect_uri in object for fapi

(caught by fapi1-advanced-final-ensure-request-object-without-redirect-uri-fails, fapi1-advanced-final-ensure-redirect-uri-in-authorization-request)

https://github.com/JanssenProject/jans/issues/801