### PR TITLE
feat(docker-jans): introduce key_ops when generating keys

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -56,7 +56,7 @@ RUN /opt/jython/bin/pip uninstall -y pip
 # ===========
 
 ENV CN_VERSION=1.0.7-SNAPSHOT
-ENV CN_BUILD_DATE='2023-01-31 09:53'
+ENV CN_BUILD_DATE='2023-02-02 08:18'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-server/${CN_VERSION}/jans-auth-server-${CN_VERSION}.war
 
 # Install Jans Auth

--- a/docker-jans-certmanager/Dockerfile
+++ b/docker-jans-certmanager/Dockerfile
@@ -17,7 +17,7 @@ RUN apk update \
 
 # JAR files required to generate OpenID Connect keys
 ENV CN_VERSION=1.0.7-SNAPSHOT
-ENV CN_BUILD_DATE='2023-01-09 12:19'
+ENV CN_BUILD_DATE='2023-02-02 08:17'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-client/${CN_VERSION}/jans-auth-client-${CN_VERSION}-jar-with-dependencies.jar
 
 RUN wget -q ${CN_SOURCE_URL} -P /app/javalibs/

--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -25,7 +25,7 @@ logging.config.dictConfig(LOGGING_CONFIG)
 logger = logging.getLogger("certmanager")
 
 SIG_KEYS = "RS256 RS384 RS512 ES256 ES384 ES512 PS256 PS384 PS512"
-ENC_KEYS = "RSA1_5 RSA-OAEP"
+ENC_KEYS = "RSA1_5 RSA-OAEP ECDH-ES"
 KEY_STRATEGIES = ("OLDER", "NEWER", "FIRST")
 
 
@@ -61,7 +61,8 @@ def generate_openid_keys(passwd, jks_path, dn, exp=48, sig_keys=SIG_KEYS, enc_ke
         "io.jans.as.client.util.KeyGenerator "
         f"-enc_keys {enc_keys} -sig_keys {sig_keys} "
         f"-dnname '{dn}' -expiration_hours {exp} "
-        f"-keystore {jks_path} -keypasswd {passwd}"
+        f"-keystore {jks_path} -keypasswd {passwd} "
+        "-key_ops connect"
     )
     return exec_cmd(cmd)
 

--- a/docker-jans-certmanager/scripts/utils.py
+++ b/docker-jans-certmanager/scripts/utils.py
@@ -36,7 +36,8 @@ def generate_openid_keys(passwd, jks_path, jwks_path, dn, exp=365, sig_keys=DEFA
         "io.jans.as.client.util.KeyGenerator "
         f"-enc_keys {enc_keys} -sig_keys {sig_keys} "
         f"-dnname '{dn}' -expiration_hours {exp} "
-        f"-keystore {jks_path} -keypasswd {passwd}"
+        f"-keystore {jks_path} -keypasswd {passwd} "
+        "-key_ops connect"
     )
 
     out, err, retcode = exec_cmd(cmd)

--- a/docker-jans-configurator/Dockerfile
+++ b/docker-jans-configurator/Dockerfile
@@ -17,7 +17,7 @@ RUN apk update \
 
 # JAR files required to generate OpenID Connect keys
 ENV CN_VERSION=1.0.7-SNAPSHOT
-ENV CN_BUILD_DATE='2023-01-09 12:19'
+ENV CN_BUILD_DATE='2023-02-02 08:17'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-client/${CN_VERSION}/jans-auth-client-${CN_VERSION}-jar-with-dependencies.jar
 
 RUN wget -q ${CN_SOURCE_URL} -P /app/javalibs/

--- a/docker-jans-configurator/scripts/bootstrap.py
+++ b/docker-jans-configurator/scripts/bootstrap.py
@@ -29,7 +29,7 @@ from parameter import params_from_file
 from settings import LOGGING_CONFIG
 
 DEFAULT_SIG_KEYS = "RS256 RS384 RS512 ES256 ES384 ES512 PS256 PS384 PS512"
-DEFAULT_ENC_KEYS = "RSA1_5 RSA-OAEP"
+DEFAULT_ENC_KEYS = "RSA1_5 RSA-OAEP ECDH-ES"
 
 DEFAULT_CONFIG_FILE = "/app/db/config.json"
 DEFAULT_SECRET_FILE = "/app/db/secret.json"
@@ -63,6 +63,7 @@ def generate_openid_keys(passwd, jks_path, jwks_path, dn, exp=365, sig_keys=DEFA
         "-expiration", "{}".format(exp),
         "-keystore", jks_path,
         "-keypasswd", passwd,
+        "-key_ops", "connect",
     ])
     out, err, retcode = exec_cmd(cmd)
     if retcode == 0:
@@ -83,6 +84,7 @@ def generate_openid_keys_hourly(passwd, jks_path, jwks_path, dn, exp=48, sig_key
         "-expiration_hours", "{}".format(exp),
         "-keystore", jks_path,
         "-keypasswd", passwd,
+        "-key_ops", "connect",
     ])
     out, err, retcode = exec_cmd(cmd)
     if retcode == 0:


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #3743 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

