### PR TITLE
feat(jans-auth-server): authorized acr values

### DIFF
--- a/jans-auth-server/client/src/main/java/io/jans/as/client/RegisterRequest.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/RegisterRequest.java
@@ -39,7 +39,7 @@ import static io.jans.as.model.util.StringUtils.toJSONArray;
  *
  * @author Javier Rojas Blum
  * @author Yuriy Zabrovarnyy
- * @version March 2, 2022
+ * @version March 17, 2022
  */
 public class RegisterRequest extends BaseRequest {
 
@@ -114,6 +114,7 @@ public class RegisterRequest extends BaseRequest {
     private String softwareVersion;
     private String softwareStatement;
     private Boolean defaultPromptLogin;
+    private List<String> authorizedAcrValues;
     private BackchannelTokenDeliveryMode backchannelTokenDeliveryMode;
     private String backchannelClientNotificationEndpoint;
     private AsymmetricSignatureAlgorithm backchannelAuthenticationRequestSigningAlg;
@@ -157,6 +158,7 @@ public class RegisterRequest extends BaseRequest {
         this.scope = new ArrayList<>();
         this.claims = new ArrayList<>();
         this.customAttributes = new HashMap<>();
+        this.authorizedAcrValues = new ArrayList<>();
     }
 
     /**
@@ -1171,6 +1173,14 @@ public class RegisterRequest extends BaseRequest {
         this.defaultPromptLogin = defaultPromptLogin;
     }
 
+    public List<String> getAuthorizedAcrValues() {
+        return authorizedAcrValues;
+    }
+
+    public void setAuthorizedAcrValues(List<String> authorizedAcrValues) {
+        this.authorizedAcrValues = authorizedAcrValues;
+    }
+
     public String getHttpMethod() {
         return httpMethod;
     }
@@ -1396,9 +1406,11 @@ public class RegisterRequest extends BaseRequest {
         if (defaultPromptLogin != null) {
             parameters.put(DEFAULT_PROMPT_LOGIN.getName(), defaultPromptLogin.toString());
         }
-
+        if (authorizedAcrValues != null && !authorizedAcrValues.isEmpty()) {
+            parameters.put(AUTHORIZED_ACR_VALUES.getName(), toJSONArray(authorizedAcrValues).toString());
+        }
         if (redirectUrisRegex != null) {
-            parameters.put(REDIRECT_URIS_REGEX.toString(), redirectUrisRegex.toString()) ;
+            parameters.put(REDIRECT_URIS_REGEX.toString(), redirectUrisRegex.toString());
         }
 
         // Custom params
@@ -1488,6 +1500,7 @@ public class RegisterRequest extends BaseRequest {
         result.setBackchannelUserCodeParameter(booleanOrNull(requestObject, BACKCHANNEL_USER_CODE_PARAMETER.toString()));
         result.setRedirectUrisRegex(requestObject.optString(REDIRECT_URIS_REGEX.toString()));
         result.setDefaultPromptLogin(requestObject.optBoolean(DEFAULT_PROMPT_LOGIN.getName()));
+        result.setAuthorizedAcrValues(extractListByKey(requestObject, AUTHORIZED_ACR_VALUES.getName()));
 
         return result;
     }
@@ -1701,11 +1714,14 @@ public class RegisterRequest extends BaseRequest {
         }
 
         if (redirectUrisRegex != null) {
-            parameters.put(REDIRECT_URIS_REGEX.toString(), redirectUrisRegex) ;
+            parameters.put(REDIRECT_URIS_REGEX.toString(), redirectUrisRegex);
         }
 
         if (defaultPromptLogin != null) {
             parameters.put(DEFAULT_PROMPT_LOGIN.getName(), defaultPromptLogin);
+        }
+        if (authorizedAcrValues != null && !authorizedAcrValues.isEmpty()) {
+            parameters.put(AUTHORIZED_ACR_VALUES.toString(), toJSONArray(authorizedAcrValues));
         }
 
         // Custom params

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/AuthorizedAcrValuesTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/AuthorizedAcrValuesTest.java
@@ -1,0 +1,117 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.as.client.ws.rs;
+
+import io.jans.as.client.*;
+import io.jans.as.client.client.AssertBuilder;
+import io.jans.as.model.common.ResponseType;
+import io.jans.as.model.register.ApplicationType;
+import io.jans.as.model.util.StringUtils;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @author Javier Rojas Blum
+ * @version March 17, 2022
+ */
+public class AuthorizedAcrValuesTest extends BaseTest {
+
+    @Parameters({"userId", "userSecret", "redirectUris", "redirectUri", "sectorIdentifierUri"})
+    @Test
+    public void authorizedAcrValues(
+            final String userId, final String userSecret, final String redirectUris, final String redirectUri,
+            final String sectorIdentifierUri) {
+        showTitle("authorizedAcrValues");
+
+        List<ResponseType> responseTypes = Arrays.asList(ResponseType.CODE, ResponseType.ID_TOKEN);
+
+        // 1. Register client
+        RegisterRequest registerRequest = new RegisterRequest(ApplicationType.WEB, "jans test app",
+                StringUtils.spaceSeparatedToList(redirectUris));
+        registerRequest.setResponseTypes(responseTypes);
+        registerRequest.setSectorIdentifierUri(sectorIdentifierUri);
+        registerRequest.setAuthorizedAcrValues(Arrays.asList(
+                "acr_1", "acr_2", "acr_3", "basic"
+        ));
+
+        RegisterClient registerClient = newRegisterClient(registerRequest);
+        RegisterResponse registerResponse = registerClient.exec();
+
+        showClient(registerClient);
+        AssertBuilder.registerResponse(registerResponse)
+                .created()
+                .check();
+
+        String clientId = registerResponse.getClientId();
+
+        List<String> scopes = Arrays.asList("openid", "profile", "address", "email");
+        String state = UUID.randomUUID().toString();
+        String nonce = UUID.randomUUID().toString();
+
+        AuthorizationRequest authorizationRequest = new AuthorizationRequest(responseTypes, clientId, scopes, redirectUri, nonce);
+        authorizationRequest.setState(state);
+        authorizationRequest.setAcrValues(Arrays.asList("basic"));
+
+        AuthorizationResponse authorizationResponse = authenticateResourceOwnerAndGrantAccess(authorizationEndpoint,
+                authorizationRequest, userId, userSecret);
+
+        AssertBuilder.authorizationResponse(authorizationResponse)
+                .responseTypes(responseTypes)
+                .check();
+    }
+
+    @Parameters({"userId", "userSecret", "redirectUris", "redirectUri", "sectorIdentifierUri"})
+    @Test
+    public void authorizedAcrValuesFail(
+            final String userId, final String userSecret, final String redirectUris, final String redirectUri,
+            final String sectorIdentifierUri) {
+        showTitle("authorizedAcrValuesFail");
+
+        List<ResponseType> responseTypes = Arrays.asList(ResponseType.CODE, ResponseType.ID_TOKEN);
+
+        // 1. Register client
+        RegisterRequest registerRequest = new RegisterRequest(ApplicationType.WEB, "jans test app",
+                StringUtils.spaceSeparatedToList(redirectUris));
+        registerRequest.setResponseTypes(responseTypes);
+        registerRequest.setSectorIdentifierUri(sectorIdentifierUri);
+        registerRequest.setAuthorizedAcrValues(Arrays.asList(
+                "acr_1", "acr_2", "acr_3"
+        ));
+
+        RegisterClient registerClient = newRegisterClient(registerRequest);
+        RegisterResponse registerResponse = registerClient.exec();
+
+        showClient(registerClient);
+        AssertBuilder.registerResponse(registerResponse)
+                .created()
+                .check();
+
+        String clientId = registerResponse.getClientId();
+
+        List<String> scopes = Arrays.asList("openid", "profile", "address", "email");
+        String state = UUID.randomUUID().toString();
+        String nonce = UUID.randomUUID().toString();
+
+        AuthorizationRequest authorizationRequest = new AuthorizationRequest(responseTypes, clientId, scopes, redirectUri, nonce);
+        authorizationRequest.setState(state);
+        authorizationRequest.setAcrValues(Arrays.asList("basic"));
+
+        AuthorizeClient authorizeClient = new AuthorizeClient(authorizationEndpoint);
+        authorizeClient.setRequest(authorizationRequest);
+
+        AuthorizationResponse authorizationResponse = authorizeClient.exec();
+
+        showClient(authorizeClient);
+        AssertBuilder.authorizationResponse(authorizationResponse)
+                .status(302)
+                .check();
+    }
+}

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/register/RegisterRequestParam.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/register/RegisterRequestParam.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang.StringUtils;
  *
  * @author Yuriy Zabrovarnyy
  * @author Javier Rojas Blum
- * @version March 2, 2022
+ * @version March 17, 2022
  */
 
 public enum RegisterRequestParam {
@@ -351,7 +351,9 @@ public enum RegisterRequestParam {
 
     REDIRECT_URIS_REGEX("redirect_uris_regex"),
 
-    DEFAULT_PROMPT_LOGIN("default_prompt_login");
+    DEFAULT_PROMPT_LOGIN("default_prompt_login"),
+
+    AUTHORIZED_ACR_VALUES("authorized_acr_values");
 
     /**
      * Parameter name

--- a/jans-auth-server/persistence-model/src/main/java/io/jans/as/persistence/model/ClientAttributes.java
+++ b/jans-auth-server/persistence-model/src/main/java/io/jans/as/persistence/model/ClientAttributes.java
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * @author Yuriy Zabrovarnyy
  * @author Javier Rojas Blum
- * @version March 2, 2022
+ * @version March 17, 2022
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ClientAttributes implements Serializable {
@@ -93,8 +93,11 @@ public class ClientAttributes implements Serializable {
     private String publicSubjectIdentifierAttribute;
 
     @JsonProperty("redirectUrisRegex")
-    private String redirectUrisRegex ;
-    
+    private String redirectUrisRegex;
+
+    @JsonProperty("jansAuthorizedAcr")
+    private List<String> authorizedAcrValues;
+
     @JsonProperty("jansDefaultPromptLogin")
     private Boolean defaultPromptLogin = false;
 
@@ -305,7 +308,18 @@ public class ClientAttributes implements Serializable {
 
     public void setRedirectUrisRegex(String redirectUrisRegex) {
         this.redirectUrisRegex = redirectUrisRegex;
-    }		
+    }
+
+    public List<String> getAuthorizedAcrValues() {
+        if (authorizedAcrValues == null) {
+            return Lists.newArrayList();
+        }
+        return authorizedAcrValues;
+    }
+
+    public void setAuthorizedAcrValues(List<String> authorizedAcrValues) {
+        this.authorizedAcrValues = authorizedAcrValues;
+    }
 
     public Boolean getDefaultPromptLogin() {
         if (defaultPromptLogin == null) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterRestWebServiceImpl.java
@@ -84,7 +84,7 @@ import static org.apache.commons.lang3.BooleanUtils.isTrue;
  * @author Javier Rojas Blum
  * @author Yuriy Zabrovarnyy
  * @author Yuriy Movchan
- * @version March 2, 2022
+ * @version March 17, 2022
  */
 @Path("/")
 public class RegisterRestWebServiceImpl implements RegisterRestWebService {
@@ -310,7 +310,7 @@ public class RegisterRestWebServiceImpl implements RegisterRestWebService {
 
             builder.entity(jsonObjectToString(jsonObject));
 
-            log.info("Client registered: clientId = {}, applicationType = {}, clientName = {}, redirectUris = {}, sectorIdentifierUri = {}, redirectUrisRegex = {}" ,
+            log.info("Client registered: clientId = {}, applicationType = {}, clientName = {}, redirectUris = {}, sectorIdentifierUri = {}, redirectUrisRegex = {}",
                     client.getClientId(), client.getApplicationType(), client.getClientName(), client.getRedirectUris(), client.getSectorIdentifierUri(), client.getAttributes().getRedirectUrisRegex());
 
             oAuth2AuditLog.setClientId(client.getClientId());
@@ -851,6 +851,12 @@ public class RegisterRestWebServiceImpl implements RegisterRestWebService {
 
         if (requestObject.getDefaultPromptLogin() != null) {
             client.getAttributes().setDefaultPromptLogin(requestObject.getDefaultPromptLogin());
+        }
+
+        List<String> authorizedAcrValues = requestObject.getAuthorizedAcrValues();
+        if (authorizedAcrValues != null && !authorizedAcrValues.isEmpty()) {
+            authorizedAcrValues = new ArrayList<>(new HashSet<>(authorizedAcrValues)); // Remove repeated elements
+            client.getAttributes().setAuthorizedAcrValues(authorizedAcrValues);
         }
 
         cibaRegisterClientMetadataService.updateClient(client, requestObject.getBackchannelTokenDeliveryMode(),


### PR DESCRIPTION
Signed-off-by: Javier Rojas Blum <javier.rojas.blum@gmail.com>

### Prepare

- [ ] Read contribution guidelines
- [ ] Read license information

-------------------

### Description

- Target issue #333
  <!-- Link this PR to issue it is fixing -->

- Implementation Details
  <!-- If the fix is involved one then communicate high level analysis and implementation approach -->
Now you can configure the authorized acr values for a client with Dynamic Client Registration endpoint to restrict requests to use only acr in the list.

-------------------
### Document the changes

- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

