### PR TITLE
fix(jans-auth-server): client tests expects "scope to claim" mapping which are disabled by default #1873

### DIFF
--- a/jans-auth-server/client/src/test/java/io/jans/as/client/BaseTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/BaseTest.java
@@ -825,7 +825,6 @@ public abstract class BaseTest {
             assertNotNull(response.getRegistrationEndpoint(), "The registrationEndpoint is null");
 
             assertTrue(response.getScopesSupported().size() > 0, "The scopesSupported is empty");
-            assertTrue(response.getScopeToClaimsMapping().size() > 0, "The scope to claims mapping is empty");
             assertTrue(response.getResponseTypesSupported().size() > 0, "The responseTypesSupported is empty");
             assertTrue(response.getGrantTypesSupported().size() > 0, "The grantTypesSupported is empty");
             assertTrue(response.getAcrValuesSupported().size() >= 0, "The acrValuesSupported is empty");


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
 client tests expects "scope to claim" mapping which are disabled by default

#### Target issue
Closes #1873


