### PR TITLE
fix: jans-linux-setup remove apache config when uninstall

### DIFF
--- a/jans-linux-setup/jans_setup/install.py
+++ b/jans-linux-setup/jans_setup/install.py
@@ -213,6 +213,7 @@ def uninstall_jans():
 
     for fn in apache_conf_fn_list:
         if os.path.exists(fn):
+            print("Removing", fn)
             os.unlink(fn)
 
 def upgrade():

--- a/jans-linux-setup/jans_setup/install.py
+++ b/jans-linux-setup/jans_setup/install.py
@@ -202,6 +202,18 @@ def uninstall_jans():
         print("Executing", cmd)
         os.system('rm -r -f ' + p)
 
+    apache_conf_fn_list = []
+
+    if shutil.which('zypper'):
+        apache_conf_fn_list = ['/etc/apache2/vhosts.d/_https_jans.conf']
+    elif shutil.which('yum') or shutil.which('dnf'):
+        apache_conf_fn_list = ['/etc/httpd/conf.d/https_jans.conf']
+    elif shutil.which('apt'):
+        apache_conf_fn_list = ['/etc/apache2/sites-enabled/https_jans.conf', '/etc/apache2/sites-available/https_jans.conf']
+
+    for fn in apache_conf_fn_list:
+        if os.path.exists(fn):
+            os.unlink(fn)
 
 def upgrade():
     check_installation()


### PR DESCRIPTION
Remove apache configuration when uninstall as described in https://github.com/JanssenProject/jans/issues/1809
Closes #1845, 