### PR TITLE
fix: jans-linux-setup installation without test client

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
@@ -157,7 +157,8 @@ class ConfigApiInstaller(JettyInstaller):
                 client_id=Config.jca_client_id,
                 encoded_pw=Config.jca_client_encoded_pw,
                 scopes=jansUmaScopes_all,
-                redirect_uri=['https://{}/admin-ui'.format(Config.hostname), 'http://localhost:4100']
+                redirect_uri=['https://{}/admin-ui'.format(Config.hostname), 'http://localhost:4100'],
+                display_name="Jans Config Api Client"
                 )
 
             self.load_ldif_files.append(self.clients_ldif_fn)

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -454,7 +454,8 @@ class JansInstaller(BaseInstaller, SetupUtils):
                 encoded_pw=encoded_pw,
                 scopes=scopes,
                 redirect_uri=redirect_uri,
-                trusted_client=trusted_client
+                display_name="Test Client with all scopes",
+                trusted_client=trusted_client,
                 )
 
         self.dbUtils.import_ldif([ldif_fn])
@@ -469,7 +470,7 @@ class JansInstaller(BaseInstaller, SetupUtils):
 
     def post_install_before_saving_properties(self):
 
-        if base.argsp.test_client_id or Config.test_client_id:
+        if base.argsp.test_client_id or Config.get('test_client_id'):
             self.create_test_client()
 
 

--- a/jans-linux-setup/jans_setup/setup_app/utils/ldif_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/ldif_utils.py
@@ -156,7 +156,7 @@ def schema2json(schema_file, out_dir=None):
     with open(out_file, 'w') as w:
         w.write(schema_str)
 
-def create_client_ldif(ldif_fn, client_id, encoded_pw, scopes, redirect_uri, trusted_client='false'):
+def create_client_ldif(ldif_fn, client_id, encoded_pw, scopes, redirect_uri, display_name, trusted_client='false'):
     clients_ldif_fd = open(ldif_fn, 'wb')
     ldif_clients_writer = LDIFWriter(clients_ldif_fd, cols=1000)
     client_dn = 'inum={},ou=clients,o=jans'.format(client_id)
@@ -165,7 +165,7 @@ def create_client_ldif(ldif_fn, client_id, encoded_pw, scopes, redirect_uri, tru
         client_dn, {
         'objectClass': ['top', 'jansClnt'],
         'del': ['false'],
-        'displayName': ['Jans Config Api Client'],
+        'displayName': [display_name],
         'inum': [client_id],
         'jansAccessTknAsJwt': ['false'],
         'jansAccessTknSigAlg': ['RS256'],


### PR DESCRIPTION
closes #3705
In this PR
* installation without test client id is fixed
* client display name is changed for TUI and test client