### PR TITLE
fix(jans-linux-setup): defaults loggingLevel to INFO

### DIFF
--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -407,7 +407,7 @@
         "delayTime": 2,
         "bruteForceProtectionEnabled": false
     },
-    "loggingLevel": "%(jans_auth_logging_level)s",
+    "loggingLevel": "INFO",
     "loggingLayout": "text",
     "errorHandlingMethod":"internal",
     "useLocalCache":true,


### PR DESCRIPTION
fix(jans-linux-setup): defaults loggingLevel to INFO