### PR TITLE
feat: add helper to create persistence entry from LDIF file

### DIFF
--- a/docker-jans-auth-server/requirements.txt
+++ b/docker-jans-auth-server/requirements.txt
@@ -1,6 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-# @TODO: remove ldif package after jans-pycloudlib updated
-ldif==4.1.1
 git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-auth-server/requirements.txt
+++ b/docker-jans-auth-server/requirements.txt
@@ -1,4 +1,6 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
+# @TODO: remove ldif package after jans-pycloudlib updated
+ldif==4.1.1
 git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-auth-server/requirements.txt
+++ b/docker-jans-auth-server/requirements.txt
@@ -3,4 +3,4 @@ grpcio==1.41.0
 libcst<0.4
 # @TODO: remove ldif package after jans-pycloudlib updated
 ldif==4.1.1
-git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-auth-server/scripts/keystore_mod.py
+++ b/docker-jans-auth-server/scripts/keystore_mod.py
@@ -2,10 +2,8 @@ import json
 import os
 
 from jans.pycloudlib.persistence.couchbase import CouchbaseClient
-from jans.pycloudlib.persistence.couchbase import get_couchbase_user
-from jans.pycloudlib.persistence.couchbase import get_couchbase_password
 from jans.pycloudlib.persistence.ldap import LdapClient
-from jans.pycloudlib.persistence.sql import SQLClient
+from jans.pycloudlib.persistence.sql import SqlClient
 from jans.pycloudlib.persistence.spanner import SpannerClient
 
 
@@ -50,10 +48,7 @@ class LdapPersistence(BasePersistence):
 
 class CouchbasePersistence(BasePersistence):
     def __init__(self, manager):
-        host = os.environ.get("CN_COUCHBASE_URL", "localhost")
-        user = get_couchbase_user(manager)
-        password = get_couchbase_password(manager)
-        self.client = CouchbaseClient(host, user, password)
+        self.client = CouchbaseClient(manager)
 
     def get_auth_config(self):
         bucket = os.environ.get("CN_COUCHBASE_BUCKET_PREFIX", "jans")
@@ -90,7 +85,7 @@ class CouchbasePersistence(BasePersistence):
 
 class SqlPersistence(BasePersistence):
     def __init__(self, manager):
