### PR TITLE
fix: a workaround for fido2 dependency

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -87,7 +87,6 @@ ARG CASA_CONFIG_BUILD_DATE="2022-05-26 13:56"
 RUN wget -q https://jenkins.gluu.org/maven/org/gluu/casa-config/${CASA_CONFIG_VERSION}/casa-config-${CASA_CONFIG_VERSION}.jar -P /usr/share/java/
 
 # A workaround for Fido2 integration
-# @TODO: possibly will be removed (depends on https://github.com/JanssenProject/jans/issues/1499)
 ARG FIDO2_CLIENT_VERSION=1.0.1-SNAPSHOT
 ARG FIDO2_CLIENT_BUILD_DATE="2022-06-22 08:13"
 RUN wget -q https://jenkins.jans.io/maven/io/jans/jans-fido2-client/${FIDO2_CLIENT_VERSION}/jans-fido2-client-${FIDO2_CLIENT_VERSION}.jar -P /usr/share/java/

--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -76,15 +76,21 @@ RUN mkdir -p ${JETTY_BASE}/jans-auth/webapps \
 RUN mkdir -p /usr/share/java
 
 ARG TWILIO_VERSION=7.17.0
-RUN wget -q https://repo1.maven.org/maven2/com/twilio/sdk/twilio/${TWILIO_VERSION}/twilio-${TWILIO_VERSION}.jar -O /usr/share/java/twilio.jar
+RUN wget -q https://repo1.maven.org/maven2/com/twilio/sdk/twilio/${TWILIO_VERSION}/twilio-${TWILIO_VERSION}.jar -P /usr/share/java/
 
 ARG JSMPP_VERSION=2.3.7
-RUN wget -q https://repo1.maven.org/maven2/org/jsmpp/jsmpp/${JSMPP_VERSION}/jsmpp-${JSMPP_VERSION}.jar -O /usr/share/java/jsmpp.jar
+RUN wget -q https://repo1.maven.org/maven2/org/jsmpp/jsmpp/${JSMPP_VERSION}/jsmpp-${JSMPP_VERSION}.jar -P /usr/share/java/
 
 # This will later be refactored and moved to be pulled from persitence or a central bucket
 ARG CASA_CONFIG_VERSION=5.0.0-SNAPSHOT
 ARG CASA_CONFIG_BUILD_DATE="2022-05-26 13:56"
-RUN wget -q https://jenkins.gluu.org/maven/org/gluu/casa-config/${CASA_CONFIG_VERSION}/casa-config-${CASA_CONFIG_VERSION}.jar -O /usr/share/java/casa-config.jar
+RUN wget -q https://jenkins.gluu.org/maven/org/gluu/casa-config/${CASA_CONFIG_VERSION}/casa-config-${CASA_CONFIG_VERSION}.jar -P /usr/share/java/
+
+# A workaround for Fido2 integration
+# @TODO: possibly will be removed (depends on https://github.com/JanssenProject/jans/issues/1499)
+ARG FIDO2_CLIENT_VERSION=1.0.1-SNAPSHOT
+ARG FIDO2_CLIENT_BUILD_DATE="2022-06-22 08:13"
+RUN wget -q https://jenkins.jans.io/maven/io/jans/jans-fido2-client/${FIDO2_CLIENT_VERSION}/jans-fido2-client-${FIDO2_CLIENT_VERSION}.jar -P /usr/share/java/
 
 # =====================
 # Casa external scripts

--- a/docker-jans-auth-server/scripts/entrypoint.sh
+++ b/docker-jans-auth-server/scripts/entrypoint.sh
@@ -16,20 +16,10 @@ get_debug_opt() {
 }
 
 move_builtin_jars() {
-    # move twilio lib
-    if [ ! -f /opt/jans/jetty/jans-auth/custom/libs/twilio.jar ]; then
-        cp /usr/share/java/twilio.jar /opt/jans/jetty/jans-auth/custom/libs/twilio.jar
-    fi
-
-    # move jsmpp lib
-    if [ ! -f /opt/jans/jetty/jans-auth/custom/libs/jsmpp.jar ]; then
-        cp /usr/share/java/jsmpp.jar /opt/jans/jetty/jans-auth/custom/libs/jsmpp.jar
-    fi
-
-    # move casa-config lib
-    if [ ! -f /opt/jans/jetty/jans-auth/custom/libs/casa-config.jar ]; then
-        cp /usr/share/java/casa-config.jar /opt/jans/jetty/jans-auth/custom/libs/casa-config.jar
-    fi
+    for src in /usr/share/java/*.jar; do
+        fname=$(basename "$src")
+        cp "$src" "/opt/jans/jetty/jans-auth/custom/libs/$fname"
+    done
 }
 
 get_prometheus_opt() {

--- a/docker-jans-auth-server/scripts/entrypoint.sh
+++ b/docker-jans-auth-server/scripts/entrypoint.sh
@@ -16,6 +16,7 @@ get_debug_opt() {
 }
 
 move_builtin_jars() {
+    #twilio, jsmpp, casa-config, jans-fido2-client
     for src in /usr/share/java/*.jar; do
         fname=$(basename "$src")
         cp "$src" "/opt/jans/jetty/jans-auth/custom/libs/$fname"


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

Ref: #1588 

#### Implementation Details

Added Fido2 client as a workaround (as mentioned [here](https://github.com/JanssenProject/jans/issues/1499#issuecomment-1163429001))