### PR TITLE
feat(jans-config-api): swagger spec change to expose user inum at root level of response

### DIFF
--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -6841,6 +6841,9 @@ components:
         userPassword:
           type: string
           description: User password
+        inum:
+          description: XRI i-number. Identifier to uniquely identify the user.
+          type: string
 
     UserPatchRequest:
       title: User Patch Request object

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/model/user/CustomUser.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/model/user/CustomUser.java
@@ -9,46 +9,69 @@ public class CustomUser extends User {
  
     private static final long serialVersionUID = 1L;
 
+    private String inum;
     private String mail;
     private String displayName;
     private String jansStatus;
     private String givenName;
     private String userPassword;
     
+        
+    public String getInum() {
+        return inum;
+    }
+    
+    public void setInum(String inum) {
+        this.inum = inum;
+    }
+    
     public String getMail() {
         return mail;
     }
+    
     public void setMail(String mail) {
         this.mail = mail;
     }
+    
     public String getDisplayName() {
         return displayName;
     }
+    
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
     }
+    
     public String getJansStatus() {
         return jansStatus;
     }
+    
     public void setJansStatus(String jansStatus) {
         this.jansStatus = jansStatus;
     }
+    
     public String getGivenName() {
         return givenName;
     }
+    
     public void setGivenName(String givenName) {
         this.givenName = givenName;
     }
+    
     public String getUserPassword() {
         return userPassword;
     }
+    
     public void setUserPassword(String userPassword) {
         this.userPassword = userPassword;
     }
+    
     @Override
     public String toString() {
-        return "CustomUser [mail=" + mail + ", displayName=" + displayName + ", jansStatus=" + jansStatus + ", givenName="
-                + givenName + ", userPassword= XXXXX ]";
+        return "CustomUser [inum=" + inum + ", mail=" + mail + ", displayName=" + displayName + ", jansStatus="
+                + jansStatus + ", givenName=" + givenName + ", userPassword=" + userPassword + "]";
     }
+    
+    
+    
     
 }

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/rest/UserResource.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/rest/UserResource.java
@@ -44,6 +44,7 @@ public class UserResource extends BaseResource {
     private static final String JANS_STATUS = "jansStatus";
     private static final String GIVEN_NAME = "givenName";
     private static final String USER_PWD = "userPassword";
+    private static final String INUM = "inum";
 
     @Inject
     Logger logger;
@@ -287,12 +288,14 @@ public class UserResource extends BaseResource {
         customUser.setJansStatus(user.getAttribute(JANS_STATUS));
         customUser.setGivenName(user.getAttribute(GIVEN_NAME));
         customUser.setUserPassword(user.getAttribute(USER_PWD));
+        customUser.setInum(user.getAttribute(INUM));
 
         customUser.removeAttribute(MAIL);
         customUser.removeAttribute(DISPLAY_NAME);
         customUser.removeAttribute(JANS_STATUS);
         customUser.removeAttribute(GIVEN_NAME);
         customUser.removeAttribute(USER_PWD);
+        customUser.removeAttribute(INUM);
 
         return customUser;
     }
@@ -316,6 +319,7 @@ public class UserResource extends BaseResource {
         user.setAttribute(JANS_STATUS, customUser.getJansStatus(), false);
         user.setAttribute(GIVEN_NAME, customUser.getGivenName(), false);
         user.setAttribute(USER_PWD, customUser.getUserPassword(), false);
+        user.setAttribute(INUM, customUser.getInum(), false);
 
         logger.debug("Custom User - user:{}", user);
         return user;


### PR DESCRIPTION
@yuriyz request you to please review and approve swagger spec change to expose inum in root level of response
Related issue https://github.com/JanssenProject/jans/issues/1348