### PR TITLE
docs: add README for technical docs

### DIFF
--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,4 +1,4 @@
-Use [assets](../assets) directory to store digital assets like images, diagrams that are used to support documentation for all modules. 
+Use the [assets](../assets) directory to store digital assets like images and diagrams that are used to support documentation for all modules. 
 
 ## Directory Structure
 Directory structure under this directory should closely follow directory structure under [docs](../docs) directory. 
@@ -10,9 +10,9 @@ Keep images and diagrams in separate directories as below.
  - `images` : to hold screenshots and other images (Max size 1MB each, preferrably `.png`)
  - `diagrams` : to hold interaction diagrams, class diagrams, sequence diagram. (Preferrably as PDF)
 
-For instance, images that support technical documetation for `jans-core` module should be located at path `jans/docs/assets/technical/jans-core/images`
+For instance, images that support technical documentation for `jans-core` module should be located in `jans/docs/assets/technical/jans-core/images`
 
-## File Naming Convensions 
+## File Naming Conventions 
 Image/diagram file names should follow the pattern: `image/diagram`-`3 tag words`-`mmddyyyy`.`type`.
 
 For example,

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,20 @@
+Use [assets](../assets) directory to store digital assets like images, diagrams that are used to support documentation for all modules. 
+
+## Directory Structure
+Directory structure under this directory should closely follow directory structure under [docs](../docs) directory. 
+
+For example, documents located under `docs/user/howto` should place their supporting images\diagrams under `docs/assets/user/howto`.
+
+## Images and Diagrams
+Keep images and diagrams in separate directories as below. 
+ - `images` : to hold screenshots and other images (Max size 1MB each, preferrably `.png`)
+ - `diagrams` : to hold interaction diagrams, class diagrams, sequence diagram. (Preferrably as PDF)
+
+For instance, images that support technical documetation for `jans-core` module should be located at path `jans/docs/assets/technical/jans-core/images`
+
+## File Naming Convensions 
+Image/diagram file names should follow the pattern: `image/diagram`-`3 tag words`-`mmddyyyy`.`type`.
+
+For example,
+- A screenshot of IDE settings for developer workspace setup can be named `image-eclipse-ide-setting-04052022.png`
+- A sequence diagram for user registration flow can be named `diagram-user-registration-sequence-03062022.pdf`

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -19,12 +19,12 @@ Contents:
   
 | Service | REST API | Javadoc |  
 | --- | --- | --- |  
