### PR TITLE
fix: jans-linux-setup key_ops_type for key regeneration tool

### DIFF
--- a/jans-linux-setup/tools/key_regeneration.py
+++ b/jans-linux-setup/tools/key_regeneration.py
@@ -391,6 +391,7 @@ class KeyRegenerator:
         print("Generating keys")
         args = [self.java_cmd, '-Dlog4j.defaultInitOverride=true',
                 '-cp', self.client_jar_fn, self.key_gen_path,
+                '-key_ops_type', 'ALL',
                 '-keystore', self.keystore_fn,
                 '-keypasswd', self.key_store_secret,
                 '-sig_keys', ' '.join(self.sig_enc['sig']),


### PR DESCRIPTION
closes #3881
