### PR TITLE
fix: avoid duplicated client when re-running persistence-loader and configurator

### DIFF
--- a/docker-jans-configurator/scripts/bootstrap.py
+++ b/docker-jans-configurator/scripts/bootstrap.py
@@ -807,8 +807,34 @@ class CtxGenerator:
         if "casa" in opt_scopes:
             self.casa_ctx()
 
+        self.admin_ui_ctx()
+        self.jans_cli_ctx()
+
         # populated config
         return self.ctx
+
+    def admin_ui_ctx(self):
+        self.set_config("admin_ui_client_id", lambda: f"1901.{uuid4()}")
+        admin_ui_client_pw = self.set_secret("admin_ui_client_pw", get_random_chars)
+        self.set_secret(
+            "admin_ui_client_encoded_pw",
+            partial(encode_text, admin_ui_client_pw, self.get_secret("encoded_salt")),
+        )
+
+        self.set_config("token_server_admin_ui_client_id", lambda: f"1901.{uuid4()}")
+        token_server_admin_ui_client_pw = self.set_secret("token_server_admin_ui_client_pw", get_random_chars)
+        self.set_secret(
+            "token_server_admin_ui_client_encoded_pw",
+            partial(encode_text, token_server_admin_ui_client_pw, self.get_secret("encoded_salt")),
+        )
+
+    def jans_cli_ctx(self):
+        self.set_config("role_based_client_id", lambda: f"2000.{uuid4()}")
+        role_based_client_pw = self.set_secret("role_based_client_pw", get_random_chars)
+        self.set_secret(
+            "role_based_client_encoded_pw",
+            partial(encode_text, role_based_client_pw, self.get_secret("encoded_salt")),
+        )
 
 
 def gen_idp3_key(storepass):

--- a/docker-jans-persistence-loader/scripts/utils.py
+++ b/docker-jans-persistence-loader/scripts/utils.py
@@ -149,6 +149,11 @@ def get_base_ctx(manager):
     # static kid
     ctx["staticKid"] = os.environ.get("CN_OB_STATIC_KID", "")
 
+    # WARNING:
+    # - deprecate configs and secrets for admin_ui and token_server_admin_ui
+    # - move the configs and secrets creation to configurator
+    # - remove them on future release
+
     # admin-ui plugins
     ctx["admin_ui_client_id"] = manager.config.get("admin_ui_client_id")
     if not ctx["admin_ui_client_id"]:
@@ -337,6 +342,11 @@ def merge_casa_ctx(manager, ctx):
 
 
 def merge_jans_cli_ctx(manager, ctx):
+    # WARNING:
+    # - deprecated configs and secrets for role_based
+    # - move the configs and secrets creation to configurator
+    # - remove them on future release
+
     # jans-cli client
     ctx["role_based_client_id"] = manager.config.get("role_based_client_id")
     if not ctx["role_based_client_id"]:


### PR DESCRIPTION
### Description

Overview:

- added missing config and secrets of clients in `configurator` (previously they are created in `persistence-loader` instead)
- added notes about deprecated clients config and secrets

#### Target issue

#1133 

#### Implementation Details

The changeset guarantees client ID and secrets are created upfront in `configurator` so they can be exported into `config.json` and `secret.json`. Note this only work in fresh installation.

For installation upgrade, make sure to run `janssenproject/configurator dump` to pull latest config and secrets into `config.json` and `secret.json`. Afterwards, proceed to upgrading images
