### PR TITLE
feat: add support to import custom ldif

### DIFF
--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -177,7 +177,7 @@ LABEL name="Persistence" \
     summary="Janssen Authorization Server Persistence loader" \
     description="Generate initial data for persistence layer"
 
-RUN mkdir -p /app/tmp /etc/certs /etc/jans/conf
+RUN mkdir -p /app/custom_ldif /etc/certs /etc/jans/conf
 
 COPY scripts /app/scripts
 # this overrides existing templates
@@ -189,9 +189,11 @@ RUN adduser -s /bin/sh -D -G root -u 1000 1000
 
  # adjust ownership
 RUN chown -R 1000:1000 /tmp \
-    && chown -R 1000:1000 /app/tmp/ \
+    && chown -R 1000:1000 /app/custom_ldif/ \
+    && chown -R 1000:1000 /app/templates/ \
     && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /app/tmp && chmod -R g=u /app/tmp \
+    && chgrp -R 0 /app/custom_ldif && chmod -R g=u /app/custom_ldif \
+    && chgrp -R 0 /app/templates && chmod -R g=u /app/templates \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans
 USER 1000

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -177,25 +177,27 @@ LABEL name="Persistence" \
     summary="Janssen Authorization Server Persistence loader" \
     description="Generate initial data for persistence layer"
 
-RUN mkdir -p /app/custom_ldif /etc/certs /etc/jans/conf
+RUN mkdir -p /app/tmp /app/custom_ldif /etc/certs /etc/jans/conf
 
 COPY scripts /app/scripts
 # this overrides existing templates
 COPY templates /app/templates
 RUN chmod +x /app/scripts/entrypoint.sh
 
-# # create non-root user
+# create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 1000
 
  # adjust ownership
 RUN chown -R 1000:1000 /tmp \
+    && chown -R 1000:1000 /app/tmp/ \
     && chown -R 1000:1000 /app/custom_ldif/ \
-    && chown -R 1000:1000 /app/templates/ \
     && chgrp -R 0 /tmp && chmod -R g=u /tmp \
+    && chgrp -R 0 /app/tmp && chmod -R g=u /app/tmp \
     && chgrp -R 0 /app/custom_ldif && chmod -R g=u /app/custom_ldif \
-    && chgrp -R 0 /app/templates && chmod -R g=u /app/templates \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans
+
 USER 1000
+
 ENTRYPOINT ["tini", "-g", "--"]
 CMD ["sh", "/app/scripts/entrypoint.sh"]

--- a/docker-jans-persistence-loader/scripts/ldap_setup.py
+++ b/docker-jans-persistence-loader/scripts/ldap_setup.py
@@ -110,7 +110,15 @@ class LDAPBackend:
 
     def _import_ldif(self, path, ctx):
         src = Path(path).resolve()
-        dst = Path(f"{path}.out").resolve()
+
+        # generated template will be saved under ``/app/tmp`` directory
+        # examples:
+        # - ``/app/templates/groups.ldif`` will be saved as ``/app/tmp/templates/groups.ldif``
+        # - ``/app/custom_ldif/groups.ldif`` will be saved as ``/app/tmp/custom_ldif/groups.ldif``
+        dst = Path("/app/tmp").joinpath(str(src).removeprefix("/app/")).resolve()
+
+        # ensure directory for generated template is exist
+        dst.parent.mkdir(parents=True, exist_ok=True)
 
         logger.info(f"Importing {src} file")
         render_ldif(src, dst, ctx)

--- a/docker-jans-persistence-loader/scripts/spanner_setup.py
+++ b/docker-jans-persistence-loader/scripts/spanner_setup.py
@@ -2,10 +2,10 @@
 import hashlib
 import json
 import logging.config
-import os
 import re
 from collections import OrderedDict
 from collections import defaultdict
+from pathlib import Path
 
 from ldif import LDIFParser
 
@@ -232,25 +232,13 @@ class SpannerBackend:
             # run the callback
             self.create_spanner_indexes(table_name, column_mapping)
 
