### PR TITLE
feat: avoid jetty hot-deployment issue

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -7,7 +7,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 RUN apk update \
     && apk add --no-cache openssl py3-pip tini curl bash py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
-    && apk add --no-cache --virtual build-deps wget git \
+    && apk add --no-cache --virtual build-deps wget git zip \
     && mkdir -p /usr/java/latest \
     && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
@@ -52,16 +52,19 @@ RUN wget -q https://github.com/fabioz/PyDev.Debugger/archive/refs/tags/pydev_deb
 # ===========
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-07 16:26'
+ENV CN_BUILD_DATE='2022-03-10 11:31'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-server/${CN_VERSION}/jans-auth-server-${CN_VERSION}.war
 
 # Install Jans Auth
-RUN wget -q ${CN_SOURCE_URL} -O /tmp/jans-auth.war \
-    && mkdir -p ${JETTY_BASE}/jans-auth/webapps/jans-auth \
-    && unzip -qq /tmp/jans-auth.war -d ${JETTY_BASE}/jans-auth/webapps/jans-auth \
-    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/jans-auth --add-to-start=server,deploy,annotations,resources,http,http-forwarded,threadpool,jsp,websocket,cdi-decorate \
-    && rm -f /tmp/jans-auth.war \
-    && rm -f ${JETTY_BASE}/jans-auth/webapps/jans-auth/WEB-INF/jetty-web.xml
+COPY jetty/jetty-env.xml /tmp/WEB-INF/jetty-env.xml
+RUN mkdir -p ${JETTY_BASE}/jans-auth/webapps \
+    && wget -q ${CN_SOURCE_URL} -O /tmp/jans-auth.war \
+    && cd /tmp \
+    && zip -d jans-auth.war WEB-INF/jetty-web.xml \
+    && zip -r jans-auth.war WEB-INF/jetty-env.xml \
+    && cp jans-auth.war ${JETTY_BASE}/jans-auth/webapps/jans-auth.war \
+    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/jans-auth --add-module=server,deploy,annotations,resources,http,http-forwarded,threadpool,jsp,websocket,cdi-decorate \
+    && rm -rf /tmp/jans-auth.war /tmp/WEB-INF
 
 # ===========
 # Custom libs
@@ -219,18 +222,18 @@ RUN mkdir -p ${JETTY_BASE}/jans-auth/custom/pages \
     ${JETTY_BASE}/jans-auth/custom/libs \
     ${JETTY_BASE}/jans-auth/custom/i18n \
     /etc/jans/conf \
-    /app/templates
+    /app/templates \
+    /opt/jetty/temp
 
 COPY certs /etc/certs
 COPY jetty/jans-auth_web_resources.xml ${JETTY_BASE}/jans-auth/webapps/
 COPY jetty/jans-auth.xml ${JETTY_BASE}/jans-auth/webapps/
