### PR TITLE
chore(jans-scim): log4j-plugin-fluency reports vulnerability

### DIFF
--- a/jans-scim/server/pom.xml
+++ b/jans-scim/server/pom.xml
@@ -108,6 +108,12 @@
 			<groupId>com.wywy</groupId>
 			<artifactId>log4j-plugin-fluency</artifactId>
 			<version>1.3.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 
 		<!-- Security -->


### PR DESCRIPTION
closes  #2780