### PR TITLE
docs: fixed navigation to config API docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,14 +184,14 @@ nav:
         - 'FAQ': 'admin/vm-ops/faq.md'
     - 'Configuration Guide':
         - 'Config API':
-            - 'admin/config-api/README.md'
-            - 'Settings': 'admin/config-api/config.md'
-            - 'Attributes': 'admin/config-api/attribute.md'
-            - 'OpenID Client': 'admin/config-api/openid-client.md'
-            - 'Security': 'admin/config-api/security.md'
-            - 'Logs': 'admin/config-api/logs.md'
-            - 'Monitoring': 'admin/config-api/monitoring.md'
-            - 'Plugins': 'admin/config-api/plugins.md'
+            - 'admin/config-guide/config-api/README.md'
+            - 'Settings': 'admin/config-guide/config-api/config.md'
+            - 'Attributes': 'admin/config-guide/config-api/attribute.md'
+            - 'OpenID Client': 'admin/config-guide/config-api/openid-client.md'
+            - 'Security': 'admin/config-guide/config-api/security.md'
+            - 'Logs': 'admin/config-guide/config-api/logs.md'
+            - 'Monitoring': 'admin/config-guide/config-api/monitoring.md'
+            - 'Plugins': 'admin/config-guide/config-api/plugins.md'
         - 'CURL Guide': 'admin/config-guide/curl.md'
         - 'Text-Based User Interface (TUI)': 'admin/config-guide/tui.md'
         - 'Command Line Interface (CLI)':


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Corrected mismatched nav address for config-api docs.

#### Target issue
  <!-- Link or describe the issue this PR is fixing --> #3486 
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #3486 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

