### PR TITLE
fix: jans-linux-setup load test data with jans-auth only

### DIFF
--- a/jans-linux-setup/jans_setup/templates/test/jans-auth/server/config-oxauth-test-data.properties
+++ b/jans-linux-setup/jans_setup/templates/test/jans-auth/server/config-oxauth-test-data.properties
@@ -27,7 +27,7 @@ sector.identifier.id.bad=840ef58d-a7d0-4986-af7b-71ed0089ce61
 contact.email.1=mike@jans.org
 contact.email.2=javier@jans.org
 
-test.keep.clients=%(scim_client_id)s, %(jca_client_id)s, AB77-1A2B, 3E20, FF81-2D39, %(jca_test_client_id)s
+test.keep.clients=%(scim_client_id)s, AB77-1A2B, 3E20, FF81-2D39
 
 clientKeyStoreFile=profiles/%(hostname)s/client_keystore.p12
 clientKeyStoreSecret=secret


### PR DESCRIPTION
closes #3429