### PR TITLE
Duplicate print function remove from init() method

### DIFF
--- a/docs/script-catalog/person_authentication/github-external-authenticator/GithubExternalAuthenticator.py
+++ b/docs/script-catalog/person_authentication/github-external-authenticator/GithubExternalAuthenticator.py
@@ -31,7 +31,6 @@ class PersonAuthentication(PersonAuthenticationType):
 
     def init(self, customScript,  configurationAttributes):
         print "GitHub. Initialization"
-        print "GitHub. Initialized successfully"
 
         # read config from github_creds_file
         github_creds_file = configurationAttributes.get("github_creds_file").getValue2()


### PR DESCRIPTION
In init() method there was duplicate print function like `print "GitHub: Initialized successfully"`. Which should be before return statement.

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

