### PR TITLE
feat: pre-populate role scope mapping dynamically

### DIFF
--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -15,14 +15,14 @@ RUN apk update \
 # ======
 
 COPY requirements.txt /app/requirements.txt
-RUN pip3 install -U pip wheel \
+RUN pip3 install --no-cache-dir -U pip wheel \
     && pip3 install --no-cache-dir --default-timeout=300 -r /app/requirements.txt
 
 # =====================
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_LINUX_SETUP_VERSION=cfdc70e6a2ddcc9d2ba4e3cf07df19344d613944
+ENV JANS_LINUX_SETUP_VERSION=b3059060bfa78d12a017b20e35c89f339971e190
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)
@@ -46,7 +46,6 @@ RUN cd /tmp/jans \
     && cp ${JANS_SETUP_DIR}/schema/custom_schema.json /app/schema/custom_schema.json \
     && cp ${JANS_SETUP_DIR}/static/opendj/index.json /app/static/opendj/index.json
 
-
 RUN mkdir -p /app/templates/jans-config-api
 
 # partially sync templates from linux-setup
@@ -61,6 +60,9 @@ RUN cd /tmp/jans \
     && cp -R ${JANS_SETUP_DIR}/templates/jans-scim /app/templates/jans-scim \
     && cp ${JANS_SETUP_DIR}/templates/jans-config-api/config.ldif /app/templates/jans-config-api/config.ldif \
     && cp -R ${JANS_SETUP_DIR}/templates/jans-cli /app/templates/jans-cli
+
+# Download jans-config-api-swagger for role_scope_mapping
+RUN wget -q https://github.com/JanssenProject/jans/raw/${JANS_LINUX_SETUP_VERSION}/jans-config-api/docs/jans-config-api-swagger.yaml -P /app/static
 
 # TODO: casa should be moved from this image
 ENV GLUU_CASA_VERSION=a8251496ff2ade9dd8101873b45f4c490ae9c64e

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -22,7 +22,7 @@ RUN pip3 install --no-cache-dir -U pip wheel \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_LINUX_SETUP_VERSION=b3059060bfa78d12a017b20e35c89f339971e190
+ENV JANS_LINUX_SETUP_VERSION=f241cdfd569daf054c844978ee868f1879442dbf
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-persistence-loader/requirements.txt
+++ b/docker-jans-persistence-loader/requirements.txt
@@ -2,4 +2,5 @@
 grpcio==1.41.0
 ldif==4.1.1
 libcst<0.4
+ruamel.yaml==0.16.10
 git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-persistence-loader/scripts/utils.py
+++ b/docker-jans-persistence-loader/scripts/utils.py
@@ -2,10 +2,12 @@ import contextlib
 import base64
 import json
 import os
+from itertools import chain
 from pathlib import Path
 from urllib.parse import urlparse
 from uuid import uuid4
 
+import ruamel.yaml
 from ldap3.utils import dn as dnutils
 
 from jans.pycloudlib.utils import as_boolean
@@ -231,6 +233,9 @@ def merge_auth_ctx(ctx):
         file_path = os.path.join(basedir, file_)
         with open(file_path) as fp:
             ctx[key] = generate_base64_contents(fp.read() % ctx)
+
+    # determine role scope mappings
+    ctx["role_scope_mappings"] = json.dumps(role_scope_mappings())
     return ctx
 
 
@@ -486,3 +491,39 @@ def id_from_dn(dn):
 
     # the actual key
     return '_'.join(dns) or "_"
+
+
+def get_config_api_swagger(path="/app/static/jans-config-api-swagger.yaml"):
+    with open(path) as f:
+        txt = f.read()
+    txt = txt.replace("\t", " ")
+    return ruamel.yaml.load(txt, Loader=ruamel.yaml.RoundTripLoader)
+
+
+def get_config_api_scopes():
+    swagger = get_config_api_swagger()
+    scope_list = []
+
+    for _, methods in swagger["paths"].items():
+        for _, attrs in methods.items():
+            if "security" not in attrs:
+                continue
+            scope_list += [attr["oauth2"] for attr in attrs["security"]]
+    return list(chain(*scope_list))
+
+
+def role_scope_mappings(path="/app/templates/jans-auth/role-scope-mappings.json"):
+    with open(path) as f:
+        role_mapping = json.loads(f.read())
+
+    scope_list = get_config_api_scopes()
+
+    # safely mutating list while iterating it
+    for i, api_role in enumerate(role_mapping["rolePermissionMapping"]):
+        if api_role["role"] != "api-admin":
+            continue
+
+        for scope in scope_list:
+            if scope not in api_role["permissions"]:
+                role_mapping["rolePermissionMapping"][i]["permissions"].append(scope)
+    return role_mapping

--- a/docker-jans-persistence-loader/templates/jans-config-api/dynamic-conf.json
+++ b/docker-jans-persistence-loader/templates/jans-config-api/dynamic-conf.json
@@ -33,5 +33,15 @@
       "corsRequestDecorate": true,
       "corsEnabled": true
     }
+  ],
+  "userExclusionAttributes": [
+    "userPassword"
+  ],
+  "userMandatoryAttributes": [
+    "mail",
+    "displayName",
+    "jansStatus",
+    "userPassword",
+    "givenName"
   ]
 }


### PR DESCRIPTION
### Description

The changeset synchronize templates + static from upstream while preserving functionality as seen in https://github.com/JanssenProject/jans/pull/1183

#### Implementation Details

Role scope mapping (i.e. `api-admin`) is now pre-populated from `jans-config-api-swagger.yaml` and `role-scope-mappings.json`.
On upgrading, the mapping will be compared between current and pre-populated mapping.