### PR TITLE
fix(jans-auth-server): removed CONFIG_API from AS supported script types #1286

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/AppInitializer.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/AppInitializer.java
@@ -220,6 +220,7 @@ public class AppInitializer {
         supportedCustomScriptTypes.remove(CustomScriptType.USER_REGISTRATION);
         supportedCustomScriptTypes.remove(CustomScriptType.SCIM);
         supportedCustomScriptTypes.remove(CustomScriptType.IDP);
+        supportedCustomScriptTypes.remove(CustomScriptType.CONFIG_API);
 
         statService.init();
 


### PR DESCRIPTION
fix(jans-auth-server): removed CONFIG_API from AS supported script types #1286