### PR TITLE
fix(config-api): plugin endpoint not returning data in subsequent call

### DIFF
--- a/jans-config-api/docs/jans-config-api-swagger-auto.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger-auto.yaml
@@ -5121,9 +5121,9 @@ paths:
     get:
       tags:
       - Plugins
-      summary: Gets list of Plugins
-      description: Gets list of Plugins
-      operationId: get-plugins_1
+      summary: Get plugin by name
+      description: Get plugin by name
+      operationId: get-plugin-by-name
       parameters:
       - name: pluginName
         in: path
@@ -7466,17 +7466,17 @@ components:
           $ref: '#/components/schemas/AttributeValidation'
         tooltip:
           type: string
-        adminCanView:
-          type: boolean
-        adminCanEdit:
+        userCanAccess:
           type: boolean
         adminCanAccess:
           type: boolean
-        userCanView:
+        adminCanEdit:
           type: boolean
         userCanEdit:
           type: boolean
-        userCanAccess:
+        adminCanView:
+          type: boolean
+        userCanView:
           type: boolean
         whitePagesCanView:
           type: boolean

--- a/jans-config-api/profiles/local/test.properties
+++ b/jans-config-api/profiles/local/test.properties
@@ -4,6 +4,6 @@ test.scopes=https://jans.io/oauth/config/acrs.readonly https://jans.io/oauth/con
 # jans.server
 token.endpoint=https://jans.server2/jans-auth/restv1/token
 token.grant.type=client_credentials
-test.client.id=1800.e1ca6eff-0b46-423c-bed5-34aba0a9ac5a
-test.client.secret=gfhn8mKT39uP
+test.client.id=1800.c9c0b756-a1fc-4013-9feb-64d531ac2dc1
+test.client.secret=ONfjpemnGAFU
 test.issuer=https://jans.server2/

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/PluginResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/PluginResource.java
@@ -60,7 +60,7 @@ public class PluginResource extends ConfigBaseResource {
         return Response.ok(getPluginNames()).build();
     }
 
-    @Operation(summary = "Gets list of Plugins", description = "Gets list of Plugins", operationId = "get-plugins", tags = {
+    @Operation(summary = "Get plugin by name", description = "Get plugin by name", operationId = "get-plugin-by-name", tags = {
             "Plugins" }, security = @SecurityRequirement(name = "oauth2", scopes = {
                     ApiAccessConstants.PLUGIN_READ_ACCESS }))
     @ApiResponses(value = {
@@ -78,8 +78,9 @@ public class PluginResource extends ConfigBaseResource {
         Boolean deployed = false;
         logger.debug("All plugins:{} ", plugins);
         if (StringUtils.isNotBlank(pluginName) && !plugins.isEmpty()) {
-            Optional<PluginConf> pluginNameOptional = plugins.stream().findAny()
-                    .filter(plugin -> pluginName.equalsIgnoreCase(plugin.getName()));
+            Optional<PluginConf> pluginNameOptional = plugins.stream()
+                    .filter(plugin -> pluginName.equalsIgnoreCase(plugin.getName())).findAny();
+
             logger.debug("pluginNameOptional:{} ", pluginNameOptional);
             if (pluginNameOptional.isPresent()) {
                 deployed = true;
@@ -92,15 +93,18 @@ public class PluginResource extends ConfigBaseResource {
     private List<PluginConf> getPluginNames() {
 
         List<PluginConf> plugins = this.authUtil.getPluginConf();
-        logger.debug("plugins:{} ", plugins);
+        logger.debug("Config plugins:{} ", plugins);
         List<PluginConf> pluginInfo = new ArrayList<>();
         for (PluginConf pluginConf : plugins) {
             logger.debug("pluginConf:{} ", pluginConf);
             if (StringUtils.isNotBlank(pluginConf.getClassName())) {
                 try {
+                    logger.debug("pluginConf.getClassName():{} ", pluginConf.getClassName());
                     Class.forName(pluginConf.getClassName());
-                    pluginConf.setClassName("");
-                    pluginInfo.add(pluginConf);
+                    PluginConf conf = new PluginConf();
+                    conf.setName(pluginConf.getName());
+                    conf.setDescription(pluginConf.getDescription());
+                    pluginInfo.add(conf);
                 } catch (ClassNotFoundException ex) {
                     logger.error("'{}' plugin not deployed", pluginConf.getName());
                 }


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Fix subsequent call to `/jans-config-api/api/v1/plugin` endpoint returning empty list

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #3632

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

