### PR TITLE
fix: jans-linux-setup ldif property objectClass should be case sensitive

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/scim.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/scim.py
@@ -112,7 +112,7 @@ class ScimInstaller(JettyInstaller):
             display_name = 'Scim {}'.format(os.path.basename(scope))
             ldif_scopes_writer.unparse(
                     scope_dn, {
-                                'objectclass': ['top', 'jansScope'],
+                                'objectClass': ['top', 'jansScope'],
                                 'description': [config_scopes[scope]],
                                 'displayName': [display_name],
                                 'inum': [inum],

--- a/jans-linux-setup/jans_setup/setup_app/utils/ldif_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/ldif_utils.py
@@ -69,7 +69,7 @@ def get_document_from_entry(dn, entry):
                 else:
                     document[k] = attribDataTypes.getTypedValue(dtype, document[k])
 
-            if k == 'objectClass':
+            if k.lower() == 'objectclass':
                 document[k].remove('top')
                 oc_list = document[k]
 


### PR DESCRIPTION
closes #3701

In this PR, setup always uses case sensitive `objectClass`. It is important when ldif is imported to non-ldap db.