### PR TITLE
feat(jans-auth-server): provided ability to set scriptDns related attributes of client (e.g. introspectionScripts) #3645

### DIFF
--- a/jans-auth-server/client/src/main/java/io/jans/as/client/RegisterRequest.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/RegisterRequest.java
@@ -81,6 +81,13 @@ public class RegisterRequest extends BaseRequest {
     private String tlsClientAuthSubjectDn;
     private Boolean allowSpontaneousScopes;
     private List<String> spontaneousScopes;
+    private List<String> spontaneousScopeScriptDns;
+    private List<String> updateTokenScriptDns;
+    private List<String> postAuthnScriptDns;
+    private List<String> consentGatheringScriptDns;
+    private List<String> introspectionScriptDns;
+    private List<String> rptClaimsScriptDns;
+    private List<String> ropcScriptDns;
     private Boolean runIntrospectionScriptBeforeJwtCreation;
     private Boolean keepClientAuthorizationAfterExpiration;
     private SubjectType subjectType;
@@ -167,11 +174,19 @@ public class RegisterRequest extends BaseRequest {
         this.customAttributes = new HashMap<>();
         this.authorizedAcrValues = new ArrayList<>();
 
-        clientName = new LocalizedString();
-        logoUri = new LocalizedString();
-        clientUri = new LocalizedString();
-        policyUri = new LocalizedString();
-        tosUri = new LocalizedString();
+        this.clientName = new LocalizedString();
+        this.logoUri = new LocalizedString();
+        this.clientUri = new LocalizedString();
+        this.policyUri = new LocalizedString();
+        this.tosUri = new LocalizedString();
+        this.additionalAudience = new ArrayList<>();
+        this.spontaneousScopeScriptDns = new ArrayList<>();
+        this.updateTokenScriptDns = new ArrayList<>();
+        this.postAuthnScriptDns = new ArrayList<>();
+        this.consentGatheringScriptDns = new ArrayList<>();
+        this.introspectionScriptDns = new ArrayList<>();
+        this.rptClaimsScriptDns = new ArrayList<>();
+        this.ropcScriptDns = new ArrayList<>();
     }
 
     /**
@@ -1379,6 +1394,132 @@ public class RegisterRequest extends BaseRequest {
     }
 
     /**
+     * Gets spontaneous scope script dns
+     *
+     * @return spontaneous scope script dns
+     */
+    public List<String> getSpontaneousScopeScriptDns() {
+        return spontaneousScopeScriptDns;
+    }
+
+    /**
+     * Sets spontaneous scope script dns
+     *
+     * @param spontaneousScopeScriptDns spontaneous scope script dns
+     */
+    public void setSpontaneousScopeScriptDns(List<String> spontaneousScopeScriptDns) {
+        this.spontaneousScopeScriptDns = spontaneousScopeScriptDns;
+    }
+
+    /**
+     * Gets update token script dns
+     *
+     * @return update token script dns
+     */
+    public List<String> getUpdateTokenScriptDns() {
+        return updateTokenScriptDns;
+    }
+
+    /**
+     * Sets update token script dns
+     *
+     * @param updateTokenScriptDns update token script dns
+     */
+    public void setUpdateTokenScriptDns(List<String> updateTokenScriptDns) {
+        this.updateTokenScriptDns = updateTokenScriptDns;
+    }
+
+    /**
+     * Gets post authn script dns
+     *
+     * @return post authn script dns
+     */
+    public List<String> getPostAuthnScriptDns() {
+        return postAuthnScriptDns;
+    }
+
+    /**
+     * Sets post authn script dns
+     *
+     * @param postAuthnScriptDns post authn script dns
+     */
+    public void setPostAuthnScriptDns(List<String> postAuthnScriptDns) {
+        this.postAuthnScriptDns = postAuthnScriptDns;
+    }
+
+    /**
+     * Gets consent gathering script dns
+     *
+     * @return consent gathering script dns
+     */
+    public List<String> getConsentGatheringScriptDns() {
+        return consentGatheringScriptDns;
+    }
+
+    /**
+     * Sets consent gathering script dns
+     *
+     * @param consentGatheringScriptDns consent gathering script dns
+     */
+    public void setConsentGatheringScriptDns(List<String> consentGatheringScriptDns) {
+        this.consentGatheringScriptDns = consentGatheringScriptDns;
+    }
+
+    /**
+     * Gets introspection script dns
+     *
+     * @return introspection script dns
+     */
+    public List<String> getIntrospectionScriptDns() {
+        return introspectionScriptDns;
+    }
+
+    /**
+     * Sets introspection script dns
+     *
+     * @param introspectionScriptDns introspection script dns
+     */
+    public void setIntrospectionScriptDns(List<String> introspectionScriptDns) {
+        this.introspectionScriptDns = introspectionScriptDns;
+    }
+
+    /**
+     * Gets rpt claims script dns
+     *
+     * @return rpt claims script dns
+     */
+    public List<String> getRptClaimsScriptDns() {
+        return rptClaimsScriptDns;
+    }
+
+    /**
+     * Sets rpt claims script dns
+     *
+     * @param rptClaimsScriptDns rpt claims script dns
+     */
+    public void setRptClaimsScriptDns(List<String> rptClaimsScriptDns) {
+        this.rptClaimsScriptDns = rptClaimsScriptDns;
+    }
+
+    /**
+     * Gets ropc script dns
+     *
+     * @return ropc script dns
+     */
+    public List<String> getRopcScriptDns() {
+        return ropcScriptDns;
+    }
+
+    /**
+     * Sets ropc script dns
+     *
+     * @param ropcScriptDns ropc script dns
+     */
+    public void setRopcScriptDns(List<String> ropcScriptDns) {
+        this.ropcScriptDns = ropcScriptDns;
+    }
+
+    /**
      * Gets custom attribute map copy.
      *
      * @return custom attribute map copy
@@ -1451,6 +1592,14 @@ public class RegisterRequest extends BaseRequest {
         result.setTlsClientAuthSubjectDn(requestObject.optString(TLS_CLIENT_AUTH_SUBJECT_DN.toString()));
         result.setAllowSpontaneousScopes(requestObject.optBoolean(ALLOW_SPONTANEOUS_SCOPES.toString()));
         result.setSpontaneousScopes(extractListByKey(requestObject, SPONTANEOUS_SCOPES.toString()));
+        result.setAdditionalAudience(extractListByKey(requestObject, ADDITIONAL_AUDIENCE.toString()));
+        result.setSpontaneousScopeScriptDns(extractListByKey(requestObject, SPONTANEOUS_SCOPE_SCRIPT_DNS.toString()));
+        result.setUpdateTokenScriptDns(extractListByKey(requestObject, UPDATE_TOKEN_SCRIPT_DNS.toString()));
+        result.setPostAuthnScriptDns(extractListByKey(requestObject, POST_AUTHN_SCRIPT_DNS.toString()));
+        result.setConsentGatheringScriptDns(extractListByKey(requestObject, CONSENT_GATHERING_SCRIPT_DNS.toString()));
+        result.setIntrospectionScriptDns(extractListByKey(requestObject, INTROSPECTION_SCRIPT_DNS.toString()));
+        result.setRptClaimsScriptDns(extractListByKey(requestObject, RPT_CLAIMS_SCRIPT_DNS.toString()));
+        result.setRopcScriptDns(extractListByKey(requestObject, ROPC_SCRIPT_DNS.toString()));
         result.setRunIntrospectionScriptBeforeJwtCreation(requestObject.optBoolean(RUN_INTROSPECTION_SCRIPT_BEFORE_JWT_CREATION.toString()));
         result.setKeepClientAuthorizationAfterExpiration(requestObject.optBoolean(KEEP_CLIENT_AUTHORIZATION_AFTER_EXPIRATION.toString()));
         result.setRptAsJwt(requestObject.optBoolean(RPT_AS_JWT.toString()));
@@ -1722,6 +1871,30 @@ public class RegisterRequest extends BaseRequest {
         }
         if (spontaneousScopes != null && !spontaneousScopes.isEmpty()) {
             function.apply(SPONTANEOUS_SCOPES.toString(), implode(spontaneousScopes, " "));
+        }
+        if (additionalAudience != null && !additionalAudience.isEmpty()) {
+            function.apply(ADDITIONAL_AUDIENCE.toString(), implode(additionalAudience, " "));
+        }
+        if (spontaneousScopeScriptDns != null && !spontaneousScopeScriptDns.isEmpty()) {
+            function.apply(SPONTANEOUS_SCOPE_SCRIPT_DNS.toString(), implode(spontaneousScopeScriptDns, " "));
+        }
+        if (updateTokenScriptDns != null && !updateTokenScriptDns.isEmpty()) {
+            function.apply(UPDATE_TOKEN_SCRIPT_DNS.toString(), implode(updateTokenScriptDns, " "));
+        }
+        if (postAuthnScriptDns != null && !postAuthnScriptDns.isEmpty()) {
+            function.apply(POST_AUTHN_SCRIPT_DNS.toString(), implode(postAuthnScriptDns, " "));
+        }
+        if (consentGatheringScriptDns != null && !consentGatheringScriptDns.isEmpty()) {
+            function.apply(CONSENT_GATHERING_SCRIPT_DNS.toString(), implode(consentGatheringScriptDns, " "));
+        }
+        if (introspectionScriptDns != null && !introspectionScriptDns.isEmpty()) {
+            function.apply(INTROSPECTION_SCRIPT_DNS.toString(), implode(introspectionScriptDns, " "));
+        }
+        if (rptClaimsScriptDns != null && !rptClaimsScriptDns.isEmpty()) {
+            function.apply(RPT_CLAIMS_SCRIPT_DNS.toString(), implode(rptClaimsScriptDns, " "));
+        }
+        if (ropcScriptDns != null && !ropcScriptDns.isEmpty()) {
+            function.apply(ROPC_SCRIPT_DNS.toString(), implode(ropcScriptDns, " "));
         }
         if (runIntrospectionScriptBeforeJwtCreation != null) {
             function.apply(RUN_INTROSPECTION_SCRIPT_BEFORE_JWT_CREATION.toString(), runIntrospectionScriptBeforeJwtCreation.toString());

--- a/jans-auth-server/docs/swagger.yaml
+++ b/jans-auth-server/docs/swagger.yaml
@@ -1419,6 +1419,42 @@ paths:
                   description: Additional audiences.
                   items:
                     type: string
+                spontaneous_scope_script_dns:
+                  type: array
+                  description: Spontaneous scope script dn
+                  items:
+                    type: string
+                update_token_script_dns:
+                  type: array
+                  description: Update token script dn
+                  items:
+                    type: string
+                post_authn_script_dns:
+                  type: array
+                  description: Post Authn script dn
+                  items:
+                    type: string
+                consent_gathering_script_dns:
+                  type: array
+                  description: Consent Gathering script dn
+                  items:
+                    type: string
+                introspection_script_dns:
+                  type: array
+                  description: Introspection script dn
+                  items:
+                    type: string
+                rpt_claims_script_dns:
+                  type: array
+                  description: RPT Claims script dn
+                  items:
+                    type: string
+                ropc_script_dns:
+                  type: array
+                  description: ROPC script dn
+                  items:
+                    type: string
+
       responses:
         200:
           description: OK
@@ -1769,6 +1805,41 @@ paths:
                 additional_audience:
                   type: array
                   description: Additional audiences.
+                  items:
+                    type: string
+                spontaneous_scope_script_dns:
+                  type: array
+                  description: Spontaneous scope script dn
+                  items:
+                    type: string
+                update_token_script_dns:
+                  type: array
+                  description: Update token script dn
+                  items:
+                    type: string
+                post_authn_script_dns:
+                  type: array
+                  description: Post Authn script dn
+                  items:
+                    type: string
+                consent_gathering_script_dns:
+                  type: array
+                  description: Consent Gathering script dn
+                  items:
+                    type: string
+                introspection_script_dns:
+                  type: array
+                  description: Introspection script dn
+                  items:
+                    type: string
+                rpt_claims_script_dns:
+                  type: array
+                  description: RPT Claims script dn
+                  items:
+                    type: string
+                ropc_script_dns:
+                  type: array
+                  description: ROPC script dn
                   items:
                     type: string
       responses:

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/register/RegisterRequestParam.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/register/RegisterRequestParam.java
@@ -315,6 +315,47 @@ public enum RegisterRequestParam {
     SPONTANEOUS_SCOPES("spontaneous_scopes"),
 
     /**
+     * list of additional audiences
+     */
+    ADDITIONAL_AUDIENCE("additional_audience"),
+
+    /**
+     * list of spontaneous scope script dns
+     */
+    SPONTANEOUS_SCOPE_SCRIPT_DNS("spontaneous_scope_script_dns"),
+
+    /**
+     * list of update token script dns
+     */
+    UPDATE_TOKEN_SCRIPT_DNS("update_token_script_dns"),
+
+    /**
+     * list of post authn script dns
+     */
+    POST_AUTHN_SCRIPT_DNS("post_authn_script_dns"),
+
+    /**
+     * list of consent gathering script dns
+     */
+    CONSENT_GATHERING_SCRIPT_DNS("consent_gathering_script_dns"),
+
+    /**
+     * list of introspection script dns
+     */
+    INTROSPECTION_SCRIPT_DNS("introspection_script_dns"),
+
+    /**
+     * list of rpt claims script dns
+     */
+    RPT_CLAIMS_SCRIPT_DNS("rpt_claims_script_dns"),
+
+    /**
+     * list of ropc script dns
+     */
+    ROPC_SCRIPT_DNS("ropc_script_dns"),
+
+
+    /**
      * boolean property which indicates whether to run introspection script and then include claims from result into access_token as JWT
      */
     RUN_INTROSPECTION_SCRIPT_BEFORE_JWT_CREATION("run_introspection_script_before_jwt_creation"),

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterService.java
@@ -192,6 +192,30 @@ public class RegisterService {
         if (requestObject.getSpontaneousScopes() != null) {
             client.getAttributes().setSpontaneousScopes(requestObject.getSpontaneousScopes());
         }
+        if (requestObject.getAdditionalAudience() != null) {
+            client.getAttributes().setAdditionalAudience(requestObject.getAdditionalAudience());
+        }
+        if (requestObject.getSpontaneousScopeScriptDns() != null) {
+            client.getAttributes().setSpontaneousScopeScriptDns(requestObject.getSpontaneousScopeScriptDns());
+        }
+        if (requestObject.getUpdateTokenScriptDns() != null) {
+            client.getAttributes().setUpdateTokenScriptDns(requestObject.getUpdateTokenScriptDns());
+        }
+        if (requestObject.getPostAuthnScriptDns() != null) {
+            client.getAttributes().setPostAuthnScripts(requestObject.getPostAuthnScriptDns());
+        }
+        if (requestObject.getConsentGatheringScriptDns() != null) {
+            client.getAttributes().setConsentGatheringScripts(requestObject.getConsentGatheringScriptDns());
+        }
+        if (requestObject.getIntrospectionScriptDns() != null) {
+            client.getAttributes().setIntrospectionScripts(requestObject.getIntrospectionScriptDns());
+        }
+        if (requestObject.getRptClaimsScriptDns() != null) {
+            client.getAttributes().setRptClaimsScripts(requestObject.getRptClaimsScriptDns());
+        }
+        if (requestObject.getRopcScriptDns() != null) {
+            client.getAttributes().setRopcScripts(requestObject.getRopcScriptDns());
+        }
         if (requestObject.getRunIntrospectionScriptBeforeJwtCreation() != null) {
             client.getAttributes().setRunIntrospectionScriptBeforeJwtCreation(requestObject.getRunIntrospectionScriptBeforeJwtCreation());
         }


### PR DESCRIPTION
### Description

feat(jans-auth-server): provided ability to set scriptDns related attributes of client (e.g. introspectionScripts) 

#### Target issue
  
closes #3645

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

