### PR TITLE
fix: jans-linux-setup use auto generated yaml file for config api scopes

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
@@ -127,7 +127,7 @@ class ConfigApiInstaller(JettyInstaller):
                 continue
 
             if not scope in scopes:
-                inum = '1800.' + os.urandom(3).hex().upper()
+                inum = '1800.{}-{}'.format(os.urandom(3).hex().upper(), os.urandom(3).hex().upper())
                 scope_dn = 'inum={},ou=scopes,o=jans'.format(inum)
                 scopes[scope] = {'dn': scope_dn}
                 display_name = 'Config API scope {}'.format(scope)

--- a/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
@@ -45,6 +45,7 @@ class ConfigApiInstaller(JettyInstaller):
         self.load_ldif_files = [self.config_ldif_fn, self.scope_ldif_fn]
         self.libDir = os.path.join(self.jetty_base, self.service_name, 'custom/libs/')
         self.custom_config_dir = os.path.join(self.jetty_base, self.service_name, 'custom/config')
+        self.config_api_swagger_yaml_fn = os.path.join(Config.data_dir, 'jans-config-api-swagger-auto.yaml')
 
         if not base.argsp.shell:
             self.extract_files()
@@ -76,7 +77,7 @@ class ConfigApiInstaller(JettyInstaller):
 
     def extract_files(self):
         base.extract_file(base.current_app.jans_zip, 'jans-config-api/server/src/main/resources/log4j2.xml', self.custom_config_dir)
-        base.extract_file(base.current_app.jans_zip, 'jans-config-api/docs/jans-config-api-swagger.yaml', Config.data_dir)
+        base.extract_file(base.current_app.jans_zip, os.path.join('jans-config-api/docs', os.path.basename(self.config_api_swagger_yaml_fn)), Config.data_dir)
 
 
     def create_folders(self):
@@ -88,8 +89,7 @@ class ConfigApiInstaller(JettyInstaller):
 
 
     def read_config_api_swagger(self):
-        config_api_swagger_yaml_fn = os.path.join(Config.data_dir, 'jans-config-api-swagger.yaml')
-        yml_str = self.readFile(config_api_swagger_yaml_fn)
+        yml_str = self.readFile(self.config_api_swagger_yaml_fn)
         yml_str = yml_str.replace('\t', ' ')
         cfg_yml = ruamel.yaml.load(yml_str, ruamel.yaml.RoundTripLoader)
         return cfg_yml

--- a/jans-linux-setup/jans_setup/setup_app/installers/scim.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/scim.py
@@ -106,7 +106,7 @@ class ScimInstaller(JettyInstaller):
         for scope in config_scopes:
             if scope in ('https://jans.io/scim/users.read', 'https://jans.io/scim/users.write'):
                 continue
-            inum = '1200.' + os.urandom(3).hex().upper()
+            inum = '1200.{}-{}'.format(os.urandom(3).hex().upper(), os.urandom(3).hex().upper())
             scope_dn = 'inum={},ou=scopes,o=jans'.format(inum)
             scopes_dn.append(scope_dn)
             display_name = 'Scim {}'.format(os.path.basename(scope))

--- a/jans-linux-setup/jans_setup/setup_app/installers/scim.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/scim.py
@@ -58,7 +58,7 @@ class ScimInstaller(JettyInstaller):
         if not os.path.exists(self.output_folder):
             os.makedirs(self.output_folder)
 
-        scope['inum'] = [inum_base + '.' + os.urandom(3).hex().upper()]
+        scope['inum'] = [inum_base + '.{}-{}'.format(os.urandom(3).hex().upper(), os.urandom(3).hex().upper())]
         ldif_scope_fn = os.path.join(self.output_folder, '{}.ldif'.format(scope['inum'][0]))
         scope_ldif_fd = open(ldif_scope_fn, 'wb')
         scope_dn = 'inum={},ou=scopes,o=jans'.format(scope['inum'][0])


### PR DESCRIPTION
closes #2695