### PR TITLE
fix: jans-linux-setup enable mysqld on boot for el8

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/rdbm.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/rdbm.py
@@ -81,6 +81,7 @@ class RDBMInstaller(BaseInstaller, SetupUtils):
                     self.enable('mariadb')
                 elif base.clone_type == 'rpm':
                     self.restart('mysqld')
+                    self.enable('mysqld')
                 result, conn = self.dbUtils.mysqlconnection(log=False)
                 if not result:
                     sql_cmd_list = [


### PR DESCRIPTION
closes #3428