### PR TITLE
fix(jans-auth-server): reduce noise in logs when session can't be found

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/SessionIdService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/SessionIdService.java
@@ -801,7 +801,7 @@ public class SessionIdService {
             return sessionId;
         } catch (Exception e) {
             if (!silently) {
-                log.error("Failed to get session by dn: " + dn + ". " + e.getMessage());
+                log.error("Failed to get session by dn: {}. {}", dn, e.getMessage());
             }
         }
         return null;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/SessionIdService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/SessionIdService.java
@@ -801,7 +801,7 @@ public class SessionIdService {
             return sessionId;
         } catch (Exception e) {
             if (!silently) {
-                log.error("Failed to get session by dn: " + dn, e);
+                log.error("Failed to get session by dn: " + dn + ". " + e.getMessage());
             }
         }
         return null;


### PR DESCRIPTION
fix(jans-auth-server): reduce noise in logs when session can't be found
https://github.com/GluuFederation/oxAuth/issues/1646