### PR TITLE
feat: jans-cli obtain list of attrbiutes from server when creating user

### DIFF
--- a/jans-cli/cli/config_cli.py
+++ b/jans-cli/cli/config_cli.py
@@ -303,11 +303,13 @@ class JCA_CLI:
         self.enums()
 
     def enums(self):
-        self.enum_dict = {}
-        enum_json = Path(os.path.join(cur_dir, 'enums.json'))
-        if enum_json.is_file():
-            self.enum_dict = json.loads(enum_json.read_text())
-
+        self.enum_dict = {
+                            "CustomAttribute": {
+                              "properties.name": {
+                                "f": "get_attrib_list"
+                              }
+                            }
+                          }
 
     def set_user(self):
         self.auth_username = None

--- a/jans-cli/cli/config_cli.py
+++ b/jans-cli/cli/config_cli.py
@@ -1020,7 +1020,7 @@ class JCA_CLI:
 
         print(tabulate(tab_data, headers, tablefmt="grid"))
 
-    def process_get(self, endpoint, return_value=False, parameters={}):
+    def process_get(self, endpoint, return_value=False, parameters=None):
         clear()
         if not return_value:
             title = endpoint.name
@@ -1204,11 +1204,8 @@ class JCA_CLI:
 
 
     def get_input_for_schema_(self, schema, model, spacing=0, initialised=False, getitem=None, required_only=False):
-        #print(self.current_menu, self.current_menu.path)
-        #print(schema)
-        #input("enter: ")
-        self.get_enum(schema)
 
+        self.get_enum(schema)
         data = {}
         for prop in schema['properties']:
             item = schema['properties'][prop]

--- a/jans-cli/cli/enums.json
+++ b/jans-cli/cli/enums.json
@@ -1,7 +1,0 @@
-{
-  "CustomAttribute": {
-    "properties.name": {
-      "f": "get_attrib_list"
-    }
-  }
-}

--- a/jans-cli/cli/enums.json
+++ b/jans-cli/cli/enums.json
@@ -1,0 +1,7 @@
+{
+  "CustomAttribute": {
+    "properties.name": {
+      "f": "get_attrib_list"
+    }
+  }
+}


### PR DESCRIPTION
When creating user we add each attrbiute as **customAttributes** schema  in the following format:
```
     {
        "name": "attribName",
        "multiValued": false,
        "values": [
          "attribValue"
        ]
      }
```

Admin should type **attribName* but he does not know which attributes are allowed. In this PR, CLI obtains list of attribute names from endpoint `/jans-config-api/api/v1/attributes` of jans-config-api, and provides as suggestion:

![image](https://user-images.githubusercontent.com/6398752/166968559-acca5861-7521-479a-9b23-45a6110e12be.png)

 