### PR TITLE
fix(jans-auth-server): fixing client tests effected by "scope to claim" mapping which is disabled by default #1873

### DIFF
--- a/jans-auth-server/client/src/test/java/io/jans/as/client/BaseTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/BaseTest.java
@@ -8,6 +8,7 @@ package io.jans.as.client;
 
 import com.google.common.collect.Maps;
 import io.jans.as.client.client.AssertBuilder;
+import io.jans.as.client.client.Asserter;
 import io.jans.as.client.dev.HostnameVerifierType;
 import io.jans.as.client.page.AbstractPage;
 import io.jans.as.client.page.PageConfig;
@@ -815,24 +816,7 @@ public abstract class BaseTest {
             OpenIdConfigurationResponse response = client.execOpenIdConfiguration();
 
             showClient(client);
-            assertEquals(response.getStatus(), 200, "Unexpected response code");
-            assertNotNull(response.getIssuer(), "The issuer is null");
-            assertNotNull(response.getAuthorizationEndpoint(), "The authorizationEndpoint is null");
-            assertNotNull(response.getTokenEndpoint(), "The tokenEndpoint is null");
-            assertNotNull(response.getRevocationEndpoint(), "The revocationEndpoint is null");
-            assertNotNull(response.getUserInfoEndpoint(), "The userInfoEndPoint is null");
-            assertNotNull(response.getJwksUri(), "The jwksUri is null");
-            assertNotNull(response.getRegistrationEndpoint(), "The registrationEndpoint is null");
-
-            assertTrue(response.getScopesSupported().size() > 0, "The scopesSupported is empty");
-            assertTrue(response.getResponseTypesSupported().size() > 0, "The responseTypesSupported is empty");
-            assertTrue(response.getGrantTypesSupported().size() > 0, "The grantTypesSupported is empty");
-            assertTrue(response.getAcrValuesSupported().size() >= 0, "The acrValuesSupported is empty");
-            assertTrue(response.getSubjectTypesSupported().size() > 0, "The subjectTypesSupported is empty");
-            assertTrue(response.getIdTokenSigningAlgValuesSupported().size() > 0, "The idTokenSigningAlgValuesSupported is empty");
-            assertTrue(response.getRequestObjectSigningAlgValuesSupported().size() > 0, "The requestObjectSigningAlgValuesSupported is empty");
-            assertTrue(response.getTokenEndpointAuthMethodsSupported().size() > 0, "The tokenEndpointAuthMethodsSupported is empty");
-            assertTrue(response.getClaimsSupported().size() > 0, "The claimsSupported is empty");
+            Asserter.assertOpenIdConfigurationResponse(response);
 
             authorizationEndpoint = response.getAuthorizationEndpoint();
             tokenEndpoint = response.getTokenEndpoint();

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/client/Asserter.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/client/Asserter.java
@@ -6,13 +6,13 @@
 
 package io.jans.as.client.client;
 
+import io.jans.as.client.OpenIdConfigurationResponse;
 import io.jans.as.client.RegisterResponse;
 import io.jans.as.model.register.RegisterRequestParam;
 
 import java.util.Arrays;
 
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * @author Yuriy Zabrovarnyy
@@ -48,5 +48,32 @@ public class Asserter {
         for (RegisterRequestParam claim : claimsToVerify) {
             assertTrue(response.getClaims().containsKey(claim.toString()), "Claim " + claim + " is not contained in response claims - code" + response.getEntity());
         }
+    }
+
+    public static void assertOpenIdConfigurationResponse(OpenIdConfigurationResponse response) {
+        assertEquals(response.getStatus(), 200, "Unexpected response code");
+        assertNotNull(response.getIssuer(), "The issuer is null");
+        assertNotNull(response.getAuthorizationEndpoint(), "The authorizationEndpoint is null");
+        assertNotNull(response.getTokenEndpoint(), "The tokenEndpoint is null");
+        assertNotNull(response.getRevocationEndpoint(), "The tokenRevocationEndpoint is null");
+        assertNotNull(response.getUserInfoEndpoint(), "The userInfoEndPoint is null");
+        assertNotNull(response.getClientInfoEndpoint(), "The clientInfoEndPoint is null");
+        assertNotNull(response.getCheckSessionIFrame(), "The checkSessionIFrame is null");
+        assertNotNull(response.getEndSessionEndpoint(), "The endSessionEndpoint is null");
+        assertNotNull(response.getJwksUri(), "The jwksUri is null");
+        assertNotNull(response.getRegistrationEndpoint(), "The registrationEndpoint is null");
+        assertNotNull(response.getIntrospectionEndpoint(), "The introspectionEndpoint is null");
+        assertNotNull(response.getParEndpoint(), "The parEndpoint is null");
+
+        assertTrue(response.getScopesSupported().size() > 0, "The scopesSupported is empty");
+        assertTrue(response.getResponseTypesSupported().size() > 0, "The responseTypesSupported is empty");
+        assertTrue(response.getGrantTypesSupported().size() > 0, "The grantTypesSupported is empty");
+        assertTrue(response.getSubjectTypesSupported().size() > 0, "The subjectTypesSupported is empty");
+        assertTrue(response.getIdTokenSigningAlgValuesSupported().size() > 0, "The idTokenSigningAlgValuesSupported is empty");
+        assertTrue(response.getRequestObjectSigningAlgValuesSupported().size() > 0, "The requestObjectSigningAlgValuesSupported is empty");
+        assertTrue(response.getTokenEndpointAuthMethodsSupported().size() > 0, "The tokenEndpointAuthMethodsSupported is empty");
+        assertTrue(response.getTokenEndpointAuthSigningAlgValuesSupported().size() > 0, "The tokenEndpointAuthSigningAlgValuesSupported is empty");
+        assertTrue(response.getClaimsSupported().size() > 0, "The claimsSupported is empty");
+
     }
 }

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/ConfigurationRestWebServiceHttpTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/ConfigurationRestWebServiceHttpTest.java
@@ -11,6 +11,7 @@ import io.jans.as.client.OpenIdConfigurationClient;
 import io.jans.as.client.OpenIdConfigurationResponse;
 import io.jans.as.client.OpenIdConnectDiscoveryClient;
 import io.jans.as.client.OpenIdConnectDiscoveryResponse;
