### PR TITLE
chore: images update

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -5,6 +5,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 # ===============
 
 RUN apk update \
+    && apk upgrade \
     && apk add --no-cache openssl py3-pip tini curl bash py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git zip \

--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -52,7 +52,7 @@ RUN wget -q https://github.com/fabioz/PyDev.Debugger/archive/refs/tags/pydev_deb
 # ===========
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-17 13:30'
+ENV CN_BUILD_DATE='2022-03-23 17:17'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-server/${CN_VERSION}/jans-auth-server-${CN_VERSION}.war
 
 # Install Jans Auth
@@ -87,7 +87,7 @@ RUN wget -q https://jenkins.gluu.org/maven/org/gluu/casa-config/${CASA_CONFIG_VE
 # Casa external scripts
 # =====================
 
-ARG CASA_EXTRAS_VERSION=2a4a7fcb16554d23ea0ff599d46f86b9de292e30
+ARG CASA_EXTRAS_VERSION=fe01bcb3d46311355b15a37b655253ca17997358
 ARG CASA_EXTRAS_DIR=casa/extras
 
 RUN mkdir -p /opt/jans/python/libs

--- a/docker-jans-certmanager/Dockerfile
+++ b/docker-jans-certmanager/Dockerfile
@@ -5,6 +5,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 # ===============
 
 RUN apk update \
+    && apk upgrade \
     && apk add --no-cache openssl py3-pip curl tini py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git \
@@ -17,7 +18,7 @@ RUN apk update \
 
 # JAR files required to generate OpenID Connect keys
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-15 17:18'
+ENV CN_BUILD_DATE='2022-03-23 18:17'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-client/${CN_VERSION}/jans-auth-client-${CN_VERSION}-jar-with-dependencies.jar
 
 RUN wget -q ${CN_SOURCE_URL} -P /app/javalibs/

--- a/docker-jans-client-api/Dockerfile
+++ b/docker-jans-client-api/Dockerfile
@@ -16,7 +16,7 @@ RUN apk update \
 # ==========
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-15 08:49'
+ENV CN_BUILD_DATE='2022-03-23 08:49'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-client-api-server/${CN_VERSION}/jans-client-api-server-${CN_VERSION}-distribution.zip
 
 RUN wget -q ${CN_SOURCE_URL} -O /tmp/client-api.zip \

--- a/docker-jans-client-api/Dockerfile
+++ b/docker-jans-client-api/Dockerfile
@@ -5,6 +5,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 # ===============
 
 RUN apk update \
+    && apk upgrade \
     && apk add --no-cache openssl py3-pip tini curl py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps unzip wget git \

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -32,7 +32,7 @@ RUN wget -q https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/${JETTY_
 # ==========
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-15 20:31'
+ENV CN_BUILD_DATE='2022-03-23 17:23'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-config-api-server/${CN_VERSION}/jans-config-api-server-${CN_VERSION}.war
 
 # Install Jans Config API

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -5,6 +5,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 # ===============
 
 RUN apk update \
+    && apk upgrade \
     && apk add --no-cache openssl py3-pip tini curl py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git zip \

--- a/docker-jans-configurator/Dockerfile
+++ b/docker-jans-configurator/Dockerfile
@@ -5,6 +5,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 # ===============
 
 RUN apk update \
+    && apk upgrade \
     && apk add --no-cache openssl py3-pip curl tini py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git \
@@ -17,7 +18,7 @@ RUN apk update \
 
 # JAR files required to generate OpenID Connect keys
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-15 17:18'
+ENV CN_BUILD_DATE='2022-03-23 18:17'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-client/${CN_VERSION}/jans-auth-client-${CN_VERSION}-jar-with-dependencies.jar
 
 RUN wget -q ${CN_SOURCE_URL} -P /app/javalibs/

--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -5,6 +5,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 # ===============
 
 RUN apk update \
+    && apk upgrade \
     && apk add --no-cache openssl py3-pip tini curl py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git zip \

--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -35,7 +35,7 @@ EXPOSE 8080
 # =====
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-15 17:18'
+ENV CN_BUILD_DATE='2022-03-23 08:13'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-fido2-server/${CN_VERSION}/jans-fido2-server-${CN_VERSION}.war
 
 # Install FIDO2

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install -U pip wheel \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_LINUX_SETUP_VERSION=2add3e9ef4d29847f77d5d7389e22ded76cc3764
+ENV JANS_LINUX_SETUP_VERSION=e3d9dbffdab29d58d31dab004f5d392f5ada0591
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -5,6 +5,7 @@ FROM alpine:3.14.4
 # ===============
 
 RUN apk update \
+    && apk upgrade \
     && apk add --no-cache py3-pip curl tini py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps git wget

--- a/docker-jans-persistence-loader/scripts/spanner_setup.py
+++ b/docker-jans-persistence-loader/scripts/spanner_setup.py
@@ -495,6 +495,10 @@ class SpannerBackend:
             ("jansClnt", "jansLogoutURI"),
             ("jansPerson", "role"),
             ("jansPerson", "mobile"),
+            ("jansCustomScr", "jansAlias"),
+            ("jansClnt", "jansReqURI"),
+            ("jansClnt", "jansClaimRedirectURI"),
+            ("jansClnt", "jansAuthorizedOrigins"),
         ]:
             column_to_array(mod[0], mod[1])
 

