### PR TITLE
fix: jans-linux-setup sync test client variable names

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -434,11 +434,9 @@ class JansInstaller(BaseInstaller, SetupUtils):
     def create_test_client(self):
         ldif_fn = self.clients_ldif_fn = os.path.join(Config.output_dir, 'test-client.ldif')
         client_id = Config.get('test_client_id') or base.argsp.test_client_id
-        client_pw = Config.get('test_client_pw') or base.argsp.test_client_secret or self.getPW()
+        client_pw = Config.get('test_client_pw') or base.argsp.test_client_pw or self.getPW()
         encoded_pw = self.obscure(client_pw)
-        trusted_client = Config.get('test_client_trusted_client')
-        if not trusted_client:
-            trusted_client = 'true' if base.argsp.test_client_trusted else 'false'
+        trusted_client = 'true' if (Config.get('test_client_trusted') or base.argsp.test_client_trusted) else 'false'
 
         if base.argsp.test_client_redirect_uri:
             redirect_uri = base.argsp.test_client_redirect_uri.split(',')
@@ -464,7 +462,7 @@ class JansInstaller(BaseInstaller, SetupUtils):
         Config.test_client_pw = client_pw
         Config.test_client_pw_encoded = encoded_pw
         Config.test_client_redirect_uri = redirect_uri
-        Config.test_client_trusted_client = trusted_client
+        Config.test_client_trusted = trusted_client
         Config.test_client_scopes = ' '.join(scopes)
 
 

--- a/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
@@ -106,7 +106,7 @@ if PROFILE != OPENBANKING_PROFILE:
 
     # test-client
     parser.add_argument('-test-client-id', help="ID of test client which has all available scopes. Must be in UUID format.")
-    parser.add_argument('-test-client-secret', help="Secret for test client")
+    parser.add_argument('-test-client-pw', help="Secret for test client")
     parser.add_argument('-test-client-redirect-uri', help="Redirect URI for test client")
     parser.add_argument('--test-client-trusted', help="Make test client trusted", action='store_true')
 


### PR DESCRIPTION
closes #3861

Test Client variable names changed:
- **Arguments:** `-test-client-id`, `-test-client-pw`, `--test-client-trusted`
- **setup.properties** and **setup.properties.last**:  `test_client_id`, `test_client_pw`, `test_client_trusted`
