### PR TITLE
fix: set permission for jans-auth.xml explicitly

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -233,7 +233,6 @@ RUN mkdir -p ${JETTY_BASE}/jans-auth/custom/pages \
 
 COPY certs /etc/certs
 COPY jetty/jans-auth_web_resources.xml ${JETTY_BASE}/jans-auth/webapps/
-COPY jetty/jans-auth.xml ${JETTY_BASE}/jans-auth/webapps/
 COPY jetty/log4j2.xml ${JETTY_BASE}/jans-auth/resources/
 COPY conf/*.tmpl /app/templates/
 COPY scripts /app/scripts
@@ -241,6 +240,8 @@ RUN chmod +x /app/scripts/entrypoint.sh
 
 # create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
+
+COPY --chown=1000:0 jetty/jans-auth.xml ${JETTY_BASE}/jans-auth/webapps/
 
 # adjust ownership and permission
 RUN chmod -R g=u ${JETTY_BASE}/jans-auth/custom \

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -190,7 +190,6 @@ RUN mkdir -p /etc/certs \
     ${JETTY_BASE}/jans-config-api/logs
 
 RUN touch /etc/hosts.back
-COPY jetty/jans-config-api.xml ${JETTY_BASE}/jans-config-api/webapps/
 COPY jetty/log4j2.xml ${JETTY_BASE}/jans-config-api/resources/
 COPY conf/*.tmpl /app/templates/
 COPY plugins /app/plugins
@@ -199,6 +198,8 @@ RUN chmod +x /app/scripts/entrypoint.sh
 
 # create non-root user
 RUN adduser -s /bin/sh -D -G root -u 1000 jetty
+
+COPY --chown=1000:0 jetty/jans-config-api.xml ${JETTY_BASE}/jans-config-api/webapps/
 
 # adjust ownership and permission
 RUN chmod -R g=u ${JETTY_BASE}/jans-config-api/custom \


### PR DESCRIPTION
### Description

Running `janssenproject/auth-server` on KNative is failed due to permission on `jans-auth.xml`. This changeset set the ownership/permission to running user (1000) explicitly.