### PR TITLE
docs: remove non-fuctional middle alignment

### DIFF
--- a/docs/admin/recipes/passwordless.md
+++ b/docs/admin/recipes/passwordless.md
@@ -4,10 +4,8 @@ This document explains how to use Janssen Server Duo interception script to conf
 
 [Duo Security](https://duo.com/) is a SaaS authentication provider that supports multi-factor authentication including push-approvals, passcode, SMS-OTP etc. Duo provides web SDK via which clients like Janssen Server can integrate with Duo Security services. 
 
-</br>
-<p align="center">
-<img src="../../assets/image-duo-integration-diagram.png"/> 
-</p>
+
+![Duo integration diagram](../../assets/image-duo-integration-diagram.png)
   
 ## Prerequisites
 - An account with Duo Security  


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Since HTML tags used for center alignment are not supported in MKDocs, the integration component diagram was not showing up in the document. 

So, removed the alignment for now so that image is visible in the doc

#### Target issue

closes #2229 


