### PR TITLE
fix: added missing values for openbanking

### DIFF
--- a/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
@@ -51,11 +51,18 @@
         "tls_client_certificate_bound_access_tokens",
         "mtls_endpoint_aliases"
     ],
+    "scopesSupported":[
+        "openid",
+        "consents",
+        "accounts",
+        "resources"
+    ],
     "responseTypesSupported":[
         ["code", "id_token"]
     ],
     "responseModesSupported":[
-        "fragment"
+        "fragment",
+        "jwt"
     ],
     "grantTypesSupported":[
         "client_credentials",
@@ -133,6 +140,7 @@
     ],
     "tokenEndpointAuthMethodsSupported":[
         "client_secret_post",
+        "private_key_jwt",
         "tls_client_auth"
     ],
     "tokenEndpointAuthSigningAlgValuesSupported":[


### PR DESCRIPTION
Added a few missing e.g. `jwt` `responseType` and `private_key_jwt` token auth method and `scopes_supported`