### PR TITLE
ci: introduce release number marker for documentation

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -86,15 +86,27 @@ jobs:
 
       - name: Generate docs
         continue-on-error: true
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
          echo "Custom work on generating docs can go here."
+          
          # Run cn docs 
          sudo bash ./automation/docs/generated-cn-docs.sh
+          
          # Generate property docs and push to main
          sudo bash ./automation/docs/generate-property-docs.sh 
          cd docs
          git add . || echo "Nothing to add"
          git commit -a -S -m "docs: automated property doc generation" || echo "Nothing to commit"
+         git push
+         cd ..
+          
+         # Replace release number markers with actual release number
+         cd docs
+         egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-janssen-version/$VERSION/g"
+         git add . || echo "Nothing to add"
+         git commit -a -S -m "docs: replace release marker with release number" || echo "Nothing to commit"
          git push
          cd ..
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -103,12 +103,14 @@ jobs:
          cd ..
           
          # Replace release number markers with actual release number
-         cd docs
-         egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-janssen-version/$VERSION/g"
-         git add . || echo "Nothing to add"
-         git commit -a -S -m "docs: replace release marker with release number" || echo "Nothing to commit"
-         git push
-         cd ..
+         if [ ! -z "$VERSION" ]; then
+           cd docs
+           egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-janssen-version/$VERSION/g"
+           git add . || echo "Nothing to add"
+           git commit -a -S -m "docs: replace release marker with release number" || echo "Nothing to commit"
+           git push
+           cd ..
+         fi
 
       - name: mike deploy ${{ github.event.inputs.version }}
         if: >-

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -214,6 +214,36 @@ tags:
 ---
 ```
 
+### Referencing Janssen Project Release in Documents
+
+When a reference to the current release is required in the documentation content, use the text `replace-janssen-version`
+instead of mentioning the current release number. Janssen Project build system will replace `replace-janssen-version`
+text with the current release number at the time of every release. i.e. at the time of releasing documentation for the Janssen Project release of v1.0.5, all occurrences of
+`replace-janssen-version` will be replaced by `v1.0.5`.
+
+For example, below is the URL used in the documentation to point to the specification of API for corresponding Janssen 
+Project release. It is important that this link points to corresponding specification of that release.
+
+```
+https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/replace-janssen-version/jans-auth-server/docs/swagger.yaml
+```
+
+In every new release of Janssen Project (and corresponding Janssen documentation) only the `replace-janssen-version` part
+of the URL changes. So, at the time of releasing the documentation for `v1.0.4`, the build system will update the 
+`replace-janssen-version` in the URL so the URL becomes
+
+```
+https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/v1.0.4/jans-auth-server/docs/swagger.yaml
+```
+
+At the time of releasing `v1.0.5`, the build system will update the same URL as below
+
+```
+https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/v1.0.5/jans-auth-server/docs/swagger.yaml
+```
+
+This way, URL always points to the specification in corresponding release without updating it manually everytime before release.
+
 ### General Text
  - Allow long lines to wrap, rather than manually breaking them. For example, the Introduction paragraph is a single line
  - Keep explanations short and clear


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------


#### Target issue
  
closes #3327 

#### Implementation Details
Added a release marker as documented in CONTRIBUTION.md

CI flow will replace the marker with the appropriate release number.

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

