### PR TITLE
Docs add search tags

### DIFF
--- a/docs/admin/auth-server/README.md
+++ b/docs/admin/auth-server/README.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/client-management/README.md
+++ b/docs/admin/auth-server/client-management/README.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - administration
+  - client
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/client-management/client-authn.md
+++ b/docs/admin/auth-server/client-management/client-authn.md
@@ -1,2 +1,8 @@
+---
+tags:
+  - administration
+  - client
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/client-schema.md
+++ b/docs/admin/auth-server/client-management/client-schema.md
@@ -1,2 +1,8 @@
+---
+tags:
+  - administration
+  - client
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/client-scripts.md
+++ b/docs/admin/auth-server/client-management/client-scripts.md
@@ -1,2 +1,8 @@
+---
+tags:
+  - administration
+  - client
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/configuration/README.md
+++ b/docs/admin/auth-server/client-management/configuration/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - client
+  - configuration
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/client-management/configuration/client-crypto.md
+++ b/docs/admin/auth-server/client-management/configuration/client-crypto.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - client
+  - configuration
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/configuration/grants.md
+++ b/docs/admin/auth-server/client-management/configuration/grants.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - client
+  - configuration
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/configuration/pre-authorization.md
+++ b/docs/admin/auth-server/client-management/configuration/pre-authorization.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - client
+  - configuration
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/configuration/redirect-uris.md
+++ b/docs/admin/auth-server/client-management/configuration/redirect-uris.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - client
+  - configuration
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/configuration/response-types.md
+++ b/docs/admin/auth-server/client-management/configuration/response-types.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - client
+  - configuration
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/sector-identifiers.md
+++ b/docs/admin/auth-server/client-management/sector-identifiers.md
@@ -1,2 +1,8 @@
+---
+tags:
+  - administration
+  - client
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/client-management/software-statements.md
+++ b/docs/admin/auth-server/client-management/software-statements.md
@@ -1,2 +1,8 @@
+---
+tags:
+  - administration
+  - client
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/configuration/README.md
+++ b/docs/admin/auth-server/configuration/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - configuration
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/configuration/json-properties.md
+++ b/docs/admin/auth-server/configuration/json-properties.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - configuration
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/configuration/jvm-considerations.md
+++ b/docs/admin/auth-server/configuration/jvm-considerations.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - configuration
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/crypto/README.md
+++ b/docs/admin/auth-server/crypto/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - cryptography
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/crypto/key-rotation.md
+++ b/docs/admin/auth-server/crypto/key-rotation.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - cryptography
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/crypto/key-storage.md
+++ b/docs/admin/auth-server/crypto/key-storage.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - cryptography
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/crypto/manual-key-regeneration.md
+++ b/docs/admin/auth-server/crypto/manual-key-regeneration.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - cryptography
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/crypto/supported-algorithms.md
+++ b/docs/admin/auth-server/crypto/supported-algorithms.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - cryptography
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/README.md
+++ b/docs/admin/auth-server/endpoints/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/endpoints/authorization.md
+++ b/docs/admin/auth-server/endpoints/authorization.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/backchannel-authentication.md
+++ b/docs/admin/auth-server/endpoints/backchannel-authentication.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 
 ## Backchannel authentication scripts
 Janssen server enables domains to render the username/pw login form, avoiding the redirect to the IDP-hosted login page. Many SSO solutions offer a proprietary endpoint to accomplish this. However, in Janssen server, this is accomplished with the OAuth/OpenID framework by using a combination of calling the /token endpoint using the OAuth password flow, and then redirecting to browser to the /authorization endpoint, but auto-submitting the form.

