### PR TITLE
fix: add link to api reference

### DIFF
--- a/docs/admin/config-api/README.md
+++ b/docs/admin/config-api/README.md
@@ -29,7 +29,7 @@ Jans Config API follow a flexible plugin architecture in which the new features 
 Config API endpoints are OAuth 2.0 protected. It supports simple bearer and JWT token.
 
 ## Documentation
-Learn more in the [jans-config-api OpenAPI documentation](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-config-api/docs/jans-config-api-swagger.yaml).
+Learn more API endpoint using [jans-config-api OpenAPI documentation](../reference/openapi.md).
 
 ### Endpoints
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Janssen config API README on documentation site was pointing to swagger documentation of `head`. 

Changed this link to point to API reference section of the documentation. 

API reference section will have dynamic links which will be updated as new versions of Janssen Project is released.

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

