### PR TITLE
Jans linux setup setup properties opendj

### DIFF
--- a/jans-linux-setup/jans_setup/setup.properties.sample
+++ b/jans-linux-setup/jans_setup/setup.properties.sample
@@ -26,6 +26,8 @@ ip=
 ### The hostname of the server
 hostname=
 
+### Password for admin user
+admin_password=
 
 ### This information is needed for self signed certificate
 orgName=
@@ -33,7 +35,6 @@ countryCode=
 city=
 state=
 admin_email=
-
 
 ## Do NOT modify below this part unless you know what you're doing
 
@@ -55,3 +56,10 @@ installFido2=
 
 ### If you want to install Scim Server, set this to True
 install_scim_server=
+
+### To use remote MySQL as backend
+# installLdap=False
+# rdbm_install=2
+# rdbm_db = gluudb
+# rdbm_user = gluu
+# rdbm_password = qwerty

--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -231,7 +231,7 @@ class PropertiesUtils(SetupUtils):
         if prop_file.endswith('-DEC~'):
             self.run(['rm', '-f', prop_file])
 
-        if not 'admin_password' in properties_list:
+        if not 'admin_password' in properties_list and 'ldapPass' in p:
             Config.admin_password = p['ldapPass']
             
         if p.get('ldap_hostname') != 'localhost':
@@ -278,9 +278,6 @@ class PropertiesUtils(SetupUtils):
             if not conn_check['result']:
                 print("Can't connect to remote LDAP Server with credentials found in setup.properties.")
                 sys.exit(1)
-
-        if not 'admin_password' in p:
-            p['admin_password'] = p['ldapPass']
 
         if not (Config.cb_install or Config.rdbm_install):
             p['opendj_install'] = InstallTypes.LOCAL

--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -110,6 +110,9 @@ class PropertiesUtils(SetupUtils):
 
         if Config.profile == 'jans':
 
+            if not (Config.cb_install or Config.rdbm_install):
+                Config.opendj_install = InstallTypes.LOCAL
+
             if not Config.ldapPass:
                 Config.ldapPass = Config.admin_password
 
@@ -129,6 +132,7 @@ class PropertiesUtils(SetupUtils):
                     print(msg.used_ports.format(','.join(used_ports)))
                     sys.exit(1)
 
+
             self.set_persistence_type()
 
             if not Config.opendj_p12_pass:
@@ -141,6 +145,10 @@ class PropertiesUtils(SetupUtils):
 
         if not Config.jans_max_mem:
             Config.jans_max_mem = int(base.current_mem_size * .83 * 1000) # 83% of physical memory
+
+
+        print(Config.cb_install, Config.rdbm_install, Config.opendj_install)
+
 
     def check_oxd_server_https(self):
 
@@ -271,15 +279,16 @@ class PropertiesUtils(SetupUtils):
                 print("Can't connect to remote LDAP Server with credentials found in setup.properties.")
                 sys.exit(1)
 
-
         if not 'admin_password' in p:
             p['admin_password'] = p['ldapPass']
 
+        if not (Config.cb_install or Config.rdbm_install):
+            p['opendj_install'] = InstallTypes.LOCAL
 
         return p
 
     def save_properties(self, prop_fn=None, obj=None):
-        
+
         if not prop_fn:
             prop_fn = Config.savedProperties
 
@@ -313,7 +322,7 @@ class PropertiesUtils(SetupUtils):
                     else:
                         value = getString(obj)
                         if value != '':
-                            p[obj_name] = value                
+                            p[obj_name] = value
 
             with open(prop_fn, 'wb') as f:
                 p.store(f, encoding="utf-8")

--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -231,7 +231,7 @@ class PropertiesUtils(SetupUtils):
         if prop_file.endswith('-DEC~'):
             self.run(['rm', '-f', prop_file])
 
-        if not 'admin_password' in properties_list and 'ldapPass' in p:
+        if 'admin_password' not in properties_list and 'ldapPass' in p:
             Config.admin_password = p['ldapPass']
             
         if p.get('ldap_hostname') != 'localhost':


### PR DESCRIPTION
1) setup should choose opendj if not set in setup.properties file as described in https://github.com/JanssenProject/jans/issues/1612
2) Add sample mysql backend usage in `setup.properties.sample`