### PR TITLE
feat: add support for requestUriBlockList config

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -55,7 +55,7 @@ RUN /opt/jython/bin/pip uninstall -y pip
 # ===========
 
 ENV CN_VERSION=1.0.1-SNAPSHOT
-ENV CN_BUILD_DATE='2022-06-06 08:14'
+ENV CN_BUILD_DATE='2022-06-16 08:14'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-server/${CN_VERSION}/jans-auth-server-${CN_VERSION}.war
 
 # Install Jans Auth
@@ -90,14 +90,14 @@ RUN wget -q https://jenkins.gluu.org/maven/org/gluu/casa-config/${CASA_CONFIG_VE
 # Casa external scripts
 # =====================
 
-ARG CASA_EXTRAS_VERSION=fe01bcb3d46311355b15a37b655253ca17997358
+ARG FLEX_SOURCE_VERSION=fe01bcb3d46311355b15a37b655253ca17997358
 ARG CASA_EXTRAS_DIR=casa/extras
 
 RUN mkdir -p /opt/jans/python/libs
 RUN git clone --filter blob:none --no-checkout https://github.com/GluuFederation/flex.git /tmp/flex \
     && cd /tmp/flex \
     && git sparse-checkout init --cone \
-    && git checkout ${CASA_EXTRAS_VERSION} \
+    && git checkout ${FLEX_SOURCE_VERSION} \
     && git sparse-checkout set ${CASA_EXTRAS_DIR} \
     && cd /opt/jans/python/libs \
     && cp /tmp/flex/${CASA_EXTRAS_DIR}/casa-external_* . \
@@ -111,14 +111,15 @@ RUN mkdir -p ${JETTY_BASE}/jans-auth/agama/fl \
     ${JETTY_BASE}/jans-auth/agama/ftl \
     ${JETTY_BASE}/jans-auth/agama/scripts
 
-ARG JANS_AGAMA_VERSION=6b23bfe19ef960039f76df4de167c159312dd930
+# janssenproject/jans SHA commit
+ARG JANS_SOURCE_VERSION=0f1a2e6761c0522acdfdab3d69adac5c8062e780
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the agama code
 RUN git clone --filter blob:none --no-checkout https://github.com/janssenproject/jans /tmp/jans \
     && cd /tmp/jans \
     && git sparse-checkout init --cone \
-    && git checkout ${JANS_AGAMA_VERSION} \
+    && git checkout ${JANS_SOURCE_VERSION} \
     && git sparse-checkout add agama/misc
 
 RUN cp -R /tmp/jans/agama/misc/* ${JETTY_BASE}/jans-auth/agama/ \

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -23,7 +23,8 @@ RUN python3 -m ensurepip \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_LINUX_SETUP_VERSION=07f544ff00c6e8923b480da1bfb4ee7847933c60
+# janssenproject/jans SHA commit
+ENV JANS_SOURCE_VERSION=0f1a2e6761c0522acdfdab3d69adac5c8062e780
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)
@@ -31,7 +32,7 @@ ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 RUN git clone --filter blob:none --no-checkout https://github.com/janssenproject/jans /tmp/jans \
     && cd /tmp/jans \
     && git sparse-checkout init --cone \
-    && git checkout ${JANS_LINUX_SETUP_VERSION} \
+    && git checkout ${JANS_SOURCE_VERSION} \
     && git sparse-checkout set ${JANS_SETUP_DIR}
 
 RUN mkdir -p /app/static /app/static/couchbase /app/schema /app/openbanking/static /app/static/opendj
@@ -63,7 +64,7 @@ RUN cd /tmp/jans \
     && cp -R ${JANS_SETUP_DIR}/templates/jans-cli /app/templates/jans-cli
 
 # Download jans-config-api-swagger for role_scope_mapping
-RUN wget -q https://github.com/JanssenProject/jans/raw/${JANS_LINUX_SETUP_VERSION}/jans-config-api/docs/jans-config-api-swagger.yaml -P /app/static
+RUN wget -q https://github.com/JanssenProject/jans/raw/${JANS_SOURCE_VERSION}/jans-config-api/docs/jans-config-api-swagger.yaml -P /app/static
 
 # cleanup
 RUN rm -rf /tmp/jans

--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -161,6 +161,13 @@ def _transform_auth_dynamic_config(conf):
         conf["httpLoggingExcludePaths"] = conf.pop("httpLoggingExludePaths", [])
         should_update = True
 
+    if "requestUriBlockList" not in conf:
+        conf["requestUriBlockList"] = [
+            "localhost",
+            "127.0.0.1",
+        ]
+        should_update = True
+
     # return the conf and flag to determine whether it needs update or not
     return conf, should_update
 

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
@@ -256,6 +256,10 @@
     "claimsParameterSupported":false,
     "requestParameterSupported":true,
     "requestUriParameterSupported":true,
+    "requestUriBlockList": [
+        "localhost",
+        "127.0.0.1"
+    ],
     "requireRequestUriRegistration":false,
     "allowPostLogoutRedirectWithoutValidation":false,
     "introspectionAccessTokenMustHaveUmaProtectionScope":false,

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
@@ -181,6 +181,10 @@
     "claimsParameterSupported":true,
     "requestParameterSupported":true,
     "requestUriParameterSupported":true,
+    "requestUriBlockList": [
+        "localhost",
+        "127.0.0.1"
+    ],
     "requireRequestUriRegistration":false,
     "allowPostLogoutRedirectWithoutValidation":false,
     "introspectionAccessTokenMustHaveUmaProtectionScope":false,


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

The changeset adds support for `requestUriBlockList` config.

Misc:
* rename `CASA_EXTRAS_VERSION` to `FLEX_SOURCE_VERSION`
* rename `JANS_AGAMA_VERSION` to `JANS_SOURCE_VERSION`
* rename `JANS_LINUX_SETUP_VERSION` to `JANS_SOURCE_VERSION`
* update `jans-auth-server` WAR file

-------------------
### Test and Document the changes

No docs need to be updated.
