### PR TITLE
feat(jans-auth-server): implemented auth server config property to disable prompt=login #3006

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -448,6 +448,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Boolean value specifying whether to include sessionId in response", defaultValue = "false")
     private Boolean includeSidInResponse = false;
 
+    @DocProperty(description = "Boolean value specifying whether to disable prompt=login", defaultValue = "false")
+    private Boolean disablePromptLogin = false;
+
 
     /**
      * SessionId will be expired after sessionIdLifetime seconds
@@ -1107,6 +1110,15 @@ public class AppConfiguration implements Configuration {
 
     public void setForceOfflineAccessScopeToEnableRefreshToken(Boolean forceOfflineAccessScopeToEnableRefreshToken) {
         this.forceOfflineAccessScopeToEnableRefreshToken = forceOfflineAccessScopeToEnableRefreshToken;
+    }
+
+    public Boolean getDisablePromptLogin() {
+        if (disablePromptLogin == null) disablePromptLogin = false;
+        return disablePromptLogin;
+    }
+
+    public void setDisablePromptLogin(Boolean disablePromptLogin) {
+        this.disablePromptLogin = disablePromptLogin;
     }
 
     public Boolean getIncludeSidInResponse() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -545,7 +545,12 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
         }
     }
 
-    private void checkPromptLogin(AuthzRequest authzRequest, List<Prompt> prompts) {
+    public void checkPromptLogin(AuthzRequest authzRequest, List<Prompt> prompts) {
+        if (isTrue(appConfiguration.getDisablePromptLogin())) {
+            log.trace("Disabled prompt=login (because disablePromptLogin=true).");
+            prompts.remove(Prompt.LOGIN);
+            return;
+        }
         if (prompts.contains(Prompt.LOGIN)) {
             boolean sessionUnauthenticated = false;
 

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImplTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImplTest.java
@@ -3,6 +3,8 @@ package io.jans.as.server.authorize.ws.rs;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.model.session.SessionId;
+import io.jans.as.model.common.Prompt;
 import io.jans.as.model.common.ResponseType;
 import io.jans.as.model.common.ScopeConstants;
 import io.jans.as.model.configuration.AppConfiguration;
@@ -25,10 +27,12 @@ import org.slf4j.Logger;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
 
 /**
  * @author Yuriy Z
@@ -110,6 +114,35 @@ public class AuthorizeRestWebServiceImplTest {
 
     @Mock
     private AuthzRequestService authzRequestService;
+
+    @Test
+    public void checkPromptLogin_whenDisablePromptLoginIsTrue_shouldNotClearSession() {
+        AuthzRequest authzRequest = new AuthzRequest();
+        authzRequest.setSessionId("some_id");
+
+        List<Prompt> promptList = new ArrayList<>();
+        promptList.add(Prompt.LOGIN);
+
+        when(appConfiguration.getDisablePromptLogin()).thenReturn(true);
+
+        authorizeRestWebService.checkPromptLogin(authzRequest, promptList);
+        assertEquals(authzRequest.getSessionId(), "some_id");
+    }
+
+    @Test
+    public void checkPromptLogin_whenDisablePromptLoginIsFalse_shouldClearSession() {
+        AuthzRequest authzRequest = new AuthzRequest();
+        authzRequest.setSessionId("some_id");
+
+        List<Prompt> promptList = new ArrayList<>();
+        promptList.add(Prompt.LOGIN);
+
+        when(identity.getSessionId()).thenReturn(new SessionId());
+        when(appConfiguration.getDisablePromptLogin()).thenReturn(false);
+
+        authorizeRestWebService.checkPromptLogin(authzRequest, promptList);
+        assertNull(authzRequest.getSessionId());
+    }
 
     @Test
     public void checkOfflineAccessScopes_whenOfflineAccessIsPresentAndConsentNot_shouldRemoveOfflineAccess() {


### PR DESCRIPTION
### Description

feat(jans-auth-server): implemented auth server config property to disable prompt=login #3006

#### Target issue
  
closes #3006

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

