### PR TITLE
feat(jans-auth,jans-cli,jans-config-api): changes to handle new attri…

### DIFF
--- a/jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
@@ -196,7 +196,7 @@ public class Client extends DeletableEntity implements Serializable {
     private Integer accessTokenLifetime;
 
     @AttributesList(name = "name", value = "values", sortByName = true)
-    private List<CustomAttribute> customAttributes = new ArrayList<CustomAttribute>();
+    private List<CustomAttribute> customAttributes = new ArrayList<>();
 
     @CustomObjectClass
     private String[] customObjectClasses;
@@ -240,6 +240,9 @@ public class Client extends DeletableEntity implements Serializable {
 
     @AttributeName(name = "jansBackchannelUsrCodeParameter")
     private Boolean backchannelUserCodeParameter;
+    
+    @AttributeName(name = "description")
+    private String description;
 
     @Expiration
     private Integer ttl;
@@ -291,10 +294,12 @@ public class Client extends DeletableEntity implements Serializable {
         return AuthenticationMethod.fromString(tokenEndpointAuthMethod);
     }
 
+    @Override
     public String getDn() {
         return dn;
     }
 
+    @Override
     public void setDn(String dn) {
         this.dn = dn;
     }
@@ -1167,8 +1172,8 @@ public class Client extends DeletableEntity implements Serializable {
         return customObjectClasses;
     }
 
-    public void setCustomObjectClasses(String[] p_customObjectClasses) {
-        customObjectClasses = p_customObjectClasses;
+    public void setCustomObjectClasses(String[] customObjectClasses) {
+        this.customObjectClasses = customObjectClasses;
     }
 
     public boolean isDisabled() {
@@ -1244,11 +1249,19 @@ public class Client extends DeletableEntity implements Serializable {
     }
 
     public String getDisplayName() {
-        return clientName;
+        return getClientName();
     }
 
     public void setDisplayName(String displayName) {
         this.clientName = displayName;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
 }

--- a/jans-cli/cli/jca.yaml
+++ b/jans-cli/cli/jca.yaml
@@ -16,15 +16,15 @@ tags:
   - name: Attribute
   - name: Default Authentication Method
   - name: Cache Configuration
-  - name: Cache Configuration - Memcached
-  - name: Cache Configuration - Redis
-  - name: Cache Configuration - in-Memory
-  - name: Cache Configuration - Native-Persistence
-  - name: Configuration - Properties
-  - name: Configuration - Fido2
-  - name: Configuration - SMTP
-  - name: Configuration - Logging
-  - name: Configuration - JWK - JSON Web Key (JWK)
+  - name: Cache Configuration – Memcached
+  - name: Cache Configuration – Redis
+  - name: Cache Configuration – in-Memory
+  - name: Cache Configuration – Native-Persistence
+  - name: Configuration – Properties
+  - name: Configuration – Fido2
+  - name: Configuration – SMTP
+  - name: Configuration – Logging
+  - name: Configuration – JWK - JSON Web Key (JWK)
   - name: Custom Scripts
   - name: Database - LDAP configuration
   - name: Database - Couchbase configuration
@@ -51,7 +51,7 @@ paths:
       security:
         - oauth2: [https://jans.io/oauth/jans-auth-server/config/properties.readonly]
       tags:
-        - Configuration - Properties
+        - Configuration – Properties
       responses:
         '200':
           description: OK
@@ -72,7 +72,7 @@ paths:
       security:
         - oauth2: [https://jans.io/oauth/jans-auth-server/config/properties.write]
       tags:
-        - Configuration - Properties
+        - Configuration – Properties
       requestBody:
         content:
           application/json-patch+json:
@@ -103,7 +103,7 @@ paths:
       security:
         - oauth2: [https://jans.io/oauth/jans-auth-server/config/properties.readonly]
       tags:
-        - Configuration - Properties
+        - Configuration – Properties
       responses:
         '200':
           description: OK
@@ -123,7 +123,7 @@ paths:
       description: Gets Jans Authorization Server Fido2 configuration properties.
       operationId: get-properties-fido2
       tags:
-        - Configuration - Fido2
+        - Configuration – Fido2
       responses:
         '200':
           description: OK
@@ -142,7 +142,7 @@ paths:
       description: Updates Fido2 configuration properties.
       operationId: put-properties-fido2
       tags:
-        - Configuration - Fido2
+        - Configuration – Fido2
       requestBody:
         content:
           application/json:
@@ -1158,7 +1158,7 @@ paths:
       description: Returns Memcached cache configuration.
       operationId: get-config-cache-memcached
       tags:
-        - Cache Configuration - Memcached
+        - Cache Configuration – Memcached
       responses:
         '200':
           description: OK
@@ -1177,7 +1177,7 @@ paths:
       description: Updates Memcached cache configuration.
       operationId: put-config-cache-memcached
       tags:
-        - Cache Configuration - Memcached
+        - Cache Configuration – Memcached
       requestBody:
         content:
           application/json:
@@ -1204,7 +1204,7 @@ paths:
       description: Partially modifies Memcached cache configuration.
       operationId: patch-config-cache-memcached
       tags:
-        - Cache Configuration - Memcached
+        - Cache Configuration – Memcached
       requestBody:
         content:
           application/json-patch+json:
@@ -1233,7 +1233,7 @@ paths:
       description: Returns Redis cache configuration.
       operationId: get-config-cache-redis
       tags:
-        - Cache Configuration - Redis
+        - Cache Configuration – Redis
       responses:
         '200':
           description: OK
@@ -1252,7 +1252,7 @@ paths:
       description: Updates Redis cache configuration.
       operationId: put-config-cache-redis
       tags:
-        - Cache Configuration - Redis
+        - Cache Configuration – Redis
       requestBody:
         content:
           application/json:
@@ -1277,7 +1277,7 @@ paths:
       description: Partially modifies Redis cache configuration.
       operationId: patch-config-cache-redis
       tags:
-        - Cache Configuration - Redis
+        - Cache Configuration – Redis
       requestBody:
         content:
           application/json-patch+json:
@@ -1306,7 +1306,7 @@ paths:
       description: Returns in-Memory cache configuration.
       operationId: get-config-cache-in-memory
       tags:
-        - Cache Configuration - in-Memory
+        - Cache Configuration – in-Memory
       responses:
         '200':
           description: OK
@@ -1325,7 +1325,7 @@ paths:
       description: Updates in-Memory cache configuration.
       operationId: put-config-cache-in-memory
       tags:
-        - Cache Configuration - in-Memory
+        - Cache Configuration – in-Memory
       requestBody:
         content:
           application/json:
@@ -1350,7 +1350,7 @@ paths:
       description: Partially modifies In-Memory cache configuration.
       operationId: patch-config-cache-in-memory
       tags:
-        - Cache Configuration - in-Memory
+        - Cache Configuration – in-Memory
       requestBody:
         content:
           application/json-patch+json:
@@ -1379,7 +1379,7 @@ paths:
       description: Returns native persistence cache configuration.
       operationId: get-config-cache-native-persistence
       tags:
-        - Cache Configuration - Native-Persistence
+        - Cache Configuration – Native-Persistence
       responses:
         '200':
           description: OK
@@ -1398,7 +1398,7 @@ paths:
       description: Updates native persistence cache configuration.
       operationId: put-config-cache-native-persistence
       tags:
-        - Cache Configuration - Native-Persistence
+        - Cache Configuration – Native-Persistence
       requestBody:
         content:
           application/json:
@@ -1423,7 +1423,7 @@ paths:
       description: Partially modifies Native Persistence cache configuration.
       operationId: patch-config-cache-native-persistence
       tags:
-        - Cache Configuration - Native-Persistence
+        - Cache Configuration – Native-Persistence
       requestBody:
         content:
           application/json-patch+json:
@@ -1452,7 +1452,7 @@ paths:
       description: Returns SMTP server configuration.
       operationId: get-config-smtp
       tags:
-        - Configuration - SMTP
+        - Configuration – SMTP
       responses:
         '200':
           description: OK
@@ -1471,7 +1471,7 @@ paths:
       description: Adds SMTP server configuration.
       operationId: post-config-smtp
       tags:
-        - Configuration - SMTP
+        - Configuration – SMTP
       requestBody:
         content:
           application/json:
@@ -1495,7 +1495,7 @@ paths:
       description: Updates SMTP server configuration.
       operationId: put-config-smtp
       tags:
-        - Configuration - SMTP
+        - Configuration – SMTP
       requestBody:
         content:
           application/json:
@@ -1521,7 +1521,7 @@ paths:
       description: Deletes SMTP server configuration.
       operationId: delete-config-smtp
       tags:
-        - Configuration - SMTP
+        - Configuration – SMTP
       responses:
         '204':
           description: No Content
@@ -1540,7 +1540,7 @@ paths:
       description: Test SMTP server configuration.
       operationId: test-config-smtp
       tags:
-        - Configuration - SMTP
+        - Configuration – SMTP
       responses:
         '200':
           description: OK
@@ -1558,7 +1558,7 @@ paths:
   /jans-config-api/api/v1/logging:
     get:
       tags:
-        - Configuration - Logging
+        - Configuration – Logging
       summary: Returns Jans Authorization Server logging settings.
       description: Returns Jans Authorization Server logging settings.
       operationId: get-config-logging
@@ -1577,7 +1577,7 @@ paths:
         - oauth2: [https://jans.io/oauth/config/logging.readonly]
     put:
       tags:
-        - Configuration - Logging
+        - Configuration – Logging
       summary: Updates Jans Authorization Server logging settings.
       description: Updates Jans Authorization Server logging settings.
       operationId: put-config-logging
@@ -1605,7 +1605,7 @@ paths:
   /jans-config-api/api/v1/config/jwks:
     get:
       tags:
-        - Configuration - JWK - JSON Web Key (JWK)
+        - Configuration – JWK - JSON Web Key (JWK)
       summary: Gets list of JSON Web Key (JWK) used by server.
       description: 'Gets list of JSON Web Key (JWK) used by server. JWK is a JSON data structure that represents a set of public keys as a JSON object [RFC4627].'
       operationId: get-config-jwks
@@ -1624,7 +1624,7 @@ paths:
         - oauth2: [https://jans.io/oauth/config/jwks.readonly]
     put:
       tags:
-        - Configuration - JWK - JSON Web Key (JWK)
+        - Configuration – JWK - JSON Web Key (JWK)
       summary: Puts/replaces JWKS
       description: Puts/replaces JSON Web Keys (JWKS).
       operationId: put-config-jwks
@@ -1648,7 +1648,7 @@ paths:
         - oauth2: [https://jans.io/oauth/config/jwks.write]
     patch:
       tags:
-        - Configuration - JWK - JSON Web Key (JWK)
+        - Configuration – JWK - JSON Web Key (JWK)
       summary: Patch JWKS
       description: Patch JSON Web Keys (JWKS).
       operationId: patch-config-jwks
@@ -1677,7 +1677,7 @@ paths:
   /jans-config-api/api/v1/config/jwks/key:
     post:
       tags:
-        - Configuration - JWK - JSON Web Key (JWK)
+        - Configuration – JWK - JSON Web Key (JWK)
       summary: Adds a new key to JSON Web Keys (JWKS)
       description: Adds a new key to JSON Web Keys (JWKS).
       operationId: post-config-jwks-key
@@ -1709,7 +1709,7 @@ paths:
         required: true
     get:
       tags:
-        - Configuration - JWK - JSON Web Key (JWK)
+        - Configuration – JWK - JSON Web Key (JWK)
       summary: Get a JSON Web Key based on kid
       description: Get a JSON Web Key based on kid
       operationId: put-config-jwk-kid
@@ -1728,7 +1728,7 @@ paths:
         - oauth2: [https://jans.io/oauth/config/jwks.readonly]
     patch:
       tags:
-        - Configuration - JWK - JSON Web Key (JWK)
+        - Configuration – JWK - JSON Web Key (JWK)
       summary: Patch a specific JSON Web Key based on kid
       description: Patch a specific JSON Web Key based on kid
       operationId: patch-config-jwk-kid
@@ -1758,7 +1758,7 @@ paths:
         - oauth2: [https://jans.io/oauth/config/jwks.write]
     delete:
       tags:
-        - Configuration - JWK - JSON Web Key (JWK)
+        - Configuration – JWK - JSON Web Key (JWK)
       summary: Delete a JSON Web Key based on kid
       description: Delete a JSON Web Key based on kid
       operationId: delete-config-jwk-kid
@@ -3543,9 +3543,12 @@ components:
             - POST_AUTHN
             - SCIM
             - CIBA_END_USER_NOTIFICATION
+            - REVOKE_TOKEN
             - PERSISTENCE_EXTENSION
             - IDP
+            - DISCOVERY
             - UPDATE_TOKEN
+            - CONFIG_API
         programmingLanguage:
           type: string
           enum:
@@ -4388,9 +4391,6 @@ components:
           type: integer
           description: The expiration notificator interval in seconds.
           example: 600
-        redirectUrisRegexEnabled:
-          type: boolean
-          description: Enable/Disable redirect uris validation using regular expression.
         authenticationFiltersEnabled:
           type: boolean
           description: Boolean value specifying whether to enable user authentication filters.
@@ -4831,6 +4831,9 @@ components:
         staticKid:
           type: string
           description: Specifies static Kid
+        redirectUrisRegexEnabled:
+          type: boolean
+          description: Enable/Disable redirect uris validation using regular expression.
 
     GluuAttribute:
       title: GluuAttribute
@@ -5513,6 +5516,9 @@ components:
           default: false
         jansId:
           description: Attribute Scope Id.
+          type: string
+        description:
+          description: Description of the client.
           type: string
 
     UmaResource:

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -3543,9 +3543,12 @@ components:
             - POST_AUTHN
             - SCIM
             - CIBA_END_USER_NOTIFICATION
+            - REVOKE_TOKEN
             - PERSISTENCE_EXTENSION
             - IDP
+            - DISCOVERY
             - UPDATE_TOKEN
+            - CONFIG_API
         programmingLanguage:
           type: string
           enum:
@@ -5513,6 +5516,9 @@ components:
           default: false
         jansId:
           description: Attribute Scope Id.
+          type: string
+        description:
+          description: Description of the client.
           type: string
 
     UmaResource:

--- a/jans-config-api/profiles/local/test.properties
+++ b/jans-config-api/profiles/local/test.properties
@@ -39,11 +39,11 @@ test.scopes=https://jans.io/oauth/config/acrs.readonly https://jans.io/oauth/con
 #test.issuer=https:// pujavs.jans.server3
 
 # jans.server1
-token.endpoint=https://jans.server1/jans-auth/restv1/token
-token.grant.type=client_credentials
-test.client.id=1800.d166622d-6771-4d5a-8fab-555566b20091
-test.client.secret=slkveBOhwJn5
-test.issuer=https://jans.server1
+#token.endpoint=https://jans.server1/jans-auth/restv1/token
+#token.grant.type=client_credentials
+#test.client.id=1800.d166622d-6771-4d5a-8fab-555566b20091
+#test.client.secret=slkveBOhwJn5
+#test.issuer=https://jans.server1
 
 # jans.server2
 #token.endpoint=https://jans.server2/jans-auth/restv1/token
@@ -67,3 +67,9 @@ test.issuer=https://jans.server1
 #test.issuer=https://jans.server4
 
 
+# jans.server1
+token.endpoint=https://jans.server/jans-auth/restv1/token
+token.grant.type=client_credentials
+test.client.id=1800.1832c189-59e0-4077-b3d9-3d03e90c8194
+test.client.secret=9WWPhtHBGktg
+test.issuer=https://jans.server

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/ClientsResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/ClientsResource.java
@@ -31,7 +31,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -99,7 +98,7 @@ public class ClientsResource extends BaseResource {
 
     @POST
     @ProtectedApi(scopes = { ApiAccessConstants.OPENID_CLIENTS_WRITE_ACCESS })
-    public Response createOpenIdConnect(@Valid Client client) throws NoSuchAlgorithmException, EncryptionException {
+    public Response createOpenIdConnect(@Valid Client client) EncryptionException {
         if (logger.isDebugEnabled()) {
             logger.debug("Client details to be added - client:{}", escapeLog(client));
         }
@@ -189,7 +188,7 @@ public class ClientsResource extends BaseResource {
         return clients;
     }
 
-    private String generatePassword() throws NoSuchAlgorithmException {
+    private String generatePassword() {
         return UUID.randomUUID().toString();
     }
 

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/ClientsResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/ClientsResource.java
@@ -98,7 +98,7 @@ public class ClientsResource extends BaseResource {
 
     @POST
     @ProtectedApi(scopes = { ApiAccessConstants.OPENID_CLIENTS_WRITE_ACCESS })
-    public Response createOpenIdConnect(@Valid Client client) EncryptionException {
+    public Response createOpenIdConnect(@Valid Client client) throws EncryptionException {
         if (logger.isDebugEnabled()) {
             logger.debug("Client details to be added - client:{}", escapeLog(client));
         }

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/ClientsResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/ClientsResource.java
@@ -30,7 +30,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/CustomScriptResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/CustomScriptResource.java
@@ -6,6 +6,7 @@
 
 package io.jans.configapi.rest.resource.auth;
 
+import static io.jans.as.model.util.Util.escapeLog;
 import io.jans.configapi.core.rest.ProtectedApi;
 import io.jans.configapi.util.ApiAccessConstants;
 import io.jans.configapi.util.ApiConstants;
@@ -66,7 +67,9 @@ public class CustomScriptResource extends BaseResource {
     @Path(PATH_SEPARATOR + ApiConstants.INUM + PATH_SEPARATOR + ApiConstants.INUM_PATH)
     @ProtectedApi(scopes = { ApiAccessConstants.SCRIPTS_READ_ACCESS })
     public Response getCustomScriptByInum(@PathParam(ApiConstants.INUM) @NotNull String inum) {
-        log.debug("Custom Script to be fetched - inum:{} ",inum);
+        if (log.isDebugEnabled()) {
+            log.debug("Custom Script to be fetched - inum:{} ", escapeLog(inum));
+        }
         CustomScript script = null;
         try {
             script = this.customScriptService.getScriptByInum(inum);
@@ -113,7 +116,9 @@ public class CustomScriptResource extends BaseResource {
     @ProtectedApi(scopes = { ApiAccessConstants.SCRIPTS_DELETE_ACCESS })
     public Response deleteScript(@PathParam(ApiConstants.INUM) @NotNull String inum) {
         try {
-            log.debug("Custom Script Resource to delete - inum:{}",inum);
+            if (log.isDebugEnabled()) {
+                log.debug("Custom Script Resource to delete - inum:{}",escapeLog(inum));
+            }
             CustomScript existingScript = customScriptService.getScriptByInum(inum);
             customScriptService.remove(existingScript);
             return Response.noContent().build();

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/CustomScriptResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/CustomScriptResource.java
@@ -43,6 +43,7 @@ public class CustomScriptResource extends BaseResource {
     @ProtectedApi(scopes = { ApiAccessConstants.SCRIPTS_READ_ACCESS })
     public Response getAllCustomScripts() {
         List<CustomScript> customScripts = customScriptService.findAllCustomScripts(null);
+        log.debug("Custom Scripts:{}", customScripts);
         return Response.ok(customScripts).build();
     }
 
@@ -54,6 +55,7 @@ public class CustomScriptResource extends BaseResource {
             @DefaultValue(DEFAULT_LIST_SIZE) @QueryParam(value = ApiConstants.LIMIT) int limit) {
         List<CustomScript> customScripts = this.customScriptService.findScriptByPatternAndType(pattern,
                 CustomScriptType.getByValue(type.toLowerCase()), limit);
+        log.debug("Custom Scripts fetched :{}", customScripts);
         if (customScripts != null && !customScripts.isEmpty())
             return Response.ok(customScripts).build();
         else
@@ -64,7 +66,7 @@ public class CustomScriptResource extends BaseResource {
     @Path(PATH_SEPARATOR + ApiConstants.INUM + PATH_SEPARATOR + ApiConstants.INUM_PATH)
     @ProtectedApi(scopes = { ApiAccessConstants.SCRIPTS_READ_ACCESS })
     public Response getCustomScriptByInum(@PathParam(ApiConstants.INUM) @NotNull String inum) {
-        log.debug("CustomScript to be fetched - inum = " + inum);
+        log.debug("Custom Script to be fetched - inum:{} ",inum);
         CustomScript script = null;
         try {
             script = this.customScriptService.getScriptByInum(inum);
@@ -74,13 +76,14 @@ public class CustomScriptResource extends BaseResource {
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
         }
+        log.debug("Custom Script fetched by inum :{}", script);
         return Response.ok(script).build();
     }
 
     @POST
     @ProtectedApi(scopes = { ApiAccessConstants.SCRIPTS_WRITE_ACCESS })
     public Response createScript(@Valid CustomScript customScript) {
-        log.debug("CustomScriptResource::createScript() - customScript = " + customScript + "\n\n");
+        log.debug("Custom Script to create - customScript:{}", customScript);
         Objects.requireNonNull(customScript, "Attempt to create null custom script");
         String inum = customScript.getInum();
         if (StringHelper.isEmpty(inum)) {
@@ -89,16 +92,18 @@ public class CustomScriptResource extends BaseResource {
         customScript.setDn(customScriptService.buildDn(inum));
         customScript.setInum(inum);
         customScriptService.add(customScript);
+        log.debug("Custom Script added {}", customScript);
         return Response.status(Response.Status.CREATED).entity(customScript).build();
     }
 
     @PUT
     @ProtectedApi(scopes = { ApiAccessConstants.SCRIPTS_WRITE_ACCESS })
     public Response updateScript(@Valid @NotNull CustomScript customScript) {
-        log.debug("CustomScriptResource::updateScript() - customScript = " + customScript + "\n\n");
+        log.debug("Custom Script to update - customScript:{}",customScript);
         CustomScript existingScript = customScriptService.getScriptByInum(customScript.getInum());
         checkResourceNotNull(existingScript, CUSTOM_SCRIPT);
         customScript.setInum(existingScript.getInum());
+        log.debug("Custom Script updated {}", customScript);
         customScriptService.update(customScript);
         return Response.ok(customScript).build();
     }
@@ -108,7 +113,7 @@ public class CustomScriptResource extends BaseResource {
     @ProtectedApi(scopes = { ApiAccessConstants.SCRIPTS_DELETE_ACCESS })
     public Response deleteScript(@PathParam(ApiConstants.INUM) @NotNull String inum) {
         try {
-            log.debug("CustomScriptResource::deleteScript() - inum = " + inum + "\n\n");
+            log.debug("Custom Script Resource to delete - inum:{}",inum);
             CustomScript existingScript = customScriptService.getScriptByInum(inum);
             customScriptService.remove(existingScript);
             return Response.noContent().build();

--- a/jans-config-api/server/src/test/resources/feature/openid/clients/openid-client.json
+++ b/jans-config-api/server/src/test/resources/feature/openid/clients/openid-client.json
@@ -1,5 +1,6 @@
 {
     "accessTokenAsJwt": false,
+	"description":"Description for test client",
     "attributes": {
         "additionalAudience": [],
         "allowSpontaneousScopes": false,


### PR DESCRIPTION
PR contains two fix
1) jans-cli issue of get custom script failing due to missing new CustomScript in swagger enum
![image](https://user-images.githubusercontent.com/43700552/158413004-56bbaa35-cf75-4396-8648-c5bf067b4813.png)
**Impacted module:**
1) `jans-config-api` : jans-config-api-swagger.yaml

2)[ Issue 1047](https://github.com/JanssenProject/jans/issues/1047)
New attribute `description` to be added to Client object for /jans-config-api/api/v1/openid/clients 
**Impacted module:**
1) `jans-auth-server`:  jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
2)  `jans-config-api` :  jans-config-api-swagger.yaml 
3) `jans-cli`: jans-cli/cli/jca.yaml
      