### PR TITLE
fix: Typo httpLoggingExludePaths to httpLoggingExcludePaths

### DIFF
--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
@@ -366,7 +366,7 @@
     "logClientIdOnClientAuthentication": true,
     "logClientNameOnClientAuthentication": false,
     "httpLoggingEnabled": false,
-    "httpLoggingExludePaths": [],
+    "httpLoggingExcludePaths": [],
     "externalLoggerConfiguration": "",
     "authorizationRequestCustomAllowedParameters" : [
         {

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
@@ -288,7 +288,7 @@
     "logClientIdOnClientAuthentication": true,
     "logClientNameOnClientAuthentication": false,
     "httpLoggingEnabled": false,
-    "httpLoggingExludePaths": [],
+    "httpLoggingExcludePaths": [],
     "externalLoggerConfiguration": "",
     "authorizationRequestCustomAllowedParameters" : [
         {

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -309,7 +309,7 @@ public class AppConfiguration implements Configuration {
     private List<String> enabledComponents;
 
     private Boolean httpLoggingEnabled; // Used in ServletLoggingFilter to enable http request/response logging.
-    private Set<String> httpLoggingExludePaths; // Used in ServletLoggingFilter to exclude some paths from logger. Paths example: ["/jans-auth/img", "/jans-auth/stylesheet"]
+    private Set<String> httpLoggingExcludePaths; // Used in ServletLoggingFilter to exclude some paths from logger. Paths example: ["/jans-auth/img", "/jans-auth/stylesheet"]
     private String externalLoggerConfiguration; // Path to external log4j2 configuration file. This property might be configured from oxTrust: /identity/logviewer/configure
 
     public Boolean getRequireRequestObjectEncryption() {
@@ -1956,12 +1956,12 @@ public class AppConfiguration implements Configuration {
         this.httpLoggingEnabled = httpLoggingEnabled;
     }
 
-    public Set<String> getHttpLoggingExludePaths() {
-        return httpLoggingExludePaths;
+    public Set<String> getHttpLoggingExcludePaths() {
+        return httpLoggingExcludePaths;
     }
 
-    public void setHttpLoggingExludePaths(Set<String> httpLoggingExludePaths) {
-        this.httpLoggingExludePaths = httpLoggingExludePaths;
+    public void setHttpLoggingExcludePaths(Set<String> httpLoggingExcludePaths) {
+        this.httpLoggingExcludePaths = httpLoggingExcludePaths;
     }
 
     public String getLoggingLevel() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/audit/debug/ServletLoggingFilter.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/audit/debug/ServletLoggingFilter.java
@@ -71,7 +71,7 @@ public class ServletLoggingFilter implements Filter {
             chain.doFilter(httpRequest, httpResponse);
             return;
         }
-        Set<String> excludedPaths = appConfiguration.getHttpLoggingExludePaths();
+        Set<String> excludedPaths = appConfiguration.getHttpLoggingExcludePaths();
         if (!CollectionUtils.isEmpty(excludedPaths)) {
             for (String excludedPath : excludedPaths) {
                 String requestURI = httpRequest.getRequestURI();

--- a/jans-cli/cli/jca.yaml
+++ b/jans-cli/cli/jca.yaml
@@ -4764,7 +4764,7 @@ components:
         httpLoggingEnabled:
           type: boolean
           description: Enable/Disable request/response logging filter.
-        httpLoggingExludePaths:
+        httpLoggingExcludePaths:
           type: array
           description: List of base URI for which request/response logging filter should not record activity.
           items:
@@ -5793,7 +5793,7 @@ components:
         externalLoggerConfiguration:
           description: Path to external log4j2 configuration file.
           type: string
-        httpLoggingExludePaths:
+        httpLoggingExcludePaths:
           description: List of paths to exclude from logger.
           type: array
           items:

--- a/jans-cli/docs/cli/cli-jans-authorization-server.md
+++ b/jans-cli/docs/cli/cli-jans-authorization-server.md
@@ -485,7 +485,7 @@ Getting access token for scope https://jans.io/oauth/jans-auth-server/config/pro
   "cibaEnabled": false,
   "discoveryCacheLifetimeInMinutes": 60,
   "httpLoggingEnabled": false,
-  "httpLoggingExludePaths": null,
+  "httpLoggingExcludePaths": null,
   "externalLoggerConfiguration": null,
   "redirectUrisRegexEnabled": false
 }

--- a/jans-cli/docs/cli/cli-logging-configuration.md
+++ b/jans-cli/docs/cli/cli-logging-configuration.md
@@ -34,7 +34,7 @@ Getting access token for scope https://jans.io/oauth/config/logging.readonly
   "disableJdkLogger": true,
   "enabledOAuthAuditLogging": false,
   "externalLoggerConfiguration": null,
-  "httpLoggingExludePaths": null
+  "httpLoggingExcludePaths": null
 }
 ```
 
@@ -53,7 +53,7 @@ To update logging configuration, get the schema first:
   "disableJdkLogger": true,
   "enabledOAuthAuditLogging": false,
   "externalLoggerConfiguration": null,
-  "httpLoggingExludePaths": [
+  "httpLoggingExcludePaths": [
     "/auth/img",
     "/auth/stylesheet"
   ]
@@ -89,7 +89,7 @@ Server Response:
   "disableJdkLogger": false,
   "enabledOAuthAuditLogging": true,
   "externalLoggerConfiguration": null,
-  "httpLoggingExludePaths": [
+  "httpLoggingExcludePaths": [
     "/auth/img",
     "/auth/stylesheet"
   ]

--- a/jans-cli/docs/im/im-jans-authorization-server.md
+++ b/jans-cli/docs/im/im-jans-authorization-server.md
@@ -459,7 +459,7 @@ Select 1 to get all the details about Jans authorization server configuration. I
   "cibaEnabled": false,
   "discoveryCacheLifetimeInMinutes": 60,
   "httpLoggingEnabled": false,
-  "httpLoggingExludePaths": null,
+  "httpLoggingExcludePaths": null,
   "externalLoggerConfiguration": null,
   "redirectUrisRegexEnabled": false
 }

--- a/jans-cli/docs/im/im-janssen-logging-configuration.md
+++ b/jans-cli/docs/im/im-janssen-logging-configuration.md
@@ -24,7 +24,7 @@ Getting access token for scope https://jans.io/oauth/config/logging.readonly
   "disableJdkLogger": true,
   "enabledOAuthAuditLogging": false,
   "externalLoggerConfiguration": null,
-  "httpLoggingExludePaths": null
+  "httpLoggingExcludePaths": null
 }
 ```
 To update the current logging configuration select option 2. For example, I have updated `logging level INFO to DEBUG` and enabled `enabledOAuthAuditLogging`.
@@ -57,7 +57,7 @@ externalLoggerConfiguration:
 
 «List of paths to exclude from logger. Type: array of string separated by _,»
 Example: /auth/img, /auth/stylesheet
-httpLoggingExludePaths: 
+httpLoggingExcludePaths: 
 Obtained Data:
 
 {
@@ -67,7 +67,7 @@ Obtained Data:
   "disableJdkLogger": true,
   "enabledOAuthAuditLogging": true,
   "externalLoggerConfiguration": null,
-  "httpLoggingExludePaths": null
+  "httpLoggingExcludePaths": null
 }
 
 Continue? y
@@ -81,7 +81,7 @@ Please wait while posting data ...
   "disableJdkLogger": true,
   "enabledOAuthAuditLogging": true,
   "externalLoggerConfiguration": null,
-  "httpLoggingExludePaths": null
+  "httpLoggingExcludePaths": null
 }
 
 ```

--- a/jans-config-api/common/src/main/java/io/jans/configapi/rest/model/Logging.java
+++ b/jans-config-api/common/src/main/java/io/jans/configapi/rest/model/Logging.java
@@ -17,7 +17,7 @@ public class Logging {
     private boolean disableJdkLogger;
     private boolean enabledOAuthAuditLogging;
     private String externalLoggerConfiguration;
-    private Set<String> httpLoggingExludePaths = new HashSet<String>();
+    private Set<String> httpLoggingExcludePaths = new HashSet<String>();
 
     public Logging() {
     }
@@ -70,11 +70,11 @@ public class Logging {
         this.externalLoggerConfiguration = externalLoggerConfiguration;
     }
 
-    public Set<String> getHttpLoggingExludePaths() {
-        return httpLoggingExludePaths;
+    public Set<String> getHttpLoggingExcludePaths() {
+        return httpLoggingExcludePaths;
     }
 
-    public void setHttpLoggingExludePaths(Set<String> httpLoggingExludePaths) {
-        this.httpLoggingExludePaths = httpLoggingExludePaths;
+    public void setHttpLoggingExcludePaths(Set<String> httpLoggingExcludePaths) {
+        this.httpLoggingExcludePaths = httpLoggingExcludePaths;
     }
 }

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -4764,7 +4764,7 @@ components:
         httpLoggingEnabled:
           type: boolean
           description: Enable/Disable request/response logging filter.
-        httpLoggingExludePaths:
+        httpLoggingExcludePaths:
           type: array
           description: List of base URI for which request/response logging filter should not record activity.
           items:
@@ -5793,7 +5793,7 @@ components:
         externalLoggerConfiguration:
           description: Path to external log4j2 configuration file.
           type: string
-        httpLoggingExludePaths:
+        httpLoggingExcludePaths:
           description: List of paths to exclude from logger.
           type: array
           items:

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/LoggingResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/LoggingResource.java
@@ -60,7 +60,7 @@ public class LoggingResource {
         if (!StringUtils.isBlank(logging.getExternalLoggerConfiguration())) {
             conf.getDynamic().setExternalLoggerConfiguration(logging.getExternalLoggerConfiguration());
         }
-        conf.getDynamic().setHttpLoggingExludePaths(logging.getHttpLoggingExludePaths());
+        conf.getDynamic().setHttpLoggingExcludePaths(logging.getHttpLoggingExcludePaths());
 
         configurationService.merge(conf);
 
@@ -82,7 +82,7 @@ public class LoggingResource {
             logging.setEnabledOAuthAuditLogging(appConfiguration.getEnabledOAuthAuditLogging());
         }
         logging.setExternalLoggerConfiguration(appConfiguration.getExternalLoggerConfiguration());
-        logging.setHttpLoggingExludePaths(appConfiguration.getHttpLoggingExludePaths());
+        logging.setHttpLoggingExcludePaths(appConfiguration.getHttpLoggingExcludePaths());
         return logging;
     }
 

--- a/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
@@ -289,7 +289,7 @@
     "logClientIdOnClientAuthentication": true,
     "logClientNameOnClientAuthentication": false,
     "httpLoggingEnabled": false,
-    "httpLoggingExludePaths": [],
+    "httpLoggingExcludePaths": [],
     "externalLoggerConfiguration": "",
     "authorizationRequestCustomAllowedParameters" : [
         {

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -377,7 +377,7 @@
     "logClientIdOnClientAuthentication": true,
     "logClientNameOnClientAuthentication": false,
     "httpLoggingEnabled": false,
-    "httpLoggingExludePaths": [],
+    "httpLoggingExcludePaths": [],
     "externalLoggerConfiguration": "",
     "authorizationRequestCustomAllowedParameters" : [
         {


### PR DESCRIPTION
- Target issue #
https://github.com/JanssenProject/jans/issues/1085

-----------------------------
- Implementation Details
Fix typo "httpLoggingExludePaths" in different places:

jans-auth-server 
jans-cli 
jans-config-api 
jans-linux-setup 
docker-jans-persistence-loader

-----------------------------
### Document changes
"httpLoggingExludePaths" was changed to "httpLoggingExcludePaths" in next documents and config files:

https://github.com/JanssenProject/jans/blob/main/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
https://github.com/JanssenProject/jans/blob/main/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
https://github.com/JanssenProject/jans/blob/main/jans-cli/cli/jca.yaml
https://github.com/JanssenProject/jans/blob/main/jans-cli/docs/cli/cli-jans-authorization-server.md
https://github.com/JanssenProject/jans/blob/main/jans-cli/docs/cli/cli-logging-configuration.md
https://github.com/JanssenProject/jans/blob/main/jans-cli/docs/im/im-jans-authorization-server.md
https://github.com/JanssenProject/jans/blob/main/jans-cli/docs/im/im-janssen-logging-configuration.md
https://github.com/JanssenProject/jans/blob/main/jans-config-api/docs/jans-config-api-swagger.yaml
https://github.com/JanssenProject/jans/blob/main/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
https://github.com/JanssenProject/jans/blob/main/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json