### PR TITLE
docs: host javadocs on GH

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -121,11 +121,11 @@ jobs:
          fi
           
          echo "Generating javadocs"
-          . ./automation/docs/generate-javadocs.sh
-          cd docs
-          git add . || echo "Nothing to add"
-          git commit -a -S -m "docs: generate and add javadocs" || echo "Nothing to commit"
-          cd ..
+         sudo bash ./automation/docs/generate-javadocs.sh
+         cd docs
+         git add . || echo "Nothing to add"
+         git commit -a -S -m "docs: generate and add javadocs" || echo "Nothing to commit"
+         cd ..
          
          git push
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -126,22 +126,21 @@ jobs:
          if [ ! -z "$VERSION" ]; then
           for module in $JVM_PROJECTS
            do
-             path=$module
              echo "Generating javadocs for module: $module and all it's sub-modules"
              mvn -f $module/pom.xml javadoc:javadoc
           
              echo "Move generated javadocs from all sub-modules to respective doc site location"
           
              echo "getting all sub-module names"
-             sub_modules=($( mvn help:evaluate -Dexpression=project.modules -q -DforceStdout | tail -n +2 | head -n -1 | sed 's/\s*<.*>\(.*\)<.*>/\1/'))
+             generated_doc_paths=( $( find $module -type d  -path '*/target/site/apidocs' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||'))
           
-             echo "Loop through sub-modules and move javadocs"
-             for sub_module in "${sub_modules[@]}"
+             echo "Loop through paths where javadoc got generated and move them to documentation site"
+             for source_path in "${generated_doc_paths[@]}"
              do
-               # check if the directory `docs/admin/reference/javadocs/$module/$sub_module` exists, if not then create one
-               mkdir -p docs/admin/reference/javadocs/$module/$sub_module
-               echo "copy javadocs for $module/$sub_module"
-               cp -rv ./$module/$sub_module/target/site/apidocs/* ./docs/admin/reference/javadocs/$module/$sub_module/
+               # check if the directory `docs/admin/reference/javadocs/$source_path` exists, if not then create one
+               mkdir -p docs/admin/reference/javadocs/$source_path
+               echo "copy javadocs for $source_path"
+               cp -rv ./$source_path/target/site/apidocs/* ./docs/admin/reference/javadocs/$source_path/
              done
            done
           cd docs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -88,13 +88,23 @@ jobs:
         continue-on-error: true
         env:
           VERSION: ${{ github.event.release.tag_name }}
+          JVM_PROJECTS: |
+            jans-auth-server
+            jans-orm
+            jans-config-api
+            jans-scim
+            jans-core
+            jans-notify
+            jans-fido2
+            jans-eleven
+            agama
         run: |
          echo "Custom work on generating docs can go here."
           
          # Run cn docs 
          sudo bash ./automation/docs/generated-cn-docs.sh
           
-         # Generate property docs and push to main
+         echo "Generating property docs and push to main"
          sudo bash ./automation/docs/generate-property-docs.sh 
          cd docs
          git add . || echo "Nothing to add"
@@ -102,7 +112,7 @@ jobs:
          git push
          cd ..
           
-         # Replace release number markers with actual release number
+         echo "Replacing release number markers with actual release number"
          if [ ! -z "$VERSION" ]; then
            cd docs
            egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-janssen-version/$VERSION/g"
@@ -111,6 +121,36 @@ jobs:
            git push
            cd ..
          fi
+          
+         echo "Generating javadocs"
+         if [ ! -z "$VERSION" ]; then
+          for module in $JVM_PROJECTS
+           do
+             path=$module
+             echo "Generating javadocs for module: $module and all it's sub-modules"
+             mvn -f $module/pom.xml javadoc:javadoc
+          
+             echo "Move generated javadocs from all sub-modules to respective doc site location"
+          
+             echo "getting all sub-module names"
+             sub_modules=($( mvn help:evaluate -Dexpression=project.modules -q -DforceStdout | tail -n +2 | head -n -1 | sed 's/\s*<.*>\(.*\)<.*>/\1/'))
+          
+             echo "Loop through sub-modules and move javadocs"
+             for sub_module in "${sub_modules[@]}"
+             do
+               # check if the directory `docs/admin/reference/javadocs/$module/$sub_module` exists, if not then create one
+               mkdir -p docs/admin/reference/javadocs/$module/$sub_module
+               echo "copy javadocs for $module/$sub_module"
+               cp -rv ./$module/$sub_module/target/site/apidocs/* ./docs/admin/reference/javadocs/$module/$sub_module/
+             done
+           done
+          cd docs
+          git add . || echo "Nothing to add"
+          git commit -a -S -m "docs: generate and add javadocs" || echo "Nothing to commit"
+          git push
+          cd ..
+         fi
+
 
       - name: mike deploy ${{ github.event.inputs.version }}
         if: >-

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -124,25 +124,7 @@ jobs:
           
          echo "Generating javadocs"
          if [ ! -z "$VERSION" ]; then
-          for module in $JVM_PROJECTS
-           do
-             echo "Generating javadocs for module: $module and all it's sub-modules"
-             mvn -f $module/pom.xml javadoc:javadoc
-          
-             echo "Move generated javadocs from all sub-modules to respective doc site location"
-          
-             echo "getting all sub-module names"
-             generated_doc_paths=( $( find $module -type d  -path '*/target/site/apidocs' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||'))
-          
-             echo "Loop through paths where javadoc got generated and move them to documentation site"
-             for source_path in "${generated_doc_paths[@]}"
-             do
-               # check if the directory `docs/admin/reference/javadocs/$source_path` exists, if not then create one
-               mkdir -p docs/admin/reference/javadocs/$source_path
-               echo "copy javadocs for $source_path"
-               cp -rv ./$source_path/target/site/apidocs/* ./docs/admin/reference/javadocs/$source_path/
-             done
-           done
+          . ./automation/docs/generate-javadocs.sh
           cd docs
           git add . || echo "Nothing to add"
           git commit -a -S -m "docs: generate and add javadocs" || echo "Nothing to commit"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -126,7 +126,6 @@ jobs:
           git add . || echo "Nothing to add"
           git commit -a -S -m "docs: generate and add javadocs" || echo "Nothing to commit"
           cd ..
-         fi
          
          git push
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -113,8 +113,11 @@ jobs:
           
          echo "Replacing release number markers with actual release number"
          if [ ! -z "$VERSION" ]; then
+          MVERSION="${VERSION:1}"
            cd docs
            egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-janssen-version/$VERSION/g"
+           # strip v from v1.x.x
+           egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-janssen-image-version/${VERSION:1}/g"
            git add . || echo "Nothing to add"
            git commit -a -S -m "docs: replace release marker with release number" || echo "Nothing to commit"
            cd ..

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -109,7 +109,6 @@ jobs:
          cd docs
          git add . || echo "Nothing to add"
          git commit -a -S -m "docs: automated property doc generation" || echo "Nothing to commit"
-         git push
          cd ..
           
          echo "Replacing release number markers with actual release number"
@@ -118,19 +117,18 @@ jobs:
            egrep -lRZ --exclude=CONTRIBUTING.md . | xargs -0 -l sed -i -e "s/replace-janssen-version/$VERSION/g"
            git add . || echo "Nothing to add"
            git commit -a -S -m "docs: replace release marker with release number" || echo "Nothing to commit"
-           git push
            cd ..
          fi
           
          echo "Generating javadocs"
-         if [ ! -z "$VERSION" ]; then
           . ./automation/docs/generate-javadocs.sh
           cd docs
           git add . || echo "Nothing to add"
           git commit -a -S -m "docs: generate and add javadocs" || echo "Nothing to commit"
-          git push
           cd ..
          fi
+         
+         git push
 
 
       - name: mike deploy ${{ github.event.inputs.version }}

--- a/automation/docs/generate-javadocs.sh
+++ b/automation/docs/generate-javadocs.sh
@@ -9,7 +9,7 @@ for module in $JVM_PROJECTS
    echo "Move generated javadocs to respective doc site location"
 
    echo "getting locations where javadocs got generated"
-   generated_doc_paths=($(find "$module" -type d  -path '*/target/site/apidocs' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||'))
+   mapfile -t generated_doc_paths < <(find "$module" -type d  -path '*/target/site/apidocs' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||')
 
    echo "move javadocs from each location to respective documentation site location"
    for source_path in "${generated_doc_paths[@]}"

--- a/automation/docs/generate-javadocs.sh
+++ b/automation/docs/generate-javadocs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 for module in $JVM_PROJECTS
  do

--- a/automation/docs/generate-javadocs.sh
+++ b/automation/docs/generate-javadocs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+for module in $JVM_PROJECTS
+ do
+   echo "Generating javadocs for module: $module and all it's sub-modules"
+   mvn -f $module/pom.xml javadoc:javadoc
+
+   echo "Move generated javadocs to respective doc site location"
+
+   echo "getting locations where javadocs got generated"
+   generated_doc_paths=( $( find $module -type d  -path '*/target/site/apidocs' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||'))
+
+   echo "move javadocs from each location to respective documentation site location"
+   for source_path in "${generated_doc_paths[@]}"
+   do
+     # check if the directory `docs/admin/reference/javadocs/$source_path` exists, if not then create one
+     mkdir -p docs/admin/reference/javadocs/$source_path
+     echo "copy javadocs for $source_path"
+     cp -rv ./$source_path/target/site/apidocs/* ./docs/admin/reference/javadocs/$source_path/
+   done
+ done

--- a/automation/docs/generate-javadocs.sh
+++ b/automation/docs/generate-javadocs.sh
@@ -4,19 +4,19 @@ set -euo pipefail
 for module in $JVM_PROJECTS
  do
    echo "Generating javadocs for module: $module and all it's sub-modules"
-   mvn -f $module/pom.xml javadoc:javadoc
+   mvn -f "$module"/pom.xml javadoc:javadoc
 
    echo "Move generated javadocs to respective doc site location"
 
    echo "getting locations where javadocs got generated"
-   generated_doc_paths=( $( find $module -type d  -path '*/target/site/apidocs' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||'))
+   generated_doc_paths=($(find "$module" -type d  -path '*/target/site/apidocs' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||' | sed -r 's|/[^/]+$||'))
 
    echo "move javadocs from each location to respective documentation site location"
    for source_path in "${generated_doc_paths[@]}"
    do
      # check if the directory `docs/admin/reference/javadocs/$source_path` exists, if not then create one
-     mkdir -p docs/admin/reference/javadocs/$source_path
+     mkdir -p docs/admin/reference/javadocs/"$source_path"
      echo "copy javadocs for $source_path"
-     cp -rv ./$source_path/target/site/apidocs/* ./docs/admin/reference/javadocs/$source_path/
+     cp -rv ./"$source_path"/target/site/apidocs/* ./docs/admin/reference/javadocs/"$source_path"/
    done
  done


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

In order to version javadocs generated by each module, it was decided to host them in GH repo. This PR will generate javadocs for all the modules and move them to respective locations under `jans/docs/admin/reference/javadoc/<module>`.

A subsequent CR will process them further and publish them on MKDocs site as discussed with Mo.

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

