### PR TITLE
docs: fix missing link to auth code flow grant

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -310,6 +310,8 @@ nav:
                 - 'Forcing Logout on Browser Exit': 'admin/auth-server/openid-features/logout/forcing-logout.md'
         - 'OAuth Features':
             - 'admin/auth-server/oauth-features/README.md'
+            - 'Authorization Code Grant': 'admin/auth-server/oauth-features/auth-code-grant.md'
+            - 'Implicit Grant': 'admin/auth-server/oauth-features/implicit-grant.md'
             - 'Password Grant': 'admin/auth-server/oauth-features/password-grant.md'
             - 'Device Grant': 'admin/auth-server/oauth-features/device-grant.md'
             - 'Client Credential Grant': 'admin/auth-server/oauth-features/client-credential-grant.md'


### PR DESCRIPTION
#3572
page admin/auth-server/oauth-features/auth-code-grant.md has been added.

