### PR TITLE
docs: create readme with index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Janssen Project Documentation
+
+- User Guides and HowTo
+  - Installation Guides
+  - How To implement usecase
+    - Implementing Authentication with Apache reverse proxy
+- Community and Contribution
+  - [Charter](./community/charter.md)
+  - [Contributing](./community/CONTRIBUTING.md)
+  - [Code of Conduct](./community/code-of-conduct.md)
+  - [Triage Process](./community/triage.md)
+  - [Testing](./community/testing.md)
+  - [Copyright Notice](./community/copyright-notices.md)
+- Technical Documentation
+- Source Code Documentation


### PR DESCRIPTION
`Main Docs` link on Github site is currently fetching 404.

To fix this, I have created a readme for `jans/docs` with an index that outlines structure of the documentation.