### PR TITLE
fix: jans-linux-setup set log level to TRACE for test data

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
+++ b/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
@@ -235,7 +235,8 @@ class TestDataLoader(BaseInstaller, SetupUtils):
                                     'sessionIdRequestParameterEnabled': True,
                                     'skipRefreshTokenDuringRefreshing': False,
                                     'enabledComponents': ['unknown', 'health_check', 'userinfo', 'clientinfo', 'id_generation', 'registration', 'introspection', 'revoke_token', 'revoke_session', 'end_session', 'status_session', 'jans_configuration', 'ciba', 'uma', 'u2f', 'device_authz', 'stat', 'par'],
-                                    'cleanServiceInterval':7200
+                                    'cleanServiceInterval':7200,
+                                    'loggingLevel': 'TRACE',
                                     }
 
         if Config.get('config_patch_creds'):

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -407,7 +407,7 @@
         "delayTime": 2,
         "bruteForceProtectionEnabled": false
     },
-    "loggingLevel": "INFO",
+    "loggingLevel": "%(jans_auth_logging_level)s",
     "loggingLayout": "text",
     "errorHandlingMethod":"internal",
     "useLocalCache":true,


### PR DESCRIPTION
In this PR logging level of jans-auth is set to TRACE when test data is loaded, that is with `-t` option.