### PR TITLE
fix(agama): after moving agama to jans-auth-server agama model tests are not run #3246

### DIFF
--- a/agama/model/pom.xml
+++ b/agama/model/pom.xml
@@ -20,7 +20,11 @@
         <dependency>
             <groupId>io.jans</groupId>
             <artifactId>jans-core-util</artifactId>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>


### PR DESCRIPTION
### Description

fix(agama): after moving agama to jans-auth-server agama model tests are not run #3246

#### Target issue
  
closes #3246
