### PR TITLE
fix: jans-linux-setup no prompt for eleven installation

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -74,9 +74,11 @@ class JansInstaller(BaseInstaller, SetupUtils):
             if Config.profile == 'jans':
                 txt += 'Install Fido2 Server'.ljust(30) + repr(Config.installFido2).rjust(35) + (' *' if 'installFido2' in Config.addPostSetupService else '') + "\n"
                 txt += 'Install Scim Server'.ljust(30) + repr(Config.install_scim_server).rjust(35) + (' *' if 'install_scim_server' in Config.addPostSetupService else '') + "\n"
-                txt += 'Install Eleven Server'.ljust(30) + repr(Config.installEleven).rjust(35) + (' *' if 'installEleven' in Config.addPostSetupService else '') + "\n"
                 txt += 'Install Jans Client Api'.ljust(30) + repr(Config.install_client_api).rjust(35) + (' *' if 'install_client_api' in Config.addPostSetupService else '') + "\n"
                 #txt += 'Install Oxd '.ljust(30) + repr(Config.installOxd).rjust(35) + (' *' if 'installOxd' in Config.addPostSetupService else '') + "\n"
+
+            if Config.profile == 'jans' and Config.installEleven:
+                txt += 'Install Eleven Server'.ljust(30) + repr(Config.installEleven).rjust(35) + (' *' if 'installEleven' in Config.addPostSetupService else '') + "\n"
 
             if base.argsp.t:
                 txt += 'Load Test Data '.ljust(30) + repr( base.argsp.t).rjust(35) + "\n"

--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -935,7 +935,7 @@ class PropertiesUtils(SetupUtils):
             self.promptForConfigApi()
             self.promptForScimServer()
             self.promptForFido2Server()
-            self.promptForEleven()
+            #self.promptForEleven()
             self.prompt_for_client_api()
             #if (not Config.installOxd) and Config.oxd_package:
             #    self.promptForOxd()


### PR DESCRIPTION
jans-eleven is not working properly, thus propmting to install jans-eleven is hided. Developers can still install jans-eleven with argument `--install-eleven`, for example:
`python3 install.py --args="--install-eleven"`
or installer
`python3 /opt/jans/jans-setup/setup.py --install-eleven`
