### PR TITLE
feat(jans-auth-server): renamed "code"->"random" uniqueness claims of id_token to avoid confusion with Authorization Code Flow #3466

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
@@ -142,7 +142,7 @@ public class IdTokenFactory {
 
         jwr.getClaims().setExpirationTime(expiration);
         jwr.getClaims().setIssuedAt(issuedAt);
-        jwr.setClaim("code", UUID.randomUUID().toString());
+        jwr.setClaim("random", UUID.randomUUID().toString()); // provided uniqueness of id_token for same RP requests, oxauth: 1493
 
         if (executionContext.getPreProcessing() != null) {
             executionContext.getPreProcessing().apply(jwr);


### PR DESCRIPTION
### Description

feat(jans-auth-server): renamed "code"->"random" uniqueness claims of id_token to avoid confusion with Authorization Code Flow 

#### Target issue
  
closes #3466

