### PR TITLE
fix: typos in jans cli doc

### DIFF
--- a/docs/user/using-jans-cli/cli-ldap-configuration.md
+++ b/docs/user/using-jans-cli/cli-ldap-configuration.md
@@ -157,7 +157,7 @@ Server Response:
 ```
 
 
-Please note that `configId` should be an unique identifier name for each configuration. Otherwise you will get error while going to post duplicate configuration into the server. In that case, you can go through the next option to replace instead of adding a new one.
+Please note that `configId` should be a unique identifier name for each configuration. Otherwise you will get error while going to post duplicate configuration into the server. In that case, you can go through the next option to replace instead of adding a new one.
 
 
 ## Updating LDAP Database Configurations

--- a/docs/user/using-jans-cli/im/im-openid-connect-clients.md
+++ b/docs/user/using-jans-cli/im/im-openid-connect-clients.md
@@ -374,7 +374,7 @@ Selection:
 
 ## Create a New OpenID Client
 
-To create a new OpenID client, you need two enter '2' from OpenID Menu.
+To create a new OpenID client, you need to enter '2' from OpenID Menu.
 It will ask to enter below information:
 
 - frontChannelLogoutSessionRequired[false, true]
@@ -727,9 +727,9 @@ Selection:
 
 ## Get OpenID client by its inum
 
-`inum` is an unique identity of an OpenID client. You can use `inum` of an OpenID client to get details informaton.
+`inum` is a unique identity of an OpenID client. You can use `inum` of an OpenID client to get more details.
 
-In my case i'm using the `inum` of the above created OpenID client:
+In my case, I'm using the `inum` of the above created OpenID client:
 
 ```
 Get OpenId Connect Client by Inum

--- a/docs/user/using-jans-cli/im/im-user.md
+++ b/docs/user/using-jans-cli/im/im-user.md
@@ -538,7 +538,7 @@ Selection:
 
 This is an alternative option to update user resources. To use this option, you need to consider the following things: 
 
-    - **id**: an unique id of user resources
+    - **id**: a unique id of user resources
     - **op**: one operation to be done from [add, remove, replace] 
     - **path**: an attribute path where this operation to be done.
     - **value**: any string type value to `add` or `replace`.


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
This PR should fix some grammar and typos in [jans cli doc](https://github.com/JanssenProject/jans/blob/main/docs/user/using-jans-cli/im/im-openid-connect-clients.md#create-a-new-openid-client).

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

