### PR TITLE
fix(jans-auth-server): during encryption AS must consider client's jwks too, not only jwks_uri

### DIFF
--- a/jans-auth-server/common/src/main/java/io/jans/as/common/util/CommonUtils.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/util/CommonUtils.java
@@ -1,0 +1,21 @@
+package io.jans.as.common.util;
+
+import com.google.common.base.Strings;
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.model.util.JwtUtil;
+import org.json.JSONObject;
+
+/**
+ * @author Yuriy Zabrovarnyy
+ */
+public class CommonUtils {
+
+    private CommonUtils() {
+    }
+
+    public static JSONObject getJwks(Client client) {
+        return Strings.isNullOrEmpty(client.getJwks())
+                ? JwtUtil.getJSONWebKeys(client.getJwksUri())
+                : new JSONObject(client.getJwks());
+    }
+}

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/auth/MTLSService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/auth/MTLSService.java
@@ -6,8 +6,8 @@
 
 package io.jans.as.server.auth;
 
-import com.google.common.base.Strings;
 import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.util.CommonUtils;
 import io.jans.as.model.authorize.AuthorizeRequestParam;
 import io.jans.as.model.common.AuthenticationMethod;
 import io.jans.as.model.common.Prompt;
@@ -19,7 +19,6 @@ import io.jans.as.model.jwk.JSONWebKeySet;
 import io.jans.as.model.token.TokenErrorResponseType;
 import io.jans.as.model.util.CertUtils;
 import io.jans.as.model.util.HashUtil;
-import io.jans.as.model.util.JwtUtil;
 import io.jans.as.server.model.common.SessionId;
 import io.jans.as.server.model.common.SessionIdState;
 import io.jans.as.server.service.SessionIdService;