--- a/docs/admin/auth-server/endpoints/client-registration.md
+++ b/docs/admin/auth-server/endpoints/client-registration.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/clientinfo.md
+++ b/docs/admin/auth-server/endpoints/clientinfo.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/configuration.md
+++ b/docs/admin/auth-server/endpoints/configuration.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/device-authorization.md
+++ b/docs/admin/auth-server/endpoints/device-authorization.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/end-session.md
+++ b/docs/admin/auth-server/endpoints/end-session.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/introspection.md
+++ b/docs/admin/auth-server/endpoints/introspection.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/session-revocation.md
+++ b/docs/admin/auth-server/endpoints/session-revocation.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/token-revocation.md
+++ b/docs/admin/auth-server/endpoints/token-revocation.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/token.md
+++ b/docs/admin/auth-server/endpoints/token.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/endpoints/userinfo.md
+++ b/docs/admin/auth-server/endpoints/userinfo.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/international/README.md
+++ b/docs/admin/auth-server/international/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - i18n
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/international/client-config.md
+++ b/docs/admin/auth-server/international/client-config.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - i18n
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/international/scope-descriptions.md
+++ b/docs/admin/auth-server/international/scope-descriptions.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - i18n
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/international/web-pages.md
+++ b/docs/admin/auth-server/international/web-pages.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - i18n
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/logging/README.md
+++ b/docs/admin/auth-server/logging/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - logging
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/logging/audit-logs.md
+++ b/docs/admin/auth-server/logging/audit-logs.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - logging
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/logging/custom-logs.md
+++ b/docs/admin/auth-server/logging/custom-logs.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - logging
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/logging/log-levels.md
+++ b/docs/admin/auth-server/logging/log-levels.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - logging
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/logging/log4j2.md
+++ b/docs/admin/auth-server/logging/log4j2.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - logging
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/logging/standard-logs.md
+++ b/docs/admin/auth-server/logging/standard-logs.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - logging
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/oauth-features/README.md
+++ b/docs/admin/auth-server/oauth-features/README.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - oauth
+  - feature
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/oauth-features/client-credential-grant.md
+++ b/docs/admin/auth-server/oauth-features/client-credential-grant.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - oauth
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/oauth-features/device-grant.md
+++ b/docs/admin/auth-server/oauth-features/device-grant.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - oauth
+  - feature
+---
+
 # OAuth 2.0 Device Authorization Grant
 
 This OAuth 2.0 protocol extension enables OAuth clients to request user authorization from applications on devices (e.g. smart TVs, media consoles, printers) that  are **input-constrained** or **browser-less** . The authorization flow defined by this [RFC 8628](https://tools.ietf.org/html/rfc8628), sometimes referred to as the "device flow", instructs the user to review the authorization request on a secondary device, such as a smartphone or a personal computer, which has the requisite input and browser capabilities to complete the user interaction.

--- a/docs/admin/auth-server/oauth-features/dpop.md
+++ b/docs/admin/auth-server/oauth-features/dpop.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - oauth
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/oauth-features/mtls.md
+++ b/docs/admin/auth-server/oauth-features/mtls.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - oauth
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/oauth-features/par.md
+++ b/docs/admin/auth-server/oauth-features/par.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - oauth
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/oauth-features/password-grant.md
+++ b/docs/admin/auth-server/oauth-features/password-grant.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - oauth
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/oauth-features/pkce.md
+++ b/docs/admin/auth-server/oauth-features/pkce.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - oauth
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/README.md
+++ b/docs/admin/auth-server/openid-features/README.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/openid-features/acrs.md
+++ b/docs/admin/auth-server/openid-features/acrs.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/ciba.md
+++ b/docs/admin/auth-server/openid-features/ciba.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/consent/README.md
+++ b/docs/admin/auth-server/openid-features/consent/README.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - consent
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/openid-features/consent/customize.md
+++ b/docs/admin/auth-server/openid-features/consent/customize.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - consent
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/consent/list-delete.md
+++ b/docs/admin/auth-server/openid-features/consent/list-delete.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - consent
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/id-token.md
+++ b/docs/admin/auth-server/openid-features/id-token.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/jarm.md
+++ b/docs/admin/auth-server/openid-features/jarm.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/logout/README.md
+++ b/docs/admin/auth-server/openid-features/logout/README.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - logout
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/openid-features/logout/back-channel.md
+++ b/docs/admin/auth-server/openid-features/logout/back-channel.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - logout
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/logout/customizing-logout.md
+++ b/docs/admin/auth-server/openid-features/logout/customizing-logout.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - logout
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/logout/forcing-logout.md
+++ b/docs/admin/auth-server/openid-features/logout/forcing-logout.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - logout
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/logout/front-channel.md
+++ b/docs/admin/auth-server/openid-features/logout/front-channel.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - logout
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/prompt-parameter.md
+++ b/docs/admin/auth-server/openid-features/prompt-parameter.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 # Prompt NONE
 
 The OpenID Connect protocol supports a prompt=none parameter on the authentication request that allows applications to indicate that the authorization server must not display any user interaction (such as authentication, consent, or MFA). Janssen will either return the requested response back to the application, or return an error if the user is not already authenticated or if some type of consent or prompt is required before proceeding.

--- a/docs/admin/auth-server/openid-features/request-objects.md
+++ b/docs/admin/auth-server/openid-features/request-objects.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/siop.md
+++ b/docs/admin/auth-server/openid-features/siop.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/subject-identifiers.md
+++ b/docs/admin/auth-server/openid-features/subject-identifiers.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/user-claims/README.md
+++ b/docs/admin/auth-server/openid-features/user-claims/README.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - claims
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/openid-features/user-claims/built-in-claims.md
+++ b/docs/admin/auth-server/openid-features/user-claims/built-in-claims.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - claims
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/user-claims/claim-uniqueness-validation.md
+++ b/docs/admin/auth-server/openid-features/user-claims/claim-uniqueness-validation.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - claims
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/openid-features/user-claims/custom-claims.md
+++ b/docs/admin/auth-server/openid-features/user-claims/custom-claims.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - openidc
+  - feature
+  - claims
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/reporting-metrics/README.md
+++ b/docs/admin/auth-server/reporting-metrics/README.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - reporting
+  - metric
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/reporting-metrics/failed-success-authn.md
+++ b/docs/admin/auth-server/reporting-metrics/failed-success-authn.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - reporting
+  - metric
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/reporting-metrics/health.md
+++ b/docs/admin/auth-server/reporting-metrics/health.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - reporting
+  - metric
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/reporting-metrics/mau.md
+++ b/docs/admin/auth-server/reporting-metrics/mau.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - reporting
+  - metric
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/reporting-metrics/tokens-issued.md
+++ b/docs/admin/auth-server/reporting-metrics/tokens-issued.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - reporting
+  - metric
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/reporting-metrics/user-client-count.md
+++ b/docs/admin/auth-server/reporting-metrics/user-client-count.md
@@ -1,2 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - reporting
+  - metric
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/session-management/README.md
+++ b/docs/admin/auth-server/session-management/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - session
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/session-management/idp-v-rp.md
+++ b/docs/admin/auth-server/session-management/idp-v-rp.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - session
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/session-management/multiple-browser-sessions.md
+++ b/docs/admin/auth-server/session-management/multiple-browser-sessions.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - session
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/session-management/multiple-sessions-one-browser.md
+++ b/docs/admin/auth-server/session-management/multiple-sessions-one-browser.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - session
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/session-management/what-is.md
+++ b/docs/admin/auth-server/session-management/what-is.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - session
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/tokens/README.md
+++ b/docs/admin/auth-server/tokens/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - token
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/tokens/oauth-access-tokens.md
+++ b/docs/admin/auth-server/tokens/oauth-access-tokens.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - token
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/tokens/oauth-refresh-tokens.md
+++ b/docs/admin/auth-server/tokens/oauth-refresh-tokens.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - token
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/tokens/openid-id-token.md
+++ b/docs/admin/auth-server/tokens/openid-id-token.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - token
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/tokens/openid-userinfo-token.md
+++ b/docs/admin/auth-server/tokens/openid-userinfo-token.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - token
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/tokens/uma-rpt-token.md
+++ b/docs/admin/auth-server/tokens/uma-rpt-token.md
@@ -1,2 +1,9 @@
+---
+tags:
+  - administration
+  - auth-server
+  - token
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/uma-features/README.md
+++ b/docs/admin/auth-server/uma-features/README.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - administration
+  - auth-server
+  - uma
+---
+
 # Overview
 
 Please use the left navigation menu to browse the content of this section while we are still working on developing content for `Overview` page.

--- a/docs/admin/auth-server/uma-features/claims-gathering-endpoint.md
+++ b/docs/admin/auth-server/uma-features/claims-gathering-endpoint.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - uma
+  - feature
+  - endpoint
+---
+
 This is a placeholder
 

--- a/docs/admin/auth-server/uma-features/rpt-endpoint.md
+++ b/docs/admin/auth-server/uma-features/rpt-endpoint.md
@@ -1,2 +1,11 @@
+---
+tags:
+  - administration
+  - auth-server
+  - uma
+  - feature
+  - endpoint
+---
+
 This is a placeholder
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -418,7 +418,6 @@ nav:
             - 'SCIM': 'admin/reference/json/scim.md'
             - 'Client API': 'admin/reference/json/client-api.md'
             - 'Config API': 'admin/reference/json/config-api.md'
-        - 'Javadocs': 'admin/reference/javadocs.md'
         - 'Kubernetes':
             - 'admin/reference/kubernetes/README.md'
             - 'Helm Chart': 'admin/reference/kubernetes/helm-chart.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ edit_uri: edit/main/docs/
 
 # Plugins
 plugins:
+   - tags
    - search
    - git-revision-date-localized:
        type: timeago


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

I have added only those tags that represent the context of the doc. When individual docs are written, the writer can add more detailed tags based on the content. 

### Implementation approach

- Some tags are added which qualify another tag. For instance, `component` along with `client-api` tag to communicate that `client-api` tag represents a Janssen Server component.


- added tag support in mkdocs config
- added tags to section: `administration` -> `Auth Server Admin Guide`

`NOTE`: 

#### Target issue

  
closes #2475 

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed `NA`
- [ ] Relevant unit and integration tests have been added/updated `NA`
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

