### PR TITLE
fix: jans-linux-setup key and crt path for CLI in ob

### DIFF
--- a/jans-linux-setup/jans_setup/jans_setup.py
+++ b/jans-linux-setup/jans_setup/jans_setup.py
@@ -447,9 +447,13 @@ def main():
             if Config.install_config_api:
                 msg.installation_completed += "/opt/jans/jans-cli/config-cli.py"
                 if base.current_app.profile == static.SetupProfiles.OPENBANKING:
-                    ca_dir = os.path.join(Config.output_dir, 'CA')
-                    crt_fn = os.path.join(ca_dir, 'client.crt')
-                    key_fn = os.path.join(ca_dir, 'client.key')
+                    if static_kid == 'ob-gluu-test':
+                        ca_dir = os.path.join(Config.output_dir, 'CA')
+                        crt_fn = os.path.join(ca_dir, 'client.crt')
+                        key_fn = os.path.join(ca_dir, 'client.key')
+                    else:
+                        crt_fn = '/path/to/client.crt'
+                        key_fn = '/path/to/client.key'
                     msg.installation_completed += ' -CC {} -CK {}'.format(crt_fn, key_fn)
                 msg.installation_completed +="\n"
             if  Config.profile == 'jans' and Config.install_scim_server:


### PR DESCRIPTION
In post setup message, path of CLI key and cert is printed as follows if gluu-test-key is used:

```
/opt/jans/jans-cli/config-cli.py -CC /opt/jans/jans-setup/output/CA/client.crt -CK /opt/jans/jans-setup/output/CA/client.key
```

Otherwise

```
/opt/jans/jans-cli/config-cli.py -CC /path/to/client.crt -CK /path/to/client.key
```