+import io.jans.as.client.client.Asserter;
 import io.jans.as.client.dev.HostnameVerifierType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
@@ -62,26 +63,10 @@ public class ConfigurationRestWebServiceHttpTest extends BaseTest {
         OpenIdConfigurationResponse response = client.execOpenIdConfiguration();
 
         showClient(client);
-        assertEquals(response.getStatus(), 200, "Unexpected response code");
-        assertNotNull(response.getIssuer(), "The issuer is null");
-        assertNotNull(response.getAuthorizationEndpoint(), "The authorizationEndpoint is null");
-        assertNotNull(response.getTokenEndpoint(), "The tokenEndpoint is null");
-        assertNotNull(response.getRevocationEndpoint(), "The tokenRevocationEndpoint is null");
-        assertNotNull(response.getUserInfoEndpoint(), "The userInfoEndPoint is null");
-        assertNotNull(response.getClientInfoEndpoint(), "The clientInfoEndPoint is null");
-        assertNotNull(response.getCheckSessionIFrame(), "The checkSessionIFrame is null");
-        assertNotNull(response.getEndSessionEndpoint(), "The endSessionEndpoint is null");
-        assertNotNull(response.getJwksUri(), "The jwksUri is null");
-        assertNotNull(response.getRegistrationEndpoint(), "The registrationEndpoint is null");
-        assertNotNull(response.getIntrospectionEndpoint(), "The introspectionEndpoint is null");
-        assertNotNull(response.getParEndpoint(), "The parEndpoint is null");
+        Asserter.assertOpenIdConfigurationResponse(response);
 
-        assertTrue(response.getScopesSupported().size() > 0, "The scopesSupported is empty");
-        assertTrue(response.getScopeToClaimsMapping().size() > 0, "The scope to claims mapping is empty");
-        assertTrue(response.getResponseTypesSupported().size() > 0, "The responseTypesSupported is empty");
         assertTrue(response.getResponseModesSupported().size() > 0, "The responseModesSupported is empty");
         assertTrue(response.getGrantTypesSupported().size() > 0, "The grantTypesSupported is empty");
-        assertTrue(response.getAcrValuesSupported().size() >= 0, "The acrValuesSupported is empty");
         assertTrue(response.getSubjectTypesSupported().size() > 0, "The subjectTypesSupported is empty");
         assertTrue(response.getUserInfoSigningAlgValuesSupported().size() > 0, "The userInfoSigningAlgValuesSupported is empty");
         assertTrue(response.getUserInfoEncryptionAlgValuesSupported().size() > 0, "The userInfoEncryptionAlgValuesSupported is empty");
@@ -92,12 +77,9 @@ public class ConfigurationRestWebServiceHttpTest extends BaseTest {
         assertTrue(response.getRequestObjectSigningAlgValuesSupported().size() > 0, "The requestObjectSigningAlgValuesSupported is empty");
         assertTrue(response.getRequestObjectEncryptionAlgValuesSupported().size() > 0, "The requestObjectEncryptionAlgValuesSupported is empty");
         assertTrue(response.getRequestObjectEncryptionEncValuesSupported().size() > 0, "The requestObjectEncryptionEncValuesSupported is empty");
-        assertTrue(response.getTokenEndpointAuthMethodsSupported().size() > 0, "The tokenEndpointAuthMethodsSupported is empty");
-        assertTrue(response.getTokenEndpointAuthSigningAlgValuesSupported().size() > 0, "The tokenEndpointAuthSigningAlgValuesSupported is empty");
 
         assertTrue(response.getDisplayValuesSupported().size() > 0, "The displayValuesSupported is empty");
         assertTrue(response.getClaimTypesSupported().size() > 0, "The claimTypesSupported is empty");
-        assertTrue(response.getClaimsSupported().size() > 0, "The claimsSupported is empty");
         assertNotNull(response.getServiceDocumentation(), "The serviceDocumentation is null");
         assertTrue(response.getClaimsLocalesSupported().size() > 0, "The claimsLocalesSupported is empty");
         assertTrue(response.getUiLocalesSupported().size() > 0, "The uiLocalesSupported is empty");
@@ -105,8 +87,6 @@ public class ConfigurationRestWebServiceHttpTest extends BaseTest {
         assertTrue(response.getRequestParameterSupported(), "The requestParameterSupported is false");
         assertTrue(response.getRequestUriParameterSupported(), "The requestUriParameterSupported is false");
         assertFalse(response.getRequireRequestUriRegistration(), "The requireRequestUriRegistration is true");
-        assertNotNull(response.getOpPolicyUri(), "The opPolicyUri is null");
-        assertNotNull(response.getOpTosUri(), "The opTosUri is null");
 
         // Jans Auth #917: Add dynamic scopes and claims to discovery
         Map<String, List<String>> scopeToClaims = response.getScopeToClaimsMapping();


### PR DESCRIPTION
…m" mapping which is disabled by default #1873

docs: no docs required

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Fixed client tests effected by "scope to claim" mapping which is disabled by default.

#### Target issue
closes #1873

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

