### PR TITLE
fix: jans-linux-setup save test_client_id to setup.properties

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -460,7 +460,7 @@ class JansInstaller(BaseInstaller, SetupUtils):
 
         self.dbUtils.import_ldif([ldif_fn])
 
-        Config.test_client_id = base.argsp.test_client_id
+        Config.test_client_id = client_id
         Config.test_client_pw = client_pw
         Config.test_client_pw_encoded = encoded_pw
         Config.test_client_redirect_uri = redirect_uri


### PR DESCRIPTION
closes #3843