### PR TITLE
docs: fix link to Janssen Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Refer to [Janssen Security Policy](.github/SECURITY.md)
 
 ## Documentation
 
-Refer to [Janssen Wiki]() for documentation.
+Refer to [Janssen Wiki](https://github.com/JanssenProject/jans/wiki) for documentation.
 
 ## Design
 


### PR DESCRIPTION
### Prepare

- [x] Read contribution guidelines
- [x] Read license information

-------------------

### Description

- Target issue #
Link to Wiki on README was broken.


