### PR TITLE
fix(jans-auth-server): "login:prompt" property passed in request object JWT breaks authentication #2493

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/util/Util.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/util/Util.java
@@ -292,10 +292,14 @@ public class Util {
     }
 
     public static int parseIntSilently(String intString) {
+        return parseIntSilently(intString, -1);
+    }
+
+    public static int parseIntSilently(String intString, int defaultValue) {
         try {
             return Integer.parseInt(intString);
         } catch (Exception e) {
-            return -1;
+            return defaultValue;
         }
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -502,6 +502,7 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
         ResponseBuilder builder = RedirectUtil.getRedirectResponseBuilder(authzRequest.getRedirectUriResponse().getRedirectUri(), authzRequest.getHttpRequest());
 
         addCustomHeaders(builder, authzRequest);
+        updateSessionRpRedirect(sessionUser);
 
         runCiba(authzRequest.getAuthReqId(), client, authzRequest.getHttpRequest(), authzRequest.getHttpResponse());
         processDeviceAuthorization(deviceAuthzUserCode, user);
@@ -572,15 +573,18 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
 
     private void checkPromptLogin(AuthzRequest authzRequest, List<Prompt> prompts) {
         if (prompts.contains(Prompt.LOGIN)) {
+            boolean sessionUnauthenticated = false;
 
             //  workaround for #1030 - remove only authenticated session, for set up acr we set it unauthenticated and then drop in AuthorizeAction
             if (identity.getSessionId().getState() == SessionIdState.AUTHENTICATED) {
-                unauthenticateSession(authzRequest.getSessionId(), authzRequest.getHttpRequest());
+                sessionUnauthenticated = unauthenticateSession(authzRequest.getSessionId(), authzRequest.getHttpRequest(), authzRequest.isPromptFromJwt());
             }
             authzRequest.setSessionId(null);
             prompts.remove(Prompt.LOGIN);
 
-            throw new WebApplicationException(redirectToAuthorizationPage(authzRequest, prompts));
+            if (sessionUnauthenticated) {
+                throw new WebApplicationException(redirectToAuthorizationPage(authzRequest, prompts));
+            }
         }
     }
 
@@ -731,7 +735,7 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
             }
         } else {
             if (prompts.contains(Prompt.LOGIN)) {
-                unauthenticateSession(authzRequest.getSessionId(), authzRequest.getHttpRequest());
+                unauthenticateSession(authzRequest.getSessionId(), authzRequest.getHttpRequest(), authzRequest.isPromptFromJwt());
                 authzRequest.setSessionId(null);
                 prompts.remove(Prompt.LOGIN);
                 authzRequest.setPrompt(implode(prompts, " "));
@@ -906,16 +910,32 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
         return builder.build();
     }
 
-    private void unauthenticateSession(String sessionId, HttpServletRequest httpRequest) {
-        identity.logout();
+    private void updateSessionRpRedirect(SessionId sessionUser) {
+        int rpRedirectCount = Util.parseIntSilently(sessionUser.getSessionAttributes().get("successful_rp_redirect_count"), 0);
+        rpRedirectCount++;
 
+        sessionUser.getSessionAttributes().put("successful_rp_redirect_count", Integer.toString(rpRedirectCount));
+        sessionIdService.updateSessionId(sessionUser);
+    }
+
+    private boolean unauthenticateSession(String sessionId, HttpServletRequest httpRequest) {
+        return unauthenticateSession(sessionId, httpRequest, false);
+    }
+
+    private boolean unauthenticateSession(String sessionId, HttpServletRequest httpRequest, boolean isPromptFromJwt) {
         SessionId sessionUser = identity.getSessionId();
+
+        if (isPromptFromJwt && sessionUser != null && !sessionUser.getSessionAttributes().containsKey("successful_rp_redirect_count")) {
+            return false; // skip unauthentication because there were no at least one successful rp redirect
+        }
 
         if (sessionUser != null) {
             sessionUser.setUserDn(null);
             sessionUser.setUser(null);
             sessionUser.setAuthenticationTime(null);
         }
+
+        identity.logout();
 
         if (StringHelper.isEmpty(sessionId)) {
             sessionId = cookieService.getSessionIdFromCookie(httpRequest);
@@ -924,7 +944,7 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
         SessionId persistenceSessionId = sessionIdService.getSessionId(sessionId);
         if (persistenceSessionId == null) {
             log.error("Failed to load session from LDAP by session_id: '{}'", sessionId);
-            return;
+            return true;
         }
 
         persistenceSessionId.setState(SessionIdState.UNAUTHENTICATED);
@@ -936,6 +956,7 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
         if (!result) {
             log.error("Failed to update session_id '{}'", sessionId);
         }
+        return result;
     }
 
     /**

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequest.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequest.java
@@ -54,6 +54,15 @@ public class AuthzRequest {
     private RedirectUriResponse redirectUriResponse;
     private Client client;
     private OAuth2AuditLog auditLog;
+    private boolean promptFromJwt;
+
+    public boolean isPromptFromJwt() {
+        return promptFromJwt;
+    }
+
+    public void setPromptFromJwt(boolean promptFromJwt) {
+        this.promptFromJwt = promptFromJwt;
+    }
 
     public OAuth2AuditLog getAuditLog() {
         return auditLog;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequestService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequestService.java
@@ -220,6 +220,7 @@ public class AuthzRequestService {
                     prompts.clear();
                     prompts.addAll(Lists.newArrayList(jwtRequest.getPrompts()));
                     authzRequest.setPrompt(implode(prompts, " "));
+                    authzRequest.setPromptFromJwt(true);
                 }
                 if (jwtRequest.getResponseMode() != null) {
                     authzRequest.setResponseMode(jwtRequest.getResponseMode().getValue());


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

"login:prompt" property passed in request object JWT breaks authentication #2493

#### Target issue
  
closes #2493

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

