### PR TITLE
feat(jans-auth-server): split grant validation logic into TokenRestWebServiceValidator  #1591

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/ExecutionContext.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/ExecutionContext.java
@@ -10,19 +10,16 @@ import io.jans.as.common.model.registration.Client;
 import io.jans.as.common.service.AttributeService;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.token.JsonWebResponse;
+import io.jans.as.server.model.audit.OAuth2AuditLog;
 import io.jans.as.server.model.ldap.TokenEntity;
 import io.jans.model.custom.script.conf.CustomScriptConfiguration;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Response;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
 import java.util.function.Function;
 
 /**
@@ -60,6 +57,7 @@ public class ExecutionContext {
     private Set<String> scopes;
     private String claimsAsString;
     private List<SessionId> userSessions;
+    private OAuth2AuditLog auditLog;
 
     @NotNull
     private final Map<String, String> attributes = new HashMap<>();
@@ -88,6 +86,14 @@ public class ExecutionContext {
 
     public HttpServletResponse getHttpResponse() {
         return httpResponse;
+    }
+
+    public OAuth2AuditLog getAuditLog() {
+        return auditLog;
+    }
+
+    public void setAuditLog(OAuth2AuditLog auditLog) {
+        this.auditLog = auditLog;
     }
 
     public Client getClient() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/util/ServerUtil.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/util/ServerUtil.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import io.jans.as.common.service.common.ApplicationFactory;
@@ -140,7 +141,7 @@ public class ServerUtil {
     }
 
     public static ObjectMapper createJsonMapper() {
-        final AnnotationIntrospector jaxb = new JaxbAnnotationIntrospector();
+        final AnnotationIntrospector jaxb = new JaxbAnnotationIntrospector(TypeFactory.defaultInstance());
         final AnnotationIntrospector jackson = new JacksonAnnotationIntrospector();
 
         final AnnotationIntrospector pair = AnnotationIntrospector.pair(jackson, jaxb);


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Split grant validation logic into TokenRestWebServiceValidator.

#### Target issue
#1591

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [-] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

