### PR TITLE
fix: jans-linux-setup config-api scope type oauth

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
@@ -99,11 +99,10 @@ class ConfigApiInstaller(JettyInstaller):
         try:
             cfg_yml = self.read_config_api_swagger()
             scopes_def = cfg_yml['components']['securitySchemes']['oauth2']['flows']['clientCredentials']['scopes']
-            scope_type = cfg_yml['components']['securitySchemes']['oauth2']['type']
         except:
             scopes_def = {}
-            scope_type = 'oauth2'
 
+        scope_type = 'oauth'
         self.check_clients([('jca_client_id', '1800.')])
 
         if not Config.get('jca_client_pw'):


### PR DESCRIPTION
closes #2317