-    def import_ldif(self):
+    def import_builtin_ldif(self, ctx):
         optional_scopes = json.loads(self.manager.config.get("optional_scopes", "[]"))
         ldif_mappings = get_ldif_mappings(optional_scopes)
 
-        ctx = prepare_template_ctx(self.manager)
-
         for _, files in ldif_mappings.items():
             for file_ in files:
-                logger.info(f"Importing {file_} file")
-                src = f"/app/templates/{file_}"
-                dst = f"/app/tmp/{file_}"
-                os.makedirs(os.path.dirname(dst), exist_ok=True)
-
-                render_ldif(src, dst, ctx)
-
-                for table_name, column_mapping in self.data_from_ldif(dst):
-                    self.client.insert_into(table_name, column_mapping)
-                    # inject rows into subtable (if any)
-                    self.insert_into_subtable(table_name, column_mapping)
+                self._import_ldif(f"/app/templates/{file_}", ctx)
 
     def initialize(self):
         logger.info("Creating tables (if not exist)")
@@ -263,7 +251,13 @@ class SpannerBackend:
         logger.info("Creating indexes (if not exist)")
         self.create_indexes()
 
-        self.import_ldif()
+        ctx = prepare_template_ctx(self.manager)
+
+        logger.info("Importing builtin LDIF files")
+        self.import_builtin_ldif(ctx)
+
+        logger.info("Importing custom LDIF files (if any)")
+        self.import_custom_ldif(ctx)
 
     def transform_value(self, key, values):
         type_ = self.sql_data_types.get(key)
@@ -555,3 +549,21 @@ class SpannerBackend:
             ("jansPerson", "jansOTPDevices"),
         ]:
             column_from_array(mod[0], mod[1])
+
+    def import_custom_ldif(self, ctx):
+        custom_dir = Path("/app/custom_ldif")
+
+        for file_ in custom_dir.rglob("*.ldif"):
+            self._import_ldif(file_, ctx)
+
+    def _import_ldif(self, path, ctx):
+        src = Path(path).resolve()
+        dst = Path(f"{path}.out").resolve()
+
+        logger.info(f"Importing {src} file")
+        render_ldif(src, dst, ctx)
+
+        for table_name, column_mapping in self.data_from_ldif(dst):
+            self.client.insert_into(table_name, column_mapping)
+            # inject rows into subtable (if any)
+            self.insert_into_subtable(table_name, column_mapping)

--- a/docker-jans-persistence-loader/scripts/spanner_setup.py
+++ b/docker-jans-persistence-loader/scripts/spanner_setup.py
@@ -558,7 +558,15 @@ class SpannerBackend:
 
     def _import_ldif(self, path, ctx):
         src = Path(path).resolve()
-        dst = Path(f"{path}.out").resolve()
+
+        # generated template will be saved under ``/app/tmp`` directory
+        # examples:
+        # - ``/app/templates/groups.ldif`` will be saved as ``/app/tmp/templates/groups.ldif``
+        # - ``/app/custom_ldif/groups.ldif`` will be saved as ``/app/tmp/custom_ldif/groups.ldif``
+        dst = Path("/app/tmp").joinpath(str(src).removeprefix("/app/")).resolve()
+
+        # ensure directory for generated template is exist
+        dst.parent.mkdir(parents=True, exist_ok=True)
 
         logger.info(f"Importing {src} file")
         render_ldif(src, dst, ctx)

--- a/docker-jans-persistence-loader/scripts/sql_setup.py
+++ b/docker-jans-persistence-loader/scripts/sql_setup.py
@@ -505,7 +505,15 @@ class SQLBackend:
 
     def _import_ldif(self, path, ctx):
         src = Path(path).resolve()
-        dst = Path(f"{path}.out").resolve()
+
+        # generated template will be saved under ``/app/tmp`` directory
+        # examples:
+        # - ``/app/templates/groups.ldif`` will be saved as ``/app/tmp/templates/groups.ldif``
+        # - ``/app/custom_ldif/groups.ldif`` will be saved as ``/app/tmp/custom_ldif/groups.ldif``
+        dst = Path("/app/tmp").joinpath(str(src).removeprefix("/app/")).resolve()
+
+        # ensure directory for generated template is exist
+        dst.parent.mkdir(parents=True, exist_ok=True)
 
         logger.info(f"Importing {src} file")
         render_ldif(src, dst, ctx)

