### PR TITLE
feat: jans-linux-setup create test client with all available scopes

### DIFF
--- a/jans-linux-setup/jans_setup/jans_setup.py
+++ b/jans-linux-setup/jans_setup/jans_setup.py
@@ -422,7 +422,7 @@ def main():
 
             # if (Config.installed_instance and 'installOxd' in Config.addPostSetupService) or (not Config.installed_instance and Config.installOxd):
             #    oxdInstaller.start_installation()
-
+            jansInstaller.post_install_before_saving_properties()
             jansProgress.progress(PostSetup.service_name, "Saving properties")
             propertiesUtils.save_properties()
             time.sleep(2)

--- a/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
@@ -11,6 +11,7 @@ from string import Template
 from setup_app import paths
 from setup_app.static import AppType, InstallOption
 from setup_app.utils import base
+from setup_app.utils.ldif_utils import create_client_ldif
 from setup_app.config import Config
 from setup_app.installers.jetty import JettyInstaller
 from setup_app.pylib.ldif4.ldif import LDIFWriter
@@ -146,42 +147,21 @@ class ConfigApiInstaller(JettyInstaller):
 
         scope_ldif_fd.close()
 
-        createClient = True
-        config_api_dn = 'inum={},ou=clients,o=jans'.format(Config.jca_client_id)
+        create_client = True
         if Config.installed_instance and self.dbUtils.search('ou=clients,o=jans', search_filter='(&(inum={})(objectClass=jansClnt))'.format(Config.jca_client_id)):
-            createClient = False
+            create_client = False
 
-        if createClient:
-            clients_ldif_fd = open(self.clients_ldif_fn, 'wb')
-            ldif_clients_writer = LDIFWriter(clients_ldif_fd, cols=1000)
-            ldif_clients_writer.unparse(
-                config_api_dn, {
-                'objectClass': ['top', 'jansClnt'],
-                'del': ['false'],
-                'displayName': ['Jans Config Api Client'],
-                'inum': [Config.jca_client_id],
-                'jansAccessTknAsJwt': ['false'],
-                'jansAccessTknSigAlg': ['RS256'],
-                'jansAppTyp': ['web'],
-                'jansAttrs': ['{"tlsClientAuthSubjectDn":"","runIntrospectionScriptBeforeJwtCreation":false,"keepClientAuthorizationAfterExpiration":false,"allowSpontaneousScopes":false,"spontaneousScopes":[],"spontaneousScopeScriptDns":[],"backchannelLogoutUri":[],"backchannelLogoutSessionRequired":false,"additionalAudience":[],"postAuthnScripts":[],"consentGatheringScripts":[],"introspectionScripts":[],"rptClaimsScripts":[]}'],
-                'jansClntSecret': [Config.jca_client_encoded_pw],
-                'jansDisabled': ['false'],
-                'jansGrantTyp': ['authorization_code', 'refresh_token', 'client_credentials'],
-                'jansIdTknSignedRespAlg': ['RS256'],
-                'jansInclClaimsInIdTkn': ['false'],
-                'jansLogoutSessRequired': ['false'],
-                'jansPersistClntAuthzs': ['true'],
-                'jansRespTyp': ['code'],
-                'jansRptAsJwt': ['false'],
-                'jansScope': jansUmaScopes_all,
-                'jansSubjectTyp': ['pairwise'],
-                'jansTknEndpointAuthMethod': ['client_secret_basic'],
-                'jansTrustedClnt': ['false'],
-                'jansRedirectURI': ['https://{}/admin-ui'.format(Config.hostname), 'http://localhost:4100']
-                })
+        if create_client:
+            create_client_ldif(
+                ldif_fn=self.clients_ldif_fn,
+                client_id=Config.jca_client_id,
+                encoded_pw=Config.jca_client_encoded_pw,
+                scopes=jansUmaScopes_all,
+                redirect_uri=['https://{}/admin-ui'.format(Config.hostname), 'http://localhost:4100']
+                )
 
-            clients_ldif_fd.close()
             self.load_ldif_files.append(self.clients_ldif_fn)
+
 
     def render_import_templates(self):
 

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -18,6 +18,7 @@ from setup_app.utils import base
 from setup_app.static import InstallTypes, AppType, InstallOption
 from setup_app.config import Config
 from setup_app.utils.setup_utils import SetupUtils
+from setup_app.utils.ldif_utils import create_client_ldif
 from setup_app.utils.progress import jansProgress
 from setup_app.installers.base import BaseInstaller
 
@@ -430,6 +431,38 @@ class JansInstaller(BaseInstaller, SetupUtils):
                 self.logIt("Error importing custom ldif file {}".format(ldif), True)
 
 
