### PR TITLE
fix(jans-auth-server): changed getAttributeValues to getAttributeObje…

### DIFF
--- a/jans-auth-server/common/src/main/java/io/jans/as/common/model/common/SimpleUser.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/model/common/SimpleUser.java
@@ -22,11 +22,11 @@ public class SimpleUser extends io.jans.orm.model.base.SimpleUser {
     public Object getAttribute(String attributeName, boolean optional, boolean multivalued) throws InvalidClaimException {
         Object attribute = null;
 
-        List<String> values = getAttributeValues(attributeName);
+        List<Object> values = getAttributeObjectValues(attributeName);
         if (values != null) {
             if (multivalued) {
                 JSONArray array = new JSONArray();
-                for (String v : values) {
+                for (Object v : values) {
                     array.put(v);
                 }
                 attribute = array;


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
During the certification process, the date of birth format was not correct.
For this, debugging found that in the `setClaimField` method, it did not enter by the condition `instanceof` Date, since the `getAttribute` method returned String data type.
  
closes #3345
