### PR TITLE
feat: config-cli enumerate scope type

### DIFF
--- a/jans-cli/cli/config_cli.py
+++ b/jans-cli/cli/config_cli.py
@@ -965,7 +965,7 @@ class JCA_CLI:
             if not param_name in parameters:
                 text_ = param['name']
                 help_text = param.get('description') or param.get('summary')
-                enforce = True if end_point_param and end_point_param['name'] == param['name'] else False
+                enforce = True if param['schema']['type'] == 'integer' or (end_point_param and end_point_param['name'] == param['name']) else False
 
                 parameters[param_name] = self.get_input(
                     text=text_.strip('.'),
@@ -973,7 +973,8 @@ class JCA_CLI:
                     default=param['schema'].get('default'),
                     enforce=enforce,
                     help_text=help_text,
-                    example=param.get('example')
+                    example=param.get('example'),
+                    values=param['schema'].get('enum', [])
                 )
 
         return parameters

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -2178,6 +2178,12 @@ paths:
       parameters:
         - schema:
             type: string
+            enum:
+              - openid
+              - dynamic
+              - uma
+              - spontaneous
+              - oauth
           in: query
           name: type
           description: Scope type.


### PR DESCRIPTION
When querying list of scopes, we can enumerate scope type as follows:

![scope_get_type](https://user-images.githubusercontent.com/6398752/167708505-b8e12de3-dc10-4c18-aeda-1fa6cb129f4d.png)
