### PR TITLE
fix: jans-linux-setup owner and permisson of files in /etc/jans

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -488,6 +488,13 @@ class JansInstaller(BaseInstaller, SetupUtils):
             self.run([paths.cmd_chmod, '-R', '660', Config.certFolder])
             self.run([paths.cmd_chmod, 'u+X', Config.certFolder])
 
+            self.chown(Config.jansBaseFolder, user=Config.jetty_user, group=Config.root_user, recursive=True)
+            for p in Path(Config.jansBaseFolder).rglob("*"):
+                if p.is_dir():
+                    self.run([paths.cmd_chmod, '770', p.as_posix()])
+                elif p.is_file():
+                    self.run([paths.cmd_chmod, '660', p.as_posix()])
+
             if not Config.installed_instance:
                 cron_service = 'crond' if base.os_type in ['centos', 'red', 'fedora'] else 'cron'
                 self.restart(cron_service)


### PR DESCRIPTION
As described in https://github.com/JanssenProject/jans/issues/1760, files under `/etc/jans` should be owned by jetty and should only be readable jetty
