### PR TITLE
fix: jans-linux-setup add dummy jansRedirectURI to scim client

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/scim.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/scim.py
@@ -143,7 +143,8 @@ class ScimInstaller(JettyInstaller):
                 'jansSubjectTyp': ['pairwise'],
                 'jansTknEndpointAuthMethod': ['client_secret_basic'],
                 'inum': [Config.scim_client_id],
-                'jansClntSecret': [Config.scim_client_encoded_pw]
+                'jansClntSecret': [Config.scim_client_encoded_pw],
+                'jansRedirectURI': ['https://{}/.well-known/scim-configuration'.format(Config.hostname)]
                 })
 
         client_ldif_fd.close()


### PR DESCRIPTION
As described in https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationRequest
a dummy **jansRedirectURI** is added to scime client.