### PR TITLE
fix(jans-auth-server): bad indentation in AS swagger.yaml #4108

### DIFF
--- a/jans-auth-server/docs/swagger.yaml
+++ b/jans-auth-server/docs/swagger.yaml
@@ -1259,9 +1259,9 @@ paths:
                   description: Requested Client Authentication method for the Token Endpoint.
                 additional_token_endpoint_auth_method:
                   type: array
-                    description: Array of additional Client Authentication methods for the Token Endpoint
-                    items:
-                      type: string
+                  description: Array of additional Client Authentication methods for the Token Endpoint
+                  items:
+                    type: string
                 token_endpoint_auth_signing_alg:
                   type: string
                   description: JWS alg algorithm (JWA) that must be used for signing the JWT used to authenticate the Client at the Token Endpoint
@@ -1652,9 +1652,9 @@ paths:
                   description: Requested Client Authentication method for the Token Endpoint.
                 additional_token_endpoint_auth_method:
                   type: array
-                    description: Array of additional Client Authentication methods for the Token Endpoint
-                    items:
-                      type: string
+                  description: Array of additional Client Authentication methods for the Token Endpoint
+                  items:
+                    type: string
                 token_endpoint_auth_signing_alg:
                   type: string
                   description: JWS alg algorithm (JWA) that must be used for signing the JWT used to authenticate the Client at the Token Endpoint
@@ -2046,9 +2046,9 @@ paths:
                     description: Requested Client Authentication method for the Token Endpoint.
                   additional_token_endpoint_auth_method:
                     type: array
-                      description: Array of additional Client Authentication methods for the Token Endpoint
-                      items:
-                        type: string
+                    description: Array of additional Client Authentication methods for the Token Endpoint
+                    items:
+                      type: string
                   token_endpoint_auth_signing_alg:
                     type: string
                     description: JWS alg algorithm (JWA) that must be used for signing the JWT used to authenticate the Client at the Token Endpoint


### PR DESCRIPTION
### Description

fix(jans-auth-server): bad indentation in AS swagger.yaml 

#### Target issue
  
closes #4108

