### PR TITLE
fix(jans-auth-server): wrong Client Authn Method at token endpoint throws npe #3503

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/AuthorizeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/AuthorizeService.java
@@ -151,13 +151,18 @@ public class AuthorizeService {
         try {
             final User user = sessionIdService.getUser(session);
             if (user == null) {
-                log.debug("Permission denied. Failed to find session user: userDn = " + session.getUserDn() + ".");
+                log.debug("Permission denied. Failed to find session user: userDn = {}", session.getUserDn());
                 permissionDenied(session);
                 return;
             }
 
             String clientId = session.getSessionAttributes().get(AuthorizeRequestParam.CLIENT_ID);
             final Client client = clientService.getClient(clientId);
+            if (client == null) {
+                log.debug("Permission denied. Failed to find client by id: {}", clientId);
+                permissionDenied(session);
+                return;
+            }
 
             String scope = session.getSessionAttributes().get(AuthorizeRequestParam.SCOPE);
             String responseType = session.getSessionAttributes().get(AuthorizeRequestParam.RESPONSE_TYPE);


### PR DESCRIPTION
### Description

fix(jans-auth-server): wrong Client Authn Method at token endpoint throws npe 

#### Target issue
  
closes #3503

