### PR TITLE
ci: fix failing Sonar check for Agama

### DIFF
--- a/agama/pom.xml
+++ b/agama/pom.xml
@@ -25,6 +25,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.min-version>3.6.3</maven.min-version>
         <jans.version>${project.version}</jans.version>
+
+        <sonar.projectKey>JanssenProject_jans-agama</sonar.projectKey>
+        <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
+        <sonar.organization>janssenproject</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <repositories>

--- a/agama/pom.xml
+++ b/agama/pom.xml
@@ -26,7 +26,7 @@
         <maven.min-version>3.6.3</maven.min-version>
         <jans.version>${project.version}</jans.version>
 
-        <sonar.projectKey>JanssenProject_jans-agama</sonar.projectKey>
+        <sonar.projectKey>janssenproject_jans-agama</sonar.projectKey>
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
         <sonar.organization>janssenproject</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
As per the description in the target issue, it seems from the error log that PR check for Sonar doesn't know where the Sonar server is as it is trying to look for server on localhost.


#### Target issue
Closes #1810 

#### Implementation Details
- pom file in Agama is missing Sonar properties. So added appropriate properties.
- At the same time, Jans project on Sonar didn't have Agama module onboarded. So I have configured that as well.

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed `NA`
- [ ] Relevant unit and integration tests have been added/updated `NA`
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc) `NA`

