### PR TITLE
feat(jans-config-api): changes ignore client.customObjectClasses value for pe…

### DIFF
--- a/jans-config-api/profiles/local/test.properties
+++ b/jans-config-api/profiles/local/test.properties
@@ -67,9 +67,9 @@ test.scopes=https://jans.io/oauth/config/acrs.readonly https://jans.io/oauth/con
 #test.issuer=https://jans.server4
 
 
-# jans.server1
+# jans.server
 token.endpoint=https://jans.server/jans-auth/restv1/token
 token.grant.type=client_credentials
-test.client.id=1800.1832c189-59e0-4077-b3d9-3d03e90c8194
-test.client.secret=9WWPhtHBGktg
+test.client.id=1800.77e9a8e6-8fee-4b86-b294-017ba6ab2112
+test.client.secret=dobHjXDhH6zh
 test.issuer=https://jans.server

--- a/jans-config-api/server/src/test/resources/feature/openid/clients/client.json
+++ b/jans-config-api/server/src/test/resources/feature/openid/clients/client.json
@@ -1,5 +1,7 @@
 {
   "applicationType": "web",
+  "description":"Description for test client",
+  "customObjectClasses":["top"],
   "accessTokenAsJwt": false,
   "claimRedirectUris": [
   ],

--- a/jans-config-api/server/src/test/resources/feature/openid/clients/clients.feature
+++ b/jans-config-api/server/src/test/resources/feature/openid/clients/clients.feature
@@ -81,6 +81,7 @@ And header Authorization = 'Bearer ' + accessToken
 And request read('client.json')
 When method POST
 Then status 201
+And print response
 Then def result = response
 Then set result.displayName = 'UpdatedQAAddedClient'
 Given url mainUrl
@@ -88,11 +89,13 @@ And header Authorization = 'Bearer ' + accessToken
 And request result
 When method PUT
 Then status 200
+And print response
 And assert response.displayName == 'UpdatedQAAddedClient'
 Given url mainUrl + '/' +response.inum
 And header Authorization = 'Bearer ' + accessToken
 When method DELETE
 Then status 204
+And print response
 
 
 Scenario: Delete a non-existion openid connect client by inum
@@ -100,6 +103,7 @@ Given url mainUrl + '/1402.66633-8675-473e-a749'
 And header Authorization = 'Bearer ' + accessToken
 When method GET
 Then status 404
+And print response
 
 
 Scenario: Patch openid connect client


### PR DESCRIPTION
In DB other than LDAP value of cusomObjectclass(OC) is used to determine table name where the entry needs to be stored.
Thus value of cusomObjectclass should be used only with LDAP and in all other cases it should be ignored

Related Issue#[1072](https://github.com/JanssenProject/jans/issues/1072)