### PR TITLE
feat(jans-auth-server): enable person authn script to have multiple a…

### DIFF
--- a/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/AuthnScriptAliasesTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/AuthnScriptAliasesTest.java
@@ -22,14 +22,14 @@ import java.util.UUID;
  * @author Javier Rojas Blum
  * @version March 18, 2022
  */
-public class AuthorizedAcrValuesTest extends BaseTest {
+public class AuthnScriptAliasesTest extends BaseTest {
 
     @Parameters({"userId", "userSecret", "redirectUris", "redirectUri", "sectorIdentifierUri"})
     @Test
-    public void authorizedAcrValues(
+    public void acrAliasTest(
             final String userId, final String userSecret, final String redirectUris, final String redirectUri,
             final String sectorIdentifierUri) {
-        showTitle("authorizedAcrValues");
+        showTitle("acrAliasTest");
 
         List<ResponseType> responseTypes = Arrays.asList(ResponseType.CODE, ResponseType.ID_TOKEN);
 
@@ -38,9 +38,6 @@ public class AuthorizedAcrValuesTest extends BaseTest {
                 StringUtils.spaceSeparatedToList(redirectUris));
         registerRequest.setResponseTypes(responseTypes);
         registerRequest.setSectorIdentifierUri(sectorIdentifierUri);
-        registerRequest.setAuthorizedAcrValues(Arrays.asList(
-                "acr_1", "acr_2", "acr_3", "basic"
-        ));
 
         RegisterClient registerClient = newRegisterClient(registerRequest);
         RegisterResponse registerResponse = registerClient.exec();
@@ -58,7 +55,7 @@ public class AuthorizedAcrValuesTest extends BaseTest {
 
         AuthorizationRequest authorizationRequest = new AuthorizationRequest(responseTypes, clientId, scopes, redirectUri, nonce);
         authorizationRequest.setState(state);
-        authorizationRequest.setAcrValues(Arrays.asList("basic"));
+        authorizationRequest.setAcrValues(Arrays.asList("basic_alias1"));
 
         AuthorizationResponse authorizationResponse = authenticateResourceOwnerAndGrantAccess(authorizationEndpoint,
                 authorizationRequest, userId, userSecret);
@@ -68,11 +65,12 @@ public class AuthorizedAcrValuesTest extends BaseTest {
                 .check();
     }
 
-    @Parameters({"redirectUris", "redirectUri", "sectorIdentifierUri"})
+    @Parameters({"userId", "userSecret", "redirectUris", "redirectUri", "sectorIdentifierUri"})
     @Test
-    public void authorizedAcrValuesFail(
-            final String redirectUris, final String redirectUri, final String sectorIdentifierUri) {
-        showTitle("authorizedAcrValuesFail");
+    public void acrAliasAuthorizedAcsValuesTest(
+            final String userId, final String userSecret, final String redirectUris, final String redirectUri,
+            final String sectorIdentifierUri) {
+        showTitle("acrAliasAuthorizedAcsValuesTest");
 
         List<ResponseType> responseTypes = Arrays.asList(ResponseType.CODE, ResponseType.ID_TOKEN);
 
@@ -82,7 +80,7 @@ public class AuthorizedAcrValuesTest extends BaseTest {
         registerRequest.setResponseTypes(responseTypes);
         registerRequest.setSectorIdentifierUri(sectorIdentifierUri);
         registerRequest.setAuthorizedAcrValues(Arrays.asList(
-                "acr_1", "acr_2", "acr_3"
+                "basic_alias1", "basic_alias2"
         ));
 
         RegisterClient registerClient = newRegisterClient(registerRequest);
@@ -101,16 +99,13 @@ public class AuthorizedAcrValuesTest extends BaseTest {
 
         AuthorizationRequest authorizationRequest = new AuthorizationRequest(responseTypes, clientId, scopes, redirectUri, nonce);
         authorizationRequest.setState(state);
-        authorizationRequest.setAcrValues(Arrays.asList("basic"));
+        authorizationRequest.setAcrValues(Arrays.asList("basic_alias2"));
 
-        AuthorizeClient authorizeClient = new AuthorizeClient(authorizationEndpoint);
-        authorizeClient.setRequest(authorizationRequest);
+        AuthorizationResponse authorizationResponse = authenticateResourceOwnerAndGrantAccess(authorizationEndpoint,
+                authorizationRequest, userId, userSecret);
 
-        AuthorizationResponse authorizationResponse = authorizeClient.exec();
-
-        showClient(authorizeClient);
         AssertBuilder.authorizationResponse(authorizationResponse)
-                .status(302)
+                .responseTypes(responseTypes)
                 .check();
     }
 }

--- a/jans-auth-server/client/src/test/resources/testng.xml
+++ b/jans-auth-server/client/src/test/resources/testng.xml
@@ -3,7 +3,7 @@
 <suite name="jansAuthClient" parallel="tests" thread-count="4">
 
     <listeners>
-        <listener class-name="io.jans.as.client.RetryListener" />
+        <listener class-name="io.jans.as.client.RetryListener"/>
     </listeners>
 
     <test name="JsonApplier Client test" enabled="true">
@@ -36,8 +36,13 @@
         </classes>
     </test>
 
-    <!-- Token binding -->
+    <test name="Authn Script Aliases Test" enabled="true">
+        <classes>
+            <class name="io.jans.as.client.ws.rs.AuthnScriptAliasesTest"/>
+        </classes>
+    </test>
 
+    <!-- Token binding -->
     <test name="Token Binding test (HTTP)" enabled="true">
         <classes>
             <class name="io.jans.as.client.ws.rs.TokenBindingHttpTest"/>
@@ -93,6 +98,12 @@
     <test name="Authorization Support Custom Params" enabled="true">
         <classes>
             <class name="io.jans.as.client.ws.rs.AuthorizationSupportCustomParams"/>
+        </classes>
+    </test>
+
+    <test name="Authorized Acr Values Test" enabled="true">
+        <classes>
+            <class name="io.jans.as.client.ws.rs.AuthorizedAcrValuesTest"/>
         </classes>
     </test>
 
@@ -256,7 +267,7 @@
             <class name="io.jans.as.client.ws.rs.SetPublicSubjectIdentifierPerClientTest"/>
         </classes>
     </test>
-    
+
     <!-- SSO with Multiple Backend Services test -->
     <test name="SSO with Multiple Backend Services test (HTTP)" enabled="true">
         <classes>
@@ -900,7 +911,8 @@
             <class name="io.jans.as.client.ws.rs.jarm.AuthorizationResponseModeFormPostJwtResponseTypeCodeIdTokenSignedHttpTest"/>
         </classes>
     </test>
-    <test name="Test Authorization Response Mode form_post.jwt Response Type code id_token token Encrypted" enabled="true">
+    <test name="Test Authorization Response Mode form_post.jwt Response Type code id_token token Encrypted"
+          enabled="true">
         <classes>
             <class name="io.jans.as.client.ws.rs.jarm.AuthorizationResponseModeFormPostJwtResponseTypeCodeIdTokenTokenEncryptedHttpTest"/>
         </classes>
@@ -961,7 +973,8 @@
             <class name="io.jans.as.client.ws.rs.jarm.AuthorizationResponseModeFragmentJwtResponseTypeCodeIdTokenSignedHttpTest"/>
         </classes>
     </test>
-    <test name="Test Authorization Response Mode fragment.jwt Response Type code id_token token Encrypted" enabled="true">
+    <test name="Test Authorization Response Mode fragment.jwt Response Type code id_token token Encrypted"
+          enabled="true">
         <classes>
             <class name="io.jans.as.client.ws.rs.jarm.AuthorizationResponseModeFragmentJwtResponseTypeCodeIdTokenTokenEncryptedHttpTest"/>
         </classes>

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalAuthenticationService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalAuthenticationService.java
@@ -29,12 +29,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Provides factory methods needed to create external authenticator
@@ -498,6 +494,15 @@ public class ExternalAuthenticationService extends ExternalScriptService {
                 map.put(level, acrs);
             }
             acrs.add(acr);
+
+            // Also publish alias configuration
+            if (script.getCustomScript() != null && script.getCustomScript().getAliases() != null) {
+                for (String alias : script.getCustomScript().getAliases()) {
+                    if (StringUtils.isNotBlank(alias)) {
+                        acrs.add(alias);
+                    }
+                }
+            }
         }
         return map;
     }

--- a/jans-linux-setup/jans_setup/templates/scripts.ldif
+++ b/jans-linux-setup/jans_setup/templates/scripts.ldif
@@ -393,6 +393,8 @@ objectClass: top
 objectClass: jansCustomScr
 jansEnabled: false
 jansProgLng: python
+jansAlias: basic_alias1
+jansAlias: basic_alias2
 
 dn: inum=A910-56AB,ou=scripts,o=jans
 description: Sample script for SCIM events


### PR DESCRIPTION
…cr names

Signed-off-by: Javier Rojas Blum <javier.rojas.blum@gmail.com>

### Prepare

- [ ] Read contribution guidelines
- [ ] Read license information

-------------------

### Description

- Target issue #306
  <!-- Link this PR to issue it is fixing -->

- Implementation Details
  <!-- If the fix is involved one then communicate high level analysis and implementation approach -->

Configure the desired aliases for a script as shown in the example:

![image](https://user-images.githubusercontent.com/2474616/159074433-206acdd2-c7c2-471f-85e6-74e83eb53512.png)

The aliases will be published in the configuration endpoint (```.well-known/openid-configuration```):

![image](https://user-images.githubusercontent.com/2474616/159074463-4e82054c-f54b-4193-911d-9618ed28b661.png)


-------------------
### Document the changes

- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

