### PR TITLE
feat(jans-auth-server): added dynamicRegistrationDefaultCustomAttributes to provide default custom attributes during dcr #3595

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -7,6 +7,7 @@
 package io.jans.as.model.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import io.jans.agama.model.EngineConfig;
 import io.jans.as.model.common.*;
@@ -256,8 +257,11 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "A list of the JWS signing algorithms (alg values) supported by the Token Endpoint for the signature on the JWT used to authenticate the Client at the Token Endpoint for the private_key_jwt and client_secret_jwt authentication methods")
     private List<String> tokenEndpointAuthSigningAlgValuesSupported;
 
-    @DocProperty(description = "This list details the custom attributes for dynamic registration")
+    @DocProperty(description = "This list details the custom attributes allowed for dynamic registration")
     private List<String> dynamicRegistrationCustomAttributes;
+
+    @DocProperty(description = "This map provides default custom attributes with values for dynamic registration")
+    private JsonNode dynamicRegistrationDefaultCustomAttributes;
 
     @DocProperty(description = "A list of the display parameter values that the OpenID Provider supports")
     private List<String> displayValuesSupported;
@@ -1842,6 +1846,14 @@ public class AppConfiguration implements Configuration {
 
     public void setTokenEndpointAuthSigningAlgValuesSupported(List<String> tokenEndpointAuthSigningAlgValuesSupported) {
         this.tokenEndpointAuthSigningAlgValuesSupported = tokenEndpointAuthSigningAlgValuesSupported;
+    }
+
+    public JsonNode getDynamicRegistrationDefaultCustomAttributes() {
+        return dynamicRegistrationDefaultCustomAttributes;
+    }
+
+    public void setDynamicRegistrationDefaultCustomAttributes(JsonNode dynamicRegistrationDefaultCustomAttributes) {
+        this.dynamicRegistrationDefaultCustomAttributes = dynamicRegistrationDefaultCustomAttributes;
     }
 
     public List<String> getDynamicRegistrationCustomAttributes() {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterServiceTest.java
@@ -1,0 +1,86 @@
+package io.jans.as.server.register.ws.rs;
+
+import com.beust.jcommander.internal.Lists;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jans.as.common.service.AttributeService;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.server.ciba.CIBARegisterClientMetadataService;
+import io.jans.as.server.service.ScopeService;
+import org.json.JSONObject;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class RegisterServiceTest {
+
+    @InjectMocks
+    @Spy
+    private RegisterService registerService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private ScopeService scopeService;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private AttributeService attributeService;
+
+    @Mock
+    private CIBARegisterClientMetadataService cibaRegisterClientMetadataService;
+
+    @Test
+    public void addDefaultCustomAttributes_whenCalledWithExistingConfigurationData_shouldPopulateRequestObject() throws JsonProcessingException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JsonNode node = mapper.readTree("{\"jansInclClaimsInIdTkn\": true, \"jansTrustedClnt\": true}");
+        when(appConfiguration.getDynamicRegistrationCustomAttributes()).thenReturn(Lists.newArrayList("jansInclClaimsInIdTkn", "jansTrustedClnt"));
+        when(appConfiguration.getDynamicRegistrationDefaultCustomAttributes()).thenReturn(node);
+
+        JSONObject requestObject = new JSONObject();
+        registerService.addDefaultCustomAttributes(requestObject);
+
+        assertTrue(requestObject.getBoolean("jansInclClaimsInIdTkn"));
+        assertTrue(requestObject.getBoolean("jansTrustedClnt"));
+    }
+
+    @Test
+    public void addDefaultCustomAttributes_whenCustomAttributePropertyIsEmpty_shouldNotTakeEffect() throws JsonProcessingException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JsonNode node = mapper.readTree("{\"jansInclClaimsInIdTkn\": true, \"jansTrustedClnt\": true}");
+        when(appConfiguration.getDynamicRegistrationCustomAttributes()).thenReturn(Lists.newArrayList());
+        when(appConfiguration.getDynamicRegistrationDefaultCustomAttributes()).thenReturn(node);
+
+        JSONObject requestObject = new JSONObject();
+        registerService.addDefaultCustomAttributes(requestObject);
+
+        assertTrue(requestObject.isEmpty());
+    }
+
+    @Test
+    public void addDefaultCustomAttributes_whenCalledWithNoData_shouldNotTakeEffect() {
+        JSONObject requestObject = new JSONObject();
+        registerService.addDefaultCustomAttributes(requestObject);
+
+        assertTrue(requestObject.isEmpty());
+    }
+}


### PR DESCRIPTION
### Description

feat(jans-auth-server): added dynamicRegistrationDefaultCustomAttributes to provide default custom attributes during dcr #3595

#### Target issue
  
closes #3595

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

