### PR TITLE
fix: jans-linux-setup add gcs module path for downloading apps

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/downloads.py
+++ b/jans-linux-setup/jans_setup/setup_app/downloads.py
@@ -80,7 +80,7 @@ def download_sqlalchemy():
 
 def download_all():
     download_files = []
-
+    sys.path.insert(0, os.path.join(base.pylib_dir, 'gcs'))
     modules = glob.glob(os.path.join(base.ces_dir, 'installers/*.py'))
 
     for installer in modules:


### PR DESCRIPTION
Since gcs path was missing in `download_all()`, download was failed