-| Jans Auth Server | | [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [server](https://jenkins.jans.io/javadocs/jans-auth/main/server/) |  
-| Jans Client API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans-client-api/master/server/src/main/resources/swagger.yaml)| |  
-| Jans Config API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans-config-api/master/docs/jans-config-api-swagger.yaml)| |  
+| Jans Auth Server | | [server](https://jenkins.jans.io/javadocs/jans-auth/main/server/) [model](https://jenkins.jans.io/javadocs/jans-auth/main/model/) [client](https://jenkins.jans.io/javadocs/jans-auth/main/client/)|  
+| Jans Client API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-client-api/server/src/main/resources/swagger.yaml)| |  
+| Jans Config API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-config-api/docs/jans-config-api-swagger.yaml)| |  
 | Jans Core | | [server](https://jenkins.jans.io/javadocs/jans-core/main/io/jans/server/filters/package-summary.html)|  
-| Jans FIDO 2 | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans-fido2/master/docs/jansFido2Swagger.yaml) | |  
-| Jans SCIM API | [Swagger](https://gluu.org/swagger-ui/?url=https:/raw.githubusercontent.com/JanssenProject/jans-scim/master/server/src/main/resources/jans-scim-openapi.yaml) | [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [server](https://jenkins.jans.io/javadocs/jans-scim/main/server/) |  
+| Jans FIDO 2 | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-fido2/docs/jansFido2Swagger.yaml) | |  
+| Jans SCIM API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-scim/server/src/main/resources/jans-scim-openapi.yaml) | [server](https://jenkins.jans.io/javadocs/jans-scim/main/server/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) |  
   
 ## Design Consideration and Guidelines
 This section outlines high-level design principles, styles and design choices that Janssen project follow. 

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -13,8 +13,6 @@ Contents:
   - [Security](#security)
   - [Scalability and Cloud Infrastructure](#scalability-and-cloud-infrastructure)
 - [Technical Documentation Guidelines](#technical-documentation-guidelines)
-  - [Storing Supporting Images and Diagrams](#storing-supporting-images-and-diagrams)
-  - [File Naming Convensions](#file-naming-convensions )
 
 
 ## API Reference
@@ -39,21 +37,9 @@ This section outlines high-level design principles, styles and design choices th
 
 ## Technical Documentation Guidelines
   
-Each module directory will hold detailed technical documentation for that module. It should have README file that follows [Technical Overview Template](./technical-overview-template.md). Also create other directories as required and as mentioned in `Directory Structure` section below. 
+- Detailed technical documentation for each module should be placed under directory with module's name. For example, technical documentation for `jans-mod` should be placed under directory `docs/technical/jans-mod`
+- Each module directory should have a README file that follows [Technical Overview Template](./technical-overview-template.md).
+- Create directories if required under module directory to further arrange documentation
+- Place all the digital assets to support your documentation under [assets](../assets) following these [guidelines](../assets/README.md)
 
 
-### Storing Supporting Images and Diagrams
-Use [assets](../assets) directory to store digital assets like images, diagrams that are used to support documentation for all modules. 
-If directory with your module name doesn't already exist under `docs/assets`, please create it under [assets](../assets) directory. 
-Under `<module-name>` directory, create directories as below to hold digital assets:
- - `images` : to hold screenshots and other images (Max size 1MB, preferrably `.png`)
- - `diagrams` : to hold interaction diagrams, class diagrams, sequence diagram. (Preferrably as PDF)
-For instance, images that support documetation for `jans-core` module should be located at path `jans/docs/assets/jans-core/images`
-
-### File Naming Convensions 
-Image/diagram file names should follow the pattern: `image/diagram`-`3 tag words`-`mmddyyyy`.`type`.
-
-For example,
-- A screenshot of IDE settings for developer workspace setup can be named `image-eclipse-ide-setting-04052022.png`
-- A sequence diagram for user registration flow can be named `diagram-user-registration-sequence-03062022.pdf`
- 

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -1,6 +1,6 @@
 # Technical Documentation
 
-Documentation here explains technical design, architecture and interations of various Janssen modules.
+This documentation explains technical design, architecture and interactions of various Janssen modules.
 
 Contents:
 
@@ -11,7 +11,7 @@ Contents:
   - [Testing](#testing)
   - [Deployment](#deployment)
   - [Security](#security)
-  - [Scallability and Cloud Infrastructure](#scallability-and-cloud-infrastructure)
+  - [Scalability and Cloud Infrastructure](#scalability-and-cloud-infrastructure)
 - [Technical Documentation Guidelines](#Technical Documentation Guidelines)
 
 
@@ -24,13 +24,13 @@ This section outlines high-level design principles, styles and design choices th
 ### Testing
 ### Deployment
 ### Security
-### Scallability and Cloud Infrastructure 
+### Scalability and Cloud Infrastructure 
 
 ## Technical Documentation Guidelines
   
 Each module directory will hold detailed technical documentation for that module. It should have README file that follows [Technical Overview Template](./technical-overview-template.md). Also create other directories as required and as mentioned in `Directory Structure` section below. 
 
 ### Directory Structure
-Create directories within your module's directory as below to support your documetation
+Create directories within your module's directory as below to support your documentation
  - `images` : to hold screenshots etc
  - `diagrams` : to hold interaction diagrams, class diagrams, sequence diagram etc

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -2,7 +2,7 @@
 
 This documentation explains technical design, architecture and interactions of various Janssen modules.
 
-Contents:
+## Contents:
 
 - [API Reference](#api-reference)
 - [Design Consideration and Guidelines](#design-consideration-and-guidelines)
@@ -14,19 +14,19 @@ Contents:
   - [Scalability and Cloud Infrastructure](#scalability-and-cloud-infrastructure)
 - [Technical Documentation Guidelines](#technical-documentation-guidelines)
 
-
 ## API Reference
-  
+
 | Service | REST API | Javadoc |  
 | --- | --- | --- |  
-| Jans Auth Server | | [server](https://jenkins.jans.io/javadocs/jans-auth/main/server/) [model](https://jenkins.jans.io/javadocs/jans-auth/main/model/) [client](https://jenkins.jans.io/javadocs/jans-auth/main/client/)|  
+| Jans Auth Server | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-auth-server/docs/swagger.yaml)| [server](https://jenkins.jans.io/javadocs/jans-auth/main/server/) [model](https://jenkins.jans.io/javadocs/jans-auth/main/model/) [client](https://jenkins.jans.io/javadocs/jans-auth/main/client/)|  
 | Jans Client API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-client-api/server/src/main/resources/swagger.yaml)| |  
 | Jans Config API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-config-api/docs/jans-config-api-swagger.yaml)| |  
 | Jans Core | | [server](https://jenkins.jans.io/javadocs/jans-core/main/io/jans/server/filters/package-summary.html)|  
 | Jans FIDO 2 | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-fido2/docs/jansFido2Swagger.yaml) | |  
-| Jans SCIM API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-scim/server/src/main/resources/jans-scim-openapi.yaml) | [server](https://jenkins.jans.io/javadocs/jans-scim/main/server/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) |  
+| Jans SCIM API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-scim/server/src/main/resources/jans-scim-openapi.yaml) | [server](https://jenkins.jans.io/javadocs/jans-scim/main/server/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) |     
   
 ## Design Consideration and Guidelines
+
 This section outlines high-level design principles, styles and design choices that Janssen project follow. 
 ### REST API Design
 ### Caching

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -17,7 +17,7 @@ Contents:
 
 ## API Reference
   
-| Service | API Reference | Javadoc |  
+| Service | REST API | Javadoc |  
 | --- | --- | --- |  
 | Jans Auth Server | | [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [server](https://jenkins.jans.io/javadocs/jans-auth/main/server/) |  
 | Jans Client API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans-client-api/master/server/src/main/resources/swagger.yaml)| |  

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -31,6 +31,6 @@ This section outlines high-level design principles, styles and design choices th
 Each module directory will hold detailed technical documentation for that module. It should have README file that follows [Technical Overview Template](./technical-overview-template.md). Also create other directories as required and as mentioned in `Directory Structure` section below. 
 
 ### Directory Structure
-Create directories within your module's directory as below to support your documentation
- - `images` : to hold screenshots etc
- - `diagrams` : to hold interaction diagrams, class diagrams, sequence diagram etc
+Create directories within your module's directory as below to support your documentation. 
+ - `images` : to hold screenshots and other images (Max size 1MB, preferrably `.png`)
+ - `diagrams` : to hold interaction diagrams, class diagrams, sequence diagram. (Preferrably as PDF)

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -16,14 +16,14 @@ This documentation explains technical design, architecture and interactions of v
 
 ## API Reference
 
-| Service | REST API | Javadoc |  
+| Service | REST API | Java API |  
 | --- | --- | --- |  
-| Jans Auth Server | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-auth-server/docs/swagger.yaml)| [server](https://jenkins.jans.io/javadocs/jans-auth/main/server/) [model](https://jenkins.jans.io/javadocs/jans-auth/main/model/) [client](https://jenkins.jans.io/javadocs/jans-auth/main/client/)|  
-| Jans Client API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-client-api/server/src/main/resources/swagger.yaml)| |  
+| Jans Auth Server | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-auth-server/docs/swagger.yaml)| [Javadoc](https://jenkins.jans.io/javadocs/jans-auth/main/)|  
+| Jans Client API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-client-api/server/src/main/resources/swagger.yaml)| [Javadoc](https://jenkins.jans.io/javadocs/jans-client-api/main/)|  
 | Jans Config API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-config-api/docs/jans-config-api-swagger.yaml)| |  
-| Jans Core | | [server](https://jenkins.jans.io/javadocs/jans-core/main/io/jans/server/filters/package-summary.html)|  
+| Jans Core | | [Javadoc](https://jenkins.jans.io/javadocs/jans-core/main/)|  
 | Jans FIDO 2 | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-fido2/docs/jansFido2Swagger.yaml) | |  
-| Jans SCIM API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-scim/server/src/main/resources/jans-scim-openapi.yaml) | [server](https://jenkins.jans.io/javadocs/jans-scim/main/server/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) |     
+| Jans SCIM API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-scim/server/src/main/resources/jans-scim-openapi.yaml) | [Javadoc](https://jenkins.jans.io/javadocs/jans-scim/main/) |     
   
 ## Design Consideration and Guidelines
 

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -1,3 +1,36 @@
-# Technical Design Documentation
+# Technical Documentation
 
-Documents that explain technical design, architecture and interations of various Janssen modules
+Documentation here explains technical design, architecture and interations of various Janssen modules.
+
+Contents:
+
+- [API Reference](#api-reference)
+- [Design Consideration and Guidelines](#design-consideration-and-guidelines)
+  - [REST API Design](#rest-api-design)
+  - [Caching](#caching)
+  - [Testing](#testing)
+  - [Deployment](#deployment)
+  - [Security](#security)
+  - [Scallability and Cloud Infrastructure](#scallability-and-cloud-infrastructure)
+- [Technical Documentation Guidelines](#Technical Documentation Guidelines)
+
+
+## API Reference
+  
+## Design Consideration and Guidelines
+This section outlines high-level design principles, styles and design choices that Janssen project follow. 
+### REST API Design
+### Caching
+### Testing
+### Deployment
+### Security
+### Scallability and Cloud Infrastructure 
+
+## Technical Documentation Guidelines
+  
+Each module directory will hold detailed technical documentation for that module. It should have README file that follows [Technical Overview Template](./technical-overview-template.md). Also create other directories as required and as mentioned in `Directory Structure` section below. 
+
+### Directory Structure
+Create directories within your module's directory as below to support your documetation
+ - `images` : to hold screenshots etc
+ - `diagrams` : to hold interaction diagrams, class diagrams, sequence diagram etc

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -12,10 +12,19 @@ Contents:
   - [Deployment](#deployment)
   - [Security](#security)
   - [Scalability and Cloud Infrastructure](#scalability-and-cloud-infrastructure)
-- [Technical Documentation Guidelines](#Technical Documentation Guidelines)
+- [Technical Documentation Guidelines](#technical-documentation-guidelines)
 
 
 ## API Reference
+  
+| Service | API Reference | Javadoc |  
+| --- | --- | --- |  
+| Jans Auth Server | | [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [server](https://jenkins.jans.io/javadocs/jans-auth/main/server/) |  
+| Jans Client API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans-client-api/master/server/src/main/resources/swagger.yaml)| |  
+| Jans Config API | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans-config-api/master/docs/jans-config-api-swagger.yaml)| |  
+| Jans Core | | [server](https://jenkins.jans.io/javadocs/jans-core/main/io/jans/server/filters/package-summary.html)|  
+| Jans FIDO 2 | [Swagger](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans-fido2/master/docs/jansFido2Swagger.yaml) | |  
+| Jans SCIM API | [Swagger](https://gluu.org/swagger-ui/?url=https:/raw.githubusercontent.com/JanssenProject/jans-scim/master/server/src/main/resources/jans-scim-openapi.yaml) | [client](https://jenkins.jans.io/javadocs/jans-scim/main/client/) [model](https://jenkins.jans.io/javadocs/jans-scim/main/model/) [server](https://jenkins.jans.io/javadocs/jans-scim/main/server/) |  
   
 ## Design Consideration and Guidelines
 This section outlines high-level design principles, styles and design choices that Janssen project follow. 

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -13,6 +13,8 @@ Contents:
   - [Security](#security)
   - [Scalability and Cloud Infrastructure](#scalability-and-cloud-infrastructure)
 - [Technical Documentation Guidelines](#technical-documentation-guidelines)
+  - [Storing Supporting Images and Diagrams](#storing-supporting-images-and-diagrams)
+  - [File Naming Convensions](#file-naming-convensions )
 
 
 ## API Reference
@@ -39,7 +41,19 @@ This section outlines high-level design principles, styles and design choices th
   
 Each module directory will hold detailed technical documentation for that module. It should have README file that follows [Technical Overview Template](./technical-overview-template.md). Also create other directories as required and as mentioned in `Directory Structure` section below. 
 
-### Directory Structure
-Create directories within your module's directory as below to support your documentation. 
+
+### Storing Supporting Images and Diagrams
+Use [assets](../assets) directory to store digital assets like images, diagrams that are used to support documentation for all modules. 
+If directory with your module name doesn't already exist under `docs/assets`, please create it under [assets](../assets) directory. 
+Under `<module-name>` directory, create directories as below to hold digital assets:
  - `images` : to hold screenshots and other images (Max size 1MB, preferrably `.png`)
  - `diagrams` : to hold interaction diagrams, class diagrams, sequence diagram. (Preferrably as PDF)
+For instance, images that support documetation for `jans-core` module should be located at path `jans/docs/assets/jans-core/images`
+
+### File Naming Convensions 
+Image/diagram file names should follow the pattern: `image/diagram`-`3 tag words`-`mmddyyyy`.`type`.
+
+For example,
+- A screenshot of IDE settings for developer workspace setup can be named `image-eclipse-ide-setting-04052022.png`
+- A sequence diagram for user registration flow can be named `diagram-user-registration-sequence-03062022.pdf`
+ 

--- a/docs/technical/technical-overview-template.md
+++ b/docs/technical/technical-overview-template.md
@@ -1,0 +1,28 @@
+# <module name>
+
+Contents:
+- [Functional Overview](#functional-overview)
+- [Design Overview](#design-overview)
+- [API and Code Reference](#api-and-code-reference)
+- [Deployment](#deployment)
+- [Data Reference](#data-reference)
+- [How to Run Tests](#how-to-run-tests)
+- [Logging](#logging)
+- [Security Considerations](#security-considerations)
+    
+
+## Functional Overview
+<!-- A high level overview of what the component is supposed to do and how it works. We recommend using diagrams to illustrate cross-module interactions and important flows within the same module -->
+## Design Overview
+<!--- Describe code structure (packages), diagrams to show how this module interacts with other modules, add class diagrams for set of core classes, sequence diagrams that depict core functionalities, design constraints,   --->
+## API and Code Reference
+- [API Reference](<!-- Link to [OpenAPI](https://swagger.io/specification/) document which can be viewed with [SwaggerUI](https://swagger.io/tools/swagger-ui/) -->)
+- [Code Reference](<!-- Link to auto-generated docs that are extracted from the code, for example, Javadocs -->)
+## Deployment 
+<!-- Instructions on how to properly deploy this component. Included are what persistence, caching, file system, network (e.g. port), compute or other system requirements are needed to make it run.-->
+## Data Reference
+<!-- If the component needs a database or cache, an overview of the required schema or information tree.-->
+## How to Run Tests
+## Logging
+ <!--- Log file name, how to enable and change logging levels for this module --->
+## Security Considerations


### PR DESCRIPTION
### Prepare

- [x] Read contribution guidelines
- [x] Read license information

-------------------

### Description

- Target issue
Currently technical documentation for Janssen modules doesn't exist. Earlier(before monorepo) documentation existed under docs repo [here](https://github.com/JanssenProject/docs/tree/main/source/janssen-modules). This documentation is scant and not available in all modules.

Under `jans` monorepo, we have to start an effort to put together detailed technical design documentation for all modules.  Under `jans` monorepo, technical design documentation should go under `docs/technical`.

- Implementation Details
This PR attempts to provide basic structure and template that all code owners can follow while writing technical design documents for respective modules:
  - README for main `/technical` directory: This is supposed to capture overall Janssen design guidelines
  - Template for technical design document for code owners

Once we agree on the content and format as laid out in this PR, I can ask code owners to write detailed design docs for respective modules.