--- a/docs/user/how-to/add-custom-ldifs.md
+++ b/docs/user/how-to/add-custom-ldifs.md
@@ -1,0 +1,79 @@
+## Contents:
+
+- [Overview](#overview)
+- [Using Kubernetes?](#kubernetes)
+
+## Overview
+
+This guide describes steps to load custom work to Janssen IDP.
+
+
+#### Hardware configuration
+
+For development and POC purposes, 4GB RAM and 10 GB HDD should be available for Janssen Server. For PROD deployments, please refer [installation guide](https://github.com/JanssenProject/jans/wiki#janssen-installation).
+  
+
+#### Prerequisites
+- Existing Janssen server installed
+
+#### Kubernetes
+
+If you are using Kubernetes please follow this section. You may create several ldif files denoting each type such as `custom_attributes.ldif`, `custom_clients.ldif`..etc. Refer to the built-in [`ldifs`](https://github.com/JanssenProject/jans/blob/main/jans-linux-setup/jans_setup/templates) for examples.
+
+1. Create your custom ldif files. These can be clients, attributes, scopes or whatever custom work you need. The example will be adding a custom attribute and we will call this file `custom_attributes.ldif`.
+
+  ```
+  dn: inum=C9B1,ou=attributes,o=jans
+  description: Maiden name of the End-User.Note that in some cultures, people can have multiple given names;all can be present, with the names being separated by space characters.
+  displayName: Maiden Name
+  inum: C9B1
+  jansAttrEditTyp: user
+  jansAttrEditTyp: admin
+  jansAttrName: givenName
+  jansAttrOrigin: jansPerson
+  jansAttrTyp: string
+  jansAttrViewTyp: user
+  jansAttrViewTyp: admin
+  jansClaimName: maiden_name
+  jansSAML1URI: urn:mace:dir:attribute-def:maidenName
+  jansSAML2URI: urn:oid:2.5.4.42
+  jansStatus: active
+  objectClass: top
+  objectClass: jansAttr
+  urn: urn:mace:dir:attribute-def:maidenName
+  ```
+
+2. Create a configmap or secret depending on the if the ldif holds and secret data such as a client secret. Here, we will be creating a configmap. 
+
+```bash
+kubectl create cm custom-attributes -n <namespace-of-jans> -f custom_attributes.ldif
+# kubectl create cm custom-attributes -n jans -f custom_attributes.ldif
+# using a secret
+# kubectl create secret generic custom-attributes -n jans -f custom_attributes.ldif
+```
+
+3. Mount the created configmap or secret inside your `values.yaml`
+
+  ```yaml
+  persistence:
+    volumes:
+     - name: custom-attributes
+        configMap:
+          name:  custom-attributes
+    #- name: custom-attributes
+    #  secret:
+    #    secretName: custom-attributes
+    # -- Configure any additional volumesMounts that need to be attached to the containers
+    volumeMounts:
+       - mountPath: "/app/custom_ldif/custom_attributes.ldif"
+         name:  custom-attributes
+         subPath: custom_attributes.ldif
+  ```
+
+4. Run helm upgrade to activate the persistence job.
+
+  ```bash
+  helm upgrade <release-name> janssen/janssen -f values.yaml -n <jans-namespace>
+  ```
+
+Your custom work should be loaded to your persistence. This also persists any changes going forward as you upgrade.


### PR DESCRIPTION
### Description

- Target issue: #891

### Implementation Details

1. the entrypoint will scan for all `.ldif` files under predefined directory `/app/custom_ldif` (where users can mount files into this directory)
1. for every `.ldif` file found, entrypoint will try to generate rendered template (if file contains template context) under `/app/tmp/`
1. entrypoint will import data parsed from the generated template into user-selected persistence (`ldap`/`sql`/`spanner`/`couchbase`)