### PR TITLE
fix:(jans-auth-server): fixed Client serialization/deserialization issue #2946

### DIFF
--- a/jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
@@ -9,6 +9,7 @@ package io.jans.as.common.model.registration;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import io.jans.as.model.common.*;
 import io.jans.as.model.crypto.signature.AsymmetricSignatureAlgorithm;
 import io.jans.as.model.register.ApplicationType;
@@ -29,7 +30,7 @@ import java.util.Locale;
  * @author Javier Rojas Blum
  * @version October 17, 2022
  */
-@DataEntry(sortBy = {"displayName"})
+@DataEntry(sortBy = {"clientName"})
 @ObjectClass(value = "jansClnt")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Client extends DeletableEntity implements Serializable {
@@ -709,22 +710,27 @@ public class Client extends DeletableEntity implements Serializable {
         return clientNameLocalized;
     }
 
+    @JsonSetter
     public void setClientNameLocalized(LocalizedString clientNameLocalized) {
         this.clientNameLocalized = clientNameLocalized;
     }
 
+    @JsonSetter
     public void setLogoUriLocalized(LocalizedString logoUriLocalized) {
         this.logoUriLocalized = logoUriLocalized;
     }
 
+    @JsonSetter
     public void setClientUriLocalized(LocalizedString clientUriLocalized) {
         this.clientUriLocalized = clientUriLocalized;
     }
 
+    @JsonSetter
     public void setPolicyUriLocalized(LocalizedString policyUriLocalized) {
         this.policyUriLocalized = policyUriLocalized;
     }
 
+    @JsonSetter
     public void setTosUriLocalized(LocalizedString tosUriLocalized) {
         this.tosUriLocalized = tosUriLocalized;
     }

--- a/jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/model/registration/Client.java
@@ -6,6 +6,7 @@
 
 package io.jans.as.common.model.registration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jans.as.model.common.*;
@@ -600,6 +601,7 @@ public class Client extends DeletableEntity implements Serializable {
         this.idTokenTokenBindingCnf = idTokenTokenBindingCnf;
     }
 
+    @JsonIgnore
     public boolean isTokenBindingSupported() {
         return StringUtils.isNotBlank(idTokenTokenBindingCnf);
     }
@@ -707,11 +709,32 @@ public class Client extends DeletableEntity implements Serializable {
         return clientNameLocalized;
     }
 
+    public void setClientNameLocalized(LocalizedString clientNameLocalized) {
+        this.clientNameLocalized = clientNameLocalized;
+    }
+
+    public void setLogoUriLocalized(LocalizedString logoUriLocalized) {
+        this.logoUriLocalized = logoUriLocalized;
+    }
+
+    public void setClientUriLocalized(LocalizedString clientUriLocalized) {
+        this.clientUriLocalized = clientUriLocalized;
+    }
+
+    public void setPolicyUriLocalized(LocalizedString policyUriLocalized) {
+        this.policyUriLocalized = policyUriLocalized;
+    }
+
+    public void setTosUriLocalized(LocalizedString tosUriLocalized) {
+        this.tosUriLocalized = tosUriLocalized;
+    }
+
     /**
      * Sets the name of the Client to be presented to the user.
      *
      * @param clientName The name of the Client to be presented to the user.
      */
+    @JsonIgnore
     public void setClientNameLocalized(String clientName) {
         this.clientName = clientName;
         this.clientNameLocalized.setValue(clientName);
@@ -723,6 +746,7 @@ public class Client extends DeletableEntity implements Serializable {
      * @param clientName The name of the Client to be presented to the user.
      * @param locale     The locale
      */
+    @JsonIgnore
     public void setClientNameLocalized(String clientName, Locale locale) {
         if (StringUtils.isNotBlank(locale.toString())) {
             this.clientNameLocalized.setValue(clientName, locale);
@@ -745,6 +769,7 @@ public class Client extends DeletableEntity implements Serializable {
      *
      * @param logoUri The URL of a logo image for the Client where it can be retrieved.
      */
+    @JsonIgnore
     public void setLogoUriLocalized(String logoUri) {
         this.logoUri = logoUri;
         this.logoUriLocalized.setValue(logoUri);
@@ -756,6 +781,7 @@ public class Client extends DeletableEntity implements Serializable {
      * @param logoUri The URL of a logo image for the Client where it can be retrieved.
      * @param locale  The locale
      */
+    @JsonIgnore
     public void setLogoUriLocalized(String logoUri, Locale locale) {
         if (StringUtils.isNotBlank(locale.toString())) {
             this.logoUriLocalized.setValue(logoUri, locale);
@@ -778,6 +804,7 @@ public class Client extends DeletableEntity implements Serializable {
      *
      * @param clientUri The URL of the home page of the Client.
      */
+    @JsonIgnore
     public void setClientUriLocalized(String clientUri) {
         this.clientUri = clientUri;
         this.clientUriLocalized.setValue(clientUri);
@@ -789,6 +816,7 @@ public class Client extends DeletableEntity implements Serializable {
      * @param clientUri The URL of the home page of the Client.
      * @param locale    The locale
      */
+    @JsonIgnore
     public void setClientUriLocalized(String clientUri, Locale locale) {
         if (StringUtils.isNotBlank(locale.toString())) {
             this.clientUriLocalized.setValue(clientUri, locale);
@@ -813,6 +841,7 @@ public class Client extends DeletableEntity implements Serializable {
      *
      * @param policyUri A URL location about how the profile data will be used.
      */
+    @JsonIgnore
     public void setPolicyUriLocalized(String policyUri) {
         this.policyUri = policyUri;
         this.policyUriLocalized.setValue(policyUri);
@@ -825,6 +854,7 @@ public class Client extends DeletableEntity implements Serializable {
      * @param policyUri A URL location about how the profile data will be used.
      * @param locale    The locale
      */
+    @JsonIgnore
     public void setPolicyUriLocalized(String policyUri, Locale locale) {
         if (StringUtils.isNotBlank(locale.toString())) {
             this.policyUriLocalized.setValue(policyUri, locale);
@@ -849,6 +879,7 @@ public class Client extends DeletableEntity implements Serializable {
      *
      * @param tosUri The terms of service URL.
      */
+    @JsonIgnore
     public void setTosUriLocalized(String tosUri) {
         this.tosUri = tosUri;
         this.tosUriLocalized.setValue(tosUri);
@@ -861,6 +892,7 @@ public class Client extends DeletableEntity implements Serializable {
      * @param tosUri The terms of service URL.
      * @param locale The Locale
      */
+    @JsonIgnore
     public void setTosUriLocalized(String tosUri, Locale locale) {
         if (StringUtils.isNotBlank(locale.toString())) {
             this.tosUriLocalized.setValue(tosUri, locale);
@@ -1419,14 +1451,6 @@ public class Client extends DeletableEntity implements Serializable {
 
     public void setBackchannelUserCodeParameter(Boolean backchannelUserCodeParameter) {
         this.backchannelUserCodeParameter = backchannelUserCodeParameter;
-    }
-
-    public String getDisplayName() {
-        return getClientName();
-    }
-
-    public void setDisplayName(String displayName) {
-        setClientName(displayName);
     }
 
     public String getDescription() {

--- a/jans-auth-server/common/src/test/java/io/jans/as/common/model/registration/ClientSerializationTest.java
+++ b/jans-auth-server/common/src/test/java/io/jans/as/common/model/registration/ClientSerializationTest.java
@@ -1,0 +1,38 @@
+package io.jans.as.common.model.registration;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jans.as.model.util.Util;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+/**
+ * @author Yuriy Zabrovarnyy
+ */
+public class ClientSerializationTest {
+
+    @Test
+    public void deserialization_whenSerialized_shouldGetCorrectValues() throws IOException {
+        Client c = new Client();
+        c.setClientName("name");
+        c.setClientNameLocalized("myLocalized");
+        c.setClientNameLocalized("myLocalized_canada", Locale.CANADA);
+        c.setClientNameLocalized("myLocalized_canadaFR", Locale.CANADA_FRENCH);
+
+        final ObjectMapper mapper = Util.createJsonMapper();
+        mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY);
+        final String asJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(c);
+
+        final Client client = mapper.readValue(asJson, Client.class);
+        assertNotNull(client);
+        assertEquals("myLocalized", client.getClientName());
+        assertEquals("myLocalized", client.getClientNameLocalized().getValue());
+        assertEquals("myLocalized_canada", client.getClientNameLocalized().getValue(Locale.CANADA));
+        assertEquals("myLocalized_canadaFR", client.getClientNameLocalized().getValue(Locale.CANADA_FRENCH));
+    }
+}

--- a/jans-orm/model/src/main/java/io/jans/orm/model/base/LocalizedString.java
+++ b/jans-orm/model/src/main/java/io/jans/orm/model/base/LocalizedString.java
@@ -6,10 +6,9 @@
 
 package io.jans.orm.model.base;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
-
-import io.jans.orm.util.StringHelper;
 
 import java.io.Serializable;
 import java.util.*;
@@ -24,7 +23,7 @@ public class LocalizedString implements Serializable {
 
     private static final long serialVersionUID = -7651487701235873969L;
 
-    private final Map<String, String> values;
+    private Map<String, String> values;
 
     public static final String EMPTY_LANG_TAG = "";
     public static final String LANG_SEPARATOR = ";";
@@ -46,22 +45,34 @@ public class LocalizedString implements Serializable {
         values.put(getLanguageTag(locale), value);
     }
 
+    @JsonIgnore
     public String getValue() {
         return getValue(EMPTY_LANG_TAG);
     }
 
+    @JsonIgnore
     public String getValue(String languageTag) {
         return values.getOrDefault(languageTag, null);
+    }
+
+    @JsonIgnore
+    public String getValue(Locale locale) {
+        return getValue(getLanguageTag(locale));
     }
 
     public Map<String, String> getValues() {
         return values;
     }
 
+    public void setValues(Map<String, String> values) {
+        this.values = values;
+    }
+
     public int size() {
         return values.size();
     }
 
+    @JsonIgnore
     public Set<String> getLanguageTags() {
         return values.keySet();
     }
@@ -76,7 +87,8 @@ public class LocalizedString implements Serializable {
                 .replace(LANG_SEPARATOR + LANG_PREFIX + LANG_JOINER, "");
     }
 
-    private String getLanguageTag(Locale locale) {
+    @JsonIgnore
+    public static String getLanguageTag(Locale locale) {
         List<String> keyParts = new ArrayList<>();
         keyParts.add(locale.getLanguage());
         keyParts.add(locale.getScript());


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

fix:(jans-auth-server): fixed Client serialization/deserialization issue #2946

```
Error: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`) at [Source: (org.eclipse.jetty.server.HttpInput); line: 25, column: 23] (through reference chain: io.jans.as.common.model.registration.Client[&quot;logoUriLocalized&quot;])
```
More details in this comment https://github.com/JanssenProject/jans/issues/2946#issuecomment-1320073974

#### Target issue
  
closes #2946

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

