### PR TITLE
docs: update docs for CLI device authn

### DIFF
--- a/docs/user/how-to/authn-with-apache-reverse-proxy.md
+++ b/docs/user/how-to/authn-with-apache-reverse-proxy.md
@@ -38,17 +38,20 @@ https://janssen.op.io/.well-known/openid-configuration
 
 #### Configure Janssen server
 
-Janssen server provides `jans-cli` CLI tool to configure Janssen server. `jans-cli` has menu-driven interface that makes it easy to configure Janssen server.
+Janssen server provides `jans-cli` CLI tool to configure Janssen server. `jans-cli` has menu-driven interface that makes it easy to configure Janssen server. Here we will use menu-driven approach as well as command-line operations to configure Janssen server. To further understand how to use menu-driven approach and get complete list of supported command-line operations, refer to [jans-cli documentation](../using-jans-cli#command-line-interface).
 
 Use steps below to configure Janssen server.
 
 - Manually register client(RP) as OpenID Connect client
   - Run command below on host running Janssen Server
+  
     ```
     /opt/jans/jans-cli/config-cli.py`
     ```
+   
   - Navigate through options to start registering new OpenID Connect client
   - Provide inputs for following properties:
+  
     ```
     displayName: <name-of-choice>
     applicationType: web
@@ -62,11 +65,16 @@ Use steps below to configure Janssen server.
     responseTypes: code
     grantTypes: authorization_code
     ```
+    
    - Copy the resulting JSON data and save it to a file, say `register-apache-rp.json`.
-   - Register client usign following command
-   ```
-   /opt/jans/jans-cli/config-cli.py --operation-id post-oauth-openid-clients --data <path>/register-apache-rp.json
-   ```
+   - Use `jans-cli` operations to register the client using the command below
+   
+     > Note: </br> In order to run operations, the `jans-cli` has to be authenticated and authorized with respective Janssen server. If `jans-cli` operation is being executed for the first time or if there is no valid access token available, then running the command below will initiate authentication and authorization flow. In that case, follow the steps for [jans-cli authorization](../using-jans-cli/cli-tips.md#cli-authorization) to continue running the command.
+   
+     ```
+     /opt/jans/jans-cli/config-cli.py --operation-id post-oauth-openid-clients --data <path>/register-apache-rp.json
+     ```
+     
    - Output of this command would be a JSON response. Save this response to a file as some of the values in it will be required when configuring *mod-auth-openidc*.
  
 

--- a/docs/user/using-jans-cli/cli-tips.md
+++ b/docs/user/using-jans-cli/cli-tips.md
@@ -88,7 +88,7 @@ In this command line:
 - `memcachedConfiguration/bufferSize:32788` is a `key:value` pair
 
 ## CLI Authorization
-To run operations on Janssen Server, CLI client has to be authenticated and authorized by the server. Since CLI has limited input capabilities, it uses [Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628) flow to get required permissions in form of an access token. After successfully receiving the token, CLI can run operations on the Janssen server while the token is valid. The steps below will summarize this action.
+To run operations on Janssen Server, CLI client will need to be authenticated and authorized by the server. Since CLI has limited input capabilities, it uses [Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628) flow to get required permissions in form of an access token. After successfully receiving the token, CLI can run operations on the Janssen server while the token is valid. The steps below will summarize this process.
 
 1. Execution of CLI command will return the following message if a valid token is not found. 
    ```

--- a/docs/user/using-jans-cli/cli-tips.md
+++ b/docs/user/using-jans-cli/cli-tips.md
@@ -87,3 +87,17 @@ In this command line:
 - `patch-replace` type of operation; used to replace values in
 - `memcachedConfiguration/bufferSize:32788` is a `key:value` pair
 
+## CLI Authorization
+To run operations on Janssen Server, CLI client has to be authenticated and authorized by the server. Since CLI has limited input capabilities, it uses [Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628) flow to get required permissions in form of an access token. After successfully receiving the token, CLI can run operations on the Janssen server while the token is valid. The steps below will summarize this action.
+
+1. Execution of CLI command will return the following message if a valid token is not found. 
+   ```
+   Access token was not found.
+   Please visit verification url <Janssen-server-device-code-url> and enter user code CGFZ-RTZR in 1800 seconds
+   Please press <<Enter>> when ready
+   ```
+2. Take `<Janssen-server-device-code-url>` from the message above and use any browser to access it from a different device
+3. User will be presented with a page where the user has to authenticate using id and password
+4. After successful user authentication, the next screen allows the user to enter the user code. Use the user code presented on command-line instruction in step 1 above.
+5. After successful code validation, the user is presented with OAuth permissions screen. This screen would list all the permissions requested by Jans CLI. The user can choose to `Allow` or `Not Allow` granting of these permissions.
+6. After allowing the grant of requested permissions, the user should come back to the command-line interface and hit <<Enter>> as instructed. This will enable CLI to run operations on the corresponding Janssen server.


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
Documentation did not cover CLI device authentication step. Adding this details to CLI documentation and other related docs.
