### PR TITLE
fix(jans-auth-server): Duplicate iss and aud on introspection as jwt #3366

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/jwt/JwtClaimSet.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/jwt/JwtClaimSet.java
@@ -202,11 +202,25 @@ public abstract class JwtClaimSet {
     }
 
     private void setClaimString(String key, Object value, boolean overrideValue) {
-        Object currentValue = getClaim(key);
-        if (overrideValue || currentValue == null) {
+        if (overrideValue) {
             setClaim(key, (String) value);
-        } else {
-            setClaim(key, Lists.newArrayList(currentValue.toString(), (String) value));
+            return;
+        }
+
+        Object currentValue = getClaim(key);
+        String valueAsString = (String) value;
+
+        if (currentValue instanceof String) {
+            if (!currentValue.equals(value)) {
+                setClaim(key, Lists.newArrayList(currentValue.toString(), valueAsString));
+            } else {
+                setClaim(key, (String) value);
+            }
+        } else if (currentValue instanceof List) {
+            List<String> currentValueAsList = (List) currentValue;
+            if (!currentValueAsList.contains(valueAsString)) {
+                currentValueAsList.add(valueAsString);
+            }
         }
     }
 

--- a/jans-auth-server/model/src/test/java/io/jans/as/model/jwt/JwtClaimsTest.java
+++ b/jans-auth-server/model/src/test/java/io/jans/as/model/jwt/JwtClaimsTest.java
@@ -1,0 +1,50 @@
+package io.jans.as.model.jwt;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Yuriy Z
+ */
+public class JwtClaimsTest {
+
+    @Test
+    public void setClaimObject_whenSetSameValue_shouldNotCreateDuplicate() {
+        JwtClaims claims = new JwtClaims();
+        claims.addAudience("client1");
+
+        claims.setClaimObject("aud", "client1", false);
+        assertEquals(claims.getClaim("aud"), "client1");
+    }
+
+    @Test
+    public void setClaimObject_whenSetDifferentValues_shouldCreateCorrectArray() {
+        JwtClaims claims = new JwtClaims();
+        claims.addAudience("client1");
+
+        claims.setClaimObject("aud", "client2", false);
+        assertEquals(claims.getClaim("aud"), Lists.newArrayList("client1", "client2"));
+    }
+
+    @Test
+    public void setClaimObject_whenSetDifferentValue_shouldCreateCorrectArray() {
+        JwtClaims claims = new JwtClaims();
+        claims.addAudience("client1");
+
+        claims.setClaimObject("aud", "client2", false);
+        claims.setClaimObject("aud", "client3", false);
+        assertEquals(claims.getClaim("aud"), Lists.newArrayList("client1", "client2", "client3"));
+    }
+
+    @Test
+    public void setClaimObject_whenSetDifferentValueWithOverride_shouldOverrideValue() {
+        JwtClaims claims = new JwtClaims();
+        claims.addAudience("client1");
+
+        claims.setClaimObject("aud", "client2", false);
+        claims.setClaimObject("aud", "client3", true);
+        assertEquals(claims.getClaim("aud"), "client3");
+    }
+}

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/introspection/ws/rs/IntrospectionWebService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/introspection/ws/rs/IntrospectionWebService.java
@@ -250,6 +250,9 @@ public class IntrospectionWebService {
                 }
             }
         }
+        if (log.isTraceEnabled()) {
+            log.trace("Response before signing: {}", jwt.getClaims().toJsonString());
+        }
 
         return jwtSigner.sign().toString();
     }


### PR DESCRIPTION
### Description

fix(jans-auth-server): Duplicate iss and aud on introspection as jwt

#### Target issue
 
closes #3366

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

