### PR TITLE
refactor: table mapping for SQL and Spanner persistence

### DIFF
--- a/docker-jans-auth-server/requirements.txt
+++ b/docker-jans-auth-server/requirements.txt
@@ -1,4 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@f88095b1f52f0639221e4109ed7262099e06d0e9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-auth-server/requirements.txt
+++ b/docker-jans-auth-server/requirements.txt
@@ -1,4 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@039310f253ded41241b9eb08a7be99abe15115da#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-certmanager/requirements.txt
+++ b/docker-jans-certmanager/requirements.txt
@@ -2,4 +2,4 @@
 grpcio==1.41.0
 click==6.7
 libcst<0.4
-git+https://github.com/JanssenProject/jans@f88095b1f52f0639221e4109ed7262099e06d0e9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-certmanager/requirements.txt
+++ b/docker-jans-certmanager/requirements.txt
@@ -2,4 +2,4 @@
 grpcio==1.41.0
 click==6.7
 libcst<0.4
-git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@039310f253ded41241b9eb08a7be99abe15115da#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-client-api/requirements.txt
+++ b/docker-jans-client-api/requirements.txt
@@ -2,4 +2,4 @@
 grpcio==1.41.0
 ruamel.yaml==0.16.10
 libcst<0.4
-git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@039310f253ded41241b9eb08a7be99abe15115da#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-client-api/requirements.txt
+++ b/docker-jans-client-api/requirements.txt
@@ -2,4 +2,4 @@
 grpcio==1.41.0
 ruamel.yaml==0.16.10
 libcst<0.4
-git+https://github.com/JanssenProject/jans@f88095b1f52f0639221e4109ed7262099e06d0e9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-config-api/requirements.txt
+++ b/docker-jans-config-api/requirements.txt
@@ -1,4 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@f88095b1f52f0639221e4109ed7262099e06d0e9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-config-api/requirements.txt
+++ b/docker-jans-config-api/requirements.txt
@@ -1,4 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@039310f253ded41241b9eb08a7be99abe15115da#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-configurator/requirements.txt
+++ b/docker-jans-configurator/requirements.txt
@@ -4,4 +4,4 @@ click==6.7
 marshmallow==3.10.0
 fqdn==1.4.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@039310f253ded41241b9eb08a7be99abe15115da#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-configurator/requirements.txt
+++ b/docker-jans-configurator/requirements.txt
@@ -4,4 +4,4 @@ click==6.7
 marshmallow==3.10.0
 fqdn==1.4.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@f88095b1f52f0639221e4109ed7262099e06d0e9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-fido2/requirements.txt
+++ b/docker-jans-fido2/requirements.txt
@@ -1,4 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@f88095b1f52f0639221e4109ed7262099e06d0e9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-fido2/requirements.txt
+++ b/docker-jans-fido2/requirements.txt
@@ -1,4 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@039310f253ded41241b9eb08a7be99abe15115da#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-persistence-loader/requirements.txt
+++ b/docker-jans-persistence-loader/requirements.txt
@@ -2,4 +2,4 @@
 grpcio==1.41.0
 ldif==4.1.1
 libcst<0.4
-git+https://github.com/JanssenProject/jans@f88095b1f52f0639221e4109ed7262099e06d0e9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-persistence-loader/requirements.txt
+++ b/docker-jans-persistence-loader/requirements.txt
@@ -2,4 +2,4 @@
 grpcio==1.41.0
 ldif==4.1.1
 libcst<0.4
-git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@039310f253ded41241b9eb08a7be99abe15115da#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-persistence-loader/scripts/spanner_setup.py
+++ b/docker-jans-persistence-loader/scripts/spanner_setup.py
@@ -402,17 +402,7 @@ class SpannerBackend:
     def update_schema(self):
         """Updates schema (may include data migration)"""
 
-        table_mapping = {}
-
-        # TODO: this should be replacing the one in jans-pycloudlib
-        for table in self.client.database.list_tables():
-            with self.client.database.snapshot() as snapshot:
-                result = snapshot.execute_sql(
-                    f"select column_name, spanner_type "
-                    "from information_schema.columns "
-                    f"where table_name = '{table.table_id}'"
-                )
-                table_mapping[table.table_id] = dict(result)
+        table_mapping = self.client.get_table_mapping()
 
         def column_to_array(table_name, col_name):
             old_data_type = table_mapping[table_name][col_name]

--- a/docker-jans-persistence-loader/scripts/sql_setup.py
+++ b/docker-jans-persistence-loader/scripts/sql_setup.py
@@ -355,12 +355,7 @@ class SQLBackend:
     def update_schema(self):
         """Updates schema (may include data migration)"""
 
-        table_mapping = {}
-        for name, table in self.client.adapter.metadata.tables.items():
-            table_mapping[name] = {
-                column.name: str(column.type)
-                for column in table.c
-            }
+        table_mapping = self.client.get_table_mapping()
 
         def column_to_json(table_name, col_name):
             old_data_type = table_mapping[table_name][col_name]
@@ -393,7 +388,7 @@ class SQLBackend:
                 self.client.update(table_name, doc_id, {col_name: {"v": value_list}})
 
         def add_column(table_name, col_name):
-            if col_name in self.client.get_table_mapping()[table_name]:
+            if col_name in table_mapping[table_name]:
                 return
 
             data_type = self.get_data_type(col_name, table_name)

--- a/docker-jans-scim/requirements.txt
+++ b/docker-jans-scim/requirements.txt
@@ -1,4 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@f88095b1f52f0639221e4109ed7262099e06d0e9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-scim/requirements.txt
+++ b/docker-jans-scim/requirements.txt
@@ -1,4 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-git+https://github.com/JanssenProject/jans@03eba074dfcf9969e47d050a5d4a0b754185fed9#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@039310f253ded41241b9eb08a7be99abe15115da#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/jans-pycloudlib/jans/pycloudlib/persistence/sql.py
+++ b/jans-pycloudlib/jans/pycloudlib/persistence/sql.py
@@ -7,6 +7,7 @@ This module contains various helpers related to SQL persistence.
 
 import logging
 import os
+from collections import defaultdict
 
 from sqlalchemy import create_engine
 from sqlalchemy import MetaData
@@ -64,7 +65,8 @@ class BaseClient:
         """Lazy init of metadata."""
 
         if not self._metadata:
-            self._metadata = MetaData(bind=self.engine, reflect=True)
+            self._metadata = MetaData(bind=self.engine)
+            self._metadata.reflect()
         return self._metadata
 
     @property
@@ -99,13 +101,14 @@ class BaseClient:
         """Get mapping of column name and type from all tables.
         """
 
-        table_mapping = {}
+        table_mapping = defaultdict(dict)
         for table_name, table in self.metadata.tables.items():
-            table_mapping[table_name] = {
-                column.name: column.type.__class__.__name__
-                for column in table.c
-            }
-        return table_mapping
+            for column in table.c:
+                # truncate COLLATION string
+                if getattr(column.type, "collation", None):
+                    column.type.collation = None
+                table_mapping[table_name][column.name] = str(column.type)
+        return dict(table_mapping)
 
     def row_exists(self, table_name, id_):
         """Check whether a row is exist."""


### PR DESCRIPTION
Overview:

- table mapping for SQL persistence now omitting extra info like COLLATION in column type
- table mapping for Spanner persistence loads the column info using queries

The changes are mainly used for comparing data type from static file against column types in persistence.