### PR TITLE
fix: update test Asserters AuthorizationRedirectUrisRegexTest Default…

### DIFF
--- a/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/AuthorizationRedirectUrisRegexTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/AuthorizationRedirectUrisRegexTest.java
@@ -1,6 +1,7 @@
 package io.jans.as.client.ws.rs;
 
 import io.jans.as.client.*;
+import io.jans.as.client.client.AssertBuilder;
 import io.jans.as.model.common.ResponseType;
 import io.jans.as.model.register.ApplicationType;
 import io.jans.as.model.util.StringUtils;
@@ -42,7 +43,9 @@ public class AuthorizationRedirectUrisRegexTest extends BaseTest {
         RegisterResponse registerResponse = registerClient.exec();
 
         showClient(registerClient);
-        assertRegisterResponseOk(registerResponse, 201, true);
+        AssertBuilder.registerResponse(registerResponse).created()
+                .notNullRegistrationClientUri()
+                .check();
 
         String clientId = registerResponse.getClientId();
         String registrationAccessToken = registerResponse.getRegistrationAccessToken();
@@ -56,7 +59,7 @@ public class AuthorizationRedirectUrisRegexTest extends BaseTest {
         RegisterResponse readClientResponse = readClient.exec();
 
         showClient(readClient);
-        assertRegisterResponseOk(readClientResponse, 200, false);
+        AssertBuilder.registerResponse(readClientResponse).ok().check();
 
         assertRegisterResponseClaimsNotNull(readClientResponse, RESPONSE_TYPES, REDIRECT_URIS. APPLICATION_TYPE, CLIENT_NAME, ID_TOKEN_SIGNED_RESPONSE_ALG, SCOPE);
 
@@ -69,8 +72,7 @@ public class AuthorizationRedirectUrisRegexTest extends BaseTest {
 
         AuthorizationResponse authorizationResponse = authenticateResourceOwnerAndGrantAccess(
                 authorizationEndpoint, authorizationRequest, userId, userSecret);
-
-        assertAuthorizationResponse(authorizationResponse, true);
+        AssertBuilder.authorizationResponse(authorizationResponse).check();
 
     }
 

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/DefaultPromptLoginTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/DefaultPromptLoginTest.java
@@ -7,6 +7,7 @@
 package io.jans.as.client.ws.rs;
 
 import io.jans.as.client.*;
+import io.jans.as.client.client.AssertBuilder;
 import io.jans.as.client.client.Asserter;
 import io.jans.as.model.common.ResponseType;
 import io.jans.as.model.register.ApplicationType;
@@ -49,7 +50,9 @@ public class DefaultPromptLoginTest extends BaseTest {
         RegisterResponse registerResponse = registerClient.exec();
 
         showClient(registerClient);
-        Asserter.assertRegisterResponseOk(registerResponse, 201, true);
+        AssertBuilder.registerResponse(registerResponse).created()
+                .notNullRegistrationClientUri()
+                .check();
 
         String clientId = registerResponse.getClientId();
         String registrationAccessToken = registerResponse.getRegistrationAccessToken();
@@ -63,8 +66,7 @@ public class DefaultPromptLoginTest extends BaseTest {
         RegisterResponse readClientResponse = readClient.exec();
 
         showClient(readClient);
-        assertEquals(readClientResponse.getStatus(), 200, "Unexpected response code: " + readClientResponse.getEntity());
-        Asserter.assertRegisterResponseOk(readClientResponse, 200, false);
+        AssertBuilder.registerResponse(readClientResponse).ok().check();
 
         assertNotNull(readClientResponse.getClaims().get(RESPONSE_TYPES.toString()));
         assertNotNull(readClientResponse.getClaims().get(REDIRECT_URIS.toString()));
@@ -86,8 +88,7 @@ public class DefaultPromptLoginTest extends BaseTest {
 
             AuthorizationResponse authorizationResponse = authenticateResourceOwnerAndGrantAccess(
                     authorizationEndpoint, authorizationRequest, userId, userSecret);
-
-            Asserter.assertAuthorizationResponse(authorizationResponse, responseTypes, true);
+            AssertBuilder.authorizationResponse(authorizationResponse).responseTypes(responseTypes).check();
 
             sessionId = authorizationResponse.getSessionId();
         }
@@ -101,7 +102,7 @@ public class DefaultPromptLoginTest extends BaseTest {
             AuthorizationResponse authorizationResponse = authenticateResourceOwnerAndGrantAccess(
                     authorizationEndpoint, authorizationRequest, userId, userSecret);
 
-            Asserter.assertAuthorizationResponse(authorizationResponse, responseTypes, true);
+            AssertBuilder.authorizationResponse(authorizationResponse).responseTypes(responseTypes).check();
         }
     }
 }


### PR DESCRIPTION
Fix test Asserters not found in classes:
 io.jans.as.client.ws.rs.AuthorizationRedirectUrisRegexTest
 io.jans.as.client.ws.rs.DefaultPromptLoginTest

due to PR https://github.com/JanssenProject/jans/pull/993



