### PR TITLE
fix: jans-linux-setup remove attributes of size 64 from sql_data_type.json

### DIFF
--- a/jans-linux-setup/jans_setup/static/rdbm/sql_data_types.json
+++ b/jans-linux-setup/jans_setup/static/rdbm/sql_data_types.json
@@ -36,56 +36,6 @@
       "type": "STRING"
     }
   },
-  "inum": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "middleName": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "nickname": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "o": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "ou": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
   "sn": {
     "mysql": {
       "size": 128,
@@ -93,16 +43,6 @@
     },
     "spanner": {
       "size": 128,
-      "type": "STRING"
-    }
-  },
-  "uid": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
       "type": "STRING"
     }
   },
@@ -126,72 +66,12 @@
       "type": "STRING"
     }
   },
-  "jansAccessTknSigAlg": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansAppTyp": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansAttrName": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansAttrOrigin": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansAttrTyp": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
   "jansAttrs": {
     "mysql": {
       "type": "TEXT"
     },
     "spanner": {
       "type": "STRING(MAX)"
-    }
-  },
-  "jansAuthMode": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
     }
   },
   "jansAuthData": {
@@ -210,26 +90,6 @@
     },
     "spanner": {
       "type": "STRING(MAX)"
-    }
-  },
-  "jansClaimName": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansClntSecret": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
     }
   },
   "jansConfApp": {
@@ -306,72 +166,12 @@
       "type": "STRING"
     }
   },
-  "jansIdTknSignedRespAlg": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansOrgShortName": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansProgLng": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
   "jansRespTyp": {
     "mysql": {
       "type": "JSON"
     },
     "spanner": {
       "type": "ARRAY<STRING(MAX)>"
-    }
-  },
-  "jansSAML1URI": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansSAML2URI": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansScopeTyp": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
     }
   },
   "jansScr": {
@@ -382,16 +182,6 @@
       "type": "STRING(MAX)"
     }
   },
-  "jansScrTyp": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
   "jansStatus": {
     "mysql": {
       "size": 16,
@@ -399,36 +189,6 @@
     },
     "spanner": {
       "size": 16,
-      "type": "STRING"
-    }
-  },
-  "jansSubjectTyp": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansThemeColor": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansTknEndpointAuthMethod": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
       "type": "STRING"
     }
   },
@@ -615,26 +375,6 @@
       "type": "STRING(MAX)"
     }
   },
-  "clnId": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
-  "jansClntId": {
-    "mysql": {
-      "size": 64,
-      "type": "VARCHAR"
-    },
-    "spanner": {
-      "size": 64,
-      "type": "STRING"
-    }
-  },
   "jwtReq": {
     "mysql": {
       "type": "TEXT"
@@ -799,7 +539,7 @@
     "mysql": {
       "type": "TINYTEXT"
     },
-  "pgsql": {
+    "pgsql": {
       "type": "TEXT"
     },
     "spanner": {


### PR DESCRIPTION
Since default string size is 64, we don't need explicitly specify attributes of size 64 in sql_data_type.json