--- a/docker-jans-persistence-loader/scripts/sql_setup.py
+++ b/docker-jans-persistence-loader/scripts/sql_setup.py
@@ -442,6 +442,10 @@ class SQLBackend:
             ("jansClnt", "jansLogoutURI"),
             ("jansPerson", "role"),
             ("jansPerson", "mobile"),
+            ("jansCustomScr", "jansAlias"),
+            ("jansClnt", "jansReqURI"),
+            ("jansClnt", "jansClaimRedirectURI"),
+            ("jansClnt", "jansAuthorizedOrigins"),
         ]:
             column_to_json(mod[0], mod[1])
 

--- a/docker-jans-persistence-loader/templates/configuration.ldif
+++ b/docker-jans-persistence-loader/templates/configuration.ldif
@@ -4,7 +4,6 @@ jansDocStoreConf: {"documentStoreType":"%(document_store_type)s","localConfigura
 jansDbAuth: {"type": "auth", "name": null, "level": 0, "priority": 1, "enabled": false, "version": 0, "config": {"configId": "auth_ldap_server",           "servers": ["%(ldap_hostname)s:%(ldaps_port)s"],           "maxConnections": 1000,           "bindDN": "%(ldap_binddn)s",           "bindPassword": "%(encoded_ox_ldap_pw)s",           "useSSL": "%(ldap_use_ssl)s",           "baseDNs": ["ou=people,o=jans"],           "primaryKey": "uid",           "localPrimaryKey": "uid",           "useAnonymousBind": false,           "enabled": false} }
 jansOrgProfileMgt: false
 jansScimEnabled: %(jansScimEnabled)s
-jansAuthMode: simple_password_auth
 objectClass: top
 objectClass: jansAppConf
 ou: configuration

--- a/docker-jans-scim/Dockerfile
+++ b/docker-jans-scim/Dockerfile
@@ -45,7 +45,7 @@ RUN wget -q https://ox.gluu.org/maven/org/gluufederation/jython-installer/${JYTH
 # ====
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-15 20:30'
+ENV CN_BUILD_DATE='2022-03-23 09:01'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-scim-server/${CN_VERSION}/jans-scim-server-${CN_VERSION}.war
 
 # Install SCIM

--- a/docker-jans-scim/Dockerfile
+++ b/docker-jans-scim/Dockerfile
@@ -5,6 +5,7 @@ FROM bellsoft/liberica-openjre-alpine:11.0.13-8
 # ===============
 
 RUN apk update \
+    && apk upgrade \
     && apk add --no-cache openssl py3-pip tini curl bash py3-cryptography py3-psycopg2 \
     && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
     && apk add --no-cache --virtual build-deps wget git zip \


### PR DESCRIPTION
### Overview

- updated `BUILD_DATE`
- synchronized upstream templates and schema in `persistence-loader` image
- upgraded `libcrypto` and `libssl` to address CVE-2022-0778