### PR TITLE
fix(jans-fido2):handling exception fido2 get endpoints by invalid params

### DIFF
--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/u2f/error/Fido2ErrorResponseFactory.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/u2f/error/Fido2ErrorResponseFactory.java
@@ -1,0 +1,26 @@
+package io.jans.fido2.model.u2f.error;
+
+import io.jans.as.model.error.DefaultErrorResponse;
+import io.jans.as.model.error.IErrorType;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+public class Fido2ErrorResponseFactory {
+
+    public static WebApplicationException createBadRequestException(IErrorType type, String reason, String description, String correlationId) {
+        final DefaultErrorResponse response = new DefaultErrorResponse();
+        response.setType(type);
+        response.setState("");
+        response.setReason(reason);
+        if (correlationId != null)
+            response.setErrorDescription(String.format(description + " CorrelationId: %s", correlationId));
+        else
+            response.setErrorDescription(description);
+        throw new WebApplicationException(Response
+                .status(Response.Status.BAD_REQUEST)
+                .entity(response.toJSonString())
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build());
+    }
+}

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/u2f/error/Fido2ErrorResponseType.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/u2f/error/Fido2ErrorResponseType.java
@@ -1,0 +1,53 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.model.u2f.error;
+
+import io.jans.as.model.error.IErrorType;
+
+/**
+ * Error codes for fido2 error responses.
+ *
+ */
+public enum Fido2ErrorResponseType implements IErrorType {
+
+    /**
+     * The request is missing a required parameter, includes an
+     * invalid parameter value or is otherwise malformed id_session.
+     */
+    INVALID_ID_SESSION("invalid_id_session"),
+
+    /**
+     *  The request is missing a required parameter, username or keyhandle
+     */
+    INVALID_USERNAME_OR_KEYHANDLE("invalid_username_or_keyhandle");
+
+
+    private final String paramName;
+
+    Fido2ErrorResponseType(String paramName) {
+        this.paramName = paramName;
+    }
+
+    /**
+     * Returns a string representation of the object. In this case, the lower
+     * case code of the error.
+     */
+    @Override
+    public String toString() {
+        return paramName;
+    }
+
+    /**
+     * Gets error parameter.
+     *
+     * @return error parameter
+     */
+    @Override
+    public String getParameter() {
+        return paramName;
+    }
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/sg/converter/AssertionSuperGluuController.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/sg/converter/AssertionSuperGluuController.java
@@ -10,7 +10,15 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
+import io.jans.as.model.config.Constants;
+import io.jans.as.model.error.DefaultErrorResponse;
+import io.jans.fido2.model.u2f.error.Fido2ErrorResponseFactory;
+import io.jans.fido2.model.u2f.error.Fido2ErrorResponseType;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.ThreadContext;
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -120,11 +128,15 @@ public class AssertionSuperGluuController {
 
         boolean valid = userSessionIdService.isValidSessionId(sessionId, userName);
         if (!valid) {
-            throw new Fido2RuntimeException(String.format("session_id '%s' is invalid", sessionId));
+            String reasonError = String.format("session_id '%s' is invalid", sessionId);
+            String descriptionError = "The session_id is null, blank or invalid, this param is required.";
+            throw Fido2ErrorResponseFactory.createBadRequestException(Fido2ErrorResponseType.INVALID_ID_SESSION, reasonError, descriptionError, ThreadContext.get(Constants.CORRELATION_ID_HEADER));
         }
 
         if (StringHelper.isEmpty(userName) && StringHelper.isEmpty(keyHandle)) {
-            throw new Fido2RuntimeException("The request should contains either username or keyhandle");
+            String reasonError = "invalid : username or keyhandle";
+            String descriptionError = "The request should contains either username or keyhandle";
+            throw Fido2ErrorResponseFactory.createBadRequestException(Fido2ErrorResponseType.INVALID_USERNAME_OR_KEYHANDLE, reasonError, descriptionError, ThreadContext.get(Constants.CORRELATION_ID_HEADER));
         }
 
         ObjectNode params = dataMapperService.createObjectNode();

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/sg/converter/AttestationSuperGluuController.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/sg/converter/AttestationSuperGluuController.java
@@ -11,7 +11,11 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.security.cert.CertificateEncodingException;
 
+import io.jans.as.model.config.Constants;
+import io.jans.fido2.model.u2f.error.Fido2ErrorResponseFactory;
+import io.jans.fido2.model.u2f.error.Fido2ErrorResponseType;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.ThreadContext;
 import org.slf4j.Logger;
 
 
@@ -124,7 +128,9 @@ public class AttestationSuperGluuController {
 
         boolean valid = userSessionIdService.isValidSessionId(sessionId, userName);
         if (!valid) {
-            throw new Fido2RuntimeException(String.format("session_id '%s' is invalid", sessionId));
+            String reasonError = String.format("session_id '%s' is invalid", sessionId);
+            String descriptionError = "The session_id is null, blank or invalid, this param is required.";
+            throw Fido2ErrorResponseFactory.createBadRequestException(Fido2ErrorResponseType.INVALID_ID_SESSION, reasonError, descriptionError, ThreadContext.get(Constants.CORRELATION_ID_HEADER));
         }
 
         ObjectNode params = dataMapperService.createObjectNode();


### PR DESCRIPTION
### Prepare

- [X] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [X] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Issue was caused due to direct exception throwing
#### Target issue
https://github.com/JanssenProject/jans/issues/3902 
 
closes #3902

#### Implementation Details
ErrorResponse was implemented similar to jans-auth-server using a WebApplicationException.
The error is showed in a detailed json.

-------------------
### Test and Document the changes
- [X] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

