### PR TITLE
fix(jans-auth-server): error from introspection interception script is not propagated during AT as JWT creation #3904

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
@@ -37,6 +37,7 @@ import io.jans.as.server.util.TokenHashUtil;
 import io.jans.model.metric.MetricType;
 import io.jans.service.CacheService;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -223,6 +224,8 @@ public abstract class AuthorizationGrant extends AbstractAuthorizationGrant {
                 log.trace("Created plain access token: {}", accessToken.getCode());
 
             return accessToken;
+        } catch (WebApplicationException e) {
+            throw e;
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             return null;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/context/ExternalScriptContext.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/context/ExternalScriptContext.java
@@ -84,6 +84,10 @@ public class ExternalScriptContext extends io.jans.service.external.context.Exte
         this.webApplicationException = webApplicationException;
     }
 
+    public WebApplicationException createWebApplicationException(Response response) {
+        return new WebApplicationException(response);
+    }
+
     public WebApplicationException createWebApplicationException(int status, String entity) {
         this.webApplicationException = new WebApplicationException(Response
                 .status(status)


### PR DESCRIPTION
### Description

fix(jans-auth-server): error from introspection interception script is not propagated during AT as JWT creation 

#### Target issue
  
closes #3904
