### PR TITLE
Feature: Block authentication flow originating from a web view (mobile app)

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -809,6 +809,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "SSA Configuration")
     private SsaConfiguration ssaConfiguration;
 
+    @DocProperty(description = "Enable/Disable block authorizations that originate from Webview (Mobile apps).", defaultValue = "false")
+    private Boolean blockWebviewAuthorizationEnabled = false;
+
     public List<SsaValidationConfig> getDcrSsaValidationConfigs() {
         if (dcrSsaValidationConfigs == null) dcrSsaValidationConfigs = new ArrayList<>();
         return dcrSsaValidationConfigs;
@@ -3084,5 +3087,13 @@ public class AppConfiguration implements Configuration {
 
     public void setSsaConfiguration(SsaConfiguration ssaConfiguration) {
         this.ssaConfiguration = ssaConfiguration;
+    }
+
+    public Boolean getBlockWebviewAuthorizationEnabled() {
+        return blockWebviewAuthorizationEnabled;
+    }
+
+    public void setBlockWebviewAuthorizationEnabled(Boolean blockWebviewAuthorizationEnabled) {
+        this.blockWebviewAuthorizationEnabled = blockWebviewAuthorizationEnabled;
     }
 }

--- a/jans-auth-server/server/conf/jans-config.json
+++ b/jans-auth-server/server/conf/jans-config.json
@@ -449,5 +449,6 @@
         "defaultResponseHeaders": {
             "Cache-Control": "max-age=0, no-store"
         }
-    }
+    },
+    "blockWebviewAuthorizationEnabled": false
 }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -168,6 +168,8 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
             String codeChallenge, String codeChallengeMethod, String customResponseHeaders, String claims, String authReqId,
             HttpServletRequest httpRequest, HttpServletResponse httpResponse, SecurityContext securityContext) {
 
+        authorizeRestWebServiceValidator.validateNotWebView(httpRequest);
+
         AuthzRequest authzRequest = new AuthzRequest();
         authzRequest.setHttpMethod(HttpMethod.GET);
         authzRequest.setScope(scope);
@@ -209,6 +211,8 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
             String sessionId, String originHeaders,
             String codeChallenge, String codeChallengeMethod, String customResponseHeaders, String claims, String authReqId,
             HttpServletRequest httpRequest, HttpServletResponse httpResponse, SecurityContext securityContext) {
+
+        authorizeRestWebServiceValidator.validateNotWebView(httpRequest);
 
         AuthzRequest authzRequest = new AuthzRequest();
         authzRequest.setHttpMethod(HttpMethod.POST);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidator.java
@@ -458,4 +458,14 @@ public class AuthorizeRestWebServiceValidator {
             throw createInvalidJwtRequestException(authzRequest.getRedirectUriResponse(), "A signed request object is required");
         }
     }
+
+    public void validateNotWebView(HttpServletRequest httpRequest) {
+        if (appConfiguration.getBlockWebviewAuthorizationEnabled()) {
+            String headerRequestedWith = httpRequest.getHeader("X-Requested-With");
+            if (headerRequestedWith != null) {
+                log.error("Unauthorized, request contains X-Requested-With: {}", headerRequestedWith);
+                throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).build());
+            }
+        }
+    }
 }

--- a/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
@@ -394,5 +394,6 @@
     "staticKid": "%(static_kid)s",
     "forceOfflineAccessScopeToEnableRefreshToken" : false,
     "redirectUrisRegexEnabled": false,
-    "useHighestLevelScriptIfAcrScriptNotFound": true
+    "useHighestLevelScriptIfAcrScriptNotFound": true,
+    "blockWebviewAuthorizationEnabled": false
 }

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -497,5 +497,6 @@
         "defaultResponseHeaders": {
             "Cache-Control": "max-age=0, no-store"
         }
-    }
+    },
+    "blockWebviewAuthorizationEnabled": false
 }


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

feat: block authentication flow originating from a web view (mobile app).

#### Target issue
  
closes #3016

#### Implementation Details

Added a new `validateNotWeview` method and also a new configuration parameter `blockWebviewAuthorizationEnabled` (default is false).
The method validation is based on request header, if there is `X-Requested-With` header then it is a request originated from a web view.

Closes #3205, 