### PR TITLE
chore: sync jans-auth dynamic config

### DIFF
--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.4
+FROM alpine:3.15.4
 
 # ===============
 # Alpine packages
@@ -6,9 +6,8 @@ FROM alpine:3.14.4
 
 RUN apk update \
     && apk upgrade \
-    && apk add --no-cache py3-pip curl tini py3-cryptography py3-psycopg2 \
-    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.15/community py3-grpcio \
-    && apk add --no-cache --virtual build-deps git wget
+    && apk add --no-cache py3-pip curl tini py3-cryptography py3-psycopg2 py3-grpcio \
+    && apk add --no-cache --virtual .build-deps git wget
 
 # ======
 # Python
@@ -22,7 +21,7 @@ RUN pip3 install --no-cache-dir -U pip wheel \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_LINUX_SETUP_VERSION=f241cdfd569daf054c844978ee868f1879442dbf
+ENV JANS_LINUX_SETUP_VERSION=fc9544c861f30eb7370f635b07d9810ae33a7dba
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)
@@ -75,7 +74,7 @@ RUN rm -rf /tmp/jans
 # Cleanup
 # =======
 
-RUN apk del build-deps \
+RUN apk del .build-deps \
     && rm -rf /var/cache/apk/*
 
 # =======

--- a/docker-jans-persistence-loader/scripts/utils.py
+++ b/docker-jans-persistence-loader/scripts/utils.py
@@ -1,5 +1,5 @@
-import contextlib
 import base64
+import contextlib
 import json
 import os
 from itertools import chain
@@ -217,6 +217,11 @@ def merge_extension_ctx(ctx):
 
 
 def merge_auth_ctx(ctx):
+    if os.environ.get("CN_PERSISTENCE_TYPE") in ("sql", "spanner"):
+        ctx["person_custom_object_class_list"] = "[]"
+    else:
+        ctx["person_custom_object_class_list"] = '["jansCustomPerson", "jansPerson"]'
+
     basedir = '/app/templates/jans-auth'
     file_mappings = {
         'auth_static_conf_base64': 'jans-auth-static-conf.json',

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
@@ -286,10 +286,7 @@
     "skipAuthorizationForOpenIdScopeAndPairwiseId": false,
     "dynamicRegistrationScopesParamEnabled":true,
     "dynamicRegistrationCustomObjectClass":"",
-    "personCustomObjectClassList":[
-        "jansCustomPerson",
-        "jansPerson"
-    ],
+    "personCustomObjectClassList": %(person_custom_object_class_list)s,
     "persistIdTokenInLdap":false,
     "persistRefreshTokenInLdap":true,
     "authenticationFiltersEnabled":false,

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
@@ -116,6 +116,7 @@
     ],
     "idTokenEncryptionEncValuesSupported":[
     ],
+    "forceSignedRequestObject": false,
     "requestObjectSigningAlgValuesSupported":[
         "HS256",
         "RS256",
@@ -360,6 +361,6 @@
     "deviceAuthzResponseTypeToProcessAuthz": "code",
     "staticKid": "%(staticKid)s",
     "forceOfflineAccessScopeToEnableRefreshToken" : false,
-    "redirectUrisRegexEnabled": true,
+    "redirectUrisRegexEnabled": false,
     "useHighestLevelScriptIfAcrScriptNotFound": true
 }


### PR DESCRIPTION
### Description

The changeset updates `jans-auth` dynamic config in persistence

#### Implementation Details

1. Templates/static/schemas are re-synchronized from `jans-linux-setup`
2. Upgrade script handles the automatic updates for existing entry