### PR TITLE
fix(jans-auth-server): native sso - return device secret if device_sso scope is present #2790

### DIFF
--- a/jans-auth-server/client/src/main/java/io/jans/as/client/TokenResponse.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/TokenResponse.java
@@ -30,6 +30,7 @@ public class TokenResponse extends BaseResponseWithErrors<TokenErrorResponseType
     private String refreshToken;
     private String scope;
     private String idToken;
+    private String deviceToken;
 
     public TokenResponse() {
     }
@@ -75,12 +76,20 @@ public class TokenResponse extends BaseResponseWithErrors<TokenErrorResponseType
                 if (jsonObj.has("id_token")) {
                     setIdToken(jsonObj.getString("id_token"));
                 }
+                setDeviceToken(jsonObj.optString("device_token"));
             } catch (JSONException e) {
                 LOG.error(e.getMessage(), e);
             }
         }
     }
 
+    public String getDeviceToken() {
+        return deviceToken;
+    }
+
+    public void setDeviceToken(String deviceToken) {
+        this.deviceToken = deviceToken;
+    }
 
     /**
      * Returns the access token issued by the authorization server.

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/client/Asserter.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/client/Asserter.java
@@ -9,6 +9,7 @@ package io.jans.as.client.client;
 import io.jans.as.client.OpenIdConfigurationResponse;
 import io.jans.as.client.RegisterResponse;
 import io.jans.as.model.register.RegisterRequestParam;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Arrays;
 
@@ -22,6 +23,22 @@ import static org.testng.Assert.*;
 public class Asserter {
 
     private Asserter() {
+    }
+
+    public static void assertBlank(String value) {
+        assertTrue(StringUtils.isNotBlank(value));
+    }
+
+    public static void assertBlank(String value, String message) {
+        assertTrue(StringUtils.isBlank(value), message);
+    }
+
+    public static void assertNotBlank(String value) {
+        assertTrue(StringUtils.isNotBlank(value));
+    }
+
+    public static void assertNotBlank(String value, String message) {
+        assertTrue(StringUtils.isNotBlank(value), message);
     }
 
     public static void assertRegisterResponseClaimsNotNull(RegisterResponse response, RegisterRequestParam... claimsToVerify) {

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/client/assertbuilders/JwtAssertBuilder.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/client/assertbuilders/JwtAssertBuilder.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.jans.as.client.BaseTest.clientEngine;
+import static io.jans.as.client.client.Asserter.assertNotBlank;
 import static org.testng.Assert.*;
 
 public class JwtAssertBuilder extends BaseAssertBuilder {
@@ -28,6 +29,7 @@ public class JwtAssertBuilder extends BaseAssertBuilder {
     private boolean notNullAuthenticationMethodReferences;
     private boolean notNullClaimsAddressdata;
     private boolean checkMemberOfClaimNoEmpty;
+    private boolean notBlankDsHash;
     private String[] claimsPresence;
     private String[] claimsNoPresence;
 
@@ -50,6 +52,11 @@ public class JwtAssertBuilder extends BaseAssertBuilder {
 
     public JwtAssertBuilder notNullAccesTokenHash() {
         this.notNullAccesTokenHash = true;
+        return this;
+    }
+
+    public JwtAssertBuilder notBlankDsHash() {
+        notBlankDsHash = true;
         return this;
     }
 
@@ -179,6 +186,10 @@ public class JwtAssertBuilder extends BaseAssertBuilder {
         if (checkMemberOfClaimNoEmpty) {
             assertNotNull(jwt.getClaims().getClaimAsStringList("member_of"));
             assertTrue(jwt.getClaims().getClaimAsStringList("member_of").size() > 1);
+        }
+
+        if (notBlankDsHash) {
+            assertNotBlank(jwt.getClaims().getClaimAsString("ds_hash"), "ds_hash claim is not present");
         }
 
         if (notNullClaimsAddressdata) {

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/client/assertbuilders/TokenResponseAssertBuilder.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/client/assertbuilders/TokenResponseAssertBuilder.java
@@ -1,9 +1,9 @@
 package io.jans.as.client.client.assertbuilders;
 
 import io.jans.as.client.TokenResponse;
-import io.jans.as.client.client.AssertBuilder;
 import io.jans.as.model.token.TokenErrorResponseType;
 
+import static io.jans.as.client.client.Asserter.assertNotBlank;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -12,6 +12,7 @@ public class TokenResponseAssertBuilder extends BaseAssertBuilder {
     private TokenResponse response;
     private int status = 200;
     private boolean notNullRefreshToken;
+    private boolean notBlankDeviceToken;
     private boolean notNullIdToken;
     private boolean notNullScope;
     private boolean nullRefreshToken;
@@ -53,6 +54,11 @@ public class TokenResponseAssertBuilder extends BaseAssertBuilder {
         return this;
     }
 
+    public TokenResponseAssertBuilder notBlankDeviceToken() {
+        this.notBlankDeviceToken = true;
+        return this;
+    }
+
     public TokenResponseAssertBuilder notNullIdToken() {
         this.notNullIdToken = true;
         return this;
@@ -88,6 +94,9 @@ public class TokenResponseAssertBuilder extends BaseAssertBuilder {
             }
             if (notNullRefreshToken) {
                 assertNotNull(response.getRefreshToken(), "The refresh token is null");
+            }
+            if (notBlankDeviceToken) {
+                assertNotBlank(response.getDeviceToken(), "The device token is blank");
             }
         } else {
             assertEquals(response.getStatus(), status, "Unexpected HTTP status response: " + response.getEntity());

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/ExecutionContext.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/ExecutionContext.java
@@ -46,6 +46,7 @@ public class ExecutionContext {
 
     private String dpop;
     private String certAsPem;
+    private String deviceSecret;
 
     private String nonce;
     private String state;
@@ -69,6 +70,14 @@ public class ExecutionContext {
     public ExecutionContext(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
         this.httpRequest = httpRequest;
         this.httpResponse = httpResponse;
+    }
+
+    public String getDeviceSecret() {
+        return deviceSecret;
+    }
+
+    public void setDeviceSecret(String deviceSecret) {
+        this.deviceSecret = deviceSecret;
     }
 
     @NotNull

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
@@ -258,7 +258,11 @@ public class IdTokenFactory {
             return;
         }
 
-        String deviceSecret = executionContext.getHttpRequest().getParameter(DEVICE_SECRET);
+        String deviceSecret = executionContext.getDeviceSecret();
+        if (StringUtils.isBlank(deviceSecret)) {
+            deviceSecret = executionContext.getHttpRequest().getParameter(DEVICE_SECRET);
+        }
+
         if (StringUtils.isNotBlank(deviceSecret) && sessionId.getDeviceSecrets().contains(deviceSecret)) {
             jwr.setClaim("ds_hash", CodeVerifier.s256(deviceSecret));
         }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/token/ws/rs/TokenExchangeServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/token/ws/rs/TokenExchangeServiceTest.java
@@ -9,7 +9,6 @@ import io.jans.as.model.error.ErrorResponseFactory;
 import io.jans.as.server.audit.ApplicationAuditLogger;
 import io.jans.as.server.service.SessionIdService;
 import org.apache.commons.lang.StringUtils;
-import org.json.JSONObject;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -17,6 +16,8 @@ import org.slf4j.Logger;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import static io.jans.as.server.util.TestUtil.assertEmpty;
+import static io.jans.as.server.util.TestUtil.assertNotEmpty;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -48,56 +49,53 @@ public class TokenExchangeServiceTest {
     private TokenExchangeService tokenExchangeService;
 
     @Test
-    public void putNewDeviceSecret_whenScopeIsNull_shouldNotGenerateDeviceSecretAndShouldNotThrowNPE() {
+    public void createNewDeviceSecret_whenScopeIsNull_shouldNotGenerateDeviceSecretAndShouldNotThrowNPE() {
         SessionId sessionId = new SessionId();
         Client client = new Client();
-        client.setGrantTypes(new GrantType[] {GrantType.AUTHORIZATION_CODE, GrantType.TOKEN_EXCHANGE});
+        client.setGrantTypes(new GrantType[]{GrantType.AUTHORIZATION_CODE, GrantType.TOKEN_EXCHANGE});
 
-        final JSONObject jsonObj = new JSONObject();
-        tokenExchangeService.putNewDeviceSecret(jsonObj, "sessionDn", client, null);
+        String deviceSecret = tokenExchangeService.createNewDeviceSecret("sessionDn", client, null);
 
+        assertEmpty(deviceSecret);
         assertTrue(sessionId.getDeviceSecrets().isEmpty());
-        assertFalse(jsonObj.has("device_token"));
     }
 
     @Test
-    public void putNewDeviceSecret_whenScopeDeviceSSOIsNotPresent_shouldNotGenerateDeviceSecret() {
+    public void createNewDeviceSecret_whenScopeDeviceSSOIsNotPresent_shouldNotGenerateDeviceSecret() {
         SessionId sessionId = new SessionId();
         Client client = new Client();
-        client.setGrantTypes(new GrantType[] {GrantType.AUTHORIZATION_CODE, GrantType.TOKEN_EXCHANGE});
+        client.setGrantTypes(new GrantType[]{GrantType.AUTHORIZATION_CODE, GrantType.TOKEN_EXCHANGE});
 
-        final JSONObject jsonObj = new JSONObject();
-        tokenExchangeService.putNewDeviceSecret(jsonObj, "sessionDn", client, "openid");
+        final String deviceSecret = tokenExchangeService.createNewDeviceSecret("sessionDn", client, "openid");
 
+        assertEmpty(deviceSecret);
         assertTrue(sessionId.getDeviceSecrets().isEmpty());
-        assertFalse(jsonObj.has("device_token"));
     }
 
     @Test
-    public void putNewDeviceSecret_whenTokenExchangeGrantIsNotPresent_shouldNotGenerateDeviceSecret() {
+    public void createNewDeviceSecret_whenTokenExchangeGrantIsNotPresent_shouldNotGenerateDeviceSecret() {
         SessionId sessionId = new SessionId();
         Client client = new Client();
-        client.setGrantTypes(new GrantType[] {GrantType.AUTHORIZATION_CODE});
+        client.setGrantTypes(new GrantType[]{GrantType.AUTHORIZATION_CODE});
 
-        final JSONObject jsonObj = new JSONObject();
-        tokenExchangeService.putNewDeviceSecret(jsonObj, "sessionDn", client, "openid device_sso");
+        final String deviceSecret = tokenExchangeService.createNewDeviceSecret("sessionDn", client, "openid device_sso");
 
+        assertEmpty(deviceSecret);
         assertTrue(sessionId.getDeviceSecrets().isEmpty());
-        assertFalse(jsonObj.has("device_token"));
     }
 
     @Test
-    public void putNewDeviceSecret_whenAllConditionsMet_shouldGenerateDeviceSecret() {
+    public void createNewDeviceSecret_whenAllConditionsMet_shouldGenerateDeviceSecret() {
         SessionId sessionId = new SessionId();
         Client client = new Client();
-        client.setGrantTypes(new GrantType[] {GrantType.AUTHORIZATION_CODE, GrantType.TOKEN_EXCHANGE});
+        client.setGrantTypes(new GrantType[]{GrantType.AUTHORIZATION_CODE, GrantType.TOKEN_EXCHANGE});
 
         when(sessionIdService.getSessionByDn("sessionDn")).thenReturn(sessionId);
 
-        final JSONObject jsonObj = new JSONObject();
-        tokenExchangeService.putNewDeviceSecret(jsonObj, "sessionDn", client, "openid device_sso");
+        final String deviceSecret = tokenExchangeService.createNewDeviceSecret("sessionDn", client, "openid device_sso");
 
-        assertTrue(sessionId.getDeviceSecrets().contains(jsonObj.getString("device_token")));
+        assertNotEmpty(deviceSecret);
+        assertTrue(sessionId.getDeviceSecrets().contains(deviceSecret));
     }
 
     @Test


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Native sso - return device secret if device_sso scope is present #2790

#### Target issue

closes #2790

Parent ticket
https://github.com/JanssenProject/jans/issues/2518
-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

