### PR TITLE
fix(jans-auth-server): generate description during built-in key rotation #1790

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/AuthCryptoProvider.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/AuthCryptoProvider.java
@@ -530,10 +530,9 @@ public class AuthCryptoProvider extends AbstractCryptoProvider {
 
         JSONObject jsonObject = new JSONObject();
 
-        jsonObject.put(JWKParameter.KEY_TYPE, algorithm.getFamily());
+        algorithm.fill(jsonObject);
+
         jsonObject.put(JWKParameter.KEY_ID, alias);
-        jsonObject.put(JWKParameter.KEY_USE, algorithm.getUse().getParamName());
-        jsonObject.put(JWKParameter.ALGORITHM, algorithm.getParamName());
         jsonObject.put(JWKParameter.EXPIRATION_TIME, expirationTime);
         if (publicKey instanceof RSAPublicKey) {
             RSAPublicKey rsaPublicKey = (RSAPublicKey) publicKey;

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/Algorithm.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/Algorithm.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.jans.as.model.crypto.signature.AlgorithmFamily;
 import io.jans.as.model.util.StringUtils;
 import io.jans.as.model.crypto.signature.RSAKeyFactory;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -133,6 +134,14 @@ public enum Algorithm {
 
     public boolean canGenerateKeys() { // based on currently supported generator, see io.jans.as.model.crypto.AuthCryptoProvider.generateKeyEncryption
         return family == AlgorithmFamily.RSA || family == AlgorithmFamily.EC || family == AlgorithmFamily.ED;
+    }
+
+    public void fill(JSONObject jsonObject) {
+        jsonObject.put(JWKParameter.NAME, getOutName());
+        jsonObject.put(JWKParameter.DESCRIPTION, getDescription());
+        jsonObject.put(JWKParameter.KEY_TYPE, getFamily());
+        jsonObject.put(JWKParameter.KEY_USE, getUse().getParamName());
+        jsonObject.put(JWKParameter.ALGORITHM, getParamName());
     }
 
     /**

--- a/jans-auth-server/model/src/test/java/io/jans/as/model/jwk/AlgorithmTest.java
+++ b/jans-auth-server/model/src/test/java/io/jans/as/model/jwk/AlgorithmTest.java
@@ -1,0 +1,24 @@
+package io.jans.as.model.jwk;
+
+import org.json.JSONObject;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Yuriy Zabrovarnyy
+ */
+public class AlgorithmTest {
+
+    @Test
+    public void fill_whenCalled_shouldPutCorrectClaims() {
+        JSONObject jsonObject = new JSONObject();
+
+        Algorithm.RS256.fill(jsonObject);
+
+        assertEquals(Algorithm.RS256.getOutName(), jsonObject.getString("name"));
+        assertEquals(Algorithm.RS256.getDescription(), jsonObject.getString("descr"));
+        assertEquals(Algorithm.RS256.getUse().getParamName(), jsonObject.getString("use"));
+        assertEquals(Algorithm.RS256.getParamName(), jsonObject.getString("alg"));
+    }
+}

--- a/jans-auth-server/model/src/test/resources/testng.xml
+++ b/jans-auth-server/model/src/test/resources/testng.xml
@@ -1,6 +1,11 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="oxAuthModel" parallel="false">
+    <test name="Unit Tests" enabled="true">
+        <classes>
+            <class name="io.jans.as.model.jwk.AlgorithmTest"/>
+        </classes>
+    </test>
     <test name="Code Verifier (PKCE)" enabled="true">
         <classes>
             <class name="io.jans.as.model.authorize.CodeVerifierTest"/>


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

fix(jans-auth-server): generate description during built-in key rotation #1790

#### Target issue
 
closes #1790

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

