### PR TITLE
fix(jans-auth-server): corrected error code for absent redirect_uri in object (fapi)

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidator.java
@@ -216,7 +216,7 @@ public class AuthorizeRestWebServiceValidator {
                 throw redirectUriResponse.createWebException(AuthorizeErrorResponseType.INVALID_REQUEST_OBJECT);
             } else {
                 throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
-                        .entity(errorResponseFactory.getErrorAsJson(AuthorizeErrorResponseType.INVALID_REQUEST_REDIRECT_URI,
+                        .entity(errorResponseFactory.getErrorAsJson(AuthorizeErrorResponseType.INVALID_REQUEST_OBJECT,
                                 jwtRequest.getState(), "Request object does not have redirect_uri claim."))
                         .type(MediaType.APPLICATION_JSON_TYPE).build());
             }


### PR DESCRIPTION
fix(jans-auth-server): corrected error code for absent redirect_uri in object (fapi)

(caught by fapi1-advanced-final-ensure-request-object-without-redirect-uri-fails, fapi1-advanced-final-ensure-redirect-uri-in-authorization-request)

https://github.com/JanssenProject/jans/issues/801