### PR TITLE
fix: use correct Ubuntu version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Janssen is not a big monolith--it's a lot of services working together. Whether 
 
 ### Quick Start
 
-For development and testing purposes, the Janssen Server can be quickly installed on an Ubuntu 22.04 VM by running the command below:
+For development and testing purposes, the Janssen Server can be quickly installed on an Ubuntu 20.04 VM by running the command below:
 
 ```
 wget https://raw.githubusercontent.com/JanssenProject/jans/main/automation/startjanssenmonolithdemo.sh && chmod u+x startjanssenmonolithdemo.sh && sudo bash startjanssenmonolithdemo.sh demoexample.jans.io MYSQL


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Janssen Project README had the wrong version of Ubuntu mentioned. Correcting the same 22.04 -> 20.04

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

