### PR TITLE
fix(jans-auth-server): WebApplicationException is not propagated out of "Update Token" script #3996

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
@@ -379,6 +379,8 @@ public abstract class AuthorizationGrant extends AbstractAuthorizationGrant {
             metricService.incCounter(MetricType.TOKEN_ID_TOKEN_COUNT);
 
             return idToken;
+        } catch (WebApplicationException e) {
+            throw e;
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             return null;


### PR DESCRIPTION
### Description

fix(jans-auth-server): WebApplicationException is not propagated out of "Update Token" script 

#### Target issue
 
closes #3996

