### PR TITLE
Feature: use key_ops=ssa to generate JWT from SSA

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/ssa/SsaErrorResponseType.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/ssa/SsaErrorResponseType.java
@@ -21,9 +21,14 @@ public enum SsaErrorResponseType implements IErrorType {
     INVALID_CLIENT("invalid_client"),
 
     /**
-     * When creating an ssa, if you get an internal error.
+     * When creating a ssa, if you get an internal error.
      */
     UNKNOWN_ERROR("unknown_error"),
+
+    /**
+     * When the signature has expired or the algorithm for signing does not exist
+     */
+    INVALID_SIGNATURE("invalid_signature"),
     ;
 
     private final String paramName;

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/ssa/ws/rs/action/SsaCreateActionTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/ssa/ws/rs/action/SsaCreateActionTest.java
@@ -112,7 +112,7 @@ public class SsaCreateActionTest {
     }
 
     @Test
-    public void create_request_valid() {
+    public void create_request_valid() throws Exception {
         BaseDnConfiguration baseDnConfiguration = new BaseDnConfiguration();
         baseDnConfiguration.setSsa("ou=ssa,o=jans");
         when(staticConfiguration.getBaseDn()).thenReturn(baseDnConfiguration);

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/ssa/ws/rs/action/SsaGetJwtActionTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/ssa/ws/rs/action/SsaGetJwtActionTest.java
@@ -44,7 +44,7 @@ public class SsaGetJwtActionTest {
     private SsaJsonService ssaJsonService;
 
     @Test
-    public void testGetJwtSsa_jti_validStatus() {
+    public void testGetJwtSsa_jti_validStatus() throws Exception {
         String jti = "test-jti";
         String jwt = "jwt-test";
         Ssa ssa = new Ssa();

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-errors.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-errors.json
@@ -550,6 +550,11 @@
             "uri": null
         },
         {
+            "id": "invalid_signature",
+            "description": "No algorithm found to sign the JWT.",
+            "uri": null
+        },
+        {
             "id": "unknown_error",
             "description": "Unknown or not found error.",
             "uri": null


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
- The `generateJwt` method has been modified to filter by `key_ops=ssa` to obtain the `keyId`.
- A new `invalid_signature` exception has been added to check that the algorithm configured in `ssaSigningAlg` exists in the `webKeysConfiguration` list.
  
closes #3746

