### PR TITLE
docs(jans-config-api): fixed swagger format issue

### DIFF
--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -4770,10 +4770,10 @@ components:
           example: '\"RS256\", \"RS512\", \"ES384\", \"PS256\"'
         discoveryDenyKeys:
           type: array
-            description: List of configuration response claims which must not be displayed in discovery endpoint response.
-            items:
-              type: string
-            example: 'id_generation_endpoint, auth_level_mapping, etc.'
+          description: List of configuration response claims which must not be displayed in discovery endpoint response.
+          items:
+            type: string
+          example: 'id_generation_endpoint, auth_level_mapping, etc.'
         discoveryAllowedKeys:
           type: array
           description: List of configuration response claim allowed to be displayed in discovery endpoint.


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Attribute indentation issue causing the parser to fail
![image](https://user-images.githubusercontent.com/43700552/180422958-48f93dd4-7516-49d7-ac97-a10710aa0713.png)

#### Target issue
[1848](https://github.com/JanssenProject/jans/issues/1848)

#### Implementation Details
Fixed indentation of the element.

-------------------
### Test and Document the changes
NA


Closes: #1850, 