### PR TITLE
feat(jans-auth-server): renamed "key_ops" -> "key_ops_type" #3790

### DIFF
--- a/jans-auth-server/client/src/main/java/io/jans/as/client/util/KeyGeneratorContext.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/util/KeyGeneratorContext.java
@@ -1,7 +1,7 @@
 package io.jans.as.client.util;
 
 import io.jans.as.model.crypto.AbstractCryptoProvider;
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -18,7 +18,7 @@ public class KeyGeneratorContext {
     private int expirationDays;
     private int expirationHours;
     private Calendar expiration;
-    private KeyOps keyOps;
+    private KeyOpsType keyOpsType;
 
     public void calculateExpiration() {
         Calendar calendar = new GregorianCalendar();
@@ -27,11 +27,11 @@ public class KeyGeneratorContext {
         this.expiration = calendar;
     }
 
-    public long getExpirationForKeyOps(KeyOps keyOps) {
+    public long getExpirationForKeyOpsType(KeyOpsType keyOpsType) {
         if (expiration == null) {
             calculateExpiration();
         }
-        if (keyOps == KeyOps.SSA) {
+        if (keyOpsType == KeyOpsType.SSA) {
             Calendar calendar = new GregorianCalendar();
             calendar.add(Calendar.YEAR, 50);
             return calendar.getTimeInMillis();
@@ -39,12 +39,12 @@ public class KeyGeneratorContext {
         return expiration.getTimeInMillis();
     }
 
-    public KeyOps getKeyOps() {
-        return keyOps;
+    public KeyOpsType getKeyOpsType() {
+        return keyOpsType;
     }
 
-    public void setKeyOps(KeyOps keyOps) {
-        this.keyOps = keyOps;
+    public void setKeyOpsType(KeyOpsType keyOpsType) {
+        this.keyOpsType = keyOpsType;
     }
 
     public Calendar getExpiration() {

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/util/KeyGeneratorContextTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/util/KeyGeneratorContextTest.java
@@ -1,6 +1,6 @@
 package io.jans.as.client.util;
 
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 import org.testng.annotations.Test;
 
 import java.util.Calendar;
@@ -17,7 +17,7 @@ public class KeyGeneratorContextTest {
         KeyGeneratorContext context = new KeyGeneratorContext();
         context.setExpirationHours(1);
 
-        final long expirationForKeyOps = context.getExpirationForKeyOps(KeyOps.CONNECT);
+        final long expirationForKeyOps = context.getExpirationForKeyOpsType(KeyOpsType.CONNECT);
 
         assertTrue(expirationForKeyOps < futureIn2Hours());
     }
@@ -27,7 +27,7 @@ public class KeyGeneratorContextTest {
         KeyGeneratorContext context = new KeyGeneratorContext();
         context.setExpirationHours(1);
 
-        final long expirationForKeyOps = context.getExpirationForKeyOps(KeyOps.SSA);
+        final long expirationForKeyOps = context.getExpirationForKeyOpsType(KeyOpsType.SSA);
 
         assertTrue(expirationForKeyOps > futureIn2Hours());
     }

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/AbstractCryptoProvider.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/AbstractCryptoProvider.java
@@ -49,7 +49,7 @@ public abstract class AbstractCryptoProvider {
 
     public abstract JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength) throws CryptoProviderException;
 
-    public abstract JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength, KeyOps keyOps) throws CryptoProviderException;
+    public abstract JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength, KeyOpsType keyOpsType) throws CryptoProviderException;
 
     public abstract String sign(String signingInput, String keyId, String sharedSecret, SignatureAlgorithm signatureAlgorithm) throws CryptoProviderException;
 
@@ -68,7 +68,7 @@ public abstract class AbstractCryptoProvider {
     public abstract PublicKey getPublicKey(String alias) throws CryptoProviderException;
 
     @SuppressWarnings("java:S1130")
-    public String getKeyId(JSONWebKeySet jsonWebKeySet, Algorithm algorithm, Use use, KeyOps keyOps) throws CryptoProviderException {
+    public String getKeyId(JSONWebKeySet jsonWebKeySet, Algorithm algorithm, Use use, KeyOpsType keyOps) throws CryptoProviderException {
         if (algorithm == null || AlgorithmFamily.HMAC.equals(algorithm.getFamily())) {
             return null;
         }

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/ElevenCryptoProvider.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/ElevenCryptoProvider.java
@@ -9,7 +9,7 @@ package io.jans.as.model.crypto;
 import io.jans.as.model.crypto.signature.SignatureAlgorithm;
 import io.jans.as.model.exception.CryptoProviderException;
 import io.jans.as.model.jwk.Algorithm;
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 import io.jans.eleven.client.DeleteKeyClient;
 import io.jans.eleven.client.DeleteKeyRequest;
 import io.jans.eleven.client.DeleteKeyResponse;
@@ -78,8 +78,8 @@ public class ElevenCryptoProvider extends AbstractCryptoProvider {
     }
 
     @Override
-    public JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength, KeyOps keyOps) throws CryptoProviderException {
-        return generateKey(algorithm, expirationTime, keyLength, KeyOps.CONNECT);
+    public JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength, KeyOpsType keyOpsType) throws CryptoProviderException {
+        return generateKey(algorithm, expirationTime, keyLength, KeyOpsType.CONNECT);
     }
 
     @Override

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/JSONWebKey.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/JSONWebKey.java
@@ -44,8 +44,8 @@ public class JSONWebKey {
     private Long exp;
     private EllipticEdvardsCurve crv;
     private List<String> x5c;
-    @JsonProperty("key_ops")
-    private List<KeyOps> keyOps;
+    @JsonProperty("key_ops_type")
+    private List<KeyOpsType> keyOpsType;
 
     /**
      * Modulus
@@ -65,17 +65,17 @@ public class JSONWebKey {
      *
      * @return key ops
      */
-    public List<KeyOps> getKeyOps() {
-        return keyOps;
+    public List<KeyOpsType> getKeyOpsType() {
+        return keyOpsType;
     }
 
     /**
      * Sets key ops
      *
-     * @param keyOps key ops
+     * @param keyOpsType key ops
      */
-    public void setKeyOps(List<KeyOps> keyOps) {
-        this.keyOps = keyOps;
+    public void setKeyOpsType(List<KeyOpsType> keyOpsType) {
+        this.keyOpsType = keyOpsType;
     }
 
     /**
@@ -373,13 +373,13 @@ public class JSONWebKey {
             jsonObj.put(JWKParameter.KEY_USE, use.getParamName());
         }
 
-        JSONArray keyOpsArray = new JSONArray();
-        if (keyOps != null) {
-            for (KeyOps keyOp : keyOps) {
-                keyOpsArray.put(keyOp.getValue());
+        JSONArray keyOpsTypeArray = new JSONArray();
+        if (keyOpsType != null) {
+            for (KeyOpsType keyOpType : keyOpsType) {
+                keyOpsTypeArray.put(keyOpType.getValue());
             }
         }
-        jsonObj.put(JWKParameter.KEY_OPS, keyOpsArray);
+        jsonObj.put(JWKParameter.KEY_OPS_TYPE, keyOpsTypeArray);
 
         jsonObj.put(JWKParameter.ALGORITHM, alg);
         jsonObj.put(JWKParameter.EXPIRATION_TIME, exp);
@@ -414,7 +414,7 @@ public class JSONWebKey {
         jwk.setKty(KeyType.fromString(jwkJSONObject.optString(JWKParameter.KEY_TYPE)));
         jwk.setUse(Use.fromString(jwkJSONObject.optString(JWKParameter.KEY_USE)));
         jwk.setAlg(Algorithm.fromString(jwkJSONObject.optString(JWKParameter.ALGORITHM)));
-        jwk.setKeyOps(KeyOps.fromJSONArray(jwkJSONObject.optJSONArray(JWKParameter.KEY_OPS)));
+        jwk.setKeyOpsType(KeyOpsType.fromJSONArray(jwkJSONObject.optJSONArray(JWKParameter.KEY_OPS_TYPE)));
         if (jwkJSONObject.has(JWKParameter.EXPIRATION_TIME)) {
             jwk.setExp(jwkJSONObject.optLong(JWKParameter.EXPIRATION_TIME));
         }

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/JWKParameter.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/JWKParameter.java
@@ -20,7 +20,7 @@ public class JWKParameter {
     public static final String JSON_WEB_KEY_SET = "keys";
     public static final String KEY_TYPE = "kty";
     public static final String KEY_USE = "use";
-    public static final String KEY_OPS = "key_ops";
+    public static final String KEY_OPS_TYPE = "key_ops_type";
     public static final String ALGORITHM = "alg";
     public static final String KEY_ID = "kid";
     public static final String EXPIRATION_TIME = "exp";

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/KeyOpsType.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/KeyOpsType.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * @author Yuriy Z
  */
-public enum KeyOps {
+public enum KeyOpsType {
     CONNECT("connect"),
     SSA("ssa"),
 
@@ -17,7 +17,7 @@ public enum KeyOps {
 
     private final String value;
 
-    KeyOps(String value) {
+    KeyOpsType(String value) {
         this.value = value;
     }
 
@@ -26,9 +26,9 @@ public enum KeyOps {
     }
 
     @JsonCreator
-    public static KeyOps fromString(String valueString) {
+    public static KeyOpsType fromString(String valueString) {
         if (valueString != null) {
-            for (KeyOps v : values()) {
+            for (KeyOpsType v : values()) {
                 if (valueString.equalsIgnoreCase(v.name())) {
                     return v;
                 }
@@ -37,14 +37,14 @@ public enum KeyOps {
         return null;
     }
 
-    public static List<KeyOps> fromJSONArray(JSONArray jsonArray) {
-        List<KeyOps> result = new ArrayList<>();
+    public static List<KeyOpsType> fromJSONArray(JSONArray jsonArray) {
+        List<KeyOpsType> result = new ArrayList<>();
         if (jsonArray == null) {
             return result;
         }
 
         for (int i = 0; i < jsonArray.length(); i++) {
-            final KeyOps v = fromString(jsonArray.optString(i));
+            final KeyOpsType v = fromString(jsonArray.optString(i));
             if (v != null) {
                 result.add(v);
             }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequestService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequestService.java
@@ -26,7 +26,7 @@ import io.jans.as.model.error.ErrorResponseFactory;
 import io.jans.as.model.jwe.Jwe;
 import io.jans.as.model.jwk.Algorithm;
 import io.jans.as.model.jwk.JSONWebKeySet;
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 import io.jans.as.model.jwk.Use;
 import io.jans.as.model.jwt.Jwt;
 import io.jans.as.model.jwt.JwtClaimName;
@@ -435,7 +435,7 @@ public class AuthzRequestService {
                             .fromString(client.getAttributes().getAuthorizationSignedResponseAlg());
 
                     String nestedKeyId = new ServerCryptoProvider(cryptoProvider).getKeyId(webKeysConfiguration,
-                            Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOps.CONNECT);
+                            Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOpsType.CONNECT);
 
                     JSONObject jsonWebKeys = CommonUtils.getJwks(client);
                     redirectUriResponse.getRedirectUri().setNestedJsonWebKeys(jsonWebKeys);
@@ -450,7 +450,7 @@ public class AuthzRequestService {
                 if (jsonWebKeys != null) {
                     keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(JSONWebKeySet.fromJSONObject(jsonWebKeys),
                             Algorithm.fromString(client.getAttributes().getAuthorizationEncryptedResponseAlg()),
-                            Use.ENCRYPTION, KeyOps.CONNECT);
+                            Use.ENCRYPTION, KeyOpsType.CONNECT);
                 }
                 String sharedSecret = clientService.decryptSecret(client.getClientSecret());
                 byte[] sharedSymmetricKey = sharedSecret.getBytes(StandardCharsets.UTF_8);
@@ -465,7 +465,7 @@ public class AuthzRequestService {
                 }
 
                 keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(webKeysConfiguration,
-                        Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOps.CONNECT);
+                        Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOpsType.CONNECT);
 
                 JSONObject jsonWebKeys = CommonUtils.getJwks(client);
                 redirectUriResponse.getRedirectUri().setJsonWebKeys(jsonWebKeys);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/JwrService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/JwrService.java
@@ -19,7 +19,7 @@ import io.jans.as.model.jwe.JweEncrypter;
 import io.jans.as.model.jwe.JweEncrypterImpl;
 import io.jans.as.model.jwk.Algorithm;
 import io.jans.as.model.jwk.JSONWebKeySet;
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 import io.jans.as.model.jwk.Use;
 import io.jans.as.model.jwt.Jwt;
 import io.jans.as.model.jwt.JwtType;
@@ -107,7 +107,7 @@ public class JwrService {
             JSONObject jsonWebKeys = CommonUtils.getJwks(client);
             String keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(JSONWebKeySet.fromJSONObject(jsonWebKeys),
                     Algorithm.fromString(keyEncryptionAlgorithm.getName()),
-                    Use.ENCRYPTION, KeyOps.CONNECT);
+                    Use.ENCRYPTION, KeyOpsType.CONNECT);
             PublicKey publicKey = cryptoProvider.getPublicKey(keyId, jsonWebKeys, null);
             jwe.getHeader().setKeyId(keyId);
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/JwtSigner.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/JwtSigner.java
@@ -14,7 +14,7 @@ import io.jans.as.model.crypto.signature.SignatureAlgorithm;
 import io.jans.as.model.exception.CryptoProviderException;
 import io.jans.as.model.jwk.Algorithm;
 import io.jans.as.model.jwk.JSONWebKeySet;
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 import io.jans.as.model.jwk.Use;
 import io.jans.as.model.jwt.Jwt;
 import io.jans.as.model.jwt.JwtType;
@@ -99,7 +99,7 @@ public class JwtSigner {
             return staticKid;
         }
 
-        return cryptoProvider.getKeyId(webKeys, Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOps.CONNECT);
+        return cryptoProvider.getKeyId(webKeys, Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOpsType.CONNECT);
     }
 
     public Jwt sign() throws Exception {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/AuthorizeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/AuthorizeService.java
@@ -23,7 +23,7 @@ import io.jans.as.model.crypto.signature.SignatureAlgorithm;
 import io.jans.as.model.error.ErrorResponseFactory;
 import io.jans.as.model.exception.CryptoProviderException;
 import io.jans.as.model.jwk.Algorithm;
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 import io.jans.as.model.jwk.Use;
 import io.jans.as.persistence.model.Scope;
 import io.jans.as.server.auth.Authenticator;
@@ -288,7 +288,7 @@ public class AuthorizeService {
 			String clientSecret = clientService.decryptSecret(client.getClientSecret());
 			redirectUri.setSharedSecret(clientSecret);
 			keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(webKeysConfiguration,
-					Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOps.CONNECT);
+					Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOpsType.CONNECT);
 		} catch (CryptoProviderException e) {
 			log.error(e.getMessage(), e);
 		} catch (StringEncrypter.EncryptionException e) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/ServerCryptoProvider.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/ServerCryptoProvider.java
@@ -41,7 +41,7 @@ public class ServerCryptoProvider extends AbstractCryptoProvider {
     }
 
     @Override
-    public String getKeyId(JSONWebKeySet jsonWebKeySet, Algorithm algorithm, Use use, KeyOps keyOps) throws CryptoProviderException {
+    public String getKeyId(JSONWebKeySet jsonWebKeySet, Algorithm algorithm, Use use, KeyOpsType keyOps) throws CryptoProviderException {
         try {
             if (algorithm == null || AlgorithmFamily.HMAC.equals(algorithm.getFamily())) {
                 return null;
@@ -85,8 +85,8 @@ public class ServerCryptoProvider extends AbstractCryptoProvider {
     }
 
     @Override
-    public JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength, KeyOps keyOps) throws CryptoProviderException {
-        return cryptoProvider.generateKey(algorithm, expirationTime, keyLength, keyOps);
+    public JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength, KeyOpsType keyOpsType) throws CryptoProviderException {
+        return cryptoProvider.generateKey(algorithm, expirationTime, keyLength, keyOpsType);
     }
 
     @Override

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImpl.java
@@ -28,7 +28,7 @@ import io.jans.as.model.jwe.JweEncrypter;
 import io.jans.as.model.jwe.JweEncrypterImpl;
 import io.jans.as.model.jwk.Algorithm;
 import io.jans.as.model.jwk.JSONWebKeySet;
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 import io.jans.as.model.jwk.Use;
 import io.jans.as.model.jwt.Jwt;
 import io.jans.as.model.jwt.JwtClaims;
@@ -243,7 +243,7 @@ public class UserInfoRestWebServiceImpl implements UserInfoRestWebService {
         jwt.getHeader().setType(JwtType.JWT);
         jwt.getHeader().setAlgorithm(signatureAlgorithm);
 
-        String keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(webKeysConfiguration, Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOps.CONNECT);
+        String keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(webKeysConfiguration, Algorithm.fromString(signatureAlgorithm.getName()), Use.SIGNATURE, KeyOpsType.CONNECT);
         if (keyId != null) {
             jwt.getHeader().setKeyId(keyId);
         }
@@ -289,7 +289,7 @@ public class UserInfoRestWebServiceImpl implements UserInfoRestWebService {
             JSONObject jsonWebKeys = CommonUtils.getJwks(authorizationGrant.getClient());
             String keyId = new ServerCryptoProvider(cryptoProvider).getKeyId(JSONWebKeySet.fromJSONObject(jsonWebKeys),
                     Algorithm.fromString(keyEncryptionAlgorithm.getName()),
-                    Use.ENCRYPTION, KeyOps.CONNECT);
+                    Use.ENCRYPTION, KeyOpsType.CONNECT);
             PublicKey publicKey = cryptoProvider.getPublicKey(keyId, jsonWebKeys, null);
 
             if (publicKey != null) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/comp/CrossEncryptionTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/comp/CrossEncryptionTest.java
@@ -44,7 +44,7 @@ import io.jans.as.model.jwe.JweEncrypterImpl;
 import io.jans.as.model.jwk.Algorithm;
 import io.jans.as.model.jwk.JSONWebKey;
 import io.jans.as.model.jwk.JSONWebKeySet;
-import io.jans.as.model.jwk.KeyOps;
+import io.jans.as.model.jwk.KeyOpsType;
 import io.jans.as.model.jws.RSASigner;
 import io.jans.as.model.jwt.Jwt;
 import io.jans.as.model.jwt.JwtType;
@@ -401,7 +401,7 @@ public class CrossEncryptionTest {
             }
 
             @Override
-            public JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength, KeyOps keyOps) throws CryptoProviderException {
+            public JSONObject generateKey(Algorithm algorithm, Long expirationTime, int keyLength, KeyOpsType keyOpsType) throws CryptoProviderException {
                 return null;
             }
 


### PR DESCRIPTION
### Description

feat(jans-auth-server): renamed "key_ops" -> "key_ops_type"

Some frameworks does not allow custom key_ops like "ssa" (e.g. nimbus)

#### Target issue
 
closes #3790
