### PR TITLE
feat(jans-linux-setup): AlmaLinux 8 Support

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/data/package_list.json
+++ b/jans-linux-setup/jans_setup/setup_app/data/package_list.json
@@ -19,6 +19,11 @@
     "mondatory": "httpd mod_ssl mod_auth_openidc curl wget tar xz unzip  rsyslog bzip2",
     "python": {"ldap3":"python3-ldap3", "requests":"python3-requests", "ruamel.yaml":"python3-ruamel-yaml", "certifi":"python3-certifi", "pymysql":"python3-PyMySQL", "Crypto": "python3-cryptography", "prompt_toolkit": "python3-prompt-toolkit"}
   },
+  "almalinux 8": {
+    "optional": "",
+    "mondatory": "httpd mod_ssl mod_auth_openidc curl wget tar xz unzip rsyslog bzip2",
+    "python": {"ldap3":"python3-ldap3", "requests":"python3-requests", "ruamel.yaml":"python3-ruamel-yaml", "certifi":"python3-certifi", "pymysql":"python3-PyMySQL", "Crypto": "python3-cryptography", "prompt_toolkit": "python3-prompt-toolkit"}
+  },
   "suse 15": {
     "optional": "",
     "mondatory": "apache2 apache2-mod_auth_openidc curl wget tar xz unzip rsyslog bzip2",

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -75,7 +75,7 @@ os_name = os_type + os_version
 deb_sysd_clone = os_name in ('ubuntu18', 'ubuntu20', 'ubuntu22', 'debian9', 'debian10', 'debian11')
 
 # Determine service path
-if (os_type in ('centos', 'red', 'fedora', 'suse') and os_initdaemon == 'systemd') or deb_sysd_clone:
+if (os_type in ('almalinux','centos', 'red', 'fedora', 'suse') and os_initdaemon == 'systemd') or deb_sysd_clone:
     service_path = shutil.which('systemctl')
 elif os_type in ['debian', 'ubuntu']:
     service_path = '/usr/sbin/service'

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -82,7 +82,7 @@ elif os_type in ['debian', 'ubuntu']:
 else:
     service_path = '/sbin/service'
 
-if os_type in ('centos', 'red', 'fedora'):
+if os_type in ('almalinux','centos', 'red', 'fedora'):
     clone_type = 'rpm'
     httpd_name = 'httpd'
 elif os_type == 'suse':


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
[AlmaLinux](https://almalinux.org/) is a GNU/Linux distribution 1:1 compatible with RHEL and pre-Stream CentOS. Jans would previously fail to install on AlmaLinux 8 systems due to checks for os_type which did not indicate almalinux as an RPM-compatible distro.

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->
This pull request adds support for AlmaLinux 8 by adding a package list for the distro and its os_type to relevant checks.

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

