### PR TITLE
feat: changes in admin-ui plugin to allow agama-developer-studio to use its OAuth2 apis #3085

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/config/adminui/AdminConf.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/config/adminui/AdminConf.java
@@ -17,7 +17,7 @@ import io.jans.orm.annotation.ObjectClass;
  * @version 0.9, 03/01/2013
  */
 @DataEntry
-@ObjectClass(value = "jansAdminConfDyn")
+@ObjectClass(value = "jansAppConf")
 public class AdminConf {
     @DN
     private String dn;
@@ -25,6 +25,10 @@ public class AdminConf {
     @JsonObject
     @AttributeName(name = "jansConfDyn")
     private DynamicConfig dynamic;
+
+    @JsonObject
+    @AttributeName(name = "jansConfApp")
+    private MainSettings mainSettings;
 
     @AttributeName(name = "jansRevision")
     private long revision;
@@ -53,6 +57,13 @@ public class AdminConf {
         this.dynamic = dynamic;
     }
 
+    public MainSettings getMainSettings() {
+        return mainSettings;
+    }
+
+    public void setMainSettings(MainSettings mainSettings) {
+        this.mainSettings = mainSettings;
+    }
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/config/adminui/MainSettings.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/config/adminui/MainSettings.java
@@ -1,0 +1,18 @@
+package io.jans.as.model.config.adminui;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MainSettings {
+
+    private OIDCSettings oidcConfig;
+
+    public OIDCSettings getOidcConfig() {
+        return oidcConfig;
+    }
+
+    public void setOidcConfig(OIDCSettings oidcConfig) {
+        this.oidcConfig = oidcConfig;
+    }
+}

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/config/adminui/OIDCClientSettings.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/config/adminui/OIDCClientSettings.java
@@ -1,0 +1,99 @@
+package io.jans.as.model.config.adminui;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OIDCClientSettings {
+
+    private String opHost;
+    private String clientId;
+    private String clientSecret;
+    private String tokenEndpoint;
+    private String redirectUri;
+    private String postLogoutUri;
+    private String frontchannelLogoutUri;
+    private List<String> scopes;
+    private List<String> acrValues;
+
+    public OIDCClientSettings() {
+        //Do not remove
+    }
+
+    public OIDCClientSettings(String opHost, String clientId, String clientSecret) {
+
+        this.opHost = opHost;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public OIDCClientSettings(String opHost, String clientId, String clientSecret, String tokenEndpoint) {
+
+        this.opHost = opHost;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.tokenEndpoint = tokenEndpoint;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getOpHost() {
+        return opHost;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getClientId() {
+        return clientId;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getTokenEndpoint() {
+        return tokenEndpoint;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+
+    public String getPostLogoutUri() {
+        return postLogoutUri;
+    }
+
+    public void setPostLogoutUri(String postLogoutUri) {
+        this.postLogoutUri = postLogoutUri;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public List<String> getAcrValues() {
+        return acrValues;
+    }
+
+    public void setAcrValues(List<String> acrValues) {
+        this.acrValues = acrValues;
+    }
+
+    public String getFrontchannelLogoutUri() {
+        return frontchannelLogoutUri;
+    }
+
+    public void setFrontchannelLogoutUri(String frontchannelLogoutUri) {
+        this.frontchannelLogoutUri = frontchannelLogoutUri;
+    }
+}

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/config/adminui/OIDCSettings.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/config/adminui/OIDCSettings.java
@@ -1,0 +1,28 @@
+package io.jans.as.model.config.adminui;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OIDCSettings {
+
+    private OIDCClientSettings authServerClient;
+    private OIDCClientSettings tokenServerClient;
+
+    public OIDCClientSettings getAuthServerClient() {
+        return authServerClient;
+    }
+
+    public void setAuthServerClient(OIDCClientSettings authServerClient) {
+        this.authServerClient = authServerClient;
+    }
+
+    public OIDCClientSettings getTokenServerClient() {
+        return tokenServerClient;
+    }
+
+    public void setTokenServerClient(OIDCClientSettings tokenServerClient) {
+        this.tokenServerClient = tokenServerClient;
+    }
+}

--- a/jans-config-api/plugins/admin-ui-plugin/pom.xml
+++ b/jans-config-api/plugins/admin-ui-plugin/pom.xml
@@ -17,6 +17,11 @@
             <artifactId>jans-config-api-shared</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.jans</groupId>
+            <artifactId>jans-config-api-server</artifactId>
+            <scope>compile</scope>
+        </dependency>
 		<dependency>
 			<groupId>io.jans</groupId>
 			<artifactId>jans-auth-client</artifactId>

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/model/config/AUIConfiguration.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/model/config/AUIConfiguration.java
@@ -2,6 +2,7 @@ package io.jans.ca.plugin.adminui.model.config;
 
 public class AUIConfiguration {
 
+    private String appType;
     //auth server
     private String authServerHost;
     private String authServerClientId;
@@ -30,6 +31,13 @@ public class AUIConfiguration {
     private String tokenServerUserInfoEndpoint;
     private String tokenServerEndSessionEndpoint;
 
+    public String getAppType() {
+        return appType;
+    }
+
+    public void setAppType(String appType) {
+        this.appType = appType;
+    }
     // LicenseSpring
     private LicenseConfiguration licenseConfiguration;
 

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/rest/auth/OAuth2Resource.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/rest/auth/OAuth2Resource.java
@@ -25,7 +25,7 @@ import jakarta.ws.rs.core.Response;
 @Hidden
 @Path("/app")
 public class OAuth2Resource {
-
+    //appType: admin-ui, ads
     static final String OAUTH2_CONFIG = "/{appType}/oauth2/config";
     static final String OAUTH2_ACCESS_TOKEN = "/{appType}/oauth2/access-token";
     static final String OAUTH2_API_PROTECTION_TOKEN = "/{appType}/oauth2/api-protection-token";

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/rest/auth/OAuth2Resource.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/rest/auth/OAuth2Resource.java
@@ -23,13 +23,13 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 @Hidden
-@Path("/admin-ui/oauth2")
+@Path("/app")
 public class OAuth2Resource {
 
-    static final String OAUTH2_CONFIG = "/config";
-    static final String OAUTH2_ACCESS_TOKEN = "/access-token";
-    static final String OAUTH2_API_PROTECTION_TOKEN = "/api-protection-token";
-    static final String OAUTH2_API_USER_INFO = "/user-info";
+    static final String OAUTH2_CONFIG = "/{appType}/oauth2/config";
+    static final String OAUTH2_ACCESS_TOKEN = "/{appType}/oauth2/access-token";
+    static final String OAUTH2_API_PROTECTION_TOKEN = "/{appType}/oauth2/api-protection-token";
+    static final String OAUTH2_API_USER_INFO = "/{appType}/oauth2/user-info";
 
     public static final String SCOPE_OPENID = "openid";
 
@@ -46,9 +46,9 @@ public class OAuth2Resource {
     @Path(OAUTH2_CONFIG)
     @Produces(MediaType.APPLICATION_JSON)
     @ProtectedApi(scopes = {SCOPE_OPENID})
-    public Response getOAuth2Config() {
+    public Response getOAuth2Config(@PathParam("appType") String appType) {
 
-        AUIConfiguration auiConfiguration = auiConfigurationService.getAUIConfiguration();
+        AUIConfiguration auiConfiguration = auiConfigurationService.getAUIConfiguration(appType);
 
         OAuth2ConfigResponse oauth2Config = new OAuth2ConfigResponse();
         oauth2Config.setAuthzBaseUrl(auiConfiguration.getAuthServerAuthzBaseUrl());
@@ -67,11 +67,11 @@ public class OAuth2Resource {
     @GET
     @Path(OAUTH2_ACCESS_TOKEN)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getAccessToken(@QueryParam("code") String code) {
+    public Response getAccessToken(@QueryParam("code") String code, @PathParam("appType") String appType) {
 
         try {
             log.info("Access token request to Auth Server.");
-            TokenResponse tokenResponse = oAuth2Service.getAccessToken(code);
+            TokenResponse tokenResponse = oAuth2Service.getAccessToken(code, appType);
             log.info("Access token received from Auth Server.");
             return Response.ok(tokenResponse).build();
         } catch (ApplicationException e) {
@@ -86,10 +86,10 @@ public class OAuth2Resource {
     @GET
     @Path(OAUTH2_API_PROTECTION_TOKEN)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getApiProtectionToken(@QueryParam("ujwt") String ujwt) {
+    public Response getApiProtectionToken(@QueryParam("ujwt") String ujwt, @PathParam("appType") String appType) {
         try {
             log.info("Api protection token request to Auth Server.");
-            TokenResponse tokenResponse = oAuth2Service.getApiProtectionToken(ujwt);
+            TokenResponse tokenResponse = oAuth2Service.getApiProtectionToken(ujwt, appType);
             log.info("Api protection token received from Auth Server.");
             return Response.ok(tokenResponse).build();
         } catch (ApplicationException e) {
@@ -104,10 +104,10 @@ public class OAuth2Resource {
     @POST
     @Path(OAUTH2_API_USER_INFO)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getUserInfo(@Valid @NotNull UserInfoRequest userInfoRequest) {
+    public Response getUserInfo(@Valid @NotNull UserInfoRequest userInfoRequest, @PathParam("appType") String appType) {
         try {
             log.info("Get User-Info request to Auth Server.");
-            UserInfoResponse userInfoResponse = oAuth2Service.getUserInfo(userInfoRequest);
+            UserInfoResponse userInfoResponse = oAuth2Service.getUserInfo(userInfoRequest, appType);
             log.info("Get User-Info received from Auth Server.");
             return Response.ok(userInfoResponse).build();
         } catch (ApplicationException e) {

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/config/AUIConfigurationService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/config/AUIConfigurationService.java
@@ -1,27 +1,34 @@
 package io.jans.ca.plugin.adminui.service.config;
 
+import com.google.api.client.util.Strings;
+import com.google.common.collect.Maps;
 import io.jans.as.model.config.adminui.AdminConf;
 import io.jans.as.model.config.adminui.LicenseSpringCredentials;
+import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.ca.plugin.adminui.model.config.AUIConfiguration;
 import io.jans.ca.plugin.adminui.model.config.LicenseConfiguration;
+import io.jans.configapi.service.auth.ConfigurationService;
 import io.jans.ca.plugin.adminui.rest.auth.OAuth2Resource;
 import io.jans.ca.plugin.adminui.utils.AppConstants;
 import io.jans.ca.plugin.adminui.utils.ErrorResponse;
 import io.jans.orm.PersistenceEntryManager;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 import java.util.Properties;
 
 @Singleton
 public class AUIConfigurationService {
 
-    private AUIConfiguration auiConfiguration;
+    private Map<String, AUIConfiguration> appConfigurationMap;
 
     @Inject
     Logger log;
@@ -29,60 +36,79 @@ public class AUIConfigurationService {
     @Inject
     private PersistenceEntryManager entryManager;
 
+    @Inject
+    ConfigurationService configurationService;
+
     public AUIConfiguration getAUIConfiguration() {
+        return getAUIConfiguration(null);
+    }
+
+    public AUIConfiguration getAUIConfiguration(String appType) {
 
         try {
-            if (this.auiConfiguration == null) {
-                Properties props = loadPropertiesFromFile();
-                this.auiConfiguration = addPropertiesToAUIConfiguration(props);
+            if (Strings.isNullOrEmpty(appType)) {
+                appType = AppConstants.APPLICATION_KEY_ADMIN_UI;
             }
 
-            return auiConfiguration;
+            if (appConfigurationMap == null) {
+                appConfigurationMap = Maps.newHashMap();
+            }
+
+            if (appConfigurationMap.get(appType) == null) {
+                AdminConf appConf = null;
+                if (appType.equals(AppConstants.APPLICATION_KEY_ADMIN_UI)) {
+                    appConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
+                } else if (appType.equals(AppConstants.APPLICATION_KEY_ADS)) {
+                    appConf = entryManager.find(AdminConf.class, AppConstants.ADS_CONFIG_DN);
+                }
+                appConfigurationMap.put(appType, addPropertiesToAUIConfiguration(appType, appConf));
+            }
+
+            return appConfigurationMap.get(appType);
         } catch (Exception e) {
             log.error(ErrorResponse.ERROR_READING_CONFIG.getDescription(), e);
             return null;
         }
+
     }
 
     public void setAuiConfiguration(AUIConfiguration auiConfiguration) {
-        this.auiConfiguration = auiConfiguration;
+        if(!Strings.isNullOrEmpty(auiConfiguration.getAppType())) {
+            this.appConfigurationMap.put(auiConfiguration.getAppType(), auiConfiguration);
+        }
     }
 
-    private AUIConfiguration addPropertiesToAUIConfiguration(Properties props) {
+    private AUIConfiguration addPropertiesToAUIConfiguration(String appType, AdminConf appConf) {
         AUIConfiguration auiConfig = new AUIConfiguration();
-        auiConfig.setAuthServerHost(props.getProperty("authserver.host"));
-        auiConfig.setAuthServerClientId(props.getProperty("authserver.clientId"));
-        auiConfig.setAuthServerClientSecret(props.getProperty("authserver.clientSecret"));
-        auiConfig.setAuthServerScope(props.getProperty("authserver.scope"));
-        auiConfig.setAuthServerRedirectUrl(props.getProperty("authserver.redirectUrl"));
-        auiConfig.setAuthServerFrontChannelLogoutUrl(props.getProperty("authserver.frontChannelLogoutUrl"));
-        auiConfig.setAuthServerPostLogoutRedirectUri(props.getProperty("authserver.postLogoutRedirectUri"));
-        auiConfig.setAuthServerAuthzBaseUrl(props.getProperty("authserver.authzBaseUrl"));
-        auiConfig.setAuthServerTokenEndpoint(props.getProperty("authserver.tokenEndpoint"));
-        auiConfig.setAuthServerIntrospectionEndpoint(props.getProperty("authserver.introspectionEndpoint"));
-        auiConfig.setAuthServerUserInfoEndpoint(props.getProperty("authserver.userInfoEndpoint"));
-        auiConfig.setAuthServerEndSessionEndpoint(props.getProperty("authserver.endSessionEndpoint"));
-        auiConfig.setAuthServerAcrValues(props.getProperty("authserver.acrValues"));
+        AppConfiguration appConfiguration = configurationService.find();
+        auiConfig.setAppType(appType);
+        auiConfig.setAuthServerHost(appConf.getMainSettings().getOidcConfig().getAuthServerClient().getOpHost());
+        auiConfig.setAuthServerClientId(appConf.getMainSettings().getOidcConfig().getAuthServerClient().getClientId());
+        auiConfig.setAuthServerClientSecret(appConf.getMainSettings().getOidcConfig().getAuthServerClient().getClientSecret());
+        auiConfig.setAuthServerScope(StringUtils.join(appConf.getMainSettings().getOidcConfig().getAuthServerClient().getScopes(), "+"));
+        auiConfig.setAuthServerRedirectUrl(appConf.getMainSettings().getOidcConfig().getAuthServerClient().getRedirectUri());
+        auiConfig.setAuthServerFrontChannelLogoutUrl(appConf.getMainSettings().getOidcConfig().getAuthServerClient().getFrontchannelLogoutUri());
+        auiConfig.setAuthServerPostLogoutRedirectUri(appConf.getMainSettings().getOidcConfig().getAuthServerClient().getPostLogoutUri());
+        auiConfig.setAuthServerAuthzBaseUrl(appConfiguration.getAuthorizationEndpoint());
+        auiConfig.setAuthServerTokenEndpoint(appConfiguration.getTokenEndpoint());
+        auiConfig.setAuthServerIntrospectionEndpoint(appConfiguration.getIntrospectionEndpoint());
+        auiConfig.setAuthServerUserInfoEndpoint(appConfiguration.getUserInfoEndpoint());
+        auiConfig.setAuthServerEndSessionEndpoint(appConfiguration.getEndSessionEndpoint());
+        auiConfig.setAuthServerAcrValues(StringUtils.join(appConf.getMainSettings().getOidcConfig().getAuthServerClient().getAcrValues(), "+"));
 
-        auiConfig.setTokenServerClientId(props.getProperty("tokenServer.clientId"));
-        auiConfig.setTokenServerClientSecret(props.getProperty("tokenServer.clientSecret"));
-        auiConfig.setTokenServerScope(props.getProperty("tokenServer.scope"));
-        auiConfig.setTokenServerRedirectUrl(props.getProperty("tokenServer.redirectUrl"));
-        auiConfig.setTokenServerFrontChannelLogoutUrl(props.getProperty("tokenServer.frontChannelLogoutUrl"));
-        auiConfig.setTokenServerPostLogoutRedirectUri(props.getProperty("tokenServer.postLogoutRedirectUri"));
-        auiConfig.setTokenServerAuthzBaseUrl(props.getProperty("tokenServer.authzBaseUrl"));
-        auiConfig.setTokenServerTokenEndpoint(props.getProperty("tokenServer.tokenEndpoint"));
-        auiConfig.setTokenServerIntrospectionEndpoint(props.getProperty("tokenServer.introspectionEndpoint"));
-        auiConfig.setTokenServerUserInfoEndpoint(props.getProperty("tokenServer.userInfoEndpoint"));
-        auiConfig.setTokenServerEndSessionEndpoint(props.getProperty("tokenServer.endSessionEndpoint"));
-        auiConfig.setTokenServerAcrValues(props.getProperty("tokenServer.acrValues"));
+        auiConfig.setTokenServerClientId(appConf.getMainSettings().getOidcConfig().getTokenServerClient().getClientId());
+        auiConfig.setTokenServerClientSecret(appConf.getMainSettings().getOidcConfig().getTokenServerClient().getClientSecret());
+        auiConfig.setTokenServerScope(StringUtils.join(appConf.getMainSettings().getOidcConfig().getTokenServerClient().getScopes(), "+"));
+        auiConfig.setTokenServerTokenEndpoint(appConf.getMainSettings().getOidcConfig().getTokenServerClient().getTokenEndpoint());
+
+        if(appType.equals(AppConstants.APPLICATION_KEY_ADS)) {
+            return auiConfig;
+        }
 
         LicenseConfiguration licenseConfiguration = new LicenseConfiguration();
-        AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
-        LicenseSpringCredentials licenseSpringCredentials = adminConf.getDynamic().getLicenseSpringCredentials();
+        LicenseSpringCredentials licenseSpringCredentials = appConf.getDynamic().getLicenseSpringCredentials();
 
-        if(licenseSpringCredentials != null)
-        {
+        if (licenseSpringCredentials != null) {
             licenseConfiguration.setApiKey(licenseSpringCredentials.getApiKey());
             licenseConfiguration.setProductCode(licenseSpringCredentials.getProductCode());
             licenseConfiguration.setSharedKey(licenseSpringCredentials.getSharedKey());
@@ -92,20 +118,6 @@ public class AUIConfigurationService {
         }
         auiConfig.setLicenseConfiguration(licenseConfiguration);
         return auiConfig;
-    }
-
-    private Properties loadPropertiesFromFile() throws IOException {
-
-        Properties props = new Properties();
-        File jarPath = new File(OAuth2Resource.class.getProtectionDomain().getCodeSource().getLocation().getPath());
-        String propertiesPath = jarPath.getParentFile().getAbsolutePath() + "/../config";
-        try (InputStream in = new FileInputStream(propertiesPath + "/auiConfiguration.properties")) {
-            props.load(in);
-            return props;
-        } catch (IOException e) {
-            log.error(ErrorResponse.ERROR_READING_CONFIG.getDescription());
-            throw e;
-        }
     }
 
 }

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/license/LicenseDetailsService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/license/LicenseDetailsService.java
@@ -74,7 +74,7 @@ public class LicenseDetailsService {
             auiConfigurationService.setAuiConfiguration(auiConfiguration);
 
             //save license spring credentials
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             adminConf.getDynamic().setLicenseSpringCredentials(licenseSpringCredentials);
             entryManager.merge(adminConf);
 
@@ -157,7 +157,7 @@ public class LicenseDetailsService {
                 JsonObject entity = response.readEntity(JsonObject.class);
                 if (entity.getString("license_key").equals(licenseRequest.getLicenseKey())) {
                     //save license spring credentials
-                    AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+                    AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
                     LicenseSpringCredentials licenseSpringCredentials = adminConf.getDynamic().getLicenseSpringCredentials();
                     licenseSpringCredentials.setLicenseKey(licenseRequest.getLicenseKey());
                     adminConf.getDynamic().setLicenseSpringCredentials(licenseSpringCredentials);

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/user/UserManagementService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/user/UserManagementService.java
@@ -31,7 +31,7 @@ public class UserManagementService {
 
     public List<AdminRole> getAllRoles() throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             return adminConf.getDynamic().getRoles();
         } catch (Exception e) {
             log.error(ErrorResponse.GET_ADMIUI_ROLES_ERROR.getDescription(), e);
@@ -41,7 +41,7 @@ public class UserManagementService {
 
     public AdminRole getRoleObjByName(String role) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             List<AdminRole> roles = adminConf.getDynamic().getRoles().stream().filter(ele -> ele.getRole().equals(role)).collect(Collectors.toList());
             if (roles.isEmpty()) {
                 log.error(ErrorResponse.ROLE_NOT_FOUND.getDescription());
@@ -59,7 +59,7 @@ public class UserManagementService {
 
     public List<AdminRole> addRole(AdminRole roleArg) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             List<AdminRole> roles = adminConf.getDynamic().getRoles();
 
             if (roles.contains(roleArg)) {
@@ -78,7 +78,7 @@ public class UserManagementService {
 
     public List<AdminRole> editRole(AdminRole roleArg) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
 
             List<AdminRole> roles = adminConf.getDynamic().getRoles();
             if (roles.stream().noneMatch(ele -> ele.equals(roleArg))) {
@@ -104,7 +104,7 @@ public class UserManagementService {
 
     public List<AdminRole> deleteRole(String role) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
 
             List<RolePermissionMapping> roleScopeMapping = adminConf.getDynamic().getRolePermissionMapping()
                     .stream().filter(ele -> ele.getRole().equalsIgnoreCase(role))
@@ -146,7 +146,7 @@ public class UserManagementService {
 
     public List<AdminPermission> getPermissions() throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             return adminConf.getDynamic().getPermissions();
         } catch (Exception e) {
             log.error(ErrorResponse.GET_ADMIUI_PERMISSIONS_ERROR.getDescription(), e);
@@ -156,7 +156,7 @@ public class UserManagementService {
 
     public AdminPermission getPermissionObjByName(String permission) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             List<AdminPermission> permissions = adminConf.getDynamic().getPermissions().stream().filter(ele -> ele.getPermission().equals(permission)).collect(Collectors.toList());
             if (permissions.isEmpty()) {
                 log.error(ErrorResponse.ROLE_NOT_FOUND.getDescription());
@@ -174,7 +174,7 @@ public class UserManagementService {
 
     public List<AdminPermission> addPermission(AdminPermission permissionArg) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             List<AdminPermission> permissions = adminConf.getDynamic().getPermissions();
 
             if (permissions.contains(permissionArg)) {
@@ -193,7 +193,7 @@ public class UserManagementService {
 
     public List<AdminPermission> editPermission(AdminPermission permissionArg) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
 
             List<AdminPermission> permissions = adminConf.getDynamic().getPermissions();
             if (permissions.stream().noneMatch(ele -> ele.equals(permissionArg))) {
@@ -218,7 +218,7 @@ public class UserManagementService {
 
     public List<AdminPermission> deletePermission(String permission) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
 
             boolean anyPermissionMapped = adminConf.getDynamic().getRolePermissionMapping()
                     .stream().anyMatch(ele -> ele.getPermissions().contains(permission));
@@ -247,7 +247,7 @@ public class UserManagementService {
 
     public List<RolePermissionMapping> getAllAdminUIRolePermissionsMapping() throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             return adminConf.getDynamic().getRolePermissionMapping();
         } catch (Exception e) {
             log.error(ErrorResponse.ERROR_READING_ROLE_PERMISSION_MAP.getDescription(), e);
@@ -257,7 +257,7 @@ public class UserManagementService {
 
     public List<RolePermissionMapping> addPermissionsToRole(RolePermissionMapping rolePermissionMappingArg) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             List<RolePermissionMapping> roleScopeMappingList = getRolePermMapByRole(adminConf, rolePermissionMappingArg);
 
             if (CollectionUtils.isNotEmpty(roleScopeMappingList)) {
@@ -290,7 +290,7 @@ public class UserManagementService {
 
     public List<RolePermissionMapping> mapPermissionsToRole(RolePermissionMapping rolePermissionMappingArg) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             List<RolePermissionMapping> roleScopeMappingList = getRolePermMapByRole(adminConf, rolePermissionMappingArg);
 
             if (roleScopeMappingList == null || roleScopeMappingList.isEmpty()) {
@@ -329,7 +329,7 @@ public class UserManagementService {
 
     public RolePermissionMapping getAdminUIRolePermissionsMapping(String role) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             List<RolePermissionMapping> roleScopeMapping = adminConf.getDynamic().getRolePermissionMapping()
                     .stream().filter(ele -> ele.getRole().equalsIgnoreCase(role))
                     .collect(Collectors.toList());
@@ -350,7 +350,7 @@ public class UserManagementService {
 
     public List<RolePermissionMapping> removePermissionsFromRole(String role) throws ApplicationException {
         try {
-            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.CONFIG_DN);
+            AdminConf adminConf = entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN);
             if (isFalse(getRoleObjByName(role).getDeletable())) {
                 log.error(ErrorResponse.ROLE_MARKED_UNDELETABLE.getDescription());
                 throw new ApplicationException(Response.Status.BAD_REQUEST.getStatusCode(), ErrorResponse.ROLE_MARKED_UNDELETABLE.getDescription());

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/utils/AppConstants.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/utils/AppConstants.java
@@ -4,6 +4,7 @@ public interface AppConstants {
     public static final String ADMIN_UI_CONFIG_DN = "ou=admin-ui,ou=configuration,o=jans";
     public static final String ADS_CONFIG_DN = "ou=agama-developer-studio,ou=configuration,o=jans";
     public static final String LICENSE_SPRING_API_URL = "https://api.licensespring.com/api/v4/";
+    //application type
     public static final String APPLICATION_KEY_ADMIN_UI = "admin-ui";
-    public static final String APPLICATION_KEY_ADS = "agama-developer-studio";
+    public static final String APPLICATION_KEY_ADS = "ads";
 }

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/utils/AppConstants.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/utils/AppConstants.java
@@ -1,6 +1,9 @@
 package io.jans.ca.plugin.adminui.utils;
 
 public interface AppConstants {
-    public static final String CONFIG_DN = "ou=admin-ui,ou=configuration,o=jans";
+    public static final String ADMIN_UI_CONFIG_DN = "ou=admin-ui,ou=configuration,o=jans";
+    public static final String ADS_CONFIG_DN = "ou=agama-developer-studio,ou=configuration,o=jans";
     public static final String LICENSE_SPRING_API_URL = "https://api.licensespring.com/api/v4/";
+    public static final String APPLICATION_KEY_ADMIN_UI = "admin-ui";
+    public static final String APPLICATION_KEY_ADS = "agama-developer-studio";
 }


### PR DESCRIPTION
ToDos:

- [x] Currently, the admin-ui plugin read the oidc client details from `auiConfiguration.properties` (placed on the server). this file contains op_host, client_id, client_secret, acrs_values, authz_endpoint, etc of oidc clients used for authentication and token generation. We will now store this information in the database (LDAP. MySQL etc..) in admin-ui configuration and remove `auiConfiguration.properties`. The plugin will read the information from DB.
- [ ] The agama-developer-studio configuration will be created in the database containing ADS oidc client details.
- [x] We will add the ability to the admin-ui plugin so that agama-developer-studio can use its following APIs.

- **appType**: `admin-ui`, `agama-developer-studio`.
1. `API`: `/app/{appType}/oauth2/config` -- To get ADS client configuration.
2. `API`: `/app/{appType}/oauth2/access-token` -- To generate access_token to get user-info
3. `API`: `/app/{appType}/oauth2/user-info` -- To get user-info
4. `API`: `/app/{appType}/oauth2/api-protection-token` -- To generate api-protection-token containing required scopes to access confg-api endpoints.

closes #3085
