### PR TITLE
fix: errors adding/upgrading data into couchbase persistence

### DIFF
--- a/docker-jans-persistence-loader/scripts/couchbase_setup.py
+++ b/docker-jans-persistence-loader/scripts/couchbase_setup.py
@@ -419,9 +419,9 @@ def get_bucket_for_key(key):
         bucket = f"{bucket_prefix}_user"
     elif key_prefix in ("site_", "cache-refresh_"):
         bucket = f"{bucket_prefix}_site"
-    elif key_prefix in ("tokens_"):
+    elif key_prefix in ("tokens_",):
         bucket = f"{bucket_prefix}_token"
-    elif key_prefix in ("cache_"):
+    elif key_prefix in ("cache_",):
         bucket = f"{bucket_prefix}_cache"
     else:
         bucket = bucket_prefix

--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -676,7 +676,10 @@ class Upgrade:
                 break
 
         # current permissions
-        current_role_mapping = json.loads(entry.attrs["jansConfDyn"])
+        try:
+            current_role_mapping = json.loads(entry.attrs["jansConfDyn"])
+        except TypeError:
+            current_role_mapping = entry.attrs["jansConfDyn"]
         should_update = False
 
         for i, api_role in enumerate(current_role_mapping["rolePermissionMapping"]):


### PR DESCRIPTION
### Description

The changeset fixes 2 errors found while using Couchbase persistence:

1. Some entries are placed into incorrect bucket
2. Loading role mapping from persistence throws `TypeError`

#### Implementation Details

1. Trailing comma must be added into the tuple (i.e. `("tokens_",)` instead of `("tokens_")`) to ensure key prefix is checked against a tuple (not a list of characters)
2. Load role mapping from persistence using `json.loads` if it's a JSON string, otherwise use the role mapping directly