### PR TITLE
ci: add closes keyword to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,10 @@
 
 #### Target issue
   <!-- Link or describe the issue this PR is fixing -->
+  
+  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
+  
+closes #issue-number-here
 
 #### Implementation Details
   <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
As per chat messages [here](https://chat.gluu.org/group/project_jans?msg=syHzy3SXJWdiRnZ6T), We have updated the PR template so that issue gets properly attached to PR.


#### Target issue
closes #1877 

#### Implementation Details
- added `closes` keyword under `Target issue` section
- added comments in `Target issue` section as a guideline around using GH task lists to create target issue

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed `NA`
- [ ] Relevant unit and integration tests have been added/updated `NA`
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc) 

