### PR TITLE
docs: fix CLI device flow link

### DIFF
--- a/docs/user/how-to/authn-with-apache-reverse-proxy.md
+++ b/docs/user/how-to/authn-with-apache-reverse-proxy.md
@@ -48,7 +48,7 @@ To register a new OpenID connect client on the Janssen server, we will use `jans
   - Run the command below on Janssen server to enter interactive mode.
 
 
-     > Note: </br> `jans-cli` has to be authenticated and authorized with the respective Janssen server. If `jans-cli` is being executed for the first time or if there is no valid access token available, then running the command below will initiate device authentication and authorization flow. In that case, follow the steps for [jans-cli authorization](../using-jans-cli/cli-tips.md#cli-authorization) to continue running the command.
+     > Note: </br> `jans-cli` has to be authenticated and authorized with the respective Janssen server. If `jans-cli` is being executed for the first time or if there is no valid access token available, then running the command below will initiate device authentication and authorization flow. In that case, follow the steps for [jans-cli authorization](../using-jans-cli/cli-index.md#cli-authorization) to continue running the command.
   
     ```
     /opt/jans/jans-cli/config-cli.py


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Link to section for Jans CLI authorization via device flow wasn't correct

