### PR TITLE
chore: update client-api image

### DIFF
--- a/docker-jans-client-api/Dockerfile
+++ b/docker-jans-client-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjre-alpine:11
+FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 
 # ===============
 # Alpine packages
@@ -16,7 +16,7 @@ RUN apk update \
 # ==========
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2021-12-21 10:52'
+ENV CN_BUILD_DATE='2022-03-10 17:03'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-client-api-server/${CN_VERSION}/jans-client-api-server-${CN_VERSION}-distribution.zip
 
 RUN wget -q ${CN_SOURCE_URL} -O /tmp/client-api.zip \

--- a/docker-jans-client-api/templates/jans.properties.tmpl
+++ b/docker-jans-client-api/templates/jans.properties.tmpl
@@ -3,6 +3,7 @@ persistence.type=%(persistence_type)s
 jansAuth_ConfigurationEntryDN=ou=jans-auth,ou=configuration,o=jans
 fido2_ConfigurationEntryDN=ou=jans-fido2,ou=configuration,o=jans
 scim_ConfigurationEntryDN=ou=jans-scim,ou=configuration,o=jans
+configApi_ConfigurationEntryDN=ou=jans-config-api,ou=configuration,o=jans
 
 certsDir=/etc/certs
 confDir=


### PR DESCRIPTION
### Description

The changeset introduces the following changes

- base image pinned to `bellsoft/liberica-openjre-alpine:11.0.13-8`
- updated `jans-client-api-server` source (contains fix for #1006)
- added missing `configApi_ConfigurationEntryDN` config in `jans.properties`