### PR TITLE
fix(jans-client-api): jans-config-api dependency removed and wrong test dependencies solved

### DIFF
--- a/jans-client-api/README.md
+++ b/jans-client-api/README.md
@@ -70,7 +70,7 @@ mvn test -Djans.base=/etc/jans
 `Djans.base` is the conf path of the local running `jans-auth-server`
 ### Running tests with external jans-client-api
 ```
-mvn test -Dtest.client.api.url=http://localhost:9999/jans-client-api-server/
+mvn test -Dmaven.test.skip=false -Dtest.client.api.url=http://localhost:9999/jans-client-api-server/
 ```
 `Dtest.client.api.url` is the url of a running `jans-client-api-server`
 

--- a/jans-client-api/gen-client/pom.xml
+++ b/jans-client-api/gen-client/pom.xml
@@ -212,6 +212,30 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>test-dependencies</id>
+            <activation>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.jans</groupId>
+                    <artifactId>jans-client-api-common</artifactId>
+                    <version>${project.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-log4j12</artifactId>
+                        </exclusion>
+                    </exclusions>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -224,19 +248,6 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.jans</groupId>
-            <artifactId>jans-client-api-common</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/jans-client-api/pom.xml
+++ b/jans-client-api/pom.xml
@@ -36,7 +36,7 @@
         <guava.version>31.1-jre</guava.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <jans.version>1.0.1</jans.version>
+        <jans.version>1.0.2-SNAPSHOT</jans.version>
         <weld.version>4.0.3.Final</weld.version>
         <jetty.version>11.0.8</jetty.version>
         <org.jboss.resteasy.client.microprofile.version>4.7.5.Final</org.jboss.resteasy.client.microprofile.version>
@@ -90,9 +90,9 @@
     </repositories>
 
     <scm>
-        <url>https://github.com/JanssenProject/jans-config-api</url>
-        <connection>scm:git:git://github.com/JanssenProject/jans-config-api.git</connection>
-        <developerConnection>scm:git:git@github.com:v/jans-config-api.git</developerConnection>
+        <url>https://github.com/JanssenProject/jans-client-api</url>
+        <connection>scm:git:git://github.com/JanssenProject/jans-client-api.git</connection>
+        <developerConnection>scm:git:git@github.com:v/jans-client-api.git</developerConnection>
     </scm>
 
     <dependencyManagement>
@@ -135,16 +135,6 @@
                 <groupId>io.jans</groupId>
                 <artifactId>jans-client-api-server</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jans</groupId>
-                <artifactId>jans-config-api-common</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jans</groupId>
-                <artifactId>jans-config-api-shared</artifactId>
-                <version>${jans.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jans</groupId>

--- a/jans-client-api/server/pom.xml
+++ b/jans-client-api/server/pom.xml
@@ -74,14 +74,6 @@
             <groupId>io.jans</groupId>
             <artifactId>jans-core-service</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.jans</groupId>
-            <artifactId>jans-config-api-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jans</groupId>
-            <artifactId>jans-config-api-shared</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>io.jans</groupId>
@@ -104,13 +96,7 @@
             <artifactId>jans-client-api-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.jans</groupId>
-            <artifactId>jans-client-api-common</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>io.jans</groupId>
             <artifactId>jans-client-api</artifactId>
@@ -832,6 +818,30 @@
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-servlet-initializer</artifactId>
                     <version>3.0.21.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>test-dependencies</id>
+            <activation>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.jans</groupId>
+                    <artifactId>jans-client-api-common</artifactId>
+                    <version>${project.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-log4j12</artifactId>
+                        </exclusion>
+                    </exclusions>
+                    <type>test-jar</type>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/jans-client-api/server/src/main/java/io/jans/ca/server/persistence/service/MainPersistenceService.java
+++ b/jans-client-api/server/src/main/java/io/jans/ca/server/persistence/service/MainPersistenceService.java
@@ -18,7 +18,6 @@ import io.jans.ca.server.configuration.model.Rp;
 import io.jans.ca.server.persistence.modal.OrganizationBranch;
 import io.jans.ca.server.persistence.modal.RpObject;
 import io.jans.ca.server.service.MigrationService;
-import io.jans.configapi.model.status.StatsData;
 import io.jans.orm.PersistenceEntryManager;
 import io.jans.orm.exception.EntryPersistenceException;
 import io.jans.orm.model.base.SimpleBranch;
@@ -49,7 +48,6 @@ public class MainPersistenceService implements PersistenceService {
     @Inject
     Logger logger;
 
-    private StatsData statsData;
     private static final String BASE_DN = "o=jans";
     private static final String OU_CONFIGURATION = "configuration";
     private static final String OU_JANS_CLIENT_API = "jans-client-api";
@@ -84,14 +82,6 @@ public class MainPersistenceService implements PersistenceService {
 
     public String getPersistenceType() {
         return configurationFactory.getBaseConfiguration().getString("persistence.type");
-    }
-
-    public StatsData getStatsData() {
-        return statsData;
-    }
-
-    public void setStatsData(StatsData statsData) {
-        this.statsData = statsData;
     }
 
     public void create() {


### PR DESCRIPTION
- jans-config-api dependency removed
- Additionally I have solved a problem to find test dependency (jans-client-api-common) when it is built with maven.test.skip = true    (https://jenkins.jans.io/jenkins/job/jans-client-api/86/)

### Prepare

- [X] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [X] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
https://github.com/JanssenProject/jans/issues/1723

#### Implementation Details
Dependency removed, and test dependencies problems fixed.

-------------------
### Test and Document the changes
- [ X] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [X] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)
README was updated (command to run test with url).