@@ -130,9 +129,7 @@ public class MTLSService {
             final PublicKey publicKey = cert.getPublicKey();
             final byte[] encodedKey = publicKey.getEncoded();
 
-            JSONObject jsonWebKeys = Strings.isNullOrEmpty(client.getJwks())
-                    ? JwtUtil.getJSONWebKeys(client.getJwksUri())
-                    : new JSONObject(client.getJwks());
+            JSONObject jsonWebKeys = CommonUtils.getJwks(client);
 
             if (jsonWebKeys == null) {
                 log.debug("Unable to load json web keys for client: {}, jwks_uri: {}, jks: {}", client.getClientId(),

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequestService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequestService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.jans.as.common.model.common.User;
 import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.util.CommonUtils;
 import io.jans.as.model.authorize.AuthorizeErrorResponseType;
 import io.jans.as.model.common.ResponseMode;
 import io.jans.as.model.config.WebKeysConfiguration;
@@ -352,7 +353,7 @@ public class AuthzRequestService {
                     String nestedKeyId = new ServerCryptoProvider(cryptoProvider).getKeyId(webKeysConfiguration,
                             Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE);
 
-                    JSONObject jsonWebKeys = JwtUtil.getJSONWebKeys(client.getJwksUri());
+                    JSONObject jsonWebKeys = CommonUtils.getJwks(client);
                     redirectUriResponse.getRedirectUri().setNestedJsonWebKeys(jsonWebKeys);
 
                     String clientSecret = clientService.decryptSecret(client.getClientSecret());
@@ -361,7 +362,7 @@ public class AuthzRequestService {
                 }
 
                 // Encrypted response
-                JSONObject jsonWebKeys = JwtUtil.getJSONWebKeys(client.getJwksUri());
+                JSONObject jsonWebKeys = CommonUtils.getJwks(client);
                 if (jsonWebKeys != null) {
                     keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(JSONWebKeySet.fromJSONObject(jsonWebKeys),
                             Algorithm.fromString(client.getAttributes().getAuthorizationEncryptedResponseAlg()),
@@ -382,7 +383,7 @@ public class AuthzRequestService {
                 keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(webKeysConfiguration,
                         Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE);
 
-                JSONObject jsonWebKeys = JwtUtil.getJSONWebKeys(client.getJwksUri());
+                JSONObject jsonWebKeys = CommonUtils.getJwks(client);
                 redirectUriResponse.getRedirectUri().setJsonWebKeys(jsonWebKeys);
 
                 String clientSecret = clientService.decryptSecret(client.getClientSecret());

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/authorize/JwtAuthorizationRequest.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/authorize/JwtAuthorizationRequest.java
@@ -6,9 +6,9 @@
 
 package io.jans.as.server.model.authorize;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.util.CommonUtils;
 import io.jans.as.model.authorize.AuthorizeErrorResponseType;
 import io.jans.as.model.common.Display;
 import io.jans.as.model.common.Prompt;
@@ -322,9 +322,7 @@ public class JwtAuthorizationRequest {
     private boolean validateSignature(@NotNull AbstractCryptoProvider cryptoProvider, SignatureAlgorithm signatureAlgorithm, Client client, String signingInput, String signature) throws Exception {
         ClientService clientService = CdiUtil.bean(ClientService.class);
         String sharedSecret = clientService.decryptSecret(client.getClientSecret());
-        JSONObject jwks = Strings.isNullOrEmpty(client.getJwks()) ?
-                JwtUtil.getJSONWebKeys(client.getJwksUri()) :
-                new JSONObject(client.getJwks());
+        JSONObject jwks = CommonUtils.getJwks(client);
         return cryptoProvider.verifySignature(signingInput, signature, keyId, jwks, sharedSecret, signatureAlgorithm);
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/ClientAssertion.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/ClientAssertion.java
@@ -6,8 +6,8 @@
 
 package io.jans.as.server.model.token;
 
-import com.google.common.base.Strings;
 import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.util.CommonUtils;
 import io.jans.as.model.common.AuthenticationMethod;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.crypto.AbstractCryptoProvider;
@@ -19,7 +19,6 @@ import io.jans.as.model.jwt.JwtClaimName;
 import io.jans.as.model.jwt.JwtHeaderName;
 import io.jans.as.model.jwt.JwtType;
 import io.jans.as.model.token.ClientAssertionType;
-import io.jans.as.model.util.JwtUtil;
 import io.jans.as.server.service.ClientService;
 import io.jans.service.cdi.util.CdiUtil;
 import io.jans.util.security.StringEncrypter;
@@ -108,9 +107,7 @@ public class ClientAssertion {
 
                                         // Validate the crypto segment
                                         String keyId = jwt.getHeader().getKeyId();
-                                        JSONObject jwks = Strings.isNullOrEmpty(client.getJwks()) ?
-                                                JwtUtil.getJSONWebKeys(client.getJwksUri()) :
-                                                new JSONObject(client.getJwks());
+                                        JSONObject jwks = CommonUtils.getJwks(client);
                                         String sharedSecret = clientService.decryptSecret(client.getClientSecret());
                                         boolean validSignature = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
                                                 keyId, jwks, sharedSecret, signatureAlgorithm);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/JwrService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/JwrService.java
@@ -7,6 +7,7 @@
 package io.jans.as.server.model.token;
 
 import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.util.CommonUtils;
 import io.jans.as.model.config.WebKeysConfiguration;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.crypto.AbstractCryptoProvider;
@@ -22,12 +23,12 @@ import io.jans.as.model.jwk.Use;
 import io.jans.as.model.jwt.Jwt;
 import io.jans.as.model.jwt.JwtType;
 import io.jans.as.model.token.JsonWebResponse;
-import io.jans.as.model.util.JwtUtil;
 import io.jans.as.server.model.common.IAuthorizationGrant;
 import io.jans.as.server.service.ClientService;
 import io.jans.as.server.service.SectorIdentifierService;
 import io.jans.as.server.service.ServerCryptoProvider;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 
@@ -91,7 +92,7 @@ public class JwrService {
 
     private Jwe encryptJwe(Jwe jwe, Client client) throws Exception {
 
-        if (appConfiguration.getUseNestedJwtDuringEncryption()) {
+        if (BooleanUtils.isTrue(appConfiguration.getUseNestedJwtDuringEncryption())) {
             JwtSigner jwtSigner = JwtSigner.newJwtSigner(appConfiguration, webKeysConfiguration, client);
             Jwt jwt = jwtSigner.newJwt();
             jwt.setClaims(jwe.getClaims());
@@ -102,7 +103,7 @@ public class JwrService {
         final BlockEncryptionAlgorithm encryptionMethod = jwe.getHeader().getEncryptionMethod();
 
         if (keyEncryptionAlgorithm == KeyEncryptionAlgorithm.RSA_OAEP || keyEncryptionAlgorithm == KeyEncryptionAlgorithm.RSA1_5) {
-            JSONObject jsonWebKeys = JwtUtil.getJSONWebKeys(client.getJwksUri());
+            JSONObject jsonWebKeys = CommonUtils.getJwks(client);
             String keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(JSONWebKeySet.fromJSONObject(jsonWebKeys),
                     Algorithm.fromString(keyEncryptionAlgorithm.getName()),
                     Use.ENCRYPTION);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImpl.java
@@ -10,6 +10,7 @@ import io.jans.as.common.claims.Audience;
 import io.jans.as.common.model.common.User;
 import io.jans.as.common.model.registration.Client;
 import io.jans.as.common.service.AttributeService;
+import io.jans.as.common.util.CommonUtils;
 import io.jans.as.model.common.ComponentType;
 import io.jans.as.model.common.ScopeType;
 import io.jans.as.model.config.Constants;
@@ -290,7 +291,7 @@ public class UserInfoRestWebServiceImpl implements UserInfoRestWebService {
         // Encryption
         if (keyEncryptionAlgorithm == KeyEncryptionAlgorithm.RSA_OAEP
                 || keyEncryptionAlgorithm == KeyEncryptionAlgorithm.RSA1_5) {
-            JSONObject jsonWebKeys = JwtUtil.getJSONWebKeys(authorizationGrant.getClient().getJwksUri());
+            JSONObject jsonWebKeys = CommonUtils.getJwks(authorizationGrant.getClient());
             String keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(JSONWebKeySet.fromJSONObject(jsonWebKeys),
                     Algorithm.fromString(keyEncryptionAlgorithm.getName()),
                     Use.ENCRYPTION);


### PR DESCRIPTION
fix(jans-auth-server): during encryption AS must consider client's jwks too, not only jwks_uri

https://github.com/JanssenProject/jans/issues/1273
