### PR TITLE
chore(jans-auth-server): move ClientAuthorizations to jans-auth-persistence-model for reusing by jans-config-api #3798

### DIFF
--- a/jans-auth-server/persistence-model/src/main/java/io/jans/as/persistence/model/ClientAuthorization.java
+++ b/jans-auth-server/persistence-model/src/main/java/io/jans/as/persistence/model/ClientAuthorization.java
@@ -4,7 +4,7 @@
  * Copyright (c) 2020, Janssen Project
  */
 
-package io.jans.as.server.model.ldap;
+package io.jans.as.persistence.model;
 
 import io.jans.orm.annotation.AttributeName;
 import io.jans.orm.annotation.DN;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -32,7 +32,7 @@ import io.jans.as.common.model.session.SessionId;
 import io.jans.as.common.model.session.SessionIdState;
 import io.jans.as.server.model.config.Constants;
 import io.jans.as.server.model.exception.AcrChangedException;
-import io.jans.as.server.model.ldap.ClientAuthorization;
+import io.jans.as.persistence.model.ClientAuthorization;
 import io.jans.as.server.security.Identity;
 import io.jans.as.server.service.*;
 import io.jans.as.server.service.ciba.CibaRequestService;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -34,7 +34,7 @@ import io.jans.as.server.model.config.Constants;
 import io.jans.as.server.model.exception.AcrChangedException;
 import io.jans.as.server.model.exception.InvalidRedirectUrlException;
 import io.jans.as.server.model.exception.InvalidSessionStateException;
-import io.jans.as.server.model.ldap.ClientAuthorization;
+import io.jans.as.persistence.model.ClientAuthorization;
 import io.jans.as.server.model.token.JwrService;
 import io.jans.as.server.security.Identity;
 import io.jans.as.server.service.*;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/CleanerTimer.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/CleanerTimer.java
@@ -25,7 +25,7 @@ import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.uma.persistence.UmaResource;
 import io.jans.as.persistence.model.Par;
 import io.jans.as.persistence.model.Scope;
-import io.jans.as.server.model.ldap.ClientAuthorization;
+import io.jans.as.persistence.model.ClientAuthorization;
 import io.jans.as.server.model.ldap.TokenEntity;
 import io.jans.as.server.uma.authorization.UmaPCT;
 import io.jans.as.server.uma.service.UmaPctService;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientAuthorizationsService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientAuthorizationsService.java
@@ -9,7 +9,7 @@ package io.jans.as.server.service;
 import io.jans.as.common.model.registration.Client;
 import io.jans.as.model.config.StaticConfiguration;
 import io.jans.as.model.configuration.AppConfiguration;
-import io.jans.as.server.model.ldap.ClientAuthorization;
+import io.jans.as.persistence.model.ClientAuthorization;
 import io.jans.orm.PersistenceEntryManager;
 import io.jans.orm.exception.EntryPersistenceException;
 import io.jans.orm.model.base.SimpleBranch;


### PR DESCRIPTION
### Description

chore(jans-auth-server): move ClientAuthorizations to jans-auth-persistence-model for reusing by jans-config-api 

#### Target issue
  
closes #3798

