### PR TITLE
feat(jans-auth-server): added allowSpontaneousScopes AS JSON config #2074

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -89,6 +89,7 @@ public class AppConfiguration implements Configuration {
     private int statTimerIntervalInSeconds;
     private String statAuthorizationScope;
 
+    private Boolean allowSpontaneousScopes;
     private int spontaneousScopeLifetime;
     private String openidSubAttribute;
     private Boolean publicSubjectIdentifierPerClientEnabled = false;
@@ -1487,6 +1488,15 @@ public class AppConfiguration implements Configuration {
 
     public void setUmaPctLifetime(int umaPctLifetime) {
         this.umaPctLifetime = umaPctLifetime;
+    }
+
+    public Boolean getAllowSpontaneousScopes() {
+        if (allowSpontaneousScopes == null) allowSpontaneousScopes = false;
+        return allowSpontaneousScopes;
+    }
+
+    public void setAllowSpontaneousScopes(Boolean allowSpontaneousScopes) {
+        this.allowSpontaneousScopes = allowSpontaneousScopes;
     }
 
     public int getSpontaneousScopeLifetime() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/SpontaneousScopeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/SpontaneousScopeService.java
@@ -14,19 +14,16 @@ import io.jans.as.model.config.StaticConfiguration;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.util.Pair;
 import io.jans.as.persistence.model.Scope;
-import org.apache.commons.lang3.BooleanUtils;
-import org.python.google.common.collect.Sets;
-import org.slf4j.Logger;
-
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Set;
-import java.util.UUID;
+import org.python.google.common.collect.Sets;
+import org.slf4j.Logger;
+
+import java.util.*;
 import java.util.regex.Pattern;
+
+import static org.apache.commons.lang3.BooleanUtils.isFalse;
 
 @Stateless
 @Named
@@ -49,7 +46,7 @@ public class SpontaneousScopeService {
         }
 
         final Pair<Boolean, String> isAllowed = isAllowedBySpontaneousScopes(regExps, scopeId);
-        if (BooleanUtils.isFalse(isAllowed.getFirst())) {
+        if (isFalse(isAllowed.getFirst())) {
             log.error("Forbidden by client. Check client configuration.");
             return null;
         }
@@ -87,7 +84,11 @@ public class SpontaneousScopeService {
     }
 
     public boolean isAllowedBySpontaneousScopes(Client client, String scopeRequested) {
-        if (BooleanUtils.isFalse(client.getAttributes().getAllowSpontaneousScopes())) {
+        if (isFalse(appConfiguration.getAllowSpontaneousScopes())) {
+            return false;
+        }
+
+        if (isFalse(client.getAttributes().getAllowSpontaneousScopes())) {
             return false;
         }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/uma/service/UmaScopeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/uma/service/UmaScopeService.java
@@ -76,6 +76,10 @@ public class UmaScopeService {
             return fromLdap;
         }
 
+        if (isFalse(appConfiguration.getAllowSpontaneousScopes())) {
+            return null;
+        }
+
         if (isFalse(client.getAttributes().getAllowSpontaneousScopes())) {
             return null;
         }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/SpontaneousScopeServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/SpontaneousScopeServiceTest.java
@@ -1,0 +1,40 @@
+package io.jans.as.server.service;
+
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.model.config.StaticConfiguration;
+import io.jans.as.model.configuration.AppConfiguration;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class SpontaneousScopeServiceTest {
+
+    @InjectMocks
+    private SpontaneousScopeService spontaneousScopeService;
+
+    @Mock
+    private Logger log;
+    @Mock
+    private StaticConfiguration staticConfiguration;
+    @Mock
+    private AppConfiguration appConfiguration;
+    @Mock
+    private ScopeService scopeService;
+
+    @Test
+    public void isAllowedBySpontaneousScopes_whenGlobalConfigReturnsFalse_shouldReturnFalse() {
+        Client client = new Client();
+        client.getAttributes().setAllowSpontaneousScopes(true);
+
+        assertFalse(spontaneousScopeService.isAllowedBySpontaneousScopes(client, "scope"));
+    }
+}

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -12,6 +12,7 @@
             <class name="io.jans.as.server.service.MTLSServiceTest" />
             <class name="io.jans.as.server.model.authorize.JwtAuthorizationRequestTest" />
 			<class name="io.jans.as.server.service.ScopeServiceTest" />
+			<class name="io.jans.as.server.service.SpontaneousScopeServiceTest" />
 			<class name="io.jans.as.server.model.CIBAGrantTest" />
 			<class name="io.jans.as.server.service.RedirectionUriServiceTest" />
 			<class name="io.jans.as.server.service.external.ExternalAuthenticationServiceTest" />

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -4249,6 +4249,9 @@ components:
         umaRestrictResourceToAssociatedClient:
           type: boolean
           description: Restrict access to resource by associated client.
+        allowSpontaneousScopes:
+          type: boolean
+          description: Specifies whether to allow spontaneous scopes
         spontaneousScopeLifetime:
           type: integer
           description: The lifetime of spontaneous scope in seconds.

--- a/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
+++ b/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
@@ -238,6 +238,7 @@ class TestDataLoader(BaseInstaller, SetupUtils):
                                     'fapiCompatibility': False,
                                     'forceIdTokenHintPrecense': False,
                                     'introspectionScriptBackwardCompatibility': False,
+                                    'allowSpontaneousScopes': True,
                                     'spontaneousScopeLifetime': 0,
                                     'tokenEndpointAuthMethodsSupported': [ 'client_secret_basic', 'client_secret_post', 'client_secret_jwt', 'private_key_jwt', 'tls_client_auth', 'self_signed_tls_client_auth', 'none' ],
                                     'sessionIdRequestParameterEnabled': True,


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Added allowSpontaneousScopes AS JSON config

#### Target issue
  
closes #2074 

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

