### PR TITLE
fix: jans-linux-setup disable script Forgot_Password_2FA_Token

### DIFF
--- a/jans-linux-setup/jans_setup/templates/scripts.ldif
+++ b/jans-linux-setup/jans_setup/templates/scripts.ldif
@@ -554,7 +554,7 @@ description: This script is a 2 in 1. It can be used to enable user to reset its
 displayName: Forgot_Password_2FA_Token
 inum: B270-381E
 jansConfProperty: {"value1":"SCRIPT_FUNCTION","value2":"forgot_password","description":""}
-jansEnabled: true
+jansEnabled: false
 jansLevel: 10
 jansModuleProperty: {"value1":"SCRIPT_FUNCTION","value2":"ldap","description":""}
 jansProgLng: python


### PR DESCRIPTION
Script **Forgot_Password_2FA_Token** is not working properly. Disabled until it is fixed.
It can be enabled after installation by `python3 /opt/jans/jans-setup/setup.py -enable-script=B270-381E` for testing.