### PR TITLE
fix(jans-config-api): config-api compilation failed in main #2030

### DIFF
--- a/jans-config-api/server/src/main/java/io/jans/configapi/service/auth/ScopeService.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/service/auth/ScopeService.java
@@ -202,7 +202,7 @@ public class ScopeService {
                     customScope.getClients().add(client);
                 }
             } else if (scope.getScopeType() == ScopeType.SPONTANEOUS) {
-                if (client.getClientId().equals(customScope.getAttributes().getSpontaneousClientId())) {
+                if (client.getClientId().equals(customScope.getCreatorId())) {
                     customScope.getClients().add(client);
                 }
             }


### PR DESCRIPTION
docs: no docs

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
closes #2030

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [] Relevant unit and integration tests have been added/updated
- [  Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

