### PR TITLE
fix(jans-linux-setup): install ncurses-compat-libs cb backend for el8

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/couchbase.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/couchbase.py
@@ -67,6 +67,7 @@ class CouchbaseInstaller(PackageUtils, BaseInstaller):
         if Config.cb_install == InstallTypes.LOCAL:
             self.add_couchbase_post_messages()
             self.couchbaseInstall()
+            Config.pbar.progress(self.service_name, "Configuring Couchbase", incr=False)
             self.checkIfJansBucketReady()
             self.couchebaseCreateCluster()
 
@@ -102,12 +103,14 @@ class CouchbaseInstaller(PackageUtils, BaseInstaller):
 
         package_name = max(cb_package_list)
         self.logIt("Found package '%s' for install" % package_name)
-
+        Config.pbar.progress(self.service_name, "Importing Couchbase package", incr=False)
         if base.clone_type == 'deb':
             apt_path = shutil.which('apt')
             self.chown(self.couchbasePackageFolder, '_apt', 'nogroup', recursive=True)
             install_output = self.run([apt_path, 'install', '-y', package_name])
         else:
+            if not self.check_installed('ncurses-compat-libs'):
+                self.installNetPackage('ncurses-compat-libs')
             install_output = self.installPackage(package_name)
 
         Config.post_messages.append(install_output)


### PR DESCRIPTION
closes #3966