### PR TITLE
chore(jans): client should use CustomObjectAttribute instead of CustomAttribute #2483

### DIFF
--- a/jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
@@ -13,7 +13,7 @@ import io.jans.as.model.crypto.signature.AsymmetricSignatureAlgorithm;
 import io.jans.as.model.register.ApplicationType;
 import io.jans.as.persistence.model.ClientAttributes;
 import io.jans.orm.annotation.*;
-import io.jans.orm.model.base.CustomAttribute;
+import io.jans.orm.model.base.CustomObjectAttribute;
 import io.jans.orm.model.base.DeletableEntity;
 import io.jans.orm.model.base.LocalizedString;
 import org.apache.commons.lang.StringUtils;
@@ -190,8 +190,8 @@ public class Client extends DeletableEntity implements Serializable {
     @AttributeName(name = "jansAccessTknLife")
     private Integer accessTokenLifetime;
 
-    @AttributesList(name = "name", value = "values", sortByName = true)
-    private List<CustomAttribute> customAttributes = new ArrayList<>();
+    @AttributesList(name = "name", value = "values", multiValued = "multiValued", sortByName = true)
+    private List<CustomObjectAttribute> customAttributes = new ArrayList<>();
 
     @CustomObjectClass
     private String[] customObjectClasses;
@@ -1199,11 +1199,11 @@ public class Client extends DeletableEntity implements Serializable {
         this.accessTokenLifetime = accessTokenLifetime;
     }
 
-    public List<CustomAttribute> getCustomAttributes() {
+    public List<CustomObjectAttribute> getCustomAttributes() {
         return customAttributes;
     }
 
-    public void setCustomAttributes(List<CustomAttribute> customAttributes) {
+    public void setCustomAttributes(List<CustomObjectAttribute> customAttributes) {
         this.customAttributes = customAttributes;
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterJsonService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterJsonService.java
@@ -19,22 +19,18 @@ import io.jans.as.server.ciba.CIBARegisterClientResponseService;
 import io.jans.as.server.service.ClientService;
 import io.jans.as.server.service.ScopeService;
 import io.jans.model.GluuAttribute;
-import io.jans.orm.model.base.CustomAttribute;
+import io.jans.orm.model.base.CustomObjectAttribute;
 import io.jans.util.security.StringEncrypter;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.List;
 
 import static io.jans.as.model.register.RegisterRequestParam.*;
-import static io.jans.as.model.register.RegisterResponseParam.CLIENT_ID_ISSUED_AT;
-import static io.jans.as.model.register.RegisterResponseParam.CLIENT_SECRET;
-import static io.jans.as.model.register.RegisterResponseParam.CLIENT_SECRET_EXPIRES_AT;
-import static io.jans.as.model.register.RegisterResponseParam.REGISTRATION_CLIENT_URI;
+import static io.jans.as.model.register.RegisterResponseParam.*;
 import static io.jans.as.model.util.StringUtils.implode;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
@@ -181,12 +177,12 @@ public class RegisterJsonService {
 
     private void putCustomAttributesInResponse(Client client, JSONObject responseJsonObject) {
         final List<String> allowedCustomAttributeNames = appConfiguration.getDynamicRegistrationCustomAttributes();
-        final List<CustomAttribute> customAttributes = client.getCustomAttributes();
+        final List<CustomObjectAttribute> customAttributes = client.getCustomAttributes();
         if (allowedCustomAttributeNames == null || allowedCustomAttributeNames.isEmpty() || customAttributes == null) {
             return;
         }
 
-        for (CustomAttribute attribute : customAttributes) {
+        for (CustomObjectAttribute attribute : customAttributes) {
             if (!allowedCustomAttributeNames.contains(attribute.getName()))
                 continue;
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterService.java
@@ -22,7 +22,7 @@ import io.jans.as.model.register.RegisterErrorResponseType;
 import io.jans.as.persistence.model.Scope;
 import io.jans.as.server.ciba.CIBARegisterClientMetadataService;
 import io.jans.as.server.service.ScopeService;
-import io.jans.orm.model.base.CustomAttribute;
+import io.jans.orm.model.base.CustomObjectAttribute;
 import io.jans.util.StringHelper;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
@@ -403,7 +403,10 @@ public class RegisterService {
             try {
                 boolean processed = processApplicationAttributes(client, attr, parameterValues);
                 if (!processed) {
-                    client.getCustomAttributes().add(new CustomAttribute(attr, parameterValues));
+                    final CustomObjectAttribute customAttribute = new CustomObjectAttribute();
+                    customAttribute.setName(attr);
+                    customAttribute.setValues(new ArrayList<>(parameterValues));
+                    client.getCustomAttributes().add(customAttribute);
                 }
             } catch (Exception e) {
                 log.debug(e.getMessage(), e);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientService.java
@@ -17,25 +17,21 @@ import io.jans.orm.PersistenceEntryManager;
 import io.jans.orm.exception.EntryPersistenceException;
 import io.jans.orm.model.base.CustomAttribute;
 import io.jans.orm.model.base.CustomEntry;
+import io.jans.orm.model.base.CustomObjectAttribute;
 import io.jans.service.BaseCacheService;
 import io.jans.service.CacheService;
 import io.jans.service.LocalCacheService;
 import io.jans.util.StringHelper;
 import io.jans.util.security.StringEncrypter;
 import io.jans.util.security.StringEncrypter.EncryptionException;
+import jakarta.ejb.Stateless;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.json.JSONArray;
 import org.python.jline.internal.Preconditions;
 import org.slf4j.Logger;
 
-import jakarta.ejb.Stateless;
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import java.util.Collection;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.List;
-import java.util.Set;
-import java.util.TimeZone;
+import java.util.*;
 
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
@@ -196,8 +192,8 @@ public class ClientService {
         }
     }
 
-    public io.jans.orm.model.base.CustomAttribute getCustomAttribute(Client client, String attributeName) {
-        for (io.jans.orm.model.base.CustomAttribute customAttribute : client.getCustomAttributes()) {
+    public CustomObjectAttribute getCustomAttribute(Client client, String attributeName) {
+        for (CustomObjectAttribute customAttribute : client.getCustomAttributes()) {
             if (StringHelper.equalsIgnoreCase(attributeName, customAttribute.getName())) {
                 return customAttribute;
             }
@@ -207,10 +203,10 @@ public class ClientService {
     }
 
     public void setCustomAttribute(Client client, String attributeName, String attributeValue) {
-        io.jans.orm.model.base.CustomAttribute customAttribute = getCustomAttribute(client, attributeName);
+        CustomObjectAttribute customAttribute = getCustomAttribute(client, attributeName);
 
         if (customAttribute == null) {
-            customAttribute = new io.jans.orm.model.base.CustomAttribute(attributeName);
+            customAttribute = new CustomObjectAttribute(attributeName);
             client.getCustomAttributes().add(customAttribute);
         }
 
@@ -315,15 +311,15 @@ public class ClientService {
                 }
                 attribute = array;
             } else {
-                for (CustomAttribute customAttribute : client.getCustomAttributes()) {
+                for (CustomObjectAttribute customAttribute : client.getCustomAttributes()) {
                     if (customAttribute.getName().equals(clientAttribute)) {
-                        List<String> values = customAttribute.getValues();
+                        List<Object> values = customAttribute.getValues();
                         if (values != null) {
                             if (values.size() == 1) {
                                 attribute = values.get(0);
                             } else {
                                 JSONArray array = new JSONArray();
-                                for (String v : values) {
+                                for (Object v : values) {
                                     array.put(v);
                                 }
                                 attribute = array;


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

chore(jans): client should use CustomObjectAttribute instead of CustomAttribute #2483

#### Target issue
 
closes #2483

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

