### PR TITLE
fix(jans-linux-setup): install cb before jans installation

### DIFF
--- a/jans-linux-setup/jans_setup/jans_setup.py
+++ b/jans-linux-setup/jans_setup/jans_setup.py
@@ -327,7 +327,7 @@ def main():
             packageUtils.check_and_install_packages()
 
         if Config.cb_install == static.InstallTypes.LOCAL:
-            print("Please wait while stup is installing couchbase package ...")
+            print("Please wait while setup is installing couchbase package ...")
             couchbaseInstaller.couchbaseInstall()
 
     # register post setup progress

--- a/jans-linux-setup/jans_setup/jans_setup.py
+++ b/jans-linux-setup/jans_setup/jans_setup.py
@@ -326,6 +326,10 @@ def main():
         if Config.rdbm_install_type == static.InstallTypes.LOCAL:
             packageUtils.check_and_install_packages()
 
+        if Config.cb_install == static.InstallTypes.LOCAL:
+            print("Please wait while stup is installing couchbase package ...")
+            couchbaseInstaller.couchbaseInstall()
+
     # register post setup progress
     class PostSetup:
         service_name = 'post-setup'

--- a/jans-linux-setup/jans_setup/setup_app/installers/couchbase.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/couchbase.py
@@ -66,7 +66,6 @@ class CouchbaseInstaller(PackageUtils, BaseInstaller):
 
         if Config.cb_install == InstallTypes.LOCAL:
             self.add_couchbase_post_messages()
-            self.couchbaseInstall()
             Config.pbar.progress(self.service_name, "Configuring Couchbase", incr=False)
             self.checkIfJansBucketReady()
             self.couchebaseCreateCluster()
@@ -103,11 +102,11 @@ class CouchbaseInstaller(PackageUtils, BaseInstaller):
 
         package_name = max(cb_package_list)
         self.logIt("Found package '%s' for install" % package_name)
-        Config.pbar.progress(self.service_name, "Installing Couchbase package", incr=False)
+
         if base.clone_type == 'deb':
             apt_path = shutil.which('apt')
             self.chown(self.couchbasePackageFolder, '_apt', 'nogroup', recursive=True)
-            install_output = self.run([apt_path, 'install', '-y', package_name])
+            install_output = self.run([apt_path, '--quiet', 'install', '-y', package_name])
         else:
             if not self.check_installed('ncurses-compat-libs'):
                 self.installNetPackage('ncurses-compat-libs')


### PR DESCRIPTION
closes  #3268
In thi PR, instead of re-writing progress bar, installing couchbase-server before jans deployment was implemented.