### PR TITLE
fix(jans): added null check to avoid NullPointerException

### DIFF
--- a/jans-config-api/docs/jans-config-api-swagger-auto.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger-auto.yaml
@@ -7178,19 +7178,19 @@ components:
           $ref: '#/components/schemas/AttributeValidation'
         tooltip:
           type: string
+        whitePagesCanView:
+          type: boolean
         adminCanAccess:
-          type: boolean
-        userCanAccess:
-          type: boolean
-        userCanView:
           type: boolean
         adminCanView:
           type: boolean
-        userCanEdit:
+        userCanAccess:
           type: boolean
         adminCanEdit:
           type: boolean
-        whitePagesCanView:
+        userCanView:
+          type: boolean
+        userCanEdit:
           type: boolean
         baseDn:
           type: string
@@ -7526,10 +7526,6 @@ components:
         ttl:
           type: integer
           format: int32
-        displayName:
-          type: string
-        tokenBindingSupported:
-          type: boolean
         authenticationMethod:
           type: string
           enum:
@@ -7645,13 +7641,6 @@ components:
         values:
           type: object
           additionalProperties:
-            type: string
-        value:
-          type: string
-        languageTags:
-          uniqueItems: true
-          type: array
-          items:
             type: string
     AppConfiguration:
       type: object
@@ -8345,17 +8334,6 @@ components:
           $ref: '#/components/schemas/EngineConfig'
         ssaConfiguration:
           $ref: '#/components/schemas/SsaConfiguration'
-        fapi:
-          type: boolean
-        allResponseTypesSupported:
-          uniqueItems: true
-          type: array
-          items:
-            type: string
-            enum:
-            - code
-            - token
-            - id_token
         enabledFeatureFlags:
           uniqueItems: true
           type: array
@@ -8383,6 +8361,17 @@ components:
             - STAT
             - PAR
             - SSA
+        allResponseTypesSupported:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+            enum:
+            - code
+            - token
+            - id_token
+        fapi:
+          type: boolean
     AuthenticationFilter:
       required:
       - baseDn
@@ -8639,13 +8628,13 @@ components:
           type: boolean
         internal:
           type: boolean
+        locationPath:
+          type: string
         locationType:
           type: string
           enum:
           - ldap
           - file
-        locationPath:
-          type: string
         baseDn:
           type: string
     ScriptError:

--- a/jans-orm/model/src/main/java/io/jans/orm/model/base/CustomObjectAttribute.java
+++ b/jans-orm/model/src/main/java/io/jans/orm/model/base/CustomObjectAttribute.java
@@ -43,7 +43,7 @@ public class CustomObjectAttribute implements Serializable, Comparable<CustomObj
             return null;
         }
 
-        if (this.values.size() > 0) {
+        if (!this.values.isEmpty()) {
             return this.values.get(0);
         }
 
@@ -51,7 +51,7 @@ public class CustomObjectAttribute implements Serializable, Comparable<CustomObj
     }
 
     public void setValue(Object value) {
-        this.values = new ArrayList<Object>();
+        this.values = new ArrayList<>();
         this.values.add(value);
         this.multiValued = false;
     }
@@ -89,7 +89,7 @@ public class CustomObjectAttribute implements Serializable, Comparable<CustomObj
         }
 
         if (values.size() == 1) {
-            return values.get(0).toString();
+            return (values.get(0)!=null ? values.get(0).toString() : "");
         }
 
         StringBuilder sb = new StringBuilder();

--- a/jans-orm/model/src/main/java/io/jans/orm/model/base/LocalizedString.java
+++ b/jans-orm/model/src/main/java/io/jans/orm/model/base/LocalizedString.java
@@ -72,9 +72,10 @@ public class LocalizedString implements Serializable {
         return values.size();
     }
 
+    @SuppressWarnings("unchecked")
     @JsonIgnore
     public Set<String> getLanguageTags() {
-        return values.keySet();
+        return (values!=null ? values.keySet() : Collections.emptySet());
     }
 
     public String addLdapLanguageTag(String ldapAttributeName, String languageTag) {


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Added null check to resolve two NullPointerException
1. CustomObjectAttribute NPE while executing User management endpoint -  jenkins build
Error: `Caused by: java.lang.NullPointerException
	at io.jans.orm.model.base.CustomObjectAttribute.getDisplayValue(CustomObjectAttribute.java:92)`

2. LocalizedString while testing OpenID Client functionality
Error: `Caused by: 
java.lang.NullPointerException
	at io.jans.orm.model.base.LocalizedString.getLanguageTags(LocalizedString.java:77)`

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #3074 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

