### PR TITLE
fix: correct the link to image

### DIFF
--- a/docs/admin/integration/custom-web-development/authn-with-apache-reverse-proxy.md
+++ b/docs/admin/integration/custom-web-development/authn-with-apache-reverse-proxy.md
@@ -56,7 +56,7 @@ To register a new OpenID connect client on the Janssen server, we will use `jans
 
     Running above command will bring up main menu as shown in sample below:
     
-    ![CLI-main-menu](../../assets/how-to/images/image-howto-mod-auth-cli-main-menu-04292022.png)
+    ![CLI-main-menu](../../../assets/how-to/images/image-howto-mod-auth-cli-main-menu-04292022.png)
     
     To register a new OpenID Connect client, select `OAuth OpenID Connect - Clients` option (`16` in above sample). Selecting an appropriate option will bring up related sub-menu. 
    


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

The link to CLI main menu was broken after the restructuring of docs.
