### PR TITLE
fix: missing comma delimiter for Postgres index fields

### DIFF
--- a/jans-linux-setup/jans_setup/static/rdbm/pgsql_index.json
+++ b/jans-linux-setup/jans_setup/static/rdbm/pgsql_index.json
@@ -219,7 +219,7 @@
       "personInum",
       "jansApp",
       "jansPublicKeyId",
-      "jansPublicKeyIdHash"
+      "jansPublicKeyIdHash",
       "jansCodeChallenge",
       "jansCodeChallengeHash"
     ],


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #3740 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

