### PR TITLE
fix(jans-pycloudlib): split aws secrets when payload is larger than 65536 bytes

### DIFF
--- a/jans-pycloudlib/jans/pycloudlib/secret/aws_secret.py
+++ b/jans-pycloudlib/jans/pycloudlib/secret/aws_secret.py
@@ -4,6 +4,7 @@ import json
 import logging
 import lzma
 import os
+import sys
 import typing as _t
 from contextlib import suppress
 from functools import cached_property
@@ -14,6 +15,7 @@ import boto3
 from botocore.exceptions import ClientError
 from botocore.exceptions import NoCredentialsError
 from botocore.exceptions import NoRegionError
+from math import ceil
 
 from jans.pycloudlib.secret.base_secret import BaseSecret
 from jans.pycloudlib.utils import safe_value
@@ -21,32 +23,10 @@ from jans.pycloudlib.utils import safe_value
 logger = logging.getLogger(__name__)
 
 
-def _dump_value(value: _t.Any) -> bytes:
-    """Dump compressed bytes from any Python data type.
-
-    Args:
-        value: Any given value.
-
-    Returns:
-        Compressed bytes contains the value.
-    """
-    return lzma.compress(json.dumps(value).encode())
-
-
-def _load_value(value: bytes) -> _t.Any:
-    """Load compressed bytes into any Python data type.
-
-    Args:
-        value: Any given value
-
-    Returns:
-        Any Python data type.
-    """
-    return json.loads(lzma.decompress(value).decode())
-
-
 class AwsSecret(BaseSecret):
     """This class interacts with AWS Secrets Manager backend.
+
+    If the secret's size is larger than the size limit (64KB), it will be stored in multiple secrets (maximum 10).
 
     The instance of this class is configured via environment variables.
 
@@ -94,7 +74,7 @@ class AwsSecret(BaseSecret):
     ```
     """
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # noqa: D107
         # unique name used as prefix to distinguish with other secrets
         # a typical usage is to use vendor/organization name
         prefix = os.environ.get("CN_AWS_SECRETS_PREFIX", "jans")
@@ -103,8 +83,11 @@ class AwsSecret(BaseSecret):
         # see https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/create-secret.html#options
         self.basepath = f"{prefix}_secrets"
 
-        # flag to determine whether AWS secrets already created
-        self.basepath_exists = False
+        # iterable contains multipart secret names
+        self.multiparts: list[str] = []
+
+        # max size of payload (currently 64K)
+        self.max_payload_size = 65536
 
     @cached_property
     def client(self) -> boto3.session.Session.client:
@@ -129,11 +112,26 @@ class AwsSecret(BaseSecret):
         Returns:
             A mapping of secrets (if any).
         """
-        self._prepare_secret()
-        resp = self.client.get_secret_value(SecretId=self.basepath)
+        # get all existing multipart secrets
+        resp = self.client.list_secrets(
+            Filters=[{"Key": "name", "Values": [self.basepath]}],
+        )
+        names = [secret["Name"] for secret in resp["SecretList"]]
 
-        # SecretBinary is a `dict` data type
-        data: dict[str, _t.Any] = _load_value(resp["SecretBinary"])
+        if not names:
+            return {}
+
+        payload = b"".join([
+            self.client.get_secret_value(SecretId=name)["SecretBinary"]
+            for name in names
+        ])
+
+        try:
+            # previously data is compressed using lzma
+            data: dict[str, _t.Any] = json.loads(lzma.decompress(payload).decode())
+            logger.warning("Loaded legacy data.")
+        except lzma.LZMAError:
+            data = json.loads(payload.decode())
         return data
 
     def get(self, key: str, default: _t.Any = "") -> _t.Any:
@@ -157,16 +155,11 @@ class AwsSecret(BaseSecret):
             value: Value of the key.
 
         Returns:
-            A boolean to mark whether config is set or not.
+            A boolean to indicate if secret was set successfully.
         """
         data = self.get_all()
         data[key] = safe_value(value)
-
-        resp = self.client.update_secret(
-            SecretId=self.basepath,
-            SecretBinary=_dump_value(data),
-        )
-        return bool(resp)
+        return self._update_secret_multipart(json.dumps(data))
 
     def set_all(self, data: dict[str, _t.Any]) -> bool:
         """Set all key-value pairs.
@@ -175,73 +168,16 @@ class AwsSecret(BaseSecret):
             data: key-value pairs of secrets.
 
         Returns:
-            A boolean indicating operation is succeed or not.
+            A boolean indicating if the operation was successful.
         """
-        self._prepare_secret()
-
         # fetch existing data (if any) as we will merge them;
         # note that existing value will be overwritten
         payload = self.get_all()
 
         for k, v in data.items():
-            # ensure value that has bytes is converted to text
+            # ensure key-value that has bytes is converted to text
             payload[k] = safe_value(v)
