### PR TITLE
ci: add new labels for new Janssen Server modules

### DIFF
--- a/automation/github-labels/labels-schema.json
+++ b/automation/github-labels/labels-schema.json
@@ -251,6 +251,24 @@
       "title-prefixes": []
     }
   },
+  "comp-agama": {
+    "color": "0052CC",
+    "description": "Touching folder /agama",
+    "auto-label": {
+      "branch": "",
+      "paths": ["agama"],
+      "title-prefixes": []
+    }
+  },
+  "comp-fidowallet": {
+    "color": "0052CC",
+    "description": "Touching folder /fidowallet",
+    "auto-label": {
+      "branch": "",
+      "paths": ["fidowallet"],
+      "title-prefixes": []
+    }
+  },
   "effort-1": {
     "color": "FEF2C0",
     "description": "Relative effort required for completion of issue or PR",


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Add new labels for Agama and fidowallet

#### Target issue
Closes #1814 

#### Implementation Details
 Labels added.