-        self.client = SQLClient()
+        self.client = SqlClient(manager)
 
     def get_auth_config(self):
         config = self.client.get(
@@ -115,7 +110,7 @@ class SqlPersistence(BasePersistence):
 
 class SpannerPersistence(SqlPersistence):
     def __init__(self, manager):
-        self.client = SpannerClient()
+        self.client = SpannerClient(manager)
 
 
 _backend_classes = {

--- a/docker-jans-certmanager/requirements.txt
+++ b/docker-jans-certmanager/requirements.txt
@@ -2,4 +2,6 @@
 grpcio==1.41.0
 click==6.7
 libcst<0.4
+# @TODO: remove ldif package after jans-pycloudlib updated
+ldif==4.1.1
 git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-certmanager/requirements.txt
+++ b/docker-jans-certmanager/requirements.txt
@@ -2,6 +2,4 @@
 grpcio==1.41.0
 click==6.7
 libcst<0.4
-# @TODO: remove ldif package after jans-pycloudlib updated
-ldif==4.1.1
 git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-certmanager/requirements.txt
+++ b/docker-jans-certmanager/requirements.txt
@@ -4,4 +4,4 @@ click==6.7
 libcst<0.4
 # @TODO: remove ldif package after jans-pycloudlib updated
 ldif==4.1.1
-git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -7,10 +7,8 @@ from collections import Counter
 from collections import deque
 
 from jans.pycloudlib.persistence.couchbase import CouchbaseClient
-from jans.pycloudlib.persistence.couchbase import get_couchbase_user
-from jans.pycloudlib.persistence.couchbase import get_couchbase_password
 from jans.pycloudlib.persistence.ldap import LdapClient
-from jans.pycloudlib.persistence.sql import SQLClient
+from jans.pycloudlib.persistence.sql import SqlClient
 from jans.pycloudlib.persistence.spanner import SpannerClient
 from jans.pycloudlib.utils import encode_text
 from jans.pycloudlib.utils import exec_cmd
@@ -110,10 +108,7 @@ class LdapPersistence(BasePersistence):
 
 class CouchbasePersistence(BasePersistence):
     def __init__(self, manager):
-        host = os.environ.get("CN_COUCHBASE_URL", "localhost")
-        user = get_couchbase_user(manager)
-        password = get_couchbase_password(manager)
-        self.client = CouchbaseClient(host, user, password)
+        self.client = CouchbaseClient(manager)
 
     def get_auth_config(self):
         bucket = os.environ.get("CN_COUCHBASE_BUCKET_PREFIX", "jans")
@@ -152,7 +147,7 @@ class CouchbasePersistence(BasePersistence):
 
 class SqlPersistence(BasePersistence):
     def __init__(self, manager):
-        self.client = SQLClient()
+        self.client = SqlClient(manager)
 
     def get_auth_config(self):
         config = self.client.get(
@@ -177,7 +172,7 @@ class SqlPersistence(BasePersistence):
 
 class SpannerPersistence(SqlPersistence):
     def __init__(self, manager):
-        self.client = SpannerClient()
+        self.client = SpannerClient(manager)
 
 
 _backend_classes = {

--- a/docker-jans-client-api/requirements.txt
+++ b/docker-jans-client-api/requirements.txt
@@ -4,4 +4,4 @@ ruamel.yaml==0.16.10
 libcst<0.4
 # @TODO: remove ldif package after jans-pycloudlib updated
 ldif==4.1.1
-git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-client-api/requirements.txt
+++ b/docker-jans-client-api/requirements.txt
@@ -2,4 +2,6 @@
 grpcio==1.41.0
 ruamel.yaml==0.16.10
 libcst<0.4
+# @TODO: remove ldif package after jans-pycloudlib updated
+ldif==4.1.1
 git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-client-api/requirements.txt
+++ b/docker-jans-client-api/requirements.txt
@@ -2,6 +2,4 @@
 grpcio==1.41.0
 ruamel.yaml==0.16.10
 libcst<0.4
-# @TODO: remove ldif package after jans-pycloudlib updated
-ldif==4.1.1
 git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-config-api/requirements.txt
+++ b/docker-jans-config-api/requirements.txt
@@ -1,6 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-# @TODO: remove ldif package after jans-pycloudlib updated
-ldif==4.1.1
 git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-config-api/requirements.txt
+++ b/docker-jans-config-api/requirements.txt
@@ -1,4 +1,6 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
+# @TODO: remove ldif package after jans-pycloudlib updated
+ldif==4.1.1
 git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-config-api/requirements.txt
+++ b/docker-jans-config-api/requirements.txt
@@ -3,4 +3,4 @@ grpcio==1.41.0
 libcst<0.4
 # @TODO: remove ldif package after jans-pycloudlib updated
 ldif==4.1.1
-git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-config-api/scripts/utils.py
+++ b/docker-jans-config-api/scripts/utils.py
@@ -3,10 +3,8 @@ import os
 from urllib.parse import urlparse
 
 from jans.pycloudlib import get_manager
-from jans.pycloudlib.persistence.couchbase import get_couchbase_user
-from jans.pycloudlib.persistence.couchbase import get_couchbase_password
 from jans.pycloudlib.persistence.couchbase import CouchbaseClient
-from jans.pycloudlib.persistence.sql import SQLClient
+from jans.pycloudlib.persistence.sql import SqlClient
 from jans.pycloudlib.persistence.ldap import LdapClient
 from jans.pycloudlib.persistence.spanner import SpannerClient
 
@@ -27,10 +25,7 @@ class LdapPersistence:
 
 class CouchbasePersistence:
     def __init__(self, manager):
-        host = os.environ.get("CN_COUCHBASE_URL", "localhost")
-        user = get_couchbase_user(manager)
-        password = get_couchbase_password(manager)
-        self.client = CouchbaseClient(host, user, password)
+        self.client = CouchbaseClient(manager)
 
     def get_auth_config(self):
         bucket = os.environ.get("CN_COUCHBASE_BUCKET_PREFIX", "jans")
@@ -48,7 +43,7 @@ class CouchbasePersistence:
 
 class SqlPersistence:
     def __init__(self, manager):
-        self.client = SQLClient()
+        self.client = SqlClient(manager)
 
     def get_auth_config(self):
         config = self.client.get(
@@ -61,7 +56,7 @@ class SqlPersistence:
 
 class SpannerPersistence(SqlPersistence):
     def __init__(self, manager):
-        self.client = SpannerClient()
+        self.client = SpannerClient(manager)
 
 
 def transform_url(url):

--- a/docker-jans-configurator/requirements.txt
+++ b/docker-jans-configurator/requirements.txt
@@ -4,6 +4,4 @@ click==6.7
 marshmallow==3.10.0
 fqdn==1.4.0
 libcst<0.4
-# @TODO: remove ldif package after jans-pycloudlib updated
-ldif==4.1.1
 git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-configurator/requirements.txt
+++ b/docker-jans-configurator/requirements.txt
@@ -6,4 +6,4 @@ fqdn==1.4.0
 libcst<0.4
 # @TODO: remove ldif package after jans-pycloudlib updated
 ldif==4.1.1
-git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-configurator/requirements.txt
+++ b/docker-jans-configurator/requirements.txt
@@ -4,4 +4,6 @@ click==6.7
 marshmallow==3.10.0
 fqdn==1.4.0
 libcst<0.4
+# @TODO: remove ldif package after jans-pycloudlib updated
+ldif==4.1.1
 git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-fido2/requirements.txt
+++ b/docker-jans-fido2/requirements.txt
@@ -1,6 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-# @TODO: remove ldif package after jans-pycloudlib updated
-ldif==4.1.1
 git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-fido2/requirements.txt
+++ b/docker-jans-fido2/requirements.txt
@@ -1,4 +1,6 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
+# @TODO: remove ldif package after jans-pycloudlib updated
+ldif==4.1.1
 git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-fido2/requirements.txt
+++ b/docker-jans-fido2/requirements.txt
@@ -3,4 +3,4 @@ grpcio==1.41.0
 libcst<0.4
 # @TODO: remove ldif package after jans-pycloudlib updated
 ldif==4.1.1
-git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-persistence-loader/requirements.txt
+++ b/docker-jans-persistence-loader/requirements.txt
@@ -1,7 +1,5 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
-# @TODO: remove ldif package after jans-pycloudlib updated
-ldif==4.1.1
 libcst<0.4
 ruamel.yaml==0.16.10
 git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-persistence-loader/requirements.txt
+++ b/docker-jans-persistence-loader/requirements.txt
@@ -4,4 +4,4 @@ grpcio==1.41.0
 ldif==4.1.1
 libcst<0.4
 ruamel.yaml==0.16.10
-git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-persistence-loader/requirements.txt
+++ b/docker-jans-persistence-loader/requirements.txt
@@ -1,5 +1,6 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
+# @TODO: remove ldif package after jans-pycloudlib updated
 ldif==4.1.1
 libcst<0.4
 ruamel.yaml==0.16.10

--- a/docker-jans-persistence-loader/scripts/couchbase_setup.py
+++ b/docker-jans-persistence-loader/scripts/couchbase_setup.py
@@ -1,24 +1,14 @@
-import contextlib
-import datetime
 import json
 import logging.config
 import os
 import time
 from pathlib import Path
 
-from ldif import LDIFParser
-
-from jans.pycloudlib.persistence.couchbase import get_couchbase_user
-from jans.pycloudlib.persistence.couchbase import get_couchbase_superuser
-from jans.pycloudlib.persistence.couchbase import get_couchbase_password
-from jans.pycloudlib.persistence.couchbase import get_couchbase_superuser_password
 from jans.pycloudlib.persistence.couchbase import CouchbaseClient
 
 from settings import LOGGING_CONFIG
 from utils import prepare_template_ctx
-from utils import render_ldif
 from utils import get_ldif_mappings
-from utils import id_from_dn
 
 logging.config.dictConfig(LOGGING_CONFIG)
 logger = logging.getLogger("entrypoint")
@@ -75,138 +65,11 @@ def get_bucket_mappings(manager):
     return bucket_mappings
 
 
-class AttrProcessor(object):
-    def __init__(self):
-        self._attrs = {}
-
-    @property
-    def syntax_types(self):
-        return {
-            '1.3.6.1.4.1.1466.115.121.1.7': 'boolean',
-            '1.3.6.1.4.1.1466.115.121.1.27': 'integer',
-            '1.3.6.1.4.1.1466.115.121.1.24': 'datetime',
-        }
-
-    def process(self):
-        attrs = {}
-
-        with open("/app/schema/opendj_types.json") as f:
-            attr_maps = json.loads(f.read())
-            for type_, names in attr_maps.items():
-                for name in names:
-                    attrs[name] = {"type": type_, "multivalued": False}
-
-        with open("/app/schema/jans_schema.json") as f:
-            schemas = json.loads(f.read()).get("attributeTypes", {})
-            for schema in schemas:
-                if schema.get("json"):
-                    type_ = "json"
-                elif schema["syntax"] in self.syntax_types:
-                    type_ = self.syntax_types[schema["syntax"]]
-                else:
-                    type_ = "string"
-
-                multivalued = schema.get("multivalued", False)
-                for name in schema["names"]:
-                    attrs[name] = {
-                        "type": type_,
-                        "multivalued": multivalued,
-                    }
-
-        # override `member`
-        attrs["member"]["multivalued"] = True
-        return attrs
-
-    @property
-    def attrs(self):
-        if not self._attrs:
-            self._attrs = self.process()
-        return self._attrs
-
-    def is_multivalued(self, name):
-        return self.attrs.get(name, {}).get("multivalued", False)
-
-    def get_type(self, name):
-        return self.attrs.get(name, {}).get("type", "string")
-
-
-def transform_values(name, values, attr_processor):
-    def as_dict(val):
-        return json.loads(val)
-
-    def as_bool(val):
-        return val.lower() in ("true", "yes", "1", "on")
-
-    def as_int(val):
-        try:
-            val = int(val)
-        except (TypeError, ValueError):
-            pass
-        return val
-
-    def as_datetime(val):
-        if '.' in val:
-            date_format = '%Y%m%d%H%M%S.%fZ'
-        else:
-            date_format = '%Y%m%d%H%M%SZ'
-
-        if not val.lower().endswith('z'):
-            val += 'Z'
-
-        dt = datetime.datetime.strptime(val, date_format)
-        return dt.isoformat()
-
-    callbacks = {
-        "json": as_dict,
-        "boolean": as_bool,
-        "integer": as_int,
-        "datetime": as_datetime,
-    }
-
-    type_ = attr_processor.get_type(name)
-    callback = callbacks.get(type_)
-
-    # maybe string
-    if not callable(callback):
-        return values
-    return [callback(item) for item in values]
-
-
-def transform_entry(entry, attr_processor):
-    for k, v in entry.items():
-        v = transform_values(k, v, attr_processor)
-
-        if len(v) == 1 and attr_processor.is_multivalued(k) is False:
-            entry[k] = v[0]
-
-        if k != "objectClass":
-            continue
-
-        entry[k].remove("top")
-        ocs = entry[k]
-
-        for oc in ocs:
-            remove_oc = any(["Custom" in oc, "jans" not in oc.lower()])
-            if len(ocs) > 1 and remove_oc:
-                ocs.remove(oc)
-        entry[k] = ocs[0]
-    return entry
-
-
 class CouchbaseBackend:
     def __init__(self, manager):
-        hostname = os.environ.get("CN_COUCHBASE_URL", "localhost")
-        user = get_couchbase_superuser(manager) or get_couchbase_user(manager)
-
-        password = ""
-        with contextlib.suppress(FileNotFoundError):
-            password = get_couchbase_superuser_password(manager)
-        password = password or get_couchbase_password(manager)
-
-        self.client = CouchbaseClient(hostname, user, password)
+        self.client = CouchbaseClient(manager)
         self.manager = manager
         self.index_num_replica = 0
-        self.attr_processor = AttrProcessor()
 
     def create_buckets(self, bucket_mappings, bucket_type="couchbase"):
         sys_info = self.client.get_system_info()
@@ -326,7 +189,7 @@ class CouchbaseBackend:
                         error = req.json()["errors"][0]
                         if error["code"] in (4300,):
                             continue
-                        logger.warning("Failed to execute query, reason={}".format(error["msg"]))
+                        logger.warning(f"Failed to execute query, reason={error['msg'].strip()}")  # .format(error["msg"]))
 
     def import_builtin_ldif(self, bucket_mappings, ctx):
         for _, mapping in bucket_mappings.items():
@@ -373,56 +236,5 @@ class CouchbaseBackend:
             self._import_ldif(file_, ctx)
 
     def _import_ldif(self, path, ctx):
-        src = Path(path).resolve()
-
-        # generated template will be saved under ``/app/tmp`` directory
-        # examples:
-        # - ``/app/templates/groups.ldif`` will be saved as ``/app/tmp/templates/groups.ldif``
-        # - ``/app/custom_ldif/groups.ldif`` will be saved as ``/app/tmp/custom_ldif/groups.ldif``
-        dst = Path("/app/tmp").joinpath(str(src).removeprefix("/app/")).resolve()
-
-        # ensure directory for generated template is exist
-        dst.parent.mkdir(parents=True, exist_ok=True)
-
-        logger.info(f"Importing {src} file")
-        render_ldif(src, dst, ctx)
-
-        with open(dst, "rb") as fd:
-            parser = LDIFParser(fd)
-
-            for dn, entry in parser.parse():
-                if len(entry) <= 2:
-                    continue
-
-                key = id_from_dn(dn)
-                bucket = get_bucket_for_key(key)
-                entry["dn"] = [dn]
-                entry = transform_entry(entry, self.attr_processor)
-                data = json.dumps(entry)
-
-                # TODO: get the bucket based on key prefix
-                # using INSERT will cause duplication error, but the data is left intact
-                query = 'INSERT INTO `%s` (KEY, VALUE) VALUES ("%s", %s)' % (bucket, key, data)
-                req = self.client.exec_query(query)
-
-                if not req.ok:
-                    logger.warning("Failed to execute query, reason={}".format(req.json()))
-
-
-def get_bucket_for_key(key):
-    bucket_prefix = os.environ.get("CN_COUCHBASE_BUCKET_PREFIX", "jans")
-
-    cursor = key.find("_")
-    key_prefix = key[:cursor + 1]
-
-    if key_prefix in ("groups_", "people_", "authorizations_"):
-        bucket = f"{bucket_prefix}_user"
-    elif key_prefix in ("site_", "cache-refresh_"):
-        bucket = f"{bucket_prefix}_site"
-    elif key_prefix in ("tokens_",):
-        bucket = f"{bucket_prefix}_token"
-    elif key_prefix in ("cache_",):
-        bucket = f"{bucket_prefix}_cache"
-    else:
-        bucket = bucket_prefix
-    return bucket
+        logger.info(f"Importing {path} file")
+        self.client.create_from_ldif(path, ctx)

--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -7,14 +7,10 @@ from collections import namedtuple
 
 from ldif import LDIFParser
 
-from jans.pycloudlib.persistence.couchbase import get_couchbase_user
-from jans.pycloudlib.persistence.couchbase import get_couchbase_superuser
-from jans.pycloudlib.persistence.couchbase import get_couchbase_password
-from jans.pycloudlib.persistence.couchbase import get_couchbase_superuser_password
 from jans.pycloudlib.persistence.couchbase import CouchbaseClient
 from jans.pycloudlib.persistence.ldap import LdapClient
 from jans.pycloudlib.persistence.spanner import SpannerClient
-from jans.pycloudlib.persistence.sql import SQLClient
+from jans.pycloudlib.persistence.sql import SqlClient
 from jans.pycloudlib.utils import as_boolean
 
 from settings import LOGGING_CONFIG
@@ -233,7 +229,7 @@ class LDAPBackend:
 class SQLBackend:
     def __init__(self, manager):
         self.manager = manager
-        self.client = SQLClient()
+        self.client = SqlClient(manager)
         self.type = "sql"
 
     def get_entry(self, key, filter_="", attrs=None, **kwargs):
@@ -253,15 +249,7 @@ class SQLBackend:
 class CouchbaseBackend:
     def __init__(self, manager):
         self.manager = manager
-        hostname = os.environ.get("CN_COUCHBASE_URL", "localhost")
-        user = get_couchbase_superuser(manager) or get_couchbase_user(manager)
-
-        password = ""
-        with contextlib.suppress(FileNotFoundError):
-            password = get_couchbase_superuser_password(manager)
-        password = password or get_couchbase_password(manager)
-
-        self.client = CouchbaseClient(hostname, user, password)
+        self.client = CouchbaseClient(manager)
         self.type = "couchbase"
 
     def get_entry(self, key, filter_="", attrs=None, **kwargs):
@@ -332,7 +320,7 @@ class CouchbaseBackend:
 class SpannerBackend:
     def __init__(self, manager):
         self.manager = manager
-        self.client = SpannerClient()
+        self.client = SpannerClient(manager)
         self.type = "spanner"
 
     def get_entry(self, key, filter_="", attrs=None, **kwargs):

--- a/docker-jans-scim/requirements.txt
+++ b/docker-jans-scim/requirements.txt
@@ -1,6 +1,4 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
-# @TODO: remove ldif package after jans-pycloudlib updated
-ldif==4.1.1
 git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-scim/requirements.txt
+++ b/docker-jans-scim/requirements.txt
@@ -1,4 +1,6 @@
 # pinned to py3-grpcio version to avoid failure on native extension build
 grpcio==1.41.0
 libcst<0.4
+# @TODO: remove ldif package after jans-pycloudlib updated
+ldif==4.1.1
 git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/docker-jans-scim/requirements.txt
+++ b/docker-jans-scim/requirements.txt
@@ -3,4 +3,4 @@ grpcio==1.41.0
 libcst<0.4
 # @TODO: remove ldif package after jans-pycloudlib updated
 ldif==4.1.1
-git+https://github.com/JanssenProject/jans@abc89dc6fadae5627a68a97ab4f4f5ceb56af809#egg=jans-pycloudlib&subdirectory=jans-pycloudlib
+git+https://github.com/JanssenProject/jans@12cf1be739f320483365e0e50b37b894b5364a6f#egg=jans-pycloudlib&subdirectory=jans-pycloudlib

--- a/jans-pycloudlib/.coveragerc
+++ b/jans-pycloudlib/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 omit =
-    */jans/pycloudlib/persistence/spanner.py
+    */jans/pycloudlib/meta/docker_meta.py

--- a/jans-pycloudlib/jans/pycloudlib/persistence/__init__.py
+++ b/jans-pycloudlib/jans/pycloudlib/persistence/__init__.py
@@ -2,12 +2,17 @@ import os
 
 from jans.pycloudlib.persistence.couchbase import render_couchbase_properties  # noqa: F401
 from jans.pycloudlib.persistence.couchbase import sync_couchbase_truststore  # noqa: F401
-
+from jans.pycloudlib.persistence.couchbase import id_from_dn  # noqa: F401
+from jans.pycloudlib.persistence.couchbase import CouchbaseClient  # noqa: F401
 from jans.pycloudlib.persistence.hybrid import render_hybrid_properties  # noqa: F401
 from jans.pycloudlib.persistence.ldap import render_ldap_properties  # noqa: F401
 from jans.pycloudlib.persistence.ldap import sync_ldap_truststore  # noqa: F401
+from jans.pycloudlib.persistence.ldap import LdapClient  # noqa: F401
 from jans.pycloudlib.persistence.sql import render_sql_properties  # noqa: F401
+from jans.pycloudlib.persistence.sql import doc_id_from_dn  # noqa: F401
+from jans.pycloudlib.persistence.sql import SqlClient  # noqa: F401
 from jans.pycloudlib.persistence.spanner import render_spanner_properties  # noqa: F401
+from jans.pycloudlib.persistence.spanner import SpannerClient  # noqa: F401
 
 
 def render_salt(manager, src: str, dest: str) -> None:

--- a/jans-pycloudlib/jans/pycloudlib/version.py
+++ b/jans-pycloudlib/jans/pycloudlib/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.15"
+__version__ = "1.0.0-beta.16"  # pragma: no cover

--- a/jans-pycloudlib/setup.py
+++ b/jans-pycloudlib/setup.py
@@ -45,6 +45,7 @@ setup(
         "psycopg2>=2.8.6",
         "google-cloud-spanner>=3.3.0",
         "Click>=6.7",
+        "ldif>=4.1.1",
     ],
     classifiers=[
         "Intended Audience :: Developers",

--- a/jans-pycloudlib/tests/conftest.py
+++ b/jans-pycloudlib/tests/conftest.py
@@ -65,18 +65,18 @@ def gk8s_secret():
 def gmanager(gconsul_config, gvault_secret):
     from jans.pycloudlib.manager import get_manager
 
-    def get_config(key, default=None):
+    def get_config(key, default=""):
         ctx = {
             "ldap_binddn": "cn=Directory Manager",
             "couchbase_server_user": "admin",
         }
         return ctx.get(key) or default
 
-    def get_secret(key, default=None):
+    def get_secret(key, default=""):
         ctx = {
-            "encoded_ox_ldap_pw": "YgH8NDxhxmA=",
-            "encoded_ldapTrustStorePass": "YgH8NDxhxmA=",
-            "ldap_pkcs12_base64": "YgH8NDxhxmA=",
+            "encoded_ox_ldap_pw": "fHL54sT5qHk=",
+            "encoded_ldapTrustStorePass": "fHL54sT5qHk=",
+            "ldap_pkcs12_base64": "fHL54sT5qHk=",
             "encoded_salt": "7MEDWVFAG3DmakHRyjMqp5EE",
             "sql_password": "secret",
             "couchbase_password": "secret",

--- a/jans-pycloudlib/tests/conftest.py
+++ b/jans-pycloudlib/tests/conftest.py
@@ -65,7 +65,7 @@ def gk8s_secret():
 def gmanager(gconsul_config, gvault_secret):
     from jans.pycloudlib.manager import get_manager
 
-    ENCODED_PASSWORD = "fHL54sT5qHk="
+    ENCODED_PASSWD = "fHL54sT5qHk="
 
     def get_config(key, default=""):
         ctx = {
@@ -76,9 +76,9 @@ def gmanager(gconsul_config, gvault_secret):
 
     def get_secret(key, default=""):
         ctx = {
-            "encoded_ox_ldap_pw": ENCODED_PASSWORD,
-            "encoded_ldapTrustStorePass": ENCODED_PASSWORD,
-            "ldap_pkcs12_base64": ENCODED_PASSWORD,
+            "encoded_ox_ldap_pw": ENCODED_PASSWD,
+            "encoded_ldapTrustStorePass": ENCODED_PASSWD,
+            "ldap_pkcs12_base64": ENCODED_PASSWD,
             "encoded_salt": "7MEDWVFAG3DmakHRyjMqp5EE",
             "sql_password": "secret",
             "couchbase_password": "secret",

--- a/jans-pycloudlib/tests/conftest.py
+++ b/jans-pycloudlib/tests/conftest.py
@@ -65,7 +65,7 @@ def gk8s_secret():
 def gmanager(gconsul_config, gvault_secret):
     from jans.pycloudlib.manager import get_manager
 
-    ENCODED_PASSWD = "fHL54sT5qHk="
+    ENCODED_PW = "fHL54sT5qHk="
 
     def get_config(key, default=""):
         ctx = {
@@ -76,9 +76,9 @@ def gmanager(gconsul_config, gvault_secret):
 
     def get_secret(key, default=""):
         ctx = {
-            "encoded_ox_ldap_pw": ENCODED_PASSWD,
-            "encoded_ldapTrustStorePass": ENCODED_PASSWD,
-            "ldap_pkcs12_base64": ENCODED_PASSWD,
+            "encoded_ox_ldap_pw": ENCODED_PW,
+            "encoded_ldapTrustStorePass": ENCODED_PW,
+            "ldap_pkcs12_base64": ENCODED_PW,
             "encoded_salt": "7MEDWVFAG3DmakHRyjMqp5EE",
             "sql_password": "secret",
             "couchbase_password": "secret",

--- a/jans-pycloudlib/tests/conftest.py
+++ b/jans-pycloudlib/tests/conftest.py
@@ -65,6 +65,8 @@ def gk8s_secret():
 def gmanager(gconsul_config, gvault_secret):
     from jans.pycloudlib.manager import get_manager
 
+    ENCODED_PASSWORD = "fHL54sT5qHk="
+
     def get_config(key, default=""):
         ctx = {
             "ldap_binddn": "cn=Directory Manager",
@@ -74,9 +76,9 @@ def gmanager(gconsul_config, gvault_secret):
 
     def get_secret(key, default=""):
         ctx = {
-            "encoded_ox_ldap_pw": "fHL54sT5qHk=",
-            "encoded_ldapTrustStorePass": "fHL54sT5qHk=",
-            "ldap_pkcs12_base64": "fHL54sT5qHk=",
+            "encoded_ox_ldap_pw": ENCODED_PASSWORD,
+            "encoded_ldapTrustStorePass": ENCODED_PASSWORD,
+            "ldap_pkcs12_base64": ENCODED_PASSWORD,
             "encoded_salt": "7MEDWVFAG3DmakHRyjMqp5EE",
             "sql_password": "secret",
             "couchbase_password": "secret",

--- a/jans-pycloudlib/tests/test_manager.py
+++ b/jans-pycloudlib/tests/test_manager.py
@@ -5,10 +5,10 @@ class GAdapter(object):
     def get(self, k, default=None):
         return "GET"
 
-    def set(self, k, v):
+    def set(self, k, v):  # noqa: A003
         return "SET"
 
-    def all(self):
+    def all(self):  # noqa: A003
         return {}
 
     def get_all(self):
@@ -68,12 +68,11 @@ def test_secret_manager_methods():
     assert manager.all() == gadapter.all()
 
 
-@pytest.mark.skip(reason="need to rewrite testcase")
 @pytest.mark.parametrize("value, expected, decode, binary_mode", [
-    ("abcd", "abcd", False, False),
-    ("YgH8NDxhxmA=", "abcd", True, False),
-    ("abcd", b"abcd", False, True),
-    ("YgH8NDxhxmA=", b"abcd", True, True),
+    ("secret", "secret", False, False),
+    ("fHL54sT5qHk=", "secret", True, False),
+    ("secret", b"secret", False, True),
+    ("fHL54sT5qHk=", b"secret", True, True),
 ])
 def test_manager_secret_to_file(
     gmanager,
@@ -84,30 +83,14 @@ def test_manager_secret_to_file(
     decode,
     binary_mode,
 ):
-    def maybe_salt(*args, **kwargs):
-        if args[1] == "encoded_salt":
-            return "a" * 24
-        return value
-
-    monkeypatch.setattr(
-        "jans.pycloudlib.secret.VaultSecret.get",
-        maybe_salt,
-    )
-
     dst = tmpdir.join("secret.txt")
-
-    result = gmanager.secret.to_file(
-        "secret_key", str(dst), decode, binary_mode,
-    )
-    assert result == expected
+    gmanager.secret.to_file("encoded_ox_ldap_pw", str(dst), decode, binary_mode)
+    assert dst.read()
 
 
-@pytest.mark.skip(reason="need to rewrite testcase")
 @pytest.mark.parametrize("value, expected, encode, binary_mode", [
-    ("abcd", "abcd", False, False),
-    ("abcd", "YgH8NDxhxmA=", True, False),
-    (b"abcd", "abcd", False, True),
-    (b"abcd", "YgH8NDxhxmA=", True, True),
+    ("secret", "fHL54sT5qHk=", True, False),
+    (b"secret", "fHL54sT5qHk=", True, True),
 ])
 def test_manager_secret_from_file(
     gmanager,
@@ -118,25 +101,8 @@ def test_manager_secret_from_file(
     encode,
     binary_mode,
 ):
-    def maybe_salt(*args, **kwargs):
-        if args[1] == "encoded_salt":
-            return "a" * 24
-        return expected
-
-    monkeypatch.setattr(
-        "jans.pycloudlib.secret.VaultSecret.get",
-        maybe_salt,
-    )
-
-    monkeypatch.setattr(
-        "jans.pycloudlib.secret.VaultSecret.set",
-        lambda instance, key, value: True,
-    )
-
     dst = tmpdir.join("secret_file")
     dst.write(value)
 
-    result = gmanager.secret.from_file(
-        "secret_key", str(dst), encode, binary_mode,
-    )
-    assert result == expected
+    gmanager.secret.from_file("encoded_ox_ldap_pw", str(dst), encode, binary_mode)
+    assert gmanager.secret.get("encoded_ox_ldap_pw") == expected

--- a/jans-pycloudlib/tests/test_persistence.py
+++ b/jans-pycloudlib/tests/test_persistence.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+from collections import namedtuple
+from io import StringIO
 
 import pytest
 
@@ -95,12 +97,12 @@ ssl.trustStorePin: {gmanager.secret.get("encoded_ldapTrustStorePass")}
     assert dest.read() == expected
 
 
-# def test_sync_ldap_truststore(tmpdir, gmanager):
-#     from jans.pycloudlib.persistence.ldap import sync_ldap_truststore
+def test_sync_ldap_truststore(tmpdir, gmanager):
+    from jans.pycloudlib.persistence.ldap import sync_ldap_truststore
 
-#     dest = tmpdir.join("opendj.pkcs12")
-#     sync_ldap_truststore(gmanager, str(dest))
-#     assert dest.read() == gmanager.secret.get("ldap_pkcs12_base64")
+    dest = tmpdir.join("opendj.pkcs12")
+    sync_ldap_truststore(gmanager, str(dest))
+    assert dest.read()
 
 
 @pytest.mark.parametrize("url, host", [
@@ -122,6 +124,13 @@ def test_resolve_ldap_port(monkeypatch, use_ssl, port):
 
     monkeypatch.setenv("CN_LDAP_USE_SSL", use_ssl)
     assert resolve_ldap_port() == port
+
+
+def test_ldap_client_init(gmanager):
+    from jans.pycloudlib.persistence.ldap import LdapClient
+
+    client = LdapClient(gmanager)
+    assert str(client.server) == "ldaps://localhost:1636 - ssl"
 
 
 # =========
@@ -242,10 +251,10 @@ def test_exec_api_unsupported_method():
     "rest_client",
     "n1ql_client",
 ])
-def test_no_couchbase_hosts(client_prop):
+def test_no_couchbase_hosts(gmanager, client_prop):
     from jans.pycloudlib.persistence.couchbase import CouchbaseClient
 
-    client = CouchbaseClient("", "admin", "password")
+    client = CouchbaseClient(gmanager, {"hosts": "", "user": "admin", "password": "password"})
     with pytest.raises(ValueError):
         getattr(client, client_prop)
 
@@ -386,6 +395,27 @@ connection.keep-alive-timeout: 2500
 
     render_couchbase_properties(gmanager, str(src), str(dest))
     assert dest.read() == expected
+
+
+@pytest.mark.parametrize("dn, id_", [
+    ("o=jans", "_"),
+    ("ou=jans-auth,ou=configuration,o=jans", "configuration_jans-auth"),
+])
+def test_id_from_dn(dn, id_):
+    from jans.pycloudlib.persistence.couchbase import id_from_dn
+    assert id_from_dn(dn) == id_
+
+
+@pytest.mark.parametrize("key, bucket", [
+    ("people_1", "jans_user"),
+    ("site_1", "jans_site"),
+    ("tokens_1", "jans_token"),
+    ("cache_1", "jans_cache"),
+    ("configuration_jans-auth", "jans"),
+])
+def test_get_bucket_for_key(key, bucket):
+    from jans.pycloudlib.persistence.couchbase import get_bucket_for_key
+    assert get_bucket_for_key(key) == bucket
 
 
 # ======
@@ -551,48 +581,130 @@ auth.userPassword=fHL54sT5qHk=
     assert dest.read() == expected
 
 
-@pytest.mark.parametrize("dialect", [
-    "mysql",
-    "pgsql",
+class PGException(Exception):
+    def __init__(self, code):
+        orig_attrs = namedtuple("OrigAttrs", "pgcode")
+        self.orig = orig_attrs(code)
+
+
+def test_postgresql_adapter_on_create_table_error():
+    from jans.pycloudlib.persistence.sql import PostgresqlAdapter
+
+    with pytest.raises(Exception):
+        exc = PGException("10P01")
+        PostgresqlAdapter().on_create_table_error(exc)
+
+
+def test_postgresql_adapter_on_create_index_error():
+    from jans.pycloudlib.persistence.sql import PostgresqlAdapter
+
+    with pytest.raises(Exception):
+        exc = PGException("10P01")
+        PostgresqlAdapter().on_create_index_error(exc)
+
+
+def test_postgresql_adapter_on_insert_into_error():
+    from jans.pycloudlib.persistence.sql import PostgresqlAdapter
+
+    with pytest.raises(Exception):
+        exc = PGException("10P01")
+        PostgresqlAdapter().on_insert_into_error(exc)
+
+
+class MSException(Exception):
+    def __init__(self, code):
+        orig_attrs = namedtuple("OrigAttrs", "args")
+        self.orig = orig_attrs([code])
+
+
+def test_mysql_adapter_on_create_table_error():
+    from jans.pycloudlib.persistence.sql import MysqlAdapter
+
+    with pytest.raises(Exception):
+        exc = MSException(1001)
+        MysqlAdapter().on_create_table_error(exc)
+
+
+def test_mysql_adapter_on_create_index_error():
+    from jans.pycloudlib.persistence.sql import MysqlAdapter
+
+    with pytest.raises(Exception):
+        exc = MSException(1001)
+        MysqlAdapter().on_create_index_error(exc)
+
+
+def test_mysql_adapter_on_insert_into_error():
+    from jans.pycloudlib.persistence.sql import MysqlAdapter
+
+    with pytest.raises(Exception):
+        exc = MSException(1001)
+        MysqlAdapter().on_insert_into_error(exc)
+
+
+@pytest.mark.parametrize("dn, doc_id", [
+    ("o=jans", "_"),
+    ("ou=jans-auth,ou=configuration,o=jans", "jans-auth"),
 ])
-def test_sql_client_init(monkeypatch, dialect, gmanager, tmpdir):
-    from jans.pycloudlib.persistence.sql import SQLClient
+def test_doc_id_from_dn(dn, doc_id):
+    from jans.pycloudlib.persistence.sql import doc_id_from_dn
+    assert doc_id_from_dn(dn) == doc_id
+
+
+def test_sql_client_engine(gmanager):
+    from jans.pycloudlib.persistence.sql import SqlClient
+    assert SqlClient(gmanager).engine is not None
+
+
+@pytest.mark.parametrize("dialect, word, quoted_word", [
+    ("pgsql", "random", '"random"'),
+    ("mysql", "random", "`random`"),
+])
+def test_sql_client_quoted_id(monkeypatch, gmanager, dialect, word, quoted_word):
+    from jans.pycloudlib.persistence.sql import SqlClient
 
     monkeypatch.setenv("CN_SQL_DB_DIALECT", dialect)
 
-    src = tmpdir.join("sql_password")
-    src.write("secret")
-    monkeypatch.setenv("CN_SQL_PASSWORD_FILE", str(src))
-
-    client = SQLClient(gmanager)
-    assert client.adapter.dialect == dialect
+    client = SqlClient(gmanager)
+    assert client.quoted_id(word) == quoted_word
 
 
-def test_sql_client_getattr(monkeypatch, gmanager, tmpdir):
-    from jans.pycloudlib.persistence.sql import SQLClient
+def test_sql_sql_data_types(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.sql import SqlClient
 
-    monkeypatch.setenv("CN_SQL_DB_DIALECT", "mysql")
+    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
 
-    src = tmpdir.join("sql_password")
-    src.write("secret")
-    monkeypatch.setenv("CN_SQL_PASSWORD_FILE", str(src))
-
-    client = SQLClient(gmanager)
-    assert client.__getattr__("create_table")
+    client = SqlClient(gmanager)
+    assert isinstance(client.sql_data_types, dict)
 
 
-def test_sql_client_getattr_error(monkeypatch, gmanager, tmpdir):
-    from jans.pycloudlib.persistence.sql import SQLClient
+def test_sql_sql_data_types_mapping(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.sql import SqlClient
 
-    monkeypatch.setenv("CN_SQL_DB_DIALECT", "mysql")
+    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
 
-    src = tmpdir.join("sql_password")
-    src.write("secret")
-    monkeypatch.setenv("CN_SQL_PASSWORD_FILE", str(src))
+    client = SqlClient(gmanager)
+    assert isinstance(client.sql_data_types_mapping, dict)
 
-    client = SQLClient(gmanager)
-    with pytest.raises(AttributeError):
-        assert client.__getattr__("random_attr")
+
+def test_sql_attr_types(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.sql import SqlClient
+
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda p: StringIO('{"attributeTypes": []}'),
+    )
+
+    client = SqlClient(gmanager)
+    assert isinstance(client.attr_types, list)
+
+
+def test_sql_opendj_attr_types(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.sql import SqlClient
+
+    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+
+    client = SqlClient(gmanager)
+    assert isinstance(client.opendj_attr_types, dict)
 
 
 # =======
@@ -667,3 +779,58 @@ connection.emulator-host=localhost:9010
 
     render_spanner_properties(gmanager, str(src), str(dest))
     assert dest.read() == expected
+
+
+def test_spanner_quoted_id(gmanager):
+    from jans.pycloudlib.persistence.spanner import SpannerClient
+
+    client = SpannerClient(gmanager)
+    assert client.quoted_id("random") == "`random`"
+
+
+def test_spanner_sql_data_types(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.spanner import SpannerClient
+
+    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+
+    client = SpannerClient(gmanager)
+    assert isinstance(client.sql_data_types, dict)
+
+
+def test_spanner_sql_data_types_mapping(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.spanner import SpannerClient
+
+    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+
+    client = SpannerClient(gmanager)
+    assert isinstance(client.sql_data_types_mapping, dict)
+
+
+def test_spanner_attr_types(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.spanner import SpannerClient
+
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda p: StringIO('{"attributeTypes": []}'),
+    )
+
+    client = SpannerClient(gmanager)
+    assert isinstance(client.attr_types, list)
+
+
+def test_spanner_opendj_attr_types(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.spanner import SpannerClient
+
+    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+
+    client = SpannerClient(gmanager)
+    assert isinstance(client.opendj_attr_types, dict)
+
+
+def test_spanner_sub_tables(gmanager, monkeypatch):
+    from jans.pycloudlib.persistence.spanner import SpannerClient
+
+    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+
+    client = SpannerClient(gmanager)
+    assert isinstance(client.sub_tables, dict)

--- a/jans-pycloudlib/tests/test_persistence.py
+++ b/jans-pycloudlib/tests/test_persistence.py
@@ -704,7 +704,7 @@ def test_sql_attr_types(gmanager, monkeypatch):
 def test_sql_opendj_attr_types(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.sql import SqlClient
 
-    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+    monkeypatch.setattr(BUILTINS_OPEN, lambda p: StringIO("{}"))
 
     client = SqlClient(gmanager)
     assert isinstance(client.opendj_attr_types, dict)
@@ -794,7 +794,7 @@ def test_spanner_quoted_id(gmanager):
 def test_spanner_sql_data_types(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.spanner import SpannerClient
 
-    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+    monkeypatch.setattr(BUILTINS_OPEN, lambda p: StringIO("{}"))
 
     client = SpannerClient(gmanager)
     assert isinstance(client.sql_data_types, dict)
@@ -803,7 +803,7 @@ def test_spanner_sql_data_types(gmanager, monkeypatch):
 def test_spanner_sql_data_types_mapping(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.spanner import SpannerClient
 
-    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+    monkeypatch.setattr(BUILTINS_OPEN, lambda p: StringIO("{}"))
 
     client = SpannerClient(gmanager)
     assert isinstance(client.sql_data_types_mapping, dict)
@@ -813,7 +813,7 @@ def test_spanner_attr_types(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.spanner import SpannerClient
 
     monkeypatch.setattr(
-        "builtins.open",
+        BUILTINS_OPEN,
         lambda p: StringIO('{"attributeTypes": []}'),
     )
 
@@ -824,7 +824,7 @@ def test_spanner_attr_types(gmanager, monkeypatch):
 def test_spanner_opendj_attr_types(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.spanner import SpannerClient
 
-    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+    monkeypatch.setattr(BUILTINS_OPEN, lambda p: StringIO("{}"))
 
     client = SpannerClient(gmanager)
     assert isinstance(client.opendj_attr_types, dict)
@@ -833,7 +833,7 @@ def test_spanner_opendj_attr_types(gmanager, monkeypatch):
 def test_spanner_sub_tables(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.spanner import SpannerClient
 
-    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+    monkeypatch.setattr(BUILTINS_OPEN, lambda p: StringIO("{}"))
 
     client = SpannerClient(gmanager)
     assert isinstance(client.sub_tables, dict)

--- a/jans-pycloudlib/tests/test_persistence.py
+++ b/jans-pycloudlib/tests/test_persistence.py
@@ -668,10 +668,13 @@ def test_sql_client_quoted_id(monkeypatch, gmanager, dialect, word, quoted_word)
     assert client.quoted_id(word) == quoted_word
 
 
+BUILTINS_OPEN = "builtins.open"
+
+
 def test_sql_sql_data_types(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.sql import SqlClient
 
-    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+    monkeypatch.setattr(BUILTINS_OPEN, lambda p: StringIO("{}"))
 
     client = SqlClient(gmanager)
     assert isinstance(client.sql_data_types, dict)
@@ -680,7 +683,7 @@ def test_sql_sql_data_types(gmanager, monkeypatch):
 def test_sql_sql_data_types_mapping(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.sql import SqlClient
 
-    monkeypatch.setattr("builtins.open", lambda p: StringIO("{}"))
+    monkeypatch.setattr(BUILTINS_OPEN, lambda p: StringIO("{}"))
 
     client = SqlClient(gmanager)
     assert isinstance(client.sql_data_types_mapping, dict)
@@ -690,7 +693,7 @@ def test_sql_attr_types(gmanager, monkeypatch):
     from jans.pycloudlib.persistence.sql import SqlClient
 
     monkeypatch.setattr(
-        "builtins.open",
+        BUILTINS_OPEN,
         lambda p: StringIO('{"attributeTypes": []}'),
     )
 

--- a/jans-pycloudlib/tests/test_wait.py
+++ b/jans-pycloudlib/tests/test_wait.py
@@ -49,3 +49,43 @@ def test_on_giveup(caplog):
     details = {"kwargs": {"label": "Service"}, "elapsed": 10.0}
     on_giveup(details)
     assert "is not ready after" in caplog.records[0].message
+
+
+def test_wait_for_config(gmanager, monkeypatch):
+    from jans.pycloudlib.wait import wait_for_config
+
+    monkeypatch.setenv("CN_WAIT_MAX_TIME", "0")
+
+    with pytest.raises(Exception):
+        wait_for_config(gmanager)
+
+
+def test_wait_for_secret(gmanager, monkeypatch):
+    from jans.pycloudlib.wait import wait_for_secret
+
+    monkeypatch.setenv("CN_WAIT_MAX_TIME", "0")
+
+    with pytest.raises(Exception):
+        wait_for_secret(gmanager)
+
+
+@pytest.mark.parametrize("persistence_type", ["ldap", "hybrid"])
+def test_wait_for_ldap(gmanager, monkeypatch, persistence_type):
+    from jans.pycloudlib.wait import wait_for_ldap
+
+    monkeypatch.setenv("CN_WAIT_MAX_TIME", "0")
+    monkeypatch.setenv("CN_PERSISTENCE_TYPE", persistence_type)
+
+    with pytest.raises(Exception):
+        wait_for_ldap(gmanager)
+
+
+@pytest.mark.parametrize("persistence_type", ["couchbase", "hybrid"])
+def test_wait_for_couchbase(gmanager, monkeypatch, persistence_type):
+    from jans.pycloudlib.wait import wait_for_couchbase
+
+    monkeypatch.setenv("CN_WAIT_MAX_TIME", "0")
+    monkeypatch.setenv("CN_PERSISTENCE_TYPE", persistence_type)
+
+    with pytest.raises(Exception):
+        wait_for_couchbase(gmanager)


### PR DESCRIPTION
### Description

Helper methods are added into jans-pycloudlib directly to promote code reuse for internal/external images (i.e. `gluufederation/casa`) that need to create entry from LDIF file.

#### Implementation Details

Each persistence client classes has `create_from_ldif` method that allows importing data from LDIF file into respected persistence (`ldap/couchbase/sql/spanner`). By providing this method, any additional LDIF files (i.e. for Casa) can be moved from `janssenproject/persistence-loader` into 3rd-party images.

### Test and Document the changes
- [x] Relevant unit and integration tests have been added/updated

