### PR TITLE
docs: add documentation guideline link

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -5,3 +5,4 @@ Documents that help developers in writing code for Janssen server.
 - Code Guidelines
 - Code styles
 - Workspace setup guides
+- [Documentation Guidelines](documentation-guidelines.md)

--- a/docs/developer/documentation-guidelines.md
+++ b/docs/developer/documentation-guidelines.md
@@ -1,0 +1,15 @@
+# Documentation Guidelines
+
+## Table of Content
+- [Document Layout](#document-layout)
+- [Component Naming](#component-naming)
+- [Color Scheme for Images and Diagrams](#color-scheme-for-images-and-diagrams)
+- [General Guidelines](#general-guidelines)
+
+## Document Layout
+
+## Component Naming
+
+## Color Scheme for Images and Diagrams
+
+## General Guidelines


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
Need documentation guidelines to maintain uniformity of fonts, styles, layouts, images, coloring themes etc across Janssen documentation

#### Implementation Details
Need guidelines around
- [ ] Markdown document structure (how deep should the title hierarchy go?)
- [ ] How to represent component names ( Should it be `jans-cli` or **jans-cli** or _jans-cli_ ?)
- [ ] color scheme to be used in diagrams and images
- [ ] General guidelines
 

