### PR TITLE
Fix: Validate redirect_uri blank and client redirect uris single item

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectionUriService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectionUriService.java
@@ -106,7 +106,7 @@ public class RedirectionUriService {
                 redirectUris = getSectorRedirectUris(sectorIdentifierUri).toArray(new String[0]);
             }
 
-            if (StringUtils.isBlank(sectorIdentifierUri) && redirectUris != null && redirectUris.length == 1) {
+            if (StringUtils.isBlank(redirectionUri) && redirectUris != null && redirectUris.length == 1) {
                 return redirectUris[0];
             }
 

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/RedirectionUriServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/RedirectionUriServiceTest.java
@@ -95,6 +95,16 @@ public class RedirectionUriServiceTest {
         assertNull(returnValue);
     }
 
+    @Test
+    public void validateRedirectionUri_redirectionUriBlankAndOneClientRedirectUri_returnSingleItem() {
+        final String singleRedirectUri = "https://client.example.com/cb2";
+        final Client client = getClientForValidateRedirectionUri_sectorIdentifierBlank_redirectURisNull();
+        client.setRedirectUris(new String[]{ singleRedirectUri });
+
+        final String returnValue = redirectionUriService.validateRedirectionUri(client, singleRedirectUri);
+        assertEquals(singleRedirectUri, returnValue);
+    }
+
     private Client getClientForValidateRedirectionUri_full() {
         final Client client = new Client();
         client.setSectorIdentifierUri("https://test.gluu.org/jans-auth/sectoridentifier/a55ede29-8f5a-461d-b06e-76caee8d40b5");

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -446,5 +446,5 @@
     "deviceAuthzRequestExpiresIn": 1800,
     "deviceAuthzTokenPollInterval": 5,
     "deviceAuthzResponseTypeToProcessAuthz": "code",
-    "redirectUrisRegexEnabled": false
+    "redirectUrisRegexEnabled": true
 }


### PR DESCRIPTION
### Description

1. Fixing redirect_uri validator issue when single item is in client redirect uris and param received is blank.
2. Enabling `redirectUrisRegexEnabled` to run test in Jenkins.