### PR TITLE
feat: adjust ownership and permission to avoid bloated images

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -227,9 +227,9 @@ RUN mkdir -p ${JETTY_BASE}/jans-auth/custom/pages \
     ${JETTY_BASE}/jans-auth/custom/static \
     ${JETTY_BASE}/jans-auth/custom/libs \
     ${JETTY_BASE}/jans-auth/custom/i18n \
+    ${JETTY_BASE}/jans-auth/logs \
     /etc/jans/conf \
-    /app/templates \
-    /opt/jetty/temp
+    /app/templates
 
 COPY certs /etc/certs
 COPY jetty/jans-auth_web_resources.xml ${JETTY_BASE}/jans-auth/webapps/
@@ -242,16 +242,13 @@ RUN chmod +x /app/scripts/entrypoint.sh
 # create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
 
- # adjust ownership
-RUN chown -R 1000:1000 /opt/jans/jetty \
-    && chown -R 1000:1000 /opt/jetty \
-    && chown -R 1000:1000 /tmp \
-    && chgrp -R 0 /opt/jans/jetty && chmod -R g=u /opt/jans/jetty \
-    && chgrp -R 0 /opt/jetty && chmod -R g=u /opt/jetty \
-    && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
-    && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \
+# adjust ownership and permission
+RUN chmod -R g=u ${JETTY_BASE}/jans-auth/custom \
+    && chmod -R g=u ${JETTY_BASE}/jans-auth/resources \
+    && chmod -R g=u ${JETTY_BASE}/jans-auth/logs \
+    && chmod -R g=u /etc/certs \
+    && chmod -R g=u /etc/jans \
+    && chmod 664 /usr/java/latest/jre/lib/security/cacerts \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml
 

--- a/docker-jans-auth-server/scripts/entrypoint.sh
+++ b/docker-jans-auth-server/scripts/entrypoint.sh
@@ -54,7 +54,7 @@ exec java \
     -Dserver.base=/opt/jans/jetty/jans-auth \
     -Dlog.base=/opt/jans/jetty/jans-auth \
     -Dpython.home=/opt/jython \
-    -Djava.io.tmpdir=/opt/jetty/temp \
+    -Djava.io.tmpdir=/tmp \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     $(get_debug_opt) \
     ${CN_JAVA_OPTIONS} \

--- a/docker-jans-certmanager/Dockerfile
+++ b/docker-jans-certmanager/Dockerfile
@@ -143,10 +143,19 @@ LABEL name="janssenproject/certmanager" \
     summary="Janssen Certmanager" \
     description="Manage certs and crypto keys for Janssen Server"
 
-COPY scripts /app/scripts
+RUN mkdir -p /etc/certs /etc/jans/conf
 
-RUN mkdir -p /etc/certs \
-    && chmod +x /app/scripts/entrypoint.sh
+COPY scripts /app/scripts
+RUN chmod +x /app/scripts/entrypoint.sh
+
+# create non-root user
+RUN adduser -s /bin/sh -D -G root -u 1000 1000
+
+# adjust ownership and permission
+RUN chmod -R g=u /etc/certs \
+    && chmod -R g=u /etc/jans
+
+USER 1000
 
 ENTRYPOINT ["tini", "-g", "--", "sh", "/app/scripts/entrypoint.sh"]
 CMD ["--help"]

--- a/docker-jans-client-api/Dockerfile
+++ b/docker-jans-client-api/Dockerfile
@@ -144,24 +144,22 @@ LABEL name="janssenproject/client-api" \
     summary="Janssen Client API" \
     description="Client software to secure apps with OAuth 2.0, OpenID Connect, and UMA"
 
