### PR TITLE
docs: fix links to contributing guide and CoC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@
 - Developer
 - Community
   - [Charter](./community/charter.md)
-  - [Contributing](./community/CONTRIBUTING.md)
-  - [Code of Conduct](./community/code-of-conduct.md)
+  - [Contributing](./CONTRIBUTING.md)
+  - [Code of Conduct](./CODE_OF_CONDUCT.md)
   - [Triage Process](./community/triage.md)
   - [Testing](./community/testing.md)
   - [Copyright Notice](./community/copyright-notices.md)


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
fix links to contributing guide and CoC