### PR TITLE
feat(jans-auth-server): allow authentication for max_age=0 #2361

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -278,6 +278,7 @@ public class AppConfiguration implements Configuration {
 
     private ErrorHandlingMethod errorHandlingMethod = ErrorHandlingMethod.INTERNAL;
 
+    private Boolean disableAuthnForMaxAgeZero;
     private Boolean keepAuthenticatorAttributesOnAcrChange = false;
     private int deviceAuthzRequestExpiresIn;
     private int deviceAuthzTokenPollInterval;
@@ -2136,6 +2137,14 @@ public class AppConfiguration implements Configuration {
 
     public void setKeepAuthenticatorAttributesOnAcrChange(Boolean keepAuthenticatorAttributesOnAcrChange) {
         this.keepAuthenticatorAttributesOnAcrChange = keepAuthenticatorAttributesOnAcrChange;
+    }
+
+    public Boolean getDisableAuthnForMaxAgeZero() {
+        return disableAuthnForMaxAgeZero;
+    }
+
+    public void setDisableAuthnForMaxAgeZero(Boolean disableAuthnForMaxAgeZero) {
+        this.disableAuthnForMaxAgeZero = disableAuthnForMaxAgeZero;
     }
 
     public String getBackchannelClientId() {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidatorTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidatorTest.java
@@ -1,0 +1,77 @@
+package io.jans.as.server.authorize.ws.rs;
+
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.model.session.SessionId;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.server.security.Identity;
+import io.jans.as.server.service.ClientService;
+import io.jans.as.server.service.DeviceAuthorizationService;
+import io.jans.as.server.service.RedirectionUriService;
+import io.jans.as.server.service.SessionIdService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class AuthorizeRestWebServiceValidatorTest {
+
+    @InjectMocks
+    private AuthorizeRestWebServiceValidator authorizeRestWebServiceValidator;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private ClientService clientService;
+
+    @Mock
+    private RedirectionUriService redirectionUriService;
+
+    @Mock
+    private DeviceAuthorizationService deviceAuthorizationService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private SessionIdService sessionIdService;
+
+    @Mock
+    private Identity identity;
+
+    @Test
+    public void isAuthnMaxAgeValid_whenMaxAgeIsZero_shouldReturnTrue() {
+        assertTrue(authorizeRestWebServiceValidator.isAuthnMaxAgeValid(0, new SessionId(), new Client()));
+    }
+
+    @Test
+    public void isAuthnMaxAgeValid_whenMaxAgeIsZeroAndDisableAuthnForMaxAgeZeroIsFalse_shouldReturnTrue() {
+        when(appConfiguration.getDisableAuthnForMaxAgeZero()).thenReturn(false);
+        assertTrue(authorizeRestWebServiceValidator.isAuthnMaxAgeValid(0, new SessionId(), new Client()));
+    }
+
+    @Test
+    public void isAuthnMaxAgeValid_whenMaxAgeIsZeroAndDisableAuthnForMaxAgeZeroIsTrue_shouldReturnFalse() {
+        when(appConfiguration.getDisableAuthnForMaxAgeZero()).thenReturn(true);
+        assertFalse(authorizeRestWebServiceValidator.isAuthnMaxAgeValid(0, new SessionId(), new Client()));
+    }
+
+    @Test
+    public void isAuthnMaxAgeValid_whenMaxAgeIsNull_shouldReturnTrue() {
+        assertTrue(authorizeRestWebServiceValidator.isAuthnMaxAgeValid(0, new SessionId(), new Client()));
+    }
+}

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -8,16 +8,19 @@
 
     <test name="Unit Tests" enabled="true">
         <classes>
-            <class name="io.jans.as.server.ws.rs.stat.MonthsTest" />
-            <class name="io.jans.as.server.service.MTLSServiceTest" />
+            <class name="io.jans.as.server.model.CIBAGrantTest" />
             <class name="io.jans.as.server.model.authorize.JwtAuthorizationRequestTest" />
-			<class name="io.jans.as.server.service.ScopeServiceTest" />
-			<class name="io.jans.as.server.service.SpontaneousScopeServiceTest" />
-			<class name="io.jans.as.server.model.CIBAGrantTest" />
-			<class name="io.jans.as.server.service.RedirectionUriServiceTest" />
-			<class name="io.jans.as.server.service.external.ExternalAuthenticationServiceTest" />
-			<class name="io.jans.as.server.token.ws.rs.TokenRestWebServiceValidatorTest" />
-			<class name="io.jans.as.server.servlet.OpenIdConfigurationTest" />
+
+            <class name="io.jans.as.server.service.MTLSServiceTest" />
+            <class name="io.jans.as.server.service.ScopeServiceTest" />
+            <class name="io.jans.as.server.service.SpontaneousScopeServiceTest" />
+            <class name="io.jans.as.server.service.RedirectionUriServiceTest" />
+            <class name="io.jans.as.server.service.external.ExternalAuthenticationServiceTest" />
+            <class name="io.jans.as.server.servlet.OpenIdConfigurationTest" />
+
+            <class name="io.jans.as.server.token.ws.rs.TokenRestWebServiceValidatorTest" />
+            <class name="io.jans.as.server.ws.rs.stat.MonthsTest" />
+            <class name="io.jans.as.server.authorize.ws.rs.AuthorizeRestWebServiceValidatorTest" />
         </classes>
     </test>
 

--- a/jans-config-api/docs/jans-config-api-swagger-auto.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger-auto.yaml
@@ -4270,6 +4270,8 @@ components:
           - remote
         keepAuthenticatorAttributesOnAcrChange:
           type: boolean
+        disableAuthnForMaxAgeZero:
+          type: boolean
         deviceAuthzRequestExpiresIn:
           type: integer
           format: int32

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -5227,6 +5227,9 @@ components:
         keepAuthenticatorAttributesOnAcrChange:
           type: boolean
           description: Boolean value specifying whether to keep authenticator attributes on ACR change.
+        disableAuthnForMaxAgeZero:
+          type: boolean
+          description: Boolean value specifying whether to disable authentication when max_age=0 (false by default)
         deviceAuthzRequestExpiresIn:
           type: integer
           description: Expiration time given for device authorization requests.


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Setting max_age parameter with 0 value in a authorization request doesn't allow user to log in at all. After postlogin call user is redirected back to login page.

In addition we can introduce `disableAuthnForMaxAgeZero` with default value `false`. If `true` - authn will be disabled.

```
max_age
OPTIONAL. Maximum Authentication Age. Specifies the allowable elapsed time in seconds since the last time the End-User was actively authenticated by the OP. If the elapsed time is greater than this value, the OP MUST attempt to actively re-authenticate the End-User. (The max_age request parameter corresponds to the OpenID 2.0 PAPE [OpenID.PAPE] max_auth_age request parameter.) When max_age is used, the ID Token returned MUST include an auth_time Claim Value.
```

#### Target issue
 
closes #2361

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

