### PR TITLE
fix: jans-linux-setup service description for jans-auth

### DIFF
--- a/jans-linux-setup/jans_setup/static/system/systemd/jans-auth.service
+++ b/jans-linux-setup/jans_setup/static/system/systemd/jans-auth.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Janssen OAauth service
+Description=Janssen Auth Server
 After=opendj.service
 
 [Service]


### PR DESCRIPTION
closes #2988
