### PR TITLE
refactor(pycloudlib): add more typehint on cli modules

### DIFF
--- a/jans-pycloudlib/docs/README.md
+++ b/jans-pycloudlib/docs/README.md
@@ -3,7 +3,7 @@ Building Documentation
 
 To build the documentation:
 
-    pip3 install sphinx sphinx-autobuild
+    pip3 install sphinx-autobuild sphinx-click
     sphinx-autobuild . --watch ../jans _build/html
 
 Visit `http://localhost:8000` in the browser.

--- a/jans-pycloudlib/docs/cli.rst
+++ b/jans-pycloudlib/docs/cli.rst
@@ -1,0 +1,6 @@
+CLI
+~~~
+
+.. click:: jans.pycloudlib.cli:cli
+   :prog: jans-pycloudlib
+   :nested: full

--- a/jans-pycloudlib/docs/conf.py
+++ b/jans-pycloudlib/docs/conf.py
@@ -45,6 +45,7 @@ release = find_version("../jans/pycloudlib/version.py")
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx_click",
 ]
 
 autodoc_mock_imports = [
@@ -59,6 +60,7 @@ autodoc_mock_imports = [
     "google",
     "ldif",
     "sqlalchemy",
+    "click",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/jans-pycloudlib/docs/index.rst
+++ b/jans-pycloudlib/docs/index.rst
@@ -45,3 +45,4 @@ This part of the documentation lists the API reference of public classes and fun
    meta
    utils
    validators
+   cli

--- a/jans-pycloudlib/jans/pycloudlib/cli/__init__.py
+++ b/jans-pycloudlib/jans/pycloudlib/cli/__init__.py
@@ -9,7 +9,7 @@ from jans.pycloudlib.cli.encoding import decode_string
 @click.group(
     context_settings={"help_option_names": ["-h", "--help"]}
 )
-def cli():  # pragma: no cover
+def cli() -> None:  # pragma: no cover
     """Entrypoint of CLI commands."""
     pass
 

--- a/jans-pycloudlib/jans/pycloudlib/cli/encoding.py
+++ b/jans-pycloudlib/jans/pycloudlib/cli/encoding.py
@@ -20,7 +20,7 @@ from jans.pycloudlib.utils import decode_text
     "--salt-literal",
     help="Salt string (overrides salt from secrets/file)",
 )
-def decode_file(path, salt_file, salt_literal):
+def decode_file(path: str, salt_file: str, salt_literal: str) -> None:
     """Decode text from a file."""
     salt = ""
     if salt_literal:
@@ -57,7 +57,7 @@ def decode_file(path, salt_file, salt_literal):
     "--salt-literal",
     help="Salt string (overrides salt from secrets/file)",
 )
-def decode_string(text, salt_file, salt_literal):
+def decode_string(text: str, salt_file: str, salt_literal: str) -> None:
     """Decode text string."""
     salt = ""
     if salt_literal:


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

The changeset adds and/or updates typehint in `jans.pycloudlib.cli` modules.

#### Target issue

This PR is a part of tasks listed in https://github.com/JanssenProject/jans/issues/1565

#### Implementation Details

Typehint are added/updated based on reports from `mypy`.

-------------------
### Test and Document the changes
- [x] Static code analysis (using `mypy`) has been run locally and issues have been fixed
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

