### PR TITLE
Relax requirement for redirect_uri for back-channel OAuth flows

### DIFF
--- a/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/RegistrationRestWebServiceHttpTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/RegistrationRestWebServiceHttpTest.java
@@ -568,6 +568,38 @@ public class RegistrationRestWebServiceHttpTest extends BaseTest {
         assertNotNull(response.getErrorDescription());
     }
 
+    @Test
+    public void registerGrantPasswordRedirectUriNull() {
+        showTitle("registerGrantPasswordRedirectUriNull");
+
+        RegisterRequest registerRequest = new RegisterRequest(ApplicationType.WEB, "Test client with grant password redirect uri null", null);
+        registerRequest.setGrantTypes(Collections.singletonList(RESOURCE_OWNER_PASSWORD_CREDENTIALS));
+        registerRequest.setResponseTypes(Collections.singletonList(CODE));
+
+        RegisterClient registerClient = new RegisterClient(registrationEndpoint);
+        registerClient.setRequest(registerRequest);
+        RegisterResponse response = registerClient.exec();
+
+        showClient(registerClient);
+        AssertBuilder.registerResponse(response).created().check();
+    }
+
+    @Test
+    public void registerGrantClientCredentialsRedirectUriEmpty() {
+        showTitle("registerGrantClientCredentialsRedirectUriEmpty");
+
+        RegisterRequest registerRequest = new RegisterRequest(ApplicationType.WEB, "Test client with grant client_credentials redirect uri empty", Collections.emptyList());
+        registerRequest.setGrantTypes(Collections.singletonList(CLIENT_CREDENTIALS));
+        registerRequest.setResponseTypes(Collections.singletonList(CODE));
+
+        RegisterClient registerClient = new RegisterClient(registrationEndpoint);
+        registerClient.setRequest(registerRequest);
+        RegisterResponse response = registerClient.exec();
+
+        showClient(registerClient);
+        AssertBuilder.registerResponse(response).created().check();
+    }
+
     @Parameters({"redirectUris"})
     @Test
     public void deleteClient(final String redirectUris) throws Exception {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/registration/RegisterParamsValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/registration/RegisterParamsValidator.java
@@ -80,7 +80,10 @@ public class RegisterParamsValidator {
 
         if (grantTypes != null &&
                 (grantTypes.contains(GrantType.AUTHORIZATION_CODE) || grantTypes.contains(GrantType.IMPLICIT)
-                        || (responseTypes.contains(ResponseType.CODE) && !grantTypes.contains(GrantType.DEVICE_CODE))
+                        || (responseTypes.contains(ResponseType.CODE) && (
+                        !grantTypes.contains(GrantType.DEVICE_CODE) &&
+                                !grantTypes.contains(GrantType.RESOURCE_OWNER_PASSWORD_CREDENTIALS) &&
+                                !grantTypes.contains(GrantType.CLIENT_CREDENTIALS)))
                         || responseTypes.contains(ResponseType.TOKEN) || responseTypes.contains(ResponseType.ID_TOKEN))) {
             if (redirectUris == null || redirectUris.isEmpty()) {
                 return new Pair<>(false, "Redirect uris are empty.");
@@ -284,7 +287,10 @@ public class RegisterParamsValidator {
                 }
             }
         } else valid = !grantTypes.contains(GrantType.AUTHORIZATION_CODE) && !grantTypes.contains(GrantType.IMPLICIT) &&
-                (!responseTypes.contains(ResponseType.CODE) || grantTypes.contains(GrantType.DEVICE_CODE))
+                (!responseTypes.contains(ResponseType.CODE) || (
+                        grantTypes.contains(GrantType.DEVICE_CODE) ||
+                                grantTypes.contains(GrantType.RESOURCE_OWNER_PASSWORD_CREDENTIALS) ||
+                                grantTypes.contains(GrantType.CLIENT_CREDENTIALS)))
                 && !responseTypes.contains(ResponseType.TOKEN) && !responseTypes.contains(ResponseType.ID_TOKEN);
 
 


### PR DESCRIPTION
### Description
Relax requirement for redirect_uri for back-channel OAuth flows

#### Target issue
https://github.com/JanssenProject/jans/issues/3017
  
closes #3017

#### Implementation Details
Updated conditions to process client registration.

-------------------
### Test and Document the changes
- [X] Static code analysis has been run locally and issues have been fixed
- [X] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

