### PR TITLE
feat: restore status/errorMessage and timeout attributes

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
@@ -150,17 +150,17 @@ public class AttestationService {
 			log.debug("Put extensions {}", extensions);
 		}
 		// incase of Apple's Touch ID and Window's Hello; timeout,status and error message cause a NotAllowedError on the browser, so skipping these attributes
-		if (params.hasNonNull("authenticatorAttachment")) {
-			if (AuthenticatorAttachment.CROSS_PLATFORM.equals(authenticatorSelectionNode.get("authenticatorAttachment").asText())) {
-				// Put timeout
-				int timeout = commonVerifiers.verifyTimeout(params);
-				log.debug("Put timeout {}", timeout);
-				optionsResponseNode.put("timeout", timeout);
+//		if (params.hasNonNull("authenticatorAttachment")) {
+//			if (AuthenticatorAttachment.CROSS_PLATFORM.equals(authenticatorSelectionNode.get("authenticatorAttachment").asText())) {
+		// Put timeout
+		int timeout = commonVerifiers.verifyTimeout(params);
+		log.debug("Put timeout {}", timeout);
+		optionsResponseNode.put("timeout", timeout);
 
-				optionsResponseNode.put("status", "ok");
-				optionsResponseNode.put("errorMessage", "");
-			}
-		}
+		optionsResponseNode.put("status", "ok");
+		optionsResponseNode.put("errorMessage", "");
+//			}
+//		}
 		
 		// Store request in DB
 		Fido2RegistrationData entity = new Fido2RegistrationData();


### PR DESCRIPTION
According to test suite:

"...MUST contain "status" field, and it MUST be of type DOMString and set to "ok" (b) response MUST contain "errorMessage" field, and it MUST be of type DOMString ...."
Closes #4241, 