### PR TITLE
fix: scim user management endpoint failing due to conflict with user …

### DIFF
--- a/jans-cli/cli/jca.yaml
+++ b/jans-cli/cli/jca.yaml
@@ -2585,7 +2585,8 @@ paths:
       security:
         - oauth2: [https://jans.io/oauth/config/user.write]
 
-  /jans-config-api/scim/user:
+
+  /jans-config-api/scim/resource/user:
     get:
       tags:
         - SCIM - User Management
@@ -2735,7 +2736,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /jans-config-api/scim/user/{id}:
+  /jans-config-api/scim/resource/user/{id}:
     get:
       tags:
         - SCIM - User Management
@@ -2986,7 +2987,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /jans-config-api/scim/user/.search:
+  /jans-config-api/scim/resource/user/.search:
     post:
       tags:
         - SCIM - User Management

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -2555,7 +2555,7 @@ paths:
         - oauth2: [https://jans.io/oauth/config/user.delete]
 
 
-  /jans-config-api/scim/user:
+  /jans-config-api/scim/resource/user:
     get:
       tags:
         - SCIM - User Management
@@ -2705,7 +2705,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /jans-config-api/scim/user/{id}:
+  /jans-config-api/scim/resource/user/{id}:
     get:
       tags:
         - SCIM - User Management
@@ -2956,7 +2956,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /jans-config-api/scim/user/.search:
+  /jans-config-api/scim/resource/user/.search:
     post:
       tags:
         - SCIM - User Management

--- a/jans-config-api/plugins/scim-plugin/src/main/java/io/jans/configapi/plugin/scim/rest/ScimResource.java
+++ b/jans-config-api/plugins/scim-plugin/src/main/java/io/jans/configapi/plugin/scim/rest/ScimResource.java
@@ -23,7 +23,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/user")
+@Path("/resource/user")
 public class ScimResource {
 
     public static final String SEARCH_SUFFIX = ".search";

--- a/jans-config-api/plugins/scim-plugin/src/test/resources/karate-config-jenkins.js
+++ b/jans-config-api/plugins/scim-plugin/src/test/resources/karate-config-jenkins.js
@@ -44,7 +44,7 @@ function() {
         accessToken: '123',
        
         //scim
-        scim_user_url: baseUrl + '/jans-config-api/scim/user',
+        scim_user_url: baseUrl + '/jans-config-api/scim/resource/user',
 		scim_config_url: baseUrl + '/jans-config-api/scim/config',
     };
 

--- a/jans-config-api/plugins/scim-plugin/src/test/resources/karate-config.js
+++ b/jans-config-api/plugins/scim-plugin/src/test/resources/karate-config.js
@@ -45,7 +45,7 @@ function() {
         
         
         //scim
-        scim_user_url: baseUrl + '/jans-config-api/scim/user',
+        scim_user_url: baseUrl + '/jans-config-api/scim/resource/user',
 		scim_config_url: baseUrl + '/jans-config-api/scim/config',
     };
 

--- a/jans-config-api/server/src/main/resources/config-api-rs-protect.json
+++ b/jans-config-api/server/src/main/resources/config-api-rs-protect.json
@@ -592,7 +592,7 @@
         ]
     },
     {
-        "path":"/jans-config-api/scim/user",
+        "path":"/jans-config-api/scim/resource/user",
         "conditions":[
             {
                 "httpMethods":["GET"],
@@ -612,7 +612,7 @@
         ]
     },
     {
-        "path":"/jans-config-api/scim/user/{id}",
+        "path":"/jans-config-api/scim/resource/user/{id}",
         "conditions":[
             {
                 "httpMethods":["GET"],
@@ -646,7 +646,7 @@
         ]
     },
     {
-        "path":"/jans-config-api/scim/user/.search",
+        "path":"/jans-config-api/scim/resource/user/.search",
         "conditions":[
             {
                 "httpMethods":["GET"],

--- a/jans-orm/model/src/main/java/io/jans/orm/model/base/CustomObjectAttribute.java
+++ b/jans-orm/model/src/main/java/io/jans/orm/model/base/CustomObjectAttribute.java
@@ -92,9 +92,12 @@ public class CustomObjectAttribute implements Serializable, Comparable<CustomObj
             return values.get(0).toString();
         }
 
-        StringBuilder sb = new StringBuilder(values.get(0).toString());
-        for (int i = 1; i < values.size(); i++) {
-            sb.append(", ").append(values.get(i).toString());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(values.get(i).toString());           
         }
 
         return sb.toString();


### PR DESCRIPTION
Fix for two issues in jenkins build for jans-config-api
### 1) jans-config-api-server : 
**Error:** CAUSED BY:</th><td>org.jboss.resteasy.spi.UnhandledException: com.fasterxml.jackson.databind.JsonMappingException: Index 0 out of bounds for length 0 (through reference chain: java.util.ArrayList[0]-&gt;io.jans.as.common.model.common.User[""customAttributes""]-&gt;java.util.ArrayList[4]-&gt;io.jans.orm.model.base.CustomObjectAttribute[""displayValue""
**Issue:** io.jans.orm.model.base.CustomObjectAttribute.java:getDisplayValue() - accessing list element without checking the size
**Fix:** io.jans.orm.model.base.CustomObjectAttribute.java:getDisplayValue() - added checked access for list element 

### 2) scim-plugin
**Error:** src.test.resources.feature.scim.user.scim-user: scim-user.feature:33 - javascript evaluation failed: mainUrl + '/' +response.Resources[0].id, TypeError: Cannot read property ""0"" from undefined in <eval> at line number 1
scim-user.feature:68 - status code was: 400, expected: 200, response time: 121, url: https://jenkins-build.jans.io/jans-config-api/scim/user/null, response: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `java.util.LinkedHashMap` (although at least one Creator exists): no String-argument constructor&#x2F;factory method to deserialize from String value (&#x27;2022-04-07T09:54:13&#x27;)
**Issue:** Conflict of endpoint path with newly added user managment service path
**Fix:** Renamed scim service path






























































