### PR TITLE
fix: update persistence schema and entry

### DIFF
--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -23,7 +23,7 @@ RUN python3 -m ensurepip \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_LINUX_SETUP_VERSION=fc9544c861f30eb7370f635b07d9810ae33a7dba
+ENV JANS_LINUX_SETUP_VERSION=eb113d09421b95671fe1ab4eaa5c4bafc2aed6af
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)


### PR DESCRIPTION
### Description

Overview:

1. Added missing permission and `defaultPermissionInToken` attribute in role-scope mapping

2. Changed `jansCodeChallengeHash` column type (from `TEXT` to `INT`)

#### Implementation Details

1. Entrypoint loads `role-scope-mappings.json` to compare to role-scope permissions in persistence. Any missing permission will be added into persistence. The same rule applied to missing `defaultPermissionToken` attribute. 
    
    Ref: d61be0bf633020c6bd989e603bb983dc7a45b78b

1. The `jansCodeChallengeHash` column type is changed to `INT` (previously a `TEXT` type). 
    
    Ref: 369129d0c2614afb536d0e1329ac106fd7da187d
