### PR TITLE
feat(jans-config-api): swagger update for default value

### DIFF
--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -1816,13 +1816,13 @@ paths:
           description: The 1-based index of the first query result.
         - schema:
             type: string
-            default: 1
+            default: inum
           in: query
           name: sortBy
           description: Attribute whose value will be used to order the returned response.
         - schema:
             type: string
-            default: 1
+            default: ascending
             enum:
               - ascending
               - descending


### PR DESCRIPTION
@yuriyz, request you to please review and approve swagger spec changes for default values for openid client endpoint.
Due to incorrect default value jans-cli was failing.

![image](https://user-images.githubusercontent.com/43700552/154710919-c52fc7cb-96b0-4748-9965-fe0360322249.png)
