### PR TITLE
fix: typo and indexing error

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -53,7 +53,7 @@ RUN wget -q https://github.com/fabioz/PyDev.Debugger/archive/refs/tags/pydev_deb
 # ===========
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-23 17:17'
+ENV CN_BUILD_DATE='2022-03-28 08:56'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-server/${CN_VERSION}/jans-auth-server-${CN_VERSION}.war
 
 # Install Jans Auth

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -33,7 +33,7 @@ RUN wget -q https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/${JETTY_
 # ==========
 
 ENV CN_VERSION=1.0.0-SNAPSHOT
-ENV CN_BUILD_DATE='2022-03-23 17:23'
+ENV CN_BUILD_DATE='2022-03-28 10:22'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-config-api-server/${CN_VERSION}/jans-config-api-server-${CN_VERSION}.war
 
 # Install Jans Config API

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -22,7 +22,7 @@ RUN pip3 install -U pip wheel \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_LINUX_SETUP_VERSION=e3d9dbffdab29d58d31dab004f5d392f5ada0591
+ENV JANS_LINUX_SETUP_VERSION=41b6fa185505d3a6a1b5423a6f6df38337a14168
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -115,6 +115,10 @@ def _transform_auth_dynamic_config(conf):
         conf["useHighestLevelScriptIfAcrScriptNotFound"] = True
         should_update = True
 
+    if "httpLoggingExcludePaths" not in conf:
+        conf["httpLoggingExcludePaths"] = conf.pop("httpLoggingExludePaths", [])
+        should_update = True
+
     # return the conf and flag to determine whether it needs update or not
     return conf, should_update
 


### PR DESCRIPTION
### Description

The changeset introduced to address several issues:

- typo on `httpLoggingExludePaths` (renamed to `httpLoggingExcludePaths`) config
- MySQL indexes for `jansClntAuthz.jansClntId` column are skipped due to unsupported feature of the server
- Spanner indexes for `ARRAY` are skipped