### PR TITLE
fix: jans-linux-setup python executable when launching setup

### DIFF
--- a/jans-linux-setup/jans_setup/install.py
+++ b/jans-linux-setup/jans_setup/install.py
@@ -235,7 +235,7 @@ def do_install():
 
     print("Launching Janssen Setup")
 
-    setup_cmd = 'python3 {}/setup.py'.format(argsp.setup_dir)
+    setup_cmd = '{} {}/setup.py'.format(sys.executable, argsp.setup_dir)
     setup_args = argsp.args or ''
     if argsp.force_download:
         setup_args += ' --force-download'


### PR DESCRIPTION
install.py is executing setup.py in shell. setup.py should be executed the same python executable of install.py because it downloads python binary library.