### PR TITLE
fix(jans-fido2): For SG authenticatorData use base64 decoding instead…

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/AuthenticatorDataParser.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/AuthenticatorDataParser.java
@@ -74,6 +74,11 @@ public class AuthenticatorDataParser {
     	byte[] incomingAuthDataBuffer = base64Service.urlDecode(incomingAuthData.getBytes());
         return parseAuthData(incomingAuthDataBuffer);
     }
+    
+    public AuthData parseAssertionDataForSuperGluu(String incomingAuthData) {
+    	byte[] incomingAuthDataBuffer = base64Service.decode(incomingAuthData.getBytes());
+        return parseAuthData(incomingAuthDataBuffer);
+    }
 
     private AuthData parseAuthData(byte[] incomingAuthDataBuffer) {
         AuthData authData = new AuthData();

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/assertion/U2FSuperGluuAssertionFormatProcessor.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/assertion/U2FSuperGluuAssertionFormatProcessor.java
@@ -84,7 +84,7 @@ public class U2FSuperGluuAssertionFormatProcessor implements AssertionFormatProc
     @Override
     public void process(String base64AuthenticatorData, String signature, String clientDataJson, Fido2RegistrationData registration,
             Fido2AuthenticationData authenticationEntity) {
-        AuthData authData = authenticatorDataParser.parseAssertionData(base64AuthenticatorData);
+        AuthData authData = authenticatorDataParser.parseAssertionDataForSuperGluu(base64AuthenticatorData);
 
 //        String clientDataRaw = commonVerifiers.verifyClientRaw(response).asText();
         userVerificationVerifier.verifyUserPresent(authData);


### PR DESCRIPTION
… of base64URL decoding #3812
