### PR TITLE
fix(jans-linux-setup): set jansAuthMode - default acr mode

### DIFF
--- a/jans-linux-setup/jans_setup/templates/configuration.ldif
+++ b/jans-linux-setup/jans_setup/templates/configuration.ldif
@@ -4,6 +4,7 @@ jansDocStoreConf: {"documentStoreType":"LOCAL","localConfiguration":{"baseLocati
 jansDbAuth: {"type": "auth", "name": null, "level": 0, "priority": 1, "enabled": false, "version": 0, "config": {"configId": "auth_ldap_server",           "servers": ["%(ldap_hostname)s:%(ldaps_port)s"],           "maxConnections": 1000,           "bindDN": "%(ldap_binddn)s",           "bindPassword": "%(encoded_ox_ldap_pw)s",           "useSSL": "true",           "baseDNs": ["ou=people,o=jans"],           "primaryKey": "uid",           "localPrimaryKey": "uid",           "useAnonymousBind": false,           "enabled": false} }
 jansOrgProfileMgt: false
 jansScimEnabled: false
+jansAuthMode: simple_password_auth
 objectClass: top
 objectClass: jansAppConf
 ou: configuration


### PR DESCRIPTION
In this PR **jansAuthMode** was set to default value as mentioned in issue #4159