### PR TITLE
fix: jans-linux-setup remove temporary link file

### DIFF
--- a/jans-linux-setup/jans_setup/templates/jans-cli/.#client.ldif
+++ b/jans-linux-setup/jans_setup/templates/jans-cli/.#client.ldif
@@ -1,1 +1,0 @@
-mbaser@ubuntu.7772


### PR DESCRIPTION
Remove unnecessary temporary link file