### PR TITLE
fix: jans-linux-setup don't call package installation unless missing packages

### DIFF
--- a/jans-linux-setup/jans_setup/install.py
+++ b/jans-linux-setup/jans_setup/install.py
@@ -75,7 +75,8 @@ def check_install_dependencies():
             print("Can't continue...")
             sys.exit()
 
-    os.system('{} install -y {}'.format(package_installer, ' '.join(package_dependencies)))
+    if package_dependencies:
+        os.system('{} install -y {}'.format(package_installer, ' '.join(package_dependencies)))
 
 
 def download_jans_acrhieve():


### PR DESCRIPTION
closes #2640