### PR TITLE
fix: jans-cli-tui include pyproject.toml

### DIFF
--- a/jans-cli-tui/pyproject.toml
+++ b/jans-cli-tui/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=45.2.0", "wheel"]


### PR DESCRIPTION
closes #3804