### PR TITLE
fix(jans-fido2): removing session id check for unauthenticated state …

### DIFF
--- a/jans-auth-server/server/src/main/webapp/casa/casa.xhtml
+++ b/jans-auth-server/server/src/main/webapp/casa/casa.xhtml
@@ -1,5 +1,5 @@
-<div xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
->
+<div	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+	xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions">
 
 	<section class="pa4 shadow-4 bg-blank gray cust-section dn" id="alternatives_section">
 
@@ -109,7 +109,7 @@
 				"bioid" : '<i class="fas fa-camera" />',
 				"cert" : '<span class="fa-layers fa-fw mr1 nl3" style="top:-.3rem"> <i class="far fa-circle" data-fa-transform="shrink-4 up-3 right-4"></i> <i class="far fa-circle" data-fa-transform="shrink-5 up-3 right-4"></i> <i class="far fa-circle" data-fa-transform="shrink-6 up-3 right-4"></i> <i class="fas fa-bookmark" data-fa-transform="rotate-30 shrink-9 down-4"></i> <i class="fas fa-bookmark" data-fa-transform="rotate--30 shrink-9 down-4 right-8"></i> </span>',
 				
-				
+				"email_2fa" : '<i class="fas fa-envelope" />'
 			}
 
 		for (let k in icons) {

--- a/jans-auth-server/server/src/main/webapp/casa/fido2.xhtml
+++ b/jans-auth-server/server/src/main/webapp/casa/fido2.xhtml
@@ -1,7 +1,8 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:f="http://xmlns.jcp.org/jsf/core"
-                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-                template="/casa/login-template.xhtml">
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	template="/casa/login-template.xhtml">
 	
 	<f:metadata>
 		<f:viewAction action="#{authenticator.prepareAuthenticationForStep}" if="#{not identity.loggedIn}" />
@@ -78,18 +79,41 @@
 		<section class="pa4 shadow-4 bg-blank gray cust-section" id="fido2_section">
 			<h2 class="f3 dark-blue2">#{msgs['casa.snd_step']}</h2>
 			<div id="messages" class="list dark-red pv2 ph0 ma0 f7-cust mw5" />
-			
-			<div class="flex flex-column items-center pa3">
-				<p class="f4 tc">#{msgs['casa.securitykey.insert']}</p>
-				<img class="w4" src="#{request.contextPath}/img/securitykey.jpg" />
-				<div class="db w5 tc f7-cust pv3">#{msgs['casa.securitykey.tap']}</div>
+			<div class="flex flex-row">
+				<div>
+					<div class="flex flex-column items-center pa3">
+						<p class="f4 tc">#{msgs['casa.securitykey.insert']}</p>
+						<img class="w4" src="#{request.contextPath}/img/securitykey.jpg" />
+						<div class="db w5 tc f7-cust pv3">#{msgs['casa.securitykey.tap']}</div>
+					</div>
+				</div>
+				<ui:fragment
+					rendered="#{identity.getWorkingParameter('platformAuthenticatorAvailable') == 'true'}">
+					<div>
+						<div class="flex flex-column items-center pa3">
+							<p class="f4 tc">#{msgs['casa.touchid.use']}</p>
+							<img class="w4" src="#{request.contextPath}/img/touchid.png" />
+							<div class="db w5 tc f7-cust pv3">#{msgs['casa.touchid.tap']}</div>
+						</div>
+					</div>
+				</ui:fragment>
 			</div>
-
 			<div class="flex justify-between f7-cust">
 				<!-- do not change the ID of anchor following -->
-				<a id="alter_link" href="javascript:showAlternative('fido2_section')" class="green hover-green">#{msgs['casa.alternative']}</a>
-
-				<a id="retry" href="javascript:retry()" class="green hover-green f7-cust pl3 dn">#{msgs['casa.fido2.retry_key']}</a>
+				<a id="alter_link"
+					href="javascript:showAlternative('fido2_section')"
+					class="green hover-green">#{msgs['casa.alternative']}</a>
+				<ui:fragment
+					rendered="#{identity.getWorkingParameter('platformAuthenticatorAvailable') != 'true'}">
+					<a id="retry" href="javascript:retry()"
+						class="green hover-green f7-cust pl3 dn">#{msgs['casa.fido2.retry_key']}</a>
+				</ui:fragment>
+				<ui:fragment
+					rendered="#{identity.getWorkingParameter('platformAuthenticatorAvailable') == 'true'}">
+					<a id="retry" href="javascript:retry()"
+						class="green hover-green f7-cust pl3 dn">#{msgs['casa.activate.touchid']}</a>
+				</ui:fragment>
+				
 			</div>
 		</section>
 		<ui:include src="/casa/casa.xhtml" />

--- a/jans-auth-server/server/src/main/webapp/casa/login.xhtml
+++ b/jans-auth-server/server/src/main/webapp/casa/login.xhtml
@@ -38,6 +38,7 @@
 					</p>
 				</h:panelGroup>
 				<h:inputHidden id="platform" />
+                <h:inputHidden id="platformAuthenticator" />
 			</h:form>
 		</section>
 		<script>
@@ -45,8 +46,24 @@
 			$(".focused-text").attr("required", "true")
 			
 			$(document).ready(function () {
-				fillPlatformField()
+                storedCredsWorkaround();
+				fillPlatformField();
+				fillPlatforAuthenticatorField();
 			})
+            
+            function storedCredsWorkaround() {
+                //Needed when browser pre-fills usr/pwd due to JSF issue with required attribute (see above)
+                let user = document.getElementById("loginForm:username")
+                let pwd = document.getElementById("loginForm:password")
+                if ($(user).val()) {
+                    $(user).focus()
+                    $(user).blur()
+                }
+                if ($(pwd).val()) {
+                    $(pwd).focus()
+                    $(pwd).blur()
+                }
+            }
 			
 			function fillPlatformField() {
 				try {
@@ -61,6 +78,23 @@
 				} catch (e) {
 				}
 			}
+			 function fillPlatforAuthenticatorField()
+	            {
+	            	
+					PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+					  .then(function(available){
+					    if(available){
+					    	 document.getElementById("loginForm:platformAuthenticator").value = "true";
+					    }
+					    else
+					    {
+					    	 document.getElementById("loginForm:platformAuthenticator").value = "false";
+					    }
+					    
+					  }).catch(function(err){
+					    console.error("Error in detecting platform authenticator : "+err);
+					  });
+	            }
 		</script>
 	</ui:define>
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/UserSessionIdService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/UserSessionIdService.java
@@ -143,11 +143,11 @@ public class UserSessionIdService {
             return null;
         }
 
-        if (SessionIdState.UNAUTHENTICATED != entity.getState()) {
-            log.warn("Unexpected session id '{}' state: '{}'", sessionId, entity.getState());
-            return null;
-        }
-
+		/*if (SessionIdState.UNAUTHENTICATED != entity.getState()) {
+			log.warn("Unexpected session id '{}' state: '{}'", sessionId, entity.getState());
+			return null;
+		}*/
+		
         return entity;
     }
 


### PR DESCRIPTION
…+ casa support for fido2 #3771

Description of the issue:
Whenever, an SG device is enrolled from an app like casa, the user has already been authenticated and then this check fails.
The check can be moved into the script. 