### PR TITLE
fix: jans-cli download yaml files for build

### DIFF
--- a/jans-cli/setup.py
+++ b/jans-cli/setup.py
@@ -8,6 +8,23 @@ import os
 import re
 from setuptools import setup
 from setuptools import find_packages
+from setuptools.command.install import install
+from urllib.request import urlretrieve
+
+class PostInstallCommand(install):
+    """Post-installation for installation mode."""
+    def run(self):
+        install.run(self)
+
+        urlretrieve(
+             'https://raw.githubusercontent.com/JanssenProject/jans/main/jans-config-api/docs/jans-config-api-swagger.yaml',
+             os.path.join(self.install_lib, 'cli/jca.yaml')
+            )
+
+        urlretrieve(
+             'https://raw.githubusercontent.com/JanssenProject/jans/main/jans-scim/server/src/main/resources/jans-scim-openapi.yaml',
+             os.path.join(self.install_lib, 'cli/scim.yaml')
+            )
 
 
 def find_version(*file_paths):
@@ -60,5 +77,8 @@ setup(
             "config-cli=cli.config_cli:main",
             "scim-cli=cli.config_cli:main",
         ],
+    },
+    cmdclass={
+        'install': PostInstallCommand,
     },
 )


### PR DESCRIPTION
In commit https://github.com/JanssenProject/jans/commit/ea929c0637c40ee75f3adbd5377c5e08aebbe087 , jans-setup copies yaml files from server directories (feat: jans-cli no local yaml files). For that reason, pyz file is missing yaml files and fails. In this PR, setup.py modified so that it downloads yaml files when building.