-
-        resp = self.client.update_secret(
-            SecretId=self.basepath,
-            SecretBinary=_dump_value(payload),
-        )
-        return bool(resp)
-
-    def _prepare_secret(self) -> None:
-        """Prepare (create if missing) secrets with empty value."""
-        # check whether secrets already exists
-        if self.basepath_exists:
-            return
-
-        try:
-            # get the secret
-            self.client.get_secret_value(SecretId=self.basepath)
-
-            # mark the secret as exists so subsequent checks made by
-            # client instance won't need to make requests to AWS service
-            self.basepath_exists = True
-
-        except ClientError as exc:
-            # raise exception if not related to missing secrets;
-            # note that missing secrets will be created
-            if exc.response["Error"]["Code"] != "ResourceNotFoundException":
-                raise RuntimeError(f"Unable to access AWS Secrets Manager service; reason={exc}")
-
-            create_secret = partial(
-                self.client.create_secret,
-                Name=self.basepath,
-                SecretBinary=_dump_value({}),
-                Description="Secrets for Janssen cluster",
-            )
-
-            if self.replica_regions:
-                # if there's replica regions, pass `AddReplicaRegions` argument;
-                # this will create replica in the specified regions, but note that
-                # a replica secret can't be updated independently from its primary secret,
-                # except for its encryption key.
-                create_secret.keywords["AddReplicaRegions"] = self.replica_regions
-                create_secret.keywords["ForceOverwriteReplicaSecret"] = True
-
-            # run the actual secrets creation
-            create_secret()
-
-            # mark the secrets as exists so subsequent checks made by
-            # client instance won't need to make requests to AWS service
-            self.basepath_exists = True
-
-        except NoCredentialsError:
-            raise RuntimeError(
-                "AWS credentials are not specified. Please specify the credentials "
-                "(contains AWS access key ID and secret access key) in a file pointed "
-                "by AWS_SHARED_CREDENTIALS_FILE environment variable, or specify profile "
-                "name via AWS_PROFILE environment variable."
-            )
+        return self._update_secret_multipart(json.dumps(payload))
 
     @cached_property
     def replica_regions(self) -> list[dict[str, _t.Any]]:
@@ -265,3 +201,93 @@ class AwsSecret(BaseSecret):
                     if region["Region"] != self.client.meta.region_name
                 ]
         return regions
+
+    def _update_secret_multipart(self, payload: _t.AnyStr) -> bool:  # noqa: D102
+        if isinstance(payload, str):
+            # Convert the string payload into a bytes. This step can be omitted if you
+            # pass in bytes instead of a str for the payload argument.
+            payload_bytes = payload.encode()
+        else:
+            payload_bytes = payload
+
+        data_length = sys.getsizeof(payload_bytes)
+        parts = ceil(data_length / self.max_payload_size)
+
+        if parts > 1:
+            logger.warning(
+                f"The secret payload size is {data_length} bytes and is exceeding max. size of {self.max_payload_size} bytes. "
+                f"It will be splitted into {parts} parts."
+            )
+
+        for part in range(0, parts):
+            name = self._prepare_secret_multipart(part)
+            start_bytes = part * self.max_payload_size
+            stop_bytes = (part + 1) * self.max_payload_size
+            fragment = payload_bytes[start_bytes:stop_bytes]
+            self.client.update_secret(SecretId=name, SecretBinary=fragment)
+        return True
+
+    def _prepare_secret_multipart(self, part: int) -> str:
+        """Check individual secrets if they exist or create new secrets with empty value if they don't.
+
+        Args:
+            part: part number of a multipart secret.
+
+        Returns:
+            Newly created secret's name
+        """
+        name = self.basepath
+
+        if part > 0:
+            name = f"{self.basepath}_{part}"
+
+        if name in self.multiparts:
+            return name
+
+        try:
+            # get the secret
+            self.client.get_secret_value(SecretId=name)
+
+            # mark the secret as exists so subsequent checks made by
+            # client instance won't need to make requests to AWS service
+            self.multiparts.append(name)
+
+        except ClientError as exc:
+            # raise exception if not related to missing secrets;
+            # note that missing secrets will be created
+            if exc.response["Error"]["Code"] != "ResourceNotFoundException":
+                raise RuntimeError(f"Unable to access AWS Secrets Manager service; reason={exc}")
+
+            create_secret = partial(
+                self.client.create_secret,
+                Name=name,
+                SecretBinary=json.dumps({}),
+                Description="Secrets for Janssen cluster",
+                Tags=[{"Key": "multipart_enabled", "Value": "true"}],
+            )
+
+            if self.replica_regions:
+                # if there's replica regions, pass `AddReplicaRegions` argument;
+                # this will create replica in the specified regions, but note that
+                # a replica secret can't be updated independently from its primary secret,
+                # except for its encryption key.
+                create_secret.keywords["AddReplicaRegions"] = self.replica_regions
+                create_secret.keywords["ForceOverwriteReplicaSecret"] = True
+
+            # run the actual secrets creation
+            create_secret()
+
+            logger.info(f"Created secret: {name}")
+
+            # mark the secret as exists so subsequent checks made by
+            # client instance won't need to make requests to AWS service
+            self.multiparts.append(name)
+
+        except NoCredentialsError:
+            raise RuntimeError(
+                "AWS credentials are not specified. Please specify the credentials "
+                "(contains AWS access key ID and secret access key) in a file pointed "
+                "by AWS_SHARED_CREDENTIALS_FILE environment variable, or specify profile "
+                "name via AWS_PROFILE environment variable."
+            )
+        return name


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #3968 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

