### PR TITLE
doc(jans-auth-server): docs has outdated run_introspection_script_before_access_token_as_jwt_creation_and_include_claims

### DIFF
--- a/docs/admin/developer/scripts/introspection.md
+++ b/docs/admin/developer/scripts/introspection.md
@@ -47,9 +47,9 @@ The introspection interception script also adds the following method(s):
         return True
         
 
-It is also possible to run introspection script during `access_token` creation as JWT. It can be controlled by `run_introspection_script_before_access_token_as_jwt_creation_and_include_claims` client property which is set to false by default.
+It is also possible to run introspection script during `access_token` creation as JWT. It can be controlled by `run_introspection_script_before_jwt_creation` client property which is set to false by default.
 
-If `run_introspection_script_before_access_token_as_jwt_creation_and_include_claims` set to true and `access_token_as_jwt` set to true then introspection script will be run before JWT (`access_token`) is created and all JSON values will be transfered to JWT. Also `context` inside script has additional method which allows to cancel transfering of claims if needed `context.setTranferIntrospectionPropertiesIntoJwtClaims(false)`
+If `run_introspection_script_before_jwt_creation` set to true and `access_token_as_jwt` set to true then introspection script will be run before JWT (`access_token`) is created and all JSON values will be transfered to JWT. Also `context` inside script has additional method which allows to cancel transfering of claims if needed `context.setTranferIntrospectionPropertiesIntoJwtClaims(false)`
         
 ## Common Use Cases
 

--- a/docs/script-catalog/introspection/README.md
+++ b/docs/script-catalog/introspection/README.md
@@ -44,9 +44,9 @@ The `configurationAttributes` parameter is `java.util.Map<String, SimpleCustomPr
         
 **Note - The preferred way to modify an access token is with the Update Token script.**
 
-It is also possible to run an introspection script during `access_token` creation as JWT. It can be controlled by `run_introspection_script_before_access_token_as_jwt_creation_and_include_claims` OpenID Client property which is set to false by default. 
+It is also possible to run an introspection script during `access_token` creation as JWT. It can be controlled by `run_introspection_script_before_jwt_creation` OpenID Client property which is set to false by default. 
 
-If OpenID Client properties `run_introspection_script_before_access_token_as_jwt_creation_and_include_claims` and `access_token_as_jwt` are set to true then an introspection script will be run before JWT (`access_token`) is created and all JSON values will be transfered to JWT. Also `context` inside the script has additional method which allows you to cancel transfering of claims if needed `context.setTranferIntrospectionPropertiesIntoJwtClaims(false)`
+If OpenID Client properties `run_introspection_script_before_jwt_creation` and `access_token_as_jwt` are set to true then an introspection script will be run before JWT (`access_token`) is created and all JSON values will be transfered to JWT. Also `context` inside the script has additional method which allows you to cancel transfering of claims if needed `context.setTranferIntrospectionPropertiesIntoJwtClaims(false)`
         
 ## Common Use Cases
 

--- a/jans-auth-server/docs/swagger.yaml
+++ b/jans-auth-server/docs/swagger.yaml
@@ -1349,7 +1349,7 @@ paths:
                   description: List of spontaneous scopes
                   items:
                     type: string
-                run_introspection_script_before_access_token_as_jwt_creation_and_include_claims:
+                run_introspection_script_before_jwt_creation:
                   type: boolean
                   description: Boolean value with default value false. If true and access_token_as_jwt=true then run introspection script
                     and transfer claims into JWT.
@@ -1737,7 +1737,7 @@ paths:
                   description: List of spontaneous scopes
                   items:
                     type: string
-                run_introspection_script_before_access_token_as_jwt_creation_and_include_claims:
+                run_introspection_script_before_jwt_creation:
                   type: boolean
                   description: Boolean value with default value false. If true and access_token_as_jwt=true then run introspection script
                     and transfer claims into JWT.
@@ -2126,7 +2126,7 @@ paths:
                     description: List of spontaneous scopes
                     items:
                       type: string
-                  run_introspection_script_before_access_token_as_jwt_creation_and_include_claims:
+                  run_introspection_script_before_jwt_creation:
                     type: boolean
                     description: Boolean value with default value false. If true and access_token_as_jwt=true then run introspection script
                       and transfer claims into JWT.


### PR DESCRIPTION
### Description

doc(jans-auth-server): docs has outdated run_introspection_script_before_access_token_as_jwt_creation_and_include_claims

instead of run_introspection_script_before_jwt_creation 

#### Target issue
  
closes #3673

