### PR TITLE
fix(docker-jans-persistence-loader): add missing persist tokens config when upgrading from previous version

### DIFF
--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -178,6 +178,14 @@ def _transform_auth_dynamic_config(conf):
         }
         should_update = True
 
+    if "persistIdToken" not in conf:
+        conf["persistIdToken"] = conf.pop("persistIdTokenInLdap", False)
+        should_update = True
+
+    if "persistRefreshToken" not in conf:
+        conf["persistRefreshToken"] = conf.pop("persistRefreshTokenInLdap", True)
+        should_update = True
+
     # specific config per distribution
     if distribution == "openbanking":
         if "dcrAuthorizationWithMTLS" not in conf:


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #3848 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

To validate the config addition, run the following command (example in mysql):

```
mysql \
    -u $DB_USER \
    --password=$DB_PASSWORD \
    $DB_NAME \
    -e "SELECT jansConfDyn FROM jansAppConf where doc_id = 'jans-auth'" | grep persistIdToken
```

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

