### PR TITLE
ci: add sleep to the workflow

### DIFF
--- a/.github/workflows/pr-ref-issue.yml
+++ b/.github/workflows/pr-ref-issue.yml
@@ -18,6 +18,9 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Wait for 5 seconds so that GH can attach issue to the PR if already mentioned by author
+        run: sleep 5s
+        shell: bash
       - name: Install dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
The problem is as described in the target issue.

Root cause is that on click of `Create PR` button, the workflow ran before GH APIs could process the PR description and identify and attach an issue if mentioned in the description by the author.

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #1908 

#### Implementation Details
Added a new step that makes the workflow wait for 5 seconds. 

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed `NA`
- [ ] Relevant unit and integration tests have been added/updated `NA`
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc) `NA`

