### PR TITLE
fix: use secure http urls for maven repositories

### DIFF
--- a/jans-eleven/pom.xml
+++ b/jans-eleven/pom.xml
@@ -34,12 +34,12 @@
 		<repository>
 			<id>repository.jboss.org</id>
 			<name>JBoss Repository</name>
-			<url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+			<url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
 		</repository>
 		<repository>
 			<id>mavencentral</id>
 			<name>maven central</name>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 		</repository>
 		<repository>
 			<id>jans</id>

--- a/jans-notify/pom.xml
+++ b/jans-notify/pom.xml
@@ -27,12 +27,12 @@
 		<repository>
 			<id>repository.jboss.org</id>
 			<name>JBoss Repository</name>
-			<url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+			<url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
 		</repository>
 		<repository>
 			<id>mavencentral</id>
 			<name>maven central</name>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 		</repository>
 		<repository>
 			<id>jans</id>
@@ -42,7 +42,7 @@
 		<repository>
 			<id>bouncycastle</id>
 			<name>Bouncy Castle</name>
-			<url>http://repo2.maven.org/maven2/org/bouncycastle</url>
+			<url>https://repo1.maven.org/maven2/org/bouncycastle</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Some of the maven repository URLs in POM files are not using secure HTTP (https). 

also, jans-notify was pointing to `repo2` in the maven repo. This URL was not accessible. It should be using `repo1`.

### Testing
Manually varify if the new https URLs are accessible. 

