### PR TITLE
fix: jans-linux-setup install dependencies without interaction if --download-exit

### DIFF
--- a/jans-linux-setup/jans_setup/install.py
+++ b/jans-linux-setup/jans_setup/install.py
@@ -75,7 +75,7 @@ def check_install_dependencies():
             print("Can't continue...")
             sys.exit()
 
-        os.system('{} install -y {}'.format(package_installer, ' '.join(package_dependencies)))
+    os.system('{} install -y {}'.format(package_installer, ' '.join(package_dependencies)))
 
 
 def download_jans_acrhieve():
@@ -272,7 +272,7 @@ def do_install():
 
 def main():
 
-    if not argsp.uninstall:
+    if not argsp.uninstall or argsp.download_exit:
         check_install_dependencies()
 
     if not (argsp.use_downloaded or argsp.uninstall):

--- a/jans-linux-setup/jans_setup/jans_setup.py
+++ b/jans-linux-setup/jans_setup/jans_setup.py
@@ -89,14 +89,14 @@ downloads.download_apps()
 
 sys.path.insert(0, base.pylib_dir)
 
-if argsp.download_exit:
-    downloads.download_all()
-    sys.exit()
-
 from setup_app.utils.package_utils import packageUtils
 
 packageUtils.check_and_install_packages()
 sys.path.insert(0, os.path.join(base.pylib_dir, 'gcs'))
+
+if argsp.download_exit:
+    downloads.download_all()
+    sys.exit()
 
 from setup_app.messages import msg
 from setup_app.config import Config


### PR DESCRIPTION
closes #2545