### PR TITLE
fix: jans-linux-setup MySQL schema name is db name

### DIFF
--- a/jans-linux-setup/jans_setup/templates/jans-mysql.properties
+++ b/jans-linux-setup/jans_setup/templates/jans-mysql.properties
@@ -1,4 +1,4 @@
-db.schema.name=jansdb
+db.schema.name=%(rdbm_db)s
 
 connection.uri=jdbc:mysql://%(rdbm_host)s:%(rdbm_port)s/%(rdbm_db)s?enabledTLSProtocols=TLSv1.2
 


### PR DESCRIPTION
closes #2591