### PR TITLE
fix: jans-linux-setup external libs in jans-fido2.xml

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/fido.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/fido.py
@@ -53,8 +53,6 @@ class FidoInstaller(JettyInstaller):
 
         self.renderTemplateInOut(self.ldif_fido2, self.template_folder, self.output_folder)
 
-        self.write_webapps_xml()
-
         ldif_files = [self.ldif_fido2]
         self.dbUtils.import_ldif(ldif_files)
 


### PR DESCRIPTION
closes #3603