### PR TITLE
fix(jans-auth-server): provided corrected public key for outdated key stores during id_token creation if key_ops_type is absent #3840

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/AuthCryptoProvider.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/AuthCryptoProvider.java
@@ -315,7 +315,7 @@ public class AuthCryptoProvider extends AbstractCryptoProvider {
             List<JSONWebKey> keysByAlgAndUse = new ArrayList<>();
 
             for (JSONWebKey key : keys) {
-                boolean keyOpsCondition = keyOpsType == null || (key.getKeyOpsType() == null || key.getKeyOpsType().contains(keyOpsType));
+                boolean keyOpsCondition = keyOpsType == null || (key.getKeyOpsType() == null || key.getKeyOpsType().isEmpty() || key.getKeyOpsType().contains(keyOpsType));
                 if (algorithm == key.getAlg() && (use == null || use == key.getUse()) && keyOpsCondition) {
                     kid = key.getKid();
                     Key keyFromStore;


### PR DESCRIPTION
### Description

fix(jans-auth-server): provided corrected public key for outdated key stores during id_token creation if key_ops_type is absent #3840

#### Target issue
  
closes #3840