+    def create_test_client(self):
+        ldif_fn = self.clients_ldif_fn = os.path.join(Config.output_dir, 'test-client.ldif')
+        client_pw = base.argsp.test_client_secret or self.getPW()
+        encoded_pw = self.obscure(client_pw)
+        trusted_client = base.argsp.test_client_trusted or 'false'
+
+        if base.argsp.test_client_redirect_uri:
+            redirect_uri = base.argsp.test_client_redirect_uri.split(',')
+        else:
+            redirect_uri = ['https://{}/admin-ui'.format(Config.hostname), 'http://localhost:4100']
+
+        result = self.dbUtils.search('ou=scopes,o=jans', search_filter='(objectClass=jansScope)', fetchmany=True)
+        scopes = [ scope[1]['dn'] for scope in result ]
+
+        create_client_ldif(
+                ldif_fn=ldif_fn,
+                client_id=base.argsp.test_client_id,
+                encoded_pw=encoded_pw,
+                scopes=scopes,
+                redirect_uri=redirect_uri,
+                trusted_client=trusted_client
+                )
+
+        self.dbUtils.import_ldif([ldif_fn])
+
+        Config.test_client_id = base.argsp.test_client_id
+        Config.test_client_pw = client_pw
+        Config.test_client_pw_encoded = encoded_pw
+        Config.test_client_redirect_uri = redirect_uri
+        Config.test_client_trusted_client = trusted_client
+        Config.test_client_scopes = str(scopes)
+
     def post_install_tasks(self):
 
         self.deleteLdapPw()
@@ -438,6 +471,9 @@ class JansInstaller(BaseInstaller, SetupUtils):
 
         if base.argsp.import_ldif:
             self.import_custom_ldif_dir(base.argsp.import_ldif)
+
+        if base.argsp.test_client_id:
+            self.create_test_client()
 
         if base.snap:
             #write post-install.py script

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -461,7 +461,14 @@ class JansInstaller(BaseInstaller, SetupUtils):
         Config.test_client_pw_encoded = encoded_pw
         Config.test_client_redirect_uri = redirect_uri
         Config.test_client_trusted_client = trusted_client
-        Config.test_client_scopes = str(scopes)
+        Config.test_client_scopes = ' '.join(scopes)
+
+
+    def post_install_before_saving_properties(self):
+
+        if base.argsp.test_client_id:
+            self.create_test_client()
+
 
     def post_install_tasks(self):
 
@@ -471,9 +478,6 @@ class JansInstaller(BaseInstaller, SetupUtils):
 
         if base.argsp.import_ldif:
             self.import_custom_ldif_dir(base.argsp.import_ldif)
-
-        if base.argsp.test_client_id:
-            self.create_test_client()
 
         if base.snap:
             #write post-install.py script

--- a/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
@@ -101,6 +101,12 @@ if PROFILE != OPENBANKING_PROFILE:
     spanner_cred_group.add_argument('-spanner-emulator-host', help="Use Spanner emulator host")
     spanner_cred_group.add_argument('-google-application-credentials', help="Path to Google application credentials json file")
 
+    # test-client
+    parser.add_argument('-test-client-id', help="ID of test client which has all available scopes")
+    parser.add_argument('-test-client-secret', help="Secret for test client")
+    parser.add_argument('-test-client-redirect-uri', help="Redirect URI for test client")
+    parser.add_argument('--test-client-trusted', help="Make test client trusted", action='store_true')
+
 else:
     # openbanking
     parser.add_argument('--no-external-key', help="Don't use external key", action='store_true')

--- a/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
@@ -1,6 +1,9 @@
 import os
+import sys
+import uuid
 import argparse
 
+from setup_app import static
 from setup_app.version import __version__
 from setup_app.utils import base
 
@@ -102,7 +105,7 @@ if PROFILE != OPENBANKING_PROFILE:
     spanner_cred_group.add_argument('-google-application-credentials', help="Path to Google application credentials json file")
 
     # test-client
-    parser.add_argument('-test-client-id', help="ID of test client which has all available scopes")
+    parser.add_argument('-test-client-id', help="ID of test client which has all available scopes. Must be in UUID format.")
     parser.add_argument('-test-client-secret', help="Secret for test client")
     parser.add_argument('-test-client-redirect-uri', help="Redirect URI for test client")
     parser.add_argument('--test-client-trusted', help="Make test client trusted", action='store_true')
@@ -141,5 +144,13 @@ def add_to_me(you):
 
 
 def get_parser():
-    argsp = parser.parse_known_args()
-    return argsp[0]
+    argsp, others = parser.parse_known_args()
+    if argsp.test_client_id:
+        try:
+            uuid.UUID(argsp.test_client_id)
+        except:
+            sys.stderr.write("{}-test-client-id should be in UUID format{}\n".format(static.colors.DANGER, static.colors.ENDC))
+            sys.stderr.flush()
+            sys.exit(2)
+
+    return argsp


### PR DESCRIPTION
closes #3695

To create test-client, the following arguments can be provided to `setup.py`
* __-test-client-id__ ID of test client which has all available scopes (this argument triggers test client creation, other arguments are optional)
* __-test-client-secret__  Secret for test client (if not provided secret will be random characters)
* __-test-client-redirect-uri__  Redirect URI for test client (you can provide multiple uri's with comma, if not provided redirect uris will be same as config-api-client)
* __--test-client-trusted__ Make test client trusted (default is **false**)
