### PR TITLE
feat(docker-jans-fido2): allow creating initial persistence entry

### DIFF
--- a/docker-jans-configurator/scripts/bootstrap.py
+++ b/docker-jans-configurator/scripts/bootstrap.py
@@ -755,10 +755,6 @@ class CtxGenerator:
         # self.set_secret("jca_pw", "admin")
         pass
 
-    def fido2_ctx(self):
-        # TODO: hardcoded in persistence-loader?
-        self.set_config("fido2ConfigFolder", "/etc/jans/conf/fido2")
-
     def sql_ctx(self):
         self.set_secret("sql_password", self.params["sql_pw"])
 
@@ -797,9 +793,6 @@ class CtxGenerator:
             self.couchbase_ctx()
 
         # self.jackrabbit_ctx()
-
-        if "fido2" in opt_scopes:
-            self.fido2_ctx()
 
         if "sql" in opt_scopes:
             self.sql_ctx()

--- a/docker-jans-configurator/scripts/parameter.py
+++ b/docker-jans-configurator/scripts/parameter.py
@@ -26,11 +26,13 @@ DEFAULT_SCOPES = (
 OPTIONAL_SCOPES = (
     "ldap",
     "scim",
-    "fido2",
-    "client-api",
     "couchbase",
     "redis",
     "sql",
+
+    # these scopes are no longer needed; not removed for backward-compat
+    "fido2",
+    "client-api",
     "casa",
 )
 

--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -68,13 +68,25 @@ RUN git clone --filter blob:none --no-checkout https://github.com/janssenproject
 RUN mkdir -p /etc/jans/conf \
     /etc/jans/conf/fido2/mds/cert \
     /etc/jans/conf/fido2/mds/toc \
-    /etc/jans/conf/fido2/server_metadata
+    /etc/jans/conf/fido2/server_metadata \
+    /app/static/rdbm \
+    /app/schema \
+    /app/templates/jans-fido2
 
-# COPY conf/fido2 /etc/jans/conf/fido2
 # sync static files from linux-setup
 RUN cd /tmp/jans \
     && cp -R ${JANS_SETUP_DIR}/static/fido2/authenticator_cert /etc/jans/conf/fido2/authenticator_cert \
-    && cp ${JANS_SETUP_DIR}/static/fido2/mds_toc_cert/metadata-root-ca.cer /etc/jans/conf/fido2/mds/cert/
+    && cp ${JANS_SETUP_DIR}/static/fido2/mds_toc_cert/metadata-root-ca.cer /etc/jans/conf/fido2/mds/cert/ \
+    && cp ${JANS_SETUP_DIR}/static/rdbm/sql_data_types.json /app/static/rdbm/ \
+    && cp ${JANS_SETUP_DIR}/static/rdbm/ldap_sql_data_type_mapping.json /app/static/rdbm/ \
+    && cp ${JANS_SETUP_DIR}/static/rdbm/opendj_attributes_syntax.json /app/static/rdbm/ \
+    && cp ${JANS_SETUP_DIR}/static/rdbm/sub_tables.json /app/static/rdbm/ \
+    && cp ${JANS_SETUP_DIR}/schema/jans_schema.json /app/schema/ \
+    && cp ${JANS_SETUP_DIR}/schema/custom_schema.json /app/schema/ \
+    && cp ${JANS_SETUP_DIR}/schema/opendj_types.json /app/schema/ \
+    && cp ${JANS_SETUP_DIR}/templates/jans-fido2/fido2.ldif /app/templates/jans-fido2/ \
+    && cp ${JANS_SETUP_DIR}/templates/jans-fido2/dynamic-conf.json /app/templates/jans-fido2/ \
+    && cp ${JANS_SETUP_DIR}/templates/jans-fido2/static-conf.json /app/templates/jans-fido2/
 
 # cleanup
 RUN rm -rf /tmp/jans

--- a/docker-jans-fido2/scripts/bootstrap.py
+++ b/docker-jans-fido2/scripts/bootstrap.py
@@ -2,6 +2,8 @@ import json
 import logging.config
 import os
 import re
+import typing as _t
+from functools import cached_property
 from string import Template
 
 from jans.pycloudlib import get_manager
@@ -14,8 +16,12 @@ from jans.pycloudlib.persistence import sync_couchbase_truststore
 from jans.pycloudlib.persistence import sync_ldap_truststore
 from jans.pycloudlib.persistence import render_sql_properties
 from jans.pycloudlib.persistence import render_spanner_properties
+from jans.pycloudlib.persistence.couchbase import CouchbaseClient
+from jans.pycloudlib.persistence.ldap import LdapClient
+from jans.pycloudlib.persistence.spanner import SpannerClient
+from jans.pycloudlib.persistence.sql import SqlClient
 from jans.pycloudlib.persistence.utils import PersistenceMapper
-from jans.pycloudlib.utils import cert_to_truststore
+from jans.pycloudlib.utils import cert_to_truststore, generate_base64_contents
 
 from settings import LOGGING_CONFIG
 
@@ -115,6 +121,9 @@ def main():
     modify_webdefault_xml()
     configure_logging()
 
+    persistence_setup = PersistenceSetup(manager)
+    persistence_setup.import_ldif_files()
+
 
 def configure_logging():
     # default config
@@ -174,6 +183,51 @@ def configure_logging():
     tmpl = Template(txt)
     with open(logfile, "w") as f:
         f.write(tmpl.safe_substitute(config))
+
+
+class PersistenceSetup:
+    def __init__(self, manager) -> None:
+        self.manager = manager
+
+        client_classes = {
+            "ldap": LdapClient,
+            "couchbase": CouchbaseClient,
+            "spanner": SpannerClient,
+            "sql": SqlClient,
+        }
+
+        # determine persistence type
+        mapper = PersistenceMapper()
+        self.persistence_type = mapper.mapping["default"]
+
+        # determine persistence client
+        client_cls = client_classes.get(self.persistence_type)
+        self.client = client_cls(manager)
+
+    @cached_property
+    def ctx(self) -> dict[str, _t.Any]:
+        ctx = {
+            "hostname": self.manager.config.get("hostname"),
+            "fido2ConfigFolder": "/etc/jans/conf/fido2",
+        }
+
+        # pre-populate fido2_dynamic_conf_base64
+        with open("/app/templates/jans-fido2/dynamic-conf.json") as f:
+            ctx["fido2_dynamic_conf_base64"] = generate_base64_contents(f.read() % ctx)
+
+        # pre-populate fido2_static_conf_base64
+        with open("/app/templates/jans-fido2/static-conf.json") as f:
+            ctx["fido2_static_conf_base64"] = generate_base64_contents(f.read())
+        return ctx
+
+    @cached_property
+    def ldif_files(self) -> list[str]:
+        return ["/app/templates/jans-fido2/fido2.ldif"]
+
+    def import_ldif_files(self) -> None:
+        for file_ in self.ldif_files:
+            logger.info(f"Importing {file_}")
+            self.client.create_from_ldif(file_, self.ctx)
 
 
 if __name__ == "__main__":

--- a/docker-jans-persistence-loader/scripts/utils.py
+++ b/docker-jans-persistence-loader/scripts/utils.py
@@ -125,7 +125,6 @@ def get_base_ctx(manager):
         "auth_openid_jks_pass": manager.secret.get("auth_openid_jks_pass"),
         "auth_legacyIdTokenClaims": manager.config.get("auth_legacyIdTokenClaims"),
         "auth_openidScopeBackwardCompatibility": manager.config.get("auth_openidScopeBackwardCompatibility"),
-        "fido2ConfigFolder": manager.config.get("fido2ConfigFolder"),
 
         "admin_inum": manager.config.get("admin_inum"),
         "scim_client_id": manager.config.get("scim_client_id"),
@@ -199,20 +198,6 @@ def merge_auth_ctx(ctx):
 
     # determine role scope mappings
     ctx["role_scope_mappings"] = json.dumps(get_role_scope_mappings())
-    return ctx
-
-
-def merge_fido2_ctx(ctx):
-    basedir = '/app/templates/jans-fido2'
-    file_mappings = {
-        'fido2_dynamic_conf_base64': 'dynamic-conf.json',
-        'fido2_static_conf_base64': 'static-conf.json',
-    }
-
-    for key, file_ in file_mappings.items():
-        file_path = os.path.join(basedir, file_)
-        with open(file_path) as fp:
-            ctx[key] = generate_base64_contents(fp.read() % ctx)
     return ctx
 
 
@@ -318,7 +303,6 @@ def prepare_template_ctx(manager):
     ctx = merge_extension_ctx(ctx)
     ctx = merge_auth_ctx(ctx)
     ctx = merge_config_api_ctx(ctx)
-    ctx = merge_fido2_ctx(ctx)
     ctx = merge_scim_ctx(ctx)
     ctx = merge_jans_cli_ctx(manager, ctx)
     return ctx
@@ -367,11 +351,6 @@ def get_ldif_mappings(group, optional_scopes=None):
                 "jans-scim/configuration.ldif",
                 "jans-scim/scopes.ldif",
                 "jans-scim/clients.ldif",
-            ]
-
-        if "fido2" in optional_scopes:
-            files += [
-                "jans-fido2/fido2.ldif",
             ]
 
         return files


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

The changeset add feature to allow creating entry directly from docker-jans-fido2.
This means redundant code in docker-jans-persistence-loader and docker-jans-configurator are removed.

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #2026 