-RUN mkdir -p /etc/certs /app/templates/ /etc/jans/conf /opt/client-api/logs
+RUN mkdir -p /etc/certs \
+    /etc/jans/conf \
+    /opt/client-api/logs
 COPY scripts /app/scripts
 COPY templates/*.tmpl /app/templates/
 RUN chmod +x /app/scripts/entrypoint.sh
 
-# # create non-root user
+# create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 1000
 
- # adjust ownership
-RUN chown -R 1000:1000 /app/templates \
-    && chown -R 1000:1000 /etc/jans \
-    && chown -R 1000:1000 /tmp \
-    && chown -R 1000:1000 /opt/client-api \
-    && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
-    && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chgrp -R 0 /opt/client-api && chmod -R g=u /opt/client-api \
-    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts
+# adjust ownership and permission
+RUN chmod -R g=u /opt/client-api/conf \
+    && chmod -R g=u /opt/client-api/logs \
+    && chmod -R g=u /etc/certs \
+    && chmod -R g=u /etc/jans \
+    && chmod 664 /usr/java/latest/jre/lib/security/cacerts
 
 USER 1000
 

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -187,7 +187,7 @@ RUN mkdir -p /etc/certs \
     /etc/jans/conf \
     ${JETTY_BASE}/jans-config-api/custom/libs \
     ${JETTY_BASE}/jans-config-api/custom/config \
-    /opt/jetty/temp
+    ${JETTY_BASE}/jans-config-api/logs
 
 RUN touch /etc/hosts.back
 COPY jetty/jans-config-api.xml ${JETTY_BASE}/jans-config-api/webapps/
@@ -200,18 +200,14 @@ RUN chmod +x /app/scripts/entrypoint.sh
 # create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
 
-# adjust ownership
-RUN chown -R 1000:1000 /opt/jans/jetty \
-    && chown -R 1000:1000 /opt/jetty \
-    && chown -R 1000:1000 /tmp \
-    && chown -R 1000:1000 /etc/hosts.back \
-    && chgrp -R 0 /etc/hosts.back && chmod -R g=u /etc/hosts.back \
-    && chgrp -R 0 /opt/jans/jetty && chmod -R g=u /opt/jans/jetty \
-    && chgrp -R 0 /opt/jetty && chmod -R g=u /opt/jetty \
-    && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
-    && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \
+# adjust ownership and permission
+RUN chmod -R g=u ${JETTY_BASE}/jans-config-api/custom \
+    && chmod -R g=u ${JETTY_BASE}/jans-config-api/resources \
+    && chmod -R g=u ${JETTY_BASE}/jans-config-api/logs \
+    && chmod -R g=u /etc/certs \
+    && chmod -R g=u /etc/jans \
+    && chmod 664 /etc/hosts.back \
+    && chmod 664 /usr/java/latest/jre/lib/security/cacerts \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml
 

--- a/docker-jans-config-api/scripts/entrypoint.sh
+++ b/docker-jans-config-api/scripts/entrypoint.sh
@@ -37,7 +37,7 @@ exec java \
     -Djans.base=/etc/jans \
     -Dserver.base=/opt/jans/jetty/jans-config-api \
     -Dlog.base=/opt/jans/jetty/jans-config-api \
-    -Djava.io.tmpdir=/opt/jetty/temp \
+    -Djava.io.tmpdir=/tmp \
     -Dlog4j2.configurationFile=$(get_logging_files) \
     ${CN_JAVA_OPTIONS} \
     -jar /opt/jetty/start.jar \

--- a/docker-jans-configurator/Dockerfile
+++ b/docker-jans-configurator/Dockerfile
@@ -120,20 +120,21 @@ LABEL name="janssenproject/configurator" \
     summary="Janssen Configuration Manager" \
     description="Manage config and secret"
 
+RUN mkdir -p /etc/certs \
+    /etc/jans/conf \
+    /app/db
+
 COPY scripts /app/scripts
-RUN mkdir -p /etc/certs /app/db \
-    && chmod +x /app/scripts/entrypoint.sh
+RUN chmod +x /app/scripts/entrypoint.sh
 
 # create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 1000
 
- # adjust ownership
-RUN chown -R 1000:1000 /tmp \
-    && chown -R 1000:1000 /app/db \
-    && chgrp -R 0 /app/db && chmod -R g=u /app/db \
-    && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
-    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts
+# adjust ownership and permission
+RUN chmod -R g=u /app/db \
+    && chmod -R g=u /etc/certs \
+    && chmod -R g=u /etc/jans \
+    && chmod 664 /usr/java/latest/jre/lib/security/cacerts
 
 USER 1000
 

--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -192,8 +192,7 @@ LABEL name="janssenproject/fido2" \
     description="FIDO2 server"
 
 RUN mkdir -p /etc/certs \
-    /app/templates \
-    /opt/jetty/temp
+    ${JETTY_BASE}/jans-fido2/logs
 
 COPY jetty/jans-fido2.xml ${JETTY_BASE}/jans-fido2/webapps/
 COPY jetty/log4j2.xml ${JETTY_BASE}/jans-fido2/resources/
@@ -205,17 +204,12 @@ RUN chmod +x /app/scripts/entrypoint.sh
 # create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
 
- # adjust ownership
-RUN chown -R 1000:1000 /opt/jans/jetty \
-    && chown -R 1000:1000 /etc/jans \
-    && chown -R 1000:1000 /opt/jetty \
-    && chown -R 1000:1000 /tmp \
-    && chgrp -R 0 /opt/jans/jetty && chmod -R g=u /opt/jans/jetty \
-    && chgrp -R 0 /opt/jetty && chmod -R g=u /opt/jetty \
-    && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
-    && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \
+# adjust ownership and permission
+RUN chmod -R g=u ${JETTY_BASE}/jans-fido2/resources \
+    && chmod -R g=u ${JETTY_BASE}/jans-fido2/logs \
+    && chmod -R g=u /etc/certs \
+    && chmod -R g=u /etc/jans \
+    && chmod 664 /usr/java/latest/jre/lib/security/cacerts \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml
 

--- a/docker-jans-fido2/scripts/entrypoint.sh
+++ b/docker-jans-fido2/scripts/entrypoint.sh
@@ -14,7 +14,7 @@ exec java \
     -Djans.base=/etc/jans \
     -Dserver.base=/opt/jans/jetty/jans-fido2 \
     -Dlog.base=/opt/jans/jetty/jans-fido2 \
-    -Djava.io.tmpdir=/opt/jetty/temp \
+    -Djava.io.tmpdir=/tmp \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     ${CN_JAVA_OPTIONS} \
     -jar /opt/jetty/start.jar jetty.deploy.scanInterval=0 jetty.httpConfig.sendServerVersion=false

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -177,7 +177,7 @@ LABEL name="janssenproject/persistence-loader" \
     summary="Janssen Authorization Server Persistence loader" \
     description="Generate initial data for persistence layer"
 
-RUN mkdir -p /app/tmp /app/custom_ldif /etc/certs /etc/jans/conf
+RUN mkdir -p /app/custom_ldif /etc/certs /etc/jans/conf
 
 COPY scripts /app/scripts
 # this overrides existing templates
@@ -187,15 +187,10 @@ RUN chmod +x /app/scripts/entrypoint.sh
 # create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 1000
 
- # adjust ownership
-RUN chown -R 1000:1000 /tmp \
-    && chown -R 1000:1000 /app/tmp/ \
-    && chown -R 1000:1000 /app/custom_ldif/ \
-    && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /app/tmp && chmod -R g=u /app/tmp \
-    && chgrp -R 0 /app/custom_ldif && chmod -R g=u /app/custom_ldif \
-    && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
-    && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans
+# adjust ownership and permission
+RUN chmod -R g=u /app/custom_ldif \
+    && chmod -R g=u /etc/certs \
+    && chmod -R g=u /etc/jans
 
 USER 1000
 

--- a/docker-jans-scim/Dockerfile
+++ b/docker-jans-scim/Dockerfile
@@ -170,8 +170,7 @@ LABEL name="janssenproject/scim" \
 
 RUN mkdir -p /etc/certs \
     /etc/jans/conf \
-    /app/templates \
-    /opt/jetty/temp
+    ${JETTY_BASE}/jans-scim/logs
 
 COPY jetty/jans-scim.xml ${JETTY_BASE}/jans-scim/webapps/
 COPY jetty/log4j2.xml ${JETTY_BASE}/jans-scim/resources/
@@ -183,17 +182,12 @@ RUN chmod +x /app/scripts/entrypoint.sh
 # create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
 
- # adjust ownership
-RUN chown -R 1000:1000 /opt/jans/jetty \
-    && chown -R 1000:1000 /etc/jans \
-    && chown -R 1000:1000 /opt/jetty \
-    && chown -R 1000:1000 /tmp \
-    && chgrp -R 0 /opt/jans/jetty && chmod -R g=u /opt/jans/jetty \
-    && chgrp -R 0 /opt/jetty && chmod -R g=u /opt/jetty \
-    && chgrp -R 0 /tmp && chmod -R g=u /tmp \
-    && chgrp -R 0 /etc/certs && chmod -R g=u /etc/certs \
-    && chgrp -R 0 /etc/jans && chmod -R g=u /etc/jans \
-    && chmod -R +w /usr/java/latest/jre/lib/security/cacerts && chgrp -R 0 /usr/java/latest/jre/lib/security/cacerts && chmod -R g=u /usr/java/latest/jre/lib/security/cacerts \
+# adjust ownership
+RUN chmod -R g=u ${JETTY_BASE}/jans-scim/resources \
+    && chmod -R g=u ${JETTY_BASE}/jans-scim/logs \
+    && chmod -R g=u /etc/certs \
+    && chmod -R g=u /etc/jans \
+    && chmod 664 /usr/java/latest/jre/lib/security/cacerts \
     && chmod 664 /opt/jetty/etc/jetty.xml \
     && chmod 664 /opt/jetty/etc/webdefault.xml
 

--- a/docker-jans-scim/scripts/entrypoint.sh
+++ b/docker-jans-scim/scripts/entrypoint.sh
@@ -14,7 +14,7 @@ exec java \
     -Djans.base=/etc/jans \
     -Dserver.base=/opt/jans/jetty/jans-scim \
     -Dlog.base=/opt/jans/jetty/jans-scim \
-    -Djava.io.tmpdir=/opt/jetty/temp \
+    -Djava.io.tmpdir=/tmp \
     -Dpython.home=/opt/jython \
     -Dlog4j2.configurationFile=resources/log4j2.xml \
     ${CN_JAVA_OPTIONS} \


### PR DESCRIPTION
### Description

The changeset fixes incorrect usage of ownership/permission (in docker context) as reported in #1307 

#### Implementation Details

- remove `chown` command as it increases the size of the image
- replace `chgroup -R` command with `chmod -R g=u` to set directory ownership/permission
- use `chmod 664` command to set file permission
