### PR TITLE
fix: change in swagger spec for jwks to return missing attributes

### DIFF
--- a/jans-cli/cli/jca.yaml
+++ b/jans-cli/cli/jca.yaml
@@ -1816,13 +1816,13 @@ paths:
           description: The 1-based index of the first query result.
         - schema:
             type: string
-            default: 1
+            default: inum
           in: query
           name: sortBy
           description: Attribute whose value will be used to order the returned response.
         - schema:
             type: string
-            default: 1
+            default: ascending
             enum:
               - ascending
               - descending
@@ -3797,6 +3797,12 @@ components:
         - alg
         - exp
       properties:
+        name:
+          type: string
+          description: Name of the key.
+        descr:
+          type: string
+          description: key description.
         kid:
           type: string
           description: The unique identifier for the key.
@@ -6471,6 +6477,9 @@ components:
         description:
           type: string
           description: role description
+        deletable:
+          type: boolean
+          description: can we delete the role?
     AdminPermission:
       type: object
       description: Admin permission

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -3797,6 +3797,12 @@ components:
         - alg
         - exp
       properties:
+        name:
+          type: string
+          description: Name of the key.
+        descr:
+          type: string
+          description: key description.
         kid:
           type: string
           description: The unique identifier for the key.

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/JwksResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/JwksResource.java
@@ -43,6 +43,7 @@ public class JwksResource extends BaseResource {
     @ProtectedApi(scopes = { ApiAccessConstants.JWKS_READ_ACCESS })
     public Response get() {
         final String json = configurationService.findConf().getWebKeys().toString();
+		log.debug("JWKS json = " + json);
         return Response.ok(json).build();
     }
 


### PR DESCRIPTION
### Description

- Target issue #
[Issue 958](https://github.com/JanssenProject/jans/issues/958):  Jwks endpoint not returning all attributes.

- Implementation Details
 Analysis: issue due to missing attributes in swagger spec
Impacted components:
1. `jans-config-api`
2. `jans-cli`

-------------------
### Document the changes
Swagger spec and jans-cli spec has been updated
