### PR TITLE
feat(image): preserve attribute's values in jans-auth config

### DIFF
--- a/docker-jans-persistence-loader/README.md
+++ b/docker-jans-persistence-loader/README.md
@@ -54,6 +54,7 @@ The following environment variables are supported by the container:
 - `CN_PERSISTENCE_TYPE`: Persistence backend being used (one of `ldap`, `couchbase`, or `hybrid`; default to `ldap`).
 - `CN_HYBRID_MAPPING`: Specify data mapping for each persistence (default to `"{}"`). Note this environment only takes effect when `CN_PERSISTENCE_TYPE` is set to `hybrid`. See [hybrid mapping](#hybrid-mapping) section for details.
 - `CN_PERSISTENCE_SKIP_INITIALIZED`: skip initialization if backend already initialized (default to `false`).
+- `CN_PERSISTENCE_UPDATE_AUTH_DYNAMIC_CONFIG`: Whether to allow automatic updates of `jans-auth` configuration (default to `true`).
 - `CN_LDAP_URL`: Address and port of LDAP server (default to `localhost:1636`).
 - `CN_LDAP_USE_SSL`: Whether to use SSL connection to LDAP server (default to `true`).
 - `CN_COUCHBASE_URL`: Address of Couchbase server (default to `localhost`).

--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -177,16 +177,16 @@ def _transform_auth_dynamic_config(conf):
         lambda x: isinstance(x, dict), conf["authorizationRequestCustomAllowedParameters"]
     ))
     if not params_with_dict:
-        conf["authorizationRequestCustomAllowedParameters"] = list(map(
-            lambda p: {"paramName": p[0], "returnInResponse": p[1]},
-            [
+        conf["authorizationRequestCustomAllowedParameters"] = [
+            {"paramName": p[0], "returnInResponse": p[1]}
+            for p in [
                 ("customParam1", False),
                 ("customParam2", False),
                 ("customParam3", False),
                 ("customParam4", True),
                 ("customParam5", True),
             ]
-        ))
+        ]
         should_update = True
 
     if "useHighestLevelScriptIfAcrScriptNotFound" not in conf:
@@ -457,7 +457,9 @@ class Upgrade:
         if hasattr(self.backend, "update_misc"):
             self.backend.update_misc()
 
-        self.update_auth_dynamic_config()
+        if as_boolean(os.environ.get("CN_PERSISTENCE_UPDATE_AUTH_DYNAMIC_CONFIG", "true")):
+            self.update_auth_dynamic_config()
+
         self.update_auth_errors_config()
         self.update_auth_static_config()
         self.update_attributes_entries()


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #2990 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

The changeset added `CN_PERSISTENCE_UPDATE_AUTH_DYNAMIC_CONFIG` env var (default to `true`) as feature flag to enable/disable automatic updates on jans-auth configuration.

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

