### PR TITLE
chore(jans-auth-server): move enabledFeatureFlags out of AppConfiguration to avoid patch issues on jans-config-api side #3577

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/common/FeatureFlagType.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/common/FeatureFlagType.java
@@ -1,5 +1,6 @@
 package io.jans.as.model.common;
 
+import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.doc.annotation.DocFeatureFlag;
 import org.apache.commons.lang3.StringUtils;
 
@@ -76,6 +77,10 @@ public enum FeatureFlagType {
         }
 
         return UNKNOWN;
+    }
+
+    public static Set<FeatureFlagType> from(AppConfiguration appConfiguration) {
+        return fromValues(appConfiguration.getFeatureFlags());
     }
 
     public static Set<FeatureFlagType> fromValues(List<String> values) {

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -904,12 +904,8 @@ public class AppConfiguration implements Configuration {
         this.checkUserPresenceOnRefreshToken = checkUserPresenceOnRefreshToken;
     }
 
-    public Set<FeatureFlagType> getEnabledFeatureFlags() {
-        return FeatureFlagType.fromValues(getFeatureFlags());
-    }
-
     public boolean isFeatureEnabled(FeatureFlagType flagType) {
-        final Set<FeatureFlagType> flags = getEnabledFeatureFlags();
+        final Set<FeatureFlagType> flags = FeatureFlagType.from(this);
         if (flags.isEmpty())
             return true;
 

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/error/ErrorResponseFactory.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/error/ErrorResponseFactory.java
@@ -104,7 +104,7 @@ public class ErrorResponseFactory implements Configuration {
     }
 
     public void validateFeatureEnabled(FeatureFlagType flagType) {
-        final Set<FeatureFlagType> enabledFlags = appConfiguration.getEnabledFeatureFlags();
+        final Set<FeatureFlagType> enabledFlags = FeatureFlagType.from(appConfiguration);
         if (enabledFlags.isEmpty()) { // no restrictions
             return;
         }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/AppInitializer.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/AppInitializer.java
@@ -702,7 +702,7 @@ public class AppInitializer {
      * should be more than 0 seconds of interval
      */
     private void initCibaRequestsProcessor() {
-        final Set<FeatureFlagType> featureFlags = appConfiguration.getEnabledFeatureFlags();
+        final Set<FeatureFlagType> featureFlags = FeatureFlagType.from(appConfiguration);
         if ((featureFlags.isEmpty() || featureFlags.contains(FeatureFlagType.CIBA)) && appConfiguration.getBackchannelRequestsProcessorJobIntervalSec() > 0) {
             if (cibaRequestsProcessorJob != null) {
                 cibaRequestsProcessorJob.initTimer();

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/stat/StatService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/stat/StatService.java
@@ -73,7 +73,7 @@ public class StatService {
 
     public boolean init() {
         try {
-            final Set<FeatureFlagType> featureFlags = appConfiguration.getEnabledFeatureFlags();
+            final Set<FeatureFlagType> featureFlags = FeatureFlagType.from(appConfiguration);
             if (!featureFlags.isEmpty() && !featureFlags.contains(FeatureFlagType.STAT)) {
                 log.trace("Stat service is not enabled.");
                 return false;


### PR DESCRIPTION
### Description

chore(jans-auth-server): move enabledFeatureFlags out of AppConfiguration to avoid patch issues on jans-config-api side 

#### Target issue
  
closes #3577