-COPY jetty/jetty-env.xml ${JETTY_BASE}/jans-auth/webapps/jans-auth/WEB-INF/
 COPY jetty/log4j2.xml ${JETTY_BASE}/jans-auth/resources/
 COPY conf/*.tmpl /app/templates/
 COPY scripts /app/scripts
 RUN chmod +x /app/scripts/entrypoint.sh
 
-# # create non-root user
+# create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
 
  # adjust ownership

--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -203,7 +203,8 @@ ENV CN_MAX_RAM_PERCENTAGE=75.0 \
     CN_SYNC_JKS_INTERVAL=30 \
     GOOGLE_PROJECT_ID="" \
     GOOGLE_APPLICATION_CREDENTIALS=/etc/jans/conf/google-credentials.json \
-    ADMIN_UI_JWKS=http://0.0.0.0:8080/jans-auth/restv1/jwks
+    ADMIN_UI_JWKS=http://0.0.0.0:8080/jans-auth/restv1/jwks \
+    CN_JETTY_REQUEST_HEADER_SIZE=8192
 
 # ==========
 # misc stuff

--- a/docker-jans-auth-server/jetty/jans-auth.xml
+++ b/docker-jans-auth-server/jetty/jans-auth.xml
@@ -4,8 +4,8 @@
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <Set name="contextPath">/jans-auth</Set>
     <Set name="war">
-        <Property name="jetty.webapps" default="." />/jans-auth
+        <Property name="jetty.webapps" default="." />/jans-auth.war
     </Set>
-    <Set name="extractWAR">false</Set>
+    <Set name="extractWAR">true</Set>
     <Set name="extraClasspath">%(extra_classpath)s</Set>
 </Configure>

--- a/docker-jans-auth-server/scripts/bootstrap.py
+++ b/docker-jans-auth-server/scripts/bootstrap.py
@@ -123,7 +123,6 @@ def main():
     #                        decode=True, binary_mode=True)
 
     modify_jetty_xml()
-    modify_server_ini()
     modify_webdefault_xml()
     configure_logging()
 
@@ -227,18 +226,6 @@ def main():
 
     # ensure we're using correct JKS file and JWKS uri
     modify_keystore_path(manager, keystore_path, jwks_uri)
-
-
-def modify_server_ini():
-    with open("/opt/jans/jetty/jans-auth/start.d/server.ini", "a") as f:
-        req_header_size = os.environ.get("CN_JETTY_REQUEST_HEADER_SIZE", "8192")
-        updates = "\n".join([
-            # disable server version info
-            "jetty.httpConfig.sendServerVersion=false",
-            # customize request header size
-            f"jetty.httpConfig.requestHeaderSize={req_header_size}",
-        ])
-        f.write(updates)
 
 
 def configure_logging():

--- a/docker-jans-auth-server/scripts/entrypoint.sh
+++ b/docker-jans-auth-server/scripts/entrypoint.sh
@@ -58,4 +58,7 @@ exec java \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     $(get_debug_opt) \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0
+    -jar /opt/jetty/start.jar \
+        jetty.deploy.scanInterval=0 \
+        jetty.httpConfig.sendServerVersion=false \
+        jetty.httpConfig.requestHeaderSize=$CN_JETTY_REQUEST_HEADER_SIZE

--- a/docker-jans-auth-server/scripts/entrypoint.sh
+++ b/docker-jans-auth-server/scripts/entrypoint.sh
@@ -45,7 +45,6 @@ python3 /app/scripts/auth_conf.py
 
 # run auth-server
 cd /opt/jans/jetty/jans-auth
-mkdir -p /opt/jetty/temp
 exec java \
     -server \
     -XX:+DisableExplicitGC \

--- a/docker-jans-auth-server/scripts/entrypoint.sh
+++ b/docker-jans-auth-server/scripts/entrypoint.sh
@@ -58,4 +58,4 @@ exec java \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     $(get_debug_opt) \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar
+    -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -7,7 +7,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 RUN apk update \
     && apk add --no-cache openssl py3-pip tini curl py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
-    && apk add --no-cache --virtual build-deps wget git \
+    && apk add --no-cache --virtual build-deps wget git zip \
     && mkdir -p /usr/java/latest \
     && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
@@ -32,16 +32,19 @@ RUN wget -q https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/${JETTY_
 # ==========
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-07 10:51'
+ENV CN_BUILD_DATE='2022-03-10 11:34'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-config-api-server/${CN_VERSION}/jans-config-api-server-${CN_VERSION}.war
 
 # Install Jans Config API
-RUN wget -q ${CN_SOURCE_URL} -O /tmp/jans-config-api.war \
-    && mkdir -p ${JETTY_BASE}/jans-config-api/webapps/jans-config-api \
-    && unzip -qq /tmp/jans-config-api.war -d ${JETTY_BASE}/jans-config-api/webapps/jans-config-api \
-    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/jans-config-api --add-to-start=server,deploy,annotations,resources,http,http-forwarded,threadpool,jsp,websocket,cdi-decorate \
-    && rm -f /tmp/jans-config-api.war \
-    && rm -f ${JETTY_BASE}/jans-config-api/webapps/jans-config-api/WEB-INF/jetty-web.xml
+COPY jetty/jetty-env.xml /tmp/WEB-INF/jetty-env.xml
+RUN mkdir -p ${JETTY_BASE}/jans-config-api/webapps \
+    && wget -q ${CN_SOURCE_URL} -O /tmp/jans-config-api.war \
+    && cd /tmp \
+    && zip -d jans-config-api.war WEB-INF/jetty-web.xml \
+    && zip -r jans-config-api.war WEB-INF/jetty-env.xml \
+    && cp jans-config-api.war ${JETTY_BASE}/jans-config-api/webapps/jans-config-api.war \
+    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/jans-config-api --add-module=server,deploy,annotations,resources,http,http-forwarded,threadpool,jsp,websocket,cdi-decorate \
+    && rm -rf /tmp/jans-config-api.war /tmp/WEB-INF
 
 # Ports exposed by config-api
 EXPOSE 8074
@@ -176,14 +179,19 @@ LABEL name="Config API" \
     maintainer="Janssen Project <support@jans.io>" \
     vendor="Janssen" \
     version="1.0.0" \
-    release="b11" \
+    release="beta.15" \
     summary="Janssen Config API" \
     description=""
 
-RUN mkdir -p /etc/certs /app/templates/ /deploy /etc/jans/conf ${JETTY_BASE}/jans-config-api/custom/libs ${JETTY_BASE}/jans-config-api/custom/config
+RUN mkdir -p /etc/certs \
+    /app/templates/ \
+    /etc/jans/conf \
+    ${JETTY_BASE}/jans-config-api/custom/libs \
+    ${JETTY_BASE}/jans-config-api/custom/config \
+    /opt/jetty/temp
+
 RUN touch /etc/hosts.back
 COPY jetty/jans-config-api.xml ${JETTY_BASE}/jans-config-api/webapps/
-COPY jetty/jetty-env.xml ${JETTY_BASE}/jans-config-api/webapps/jans-config-api/WEB-INF/
 COPY jetty/log4j2.xml ${JETTY_BASE}/jans-config-api/resources/
 COPY conf/*.tmpl /app/templates/
 COPY plugins /app/plugins
@@ -196,14 +204,12 @@ RUN adduser -s /bin/sh -D -G root -u 1000 jetty
 # adjust ownership
 RUN chown -R 1000:1000 /opt/jans/jetty \
     && chown -R 1000:1000 /opt/jetty \
-    && chown -R 1000:1000 /deploy \
     && chown -R 1000:1000 /tmp \
     && chown -R 1000:1000 /etc/hosts.back \
     && chgrp -R 0 /etc/hosts.back && chmod -R g=u /etc/hosts.back \
     && chgrp -R 0 /opt/jans/jetty && chmod -R g=u /opt/jans/jetty \
     && chgrp -R 0 /opt/jetty && chmod -R g=u /opt/jetty \
     && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /deploy && chmod -R g=u /deploy \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
     && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \

--- a/docker-jans-config-api/jetty/jans-config-api.xml
+++ b/docker-jans-config-api/jetty/jans-config-api.xml
@@ -4,8 +4,8 @@
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <Set name="contextPath">/jans-config-api</Set>
     <Set name="war">
-        <Property name="jetty.webapps" default="." />/jans-config-api
+        <Property name="jetty.webapps" default="." />/jans-config-api.war
     </Set>
-    <Set name="extractWAR">false</Set>
+    <Set name="extractWAR">true</Set>
     <Set name="extraClasspath">%(extra_classpath)s</Set>
 </Configure>

--- a/docker-jans-config-api/scripts/bootstrap.py
+++ b/docker-jans-config-api/scripts/bootstrap.py
@@ -81,7 +81,6 @@ def main():
 
     modify_jetty_xml()
     modify_webdefault_xml()
-    modify_server_ini()
     configure_logging()
 
     plugins = discover_plugins()
@@ -124,15 +123,6 @@ def modify_webdefault_xml():
     )
 
     with open(fn, "w") as f:
-        f.write(updates)
-
-
-def modify_server_ini():
-    with open("/opt/jans/jetty/jans-config-api/start.d/server.ini", "a") as f:
-        updates = "\n".join([
-            # disable server version info
-            "jetty.httpConfig.sendServerVersion=false",
-        ])
         f.write(updates)
 
 

--- a/docker-jans-config-api/scripts/entrypoint.sh
+++ b/docker-jans-config-api/scripts/entrypoint.sh
@@ -40,4 +40,7 @@ exec java \
     -Djava.io.tmpdir=/opt/jetty/temp \
     -Dlog4j2.configurationFile=$(get_logging_files) \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar jetty.http.port=8074 jetty.deploy.scanInterval=0
+    -jar /opt/jetty/start.jar \
+        jetty.http.port=8074 \
+        jetty.deploy.scanInterval=0 \
+        jetty.httpConfig.sendServerVersion=false

--- a/docker-jans-config-api/scripts/entrypoint.sh
+++ b/docker-jans-config-api/scripts/entrypoint.sh
@@ -40,4 +40,4 @@ exec java \
     -Djava.io.tmpdir=/opt/jetty/temp \
     -Dlog4j2.configurationFile=$(get_logging_files) \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar jetty.http.port=8074
+    -jar /opt/jetty/start.jar jetty.http.port=8074 jetty.deploy.scanInterval=0

--- a/docker-jans-config-api/scripts/entrypoint.sh
+++ b/docker-jans-config-api/scripts/entrypoint.sh
@@ -25,13 +25,9 @@ python3 /app/scripts/wait.py
 
 copy_builtin_plugins
 
-if [ ! -f /deploy/touched  ]; then
-    python3 /app/scripts/bootstrap.py
-    touch /deploy/touched
-fi
+python3 /app/scripts/bootstrap.py
 
 # run config-api
-mkdir -p /opt/jetty/temp
 cd /opt/jans/jetty/jans-config-api
 exec java \
     -server \

--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -7,7 +7,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 RUN apk update \
     && apk add --no-cache openssl py3-pip tini curl py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
-    && apk add --no-cache --virtual build-deps wget git \
+    && apk add --no-cache --virtual build-deps wget git zip \
     && mkdir -p /usr/java/latest \
     && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
@@ -35,16 +35,20 @@ EXPOSE 8080
 # =====
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-07 08:41'
+ENV CN_BUILD_DATE='2022-03-10 08:13'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-fido2-server/${CN_VERSION}/jans-fido2-server-${CN_VERSION}.war
 
 # Install FIDO2
-RUN wget -q ${CN_SOURCE_URL} -O /tmp/fido2.war \
-    && mkdir -p ${JETTY_BASE}/jans-fido2/webapps/jans-fido2 \
-    && unzip -qq /tmp/fido2.war -d ${JETTY_BASE}/jans-fido2/webapps/jans-fido2 \
-    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/jans-fido2 --add-to-start=server,deploy,resources,http,http-forwarded,threadpool,jsp,cdi-decorate \
-    && rm -f /tmp/fido2.war \
-    && rm -f ${JETTY_BASE}/jans-fido2/webapps/jans-fido2/WEB-INF/jetty-web.xml
+
+COPY jetty/jetty-env.xml /tmp/WEB-INF/jetty-env.xml
+RUN mkdir -p ${JETTY_BASE}/jans-fido2/webapps \
+    && wget -q ${CN_SOURCE_URL} -O /tmp/jans-fido2.war \
+    && cd /tmp \
+    && zip -d jans-fido2.war WEB-INF/jetty-web.xml \
+    && zip -r jans-fido2.war WEB-INF/jetty-env.xml \
+    && cp jans-fido2.war ${JETTY_BASE}/jans-fido2/webapps/jans-fido2.war \
+    && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/jans-fido2 --add-module=server,deploy,resources,http,http-forwarded,threadpool,jsp,cdi-decorate \
+    && rm -rf /tmp/jans-fido2.war /tmp/WEB-INF
 
 # ======
 # Python
@@ -149,39 +153,37 @@ LABEL name="FIDO2" \
     maintainer="Janssen io <support@jans.io>" \
     vendor="Janssen Project" \
     version="1.0.0" \
-    release="b12" \
+    release="beta.15" \
     summary="Janssen FIDO2" \
     description="FIDO2 server"
 
-RUN mkdir -p /etc/certs /deploy \
+RUN mkdir -p /etc/certs \
     /etc/jans/conf \
-    /app/templates
+    /etc/jans/conf/fido2/mds/cert \
+    /etc/jans/conf/fido2/mds/toc \
+    /etc/jans/conf/fido2/server_metadata \
+    /app/templates \
+    /opt/jetty/temp
 
 COPY jetty/jans-fido2.xml ${JETTY_BASE}/jans-fido2/webapps/
-COPY jetty/jetty-env.xml ${JETTY_BASE}/jans-fido2/webapps/jans-fido2/WEB-INF/
 COPY jetty/log4j2.xml ${JETTY_BASE}/jans-fido2/resources/
 COPY conf/*.tmpl /app/templates/
 COPY conf/fido2 /etc/jans/conf/fido2
-RUN mkdir -p /etc/jans/conf/fido2/mds/cert \
-    /etc/jans/conf/fido2/mds/toc \
-    /etc/jans/conf/fido2/server_metadata
 
 COPY scripts /app/scripts
 RUN chmod +x /app/scripts/entrypoint.sh
 
-# # create non-root user
+# create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
 
  # adjust ownership
 RUN chown -R 1000:1000 /opt/jans/jetty \
     && chown -R 1000:1000 /etc/jans \
     && chown -R 1000:1000 /opt/jetty \
-    && chown -R 1000:1000 /deploy \
     && chown -R 1000:1000 /tmp \
     && chgrp -R 0 /opt/jans/jetty && chmod -R g=u /opt/jans/jetty \
     && chgrp -R 0 /opt/jetty && chmod -R g=u /opt/jetty \
     && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /deploy && chmod -R g=u /deploy \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
     && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \

--- a/docker-jans-fido2/jetty/jans-fido2.xml
+++ b/docker-jans-fido2/jetty/jans-fido2.xml
@@ -4,8 +4,8 @@
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <Set name="contextPath">/jans-fido2</Set>
     <Set name="war">
-        <Property name="jetty.webapps" default="." />/jans-fido2
+        <Property name="jetty.webapps" default="." />/jans-fido2.war
     </Set>
-    <Set name="extractWAR">false</Set>
+    <Set name="extractWAR">true</Set>
     <!-- <Set name="extraClasspath">%(extra_classpath)s</Set> -->
 </Configure>

--- a/docker-jans-fido2/scripts/bootstrap.py
+++ b/docker-jans-fido2/scripts/bootstrap.py
@@ -109,17 +109,7 @@ def main():
 
     modify_jetty_xml()
     modify_webdefault_xml()
-    modify_server_ini()
     configure_logging()
-
-
-def modify_server_ini():
-    with open("/opt/jans/jetty/jans-fido2/start.d/server.ini", "a") as f:
-        updates = "\n".join([
-            # disable server version info
-            "jetty.httpConfig.sendServerVersion=false",
-        ])
-        f.write(updates)
 
 
 def configure_logging():

--- a/docker-jans-fido2/scripts/entrypoint.sh
+++ b/docker-jans-fido2/scripts/entrypoint.sh
@@ -3,11 +3,7 @@
 set -e
 
 python3 /app/scripts/wait.py
-
-if [ ! -f /deploy/touched ]; then
-    python3 /app/scripts/bootstrap.py
-    touch /deploy/touched
-fi
+python3 /app/scripts/bootstrap.py
 
 cd /opt/jans/jetty/jans-fido2
 exec java \
@@ -18,7 +14,7 @@ exec java \
     -Djans.base=/etc/jans \
     -Dserver.base=/opt/jans/jetty/jans-fido2 \
     -Dlog.base=/opt/jans/jetty/jans-fido2 \
-    -Djava.io.tmpdir=/tmp \
+    -Djava.io.tmpdir=/opt/jetty/temp \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar
+    -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0

--- a/docker-jans-fido2/scripts/entrypoint.sh
+++ b/docker-jans-fido2/scripts/entrypoint.sh
@@ -17,4 +17,4 @@ exec java \
     -Djava.io.tmpdir=/opt/jetty/temp \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0
+    -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0 jetty.httpConfig.sendServerVersion=false

--- a/docker-jans-scim/Dockerfile
+++ b/docker-jans-scim/Dockerfile
@@ -7,7 +7,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 RUN apk update \
     && apk add --no-cache openssl py3-pip tini curl bash py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
-    && apk add --no-cache --virtual build-deps wget git \
+    && apk add --no-cache --virtual build-deps wget git zip \
     && mkdir -p /usr/java/latest \
     && ln -sf /usr/lib/jvm/jre /usr/java/latest/jre
 
@@ -45,16 +45,19 @@ RUN wget -q https://ox.gluu.org/maven/org/gluufederation/jython-installer/${JYTH
 # ====
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-07 10:49'
+ENV CN_BUILD_DATE='2022-03-10 11:32'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-scim-server/${CN_VERSION}/jans-scim-server-${CN_VERSION}.war
 
 # Install SCIM
-RUN wget -q ${CN_SOURCE_URL} -O /tmp/scim.war \
-    && mkdir -p ${JETTY_BASE}/jans-scim/webapps/jans-scim \
-    && unzip -qq /tmp/scim.war -d ${JETTY_BASE}/jans-scim/webapps/jans-scim \
+COPY jetty/jetty-env.xml /tmp/WEB-INF/jetty-env.xml
+RUN mkdir -p ${JETTY_BASE}/jans-scim/webapps \
+    && wget -q ${CN_SOURCE_URL} -O /tmp/jans-scim.war \
+    && cd /tmp \
+    && zip -d jans-scim.war WEB-INF/jetty-web.xml \
+    && zip -r jans-scim.war WEB-INF/jetty-env.xml \
+    && cp jans-scim.war ${JETTY_BASE}/jans-scim/webapps/jans-scim.war \
     && java -jar ${JETTY_HOME}/start.jar jetty.home=${JETTY_HOME} jetty.base=${JETTY_BASE}/jans-scim --add-to-start=server,deploy,resources,http,http-forwarded,jsp,websocket,cdi-decorate \
-    && rm -f /tmp/scim.war \
-    && rm -f ${JETTY_BASE}/jans-scim/webapps/jans-scim/WEB-INF/jetty-web.xml
+    && rm -rf /tmp/jans-scim.war /tmp/WEB-INF
 
 # ======
 # Python
@@ -159,35 +162,33 @@ LABEL name="SCIM" \
     maintainer="Janssen Project <support@jans.io>" \
     vendor="Janssen Project" \
     version="1.0.0" \
-    release="b12" \
+    release="beta.15" \
     summary="Janssen SCIM" \
     description="SCIM server"
 
-RUN mkdir -p /etc/certs /deploy \
+RUN mkdir -p /etc/certs \
     /etc/jans/conf \
-    /app/templates
+    /app/templates \
+    /opt/jetty/temp
 
 COPY jetty/jans-scim.xml ${JETTY_BASE}/jans-scim/webapps/
-COPY jetty/jetty-env.xml ${JETTY_BASE}/jans-scim/webapps/jans-scim/WEB-INF/
 COPY jetty/log4j2.xml ${JETTY_BASE}/jans-scim/resources/
 COPY conf/*.tmpl /app/templates/
 
 COPY scripts /app/scripts
 RUN chmod +x /app/scripts/entrypoint.sh
 
-# # create non-root user
+# create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
 
  # adjust ownership
 RUN chown -R 1000:1000 /opt/jans/jetty \
     && chown -R 1000:1000 /etc/jans \
     && chown -R 1000:1000 /opt/jetty \
-    && chown -R 1000:1000 /deploy \
     && chown -R 1000:1000 /tmp \
     && chgrp -R 0 /opt/jans/jetty && chmod -R g=u /opt/jans/jetty \
     && chgrp -R 0 /opt/jetty && chmod -R g=u /opt/jetty \
     && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /deploy && chmod -R g=u /deploy \
     && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
     && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
     && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \

--- a/docker-jans-scim/jetty/jans-scim.xml
+++ b/docker-jans-scim/jetty/jans-scim.xml
@@ -4,8 +4,8 @@
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
     <Set name="contextPath">/jans-scim</Set>
     <Set name="war">
-        <Property name="jetty.webapps" default="." />/jans-scim
+        <Property name="jetty.webapps" default="." />/jans-scim.war
     </Set>
-    <Set name="extractWAR">false</Set>
+    <Set name="extractWAR">true</Set>
     <!-- <Set name="extraClasspath">%(extra_classpath)s</Set> -->
 </Configure>

--- a/docker-jans-scim/jetty/log4j2.xml
+++ b/docker-jans-scim/jetty/log4j2.xml
@@ -56,7 +56,7 @@
     </Appenders>
 
     <Loggers>
-        <Logger name="io.jans.scim" level="$scim_log_level">
+        <Logger name="io.jans.scim" level="$scim_log_level" additivity="false">
             <AppenderRef ref="$scim_log_target" />
         </Logger>
 

--- a/docker-jans-scim/scripts/bootstrap.py
+++ b/docker-jans-scim/scripts/bootstrap.py
@@ -109,17 +109,7 @@ def main():
 
     modify_jetty_xml()
     modify_webdefault_xml()
-    modify_server_ini()
     configure_logging()
-
-
-def modify_server_ini():
-    with open("/opt/jans/jetty/jans-scim/start.d/server.ini", "a") as f:
-        updates = "\n".join([
-            # disable server version info
-            "jetty.httpConfig.sendServerVersion=false",
-        ])
-        f.write(updates)
 
 
 def configure_logging():

--- a/docker-jans-scim/scripts/entrypoint.sh
+++ b/docker-jans-scim/scripts/entrypoint.sh
@@ -18,4 +18,4 @@ exec java \
     -Dpython.home=/opt/jython \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0
+    -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0 jetty.httpConfig.sendServerVersion=false

--- a/docker-jans-scim/scripts/entrypoint.sh
+++ b/docker-jans-scim/scripts/entrypoint.sh
@@ -3,11 +3,7 @@
 set -e
 
 python3 /app/scripts/wait.py
-
-if [ ! -f /deploy/touched ]; then
-    python3 /app/scripts/bootstrap.py
-    touch /deploy/touched
-fi
+python3 /app/scripts/bootstrap.py
 
 cd /opt/jans/jetty/jans-scim
 exec java \
@@ -18,8 +14,8 @@ exec java \
     -Djans.base=/etc/jans \
     -Dserver.base=/opt/jans/jetty/jans-scim \
     -Dlog.base=/opt/jans/jetty/jans-scim \
-    -Djava.io.tmpdir=/tmp \
+    -Djava.io.tmpdir=/opt/jetty/temp \
     -Dpython.home=/opt/jython \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     ${CN_JAVA_OPTIONS} \
-    -jar /opt/jetty/start.jar
+    -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0


### PR DESCRIPTION
### Description

- Target issue #1010 
- Implementation Details
  1. switch to archived `.war` instead of exploded directory under `/opt/jans/jetty/$app/webapps`
  1. set `jetty.deploy.scanInterval=0` via command-line to disable hot-deployment
- Misc.
  - customization on `/opt/jans/jetty/$app/start.d/server.ini` file is removed in favor of passing arguments when running Jetty
  - added missing `additivity` attribute for SCIM `log4j2.xml` file


