### PR TITLE
fix: invalid LDAP schema reading token_server client ID

### DIFF
--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -633,6 +633,11 @@ class Upgrade:
         def _update_token_server_client():
             kwargs = {}
             token_server_admin_ui_client_id = self.manager.config.get("token_server_admin_ui_client_id")
+
+            # admin-ui is not available
+            if not token_server_admin_ui_client_id:
+                return
+
             id_ = f"inum={token_server_admin_ui_client_id},ou=clients,o=jans"
 
             if self.backend.type in ("sql", "spanner"):


### PR DESCRIPTION
### Description

While trying to upgrade data using `ldap` persistence, a LDAP schema error is thrown.

Here's the problematic line:

```
inum={token_server_admin_ui_client_id},ou=clients,o=jans
```

As `token_server_admin_ui_client_id` fetched from config layer may returns empty string (possibly `admin-ui` is not deployed), the empty `inum` value produces invalid DN.

This changeset checks whether the config is available before running data upgrade.