### PR TITLE
fix(jans auth server): well known uppercase grant_types response_mode

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
@@ -35,13 +35,10 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static io.jans.as.model.configuration.ConfigurationResponseClaim.*;
 import static io.jans.as.model.util.StringUtils.implode;
@@ -147,22 +144,22 @@ public class OpenIdConfiguration extends HttpServlet {
                 jsonObj.put(RESPONSE_TYPES_SUPPORTED, responseTypesSupported);
             }
 
-            JSONArray responseModesSupported = new JSONArray();
+            List<String> listResponseModesSupported = new ArrayList<>();
             if (appConfiguration.getResponseModesSupported() != null) {
                 for (ResponseMode responseMode : appConfiguration.getResponseModesSupported()) {
-                    responseModesSupported.put(responseMode);
+                    listResponseModesSupported.add(responseMode.getValue());
                 }
             }
-            if (responseModesSupported.length() > 0) {
-                jsonObj.put(RESPONSE_MODES_SUPPORTED, responseModesSupported);
+            if (!listResponseModesSupported.isEmpty()) {
+                Util.putArray(jsonObj, listResponseModesSupported, RESPONSE_MODES_SUPPORTED);
             }
 
-            JSONArray grantTypesSupported = new JSONArray();
+            List<String> listGrantTypesSupported = new ArrayList<>();
             for (GrantType grantType : appConfiguration.getGrantTypesSupported()) {
-                grantTypesSupported.put(grantType);
+                listGrantTypesSupported.add(grantType.getValue());
             }
-            if (grantTypesSupported.length() > 0) {
-                jsonObj.put(GRANT_TYPES_SUPPORTED, grantTypesSupported);
+            if (!listGrantTypesSupported.isEmpty()) {
+                Util.putArray(jsonObj, listGrantTypesSupported, GRANT_TYPES_SUPPORTED);
             }
 
             JSONArray acrValuesSupported = new JSONArray();

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
@@ -147,7 +147,7 @@ public class OpenIdConfiguration extends HttpServlet {
             List<String> listResponseModesSupported = new ArrayList<>();
             if (appConfiguration.getResponseModesSupported() != null) {
                 for (ResponseMode responseMode : appConfiguration.getResponseModesSupported()) {
-                    listResponseModesSupported.add(responseMode.toString());
+                    listResponseModesSupported.add(responseMode.getValue());
                 }
             }
             if (!listResponseModesSupported.isEmpty()) {
@@ -156,7 +156,7 @@ public class OpenIdConfiguration extends HttpServlet {
 
             List<String> listGrantTypesSupported = new ArrayList<>();
             for (GrantType grantType : appConfiguration.getGrantTypesSupported()) {
-                listGrantTypesSupported.add(grantType.toString());
+                listGrantTypesSupported.add(grantType.getValue());
             }
             if (!listGrantTypesSupported.isEmpty()) {
                 Util.putArray(jsonObj, listGrantTypesSupported, GRANT_TYPES_SUPPORTED);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
@@ -147,7 +147,7 @@ public class OpenIdConfiguration extends HttpServlet {
             List<String> listResponseModesSupported = new ArrayList<>();
             if (appConfiguration.getResponseModesSupported() != null) {
                 for (ResponseMode responseMode : appConfiguration.getResponseModesSupported()) {
-                    listResponseModesSupported.add(responseMode.getValue());
+                    listResponseModesSupported.add(responseMode.toString());
                 }
             }
             if (!listResponseModesSupported.isEmpty()) {
@@ -156,7 +156,7 @@ public class OpenIdConfiguration extends HttpServlet {
 
             List<String> listGrantTypesSupported = new ArrayList<>();
             for (GrantType grantType : appConfiguration.getGrantTypesSupported()) {
-                listGrantTypesSupported.add(grantType.getValue());
+                listGrantTypesSupported.add(grantType.toString());
             }
             if (!listGrantTypesSupported.isEmpty()) {
                 Util.putArray(jsonObj, listGrantTypesSupported, GRANT_TYPES_SUPPORTED);


### PR DESCRIPTION
### Prepare

- [X] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [X] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Requesting `/.well-known/openid-configuration` for the first time returns unexpected output for `grant_types_supported` and `response_mode_supported`, it returns uppercase values.

#### Target issue
https://github.com/JanssenProject/jans/issues/2183
  
closes #2183

#### Implementation Details
Loading of `grant_types_supported` and `response_mode_supported`
was modified to `List<String>` in endpoint `/.well-known/openid-configuration`
because `JSONArray` loading was causing the issue.

-------------------
### Test and Document the changes
- [X] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

