### PR TITLE
fix: jans-linux-setup lowercase admin user status

### DIFF
--- a/jans-linux-setup/jans_setup/templates/jans-auth/people.ldif
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/people.ldif
@@ -9,7 +9,7 @@ middleName: Admin
 nickname: Admin
 sn: User
 userPassword: %(encoded_admin_password)s
-jansStatus: ACTIVE
+jansStatus: active
 memberOf: inum=60B7,ou=groups,o=jans
 displayName: Default Admin User
 mail: admin@%(hostname)s


### PR DESCRIPTION
closes https://github.com/JanssenProject/jans/issues/1830

