### PR TITLE
fix(docker-jans-persistence-loader): set highest level script to false by default

### DIFF
--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -117,7 +117,7 @@ def _transform_auth_dynamic_config(conf):
         should_update = True
 
     if "useHighestLevelScriptIfAcrScriptNotFound" not in conf:
-        conf["useHighestLevelScriptIfAcrScriptNotFound"] = True
+        conf["useHighestLevelScriptIfAcrScriptNotFound"] = False
         should_update = True
 
     if "httpLoggingExcludePaths" not in conf:

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
@@ -477,7 +477,7 @@
     "deviceAuthzTokenPollInterval": 5,
     "deviceAuthzResponseTypeToProcessAuthz": "code",
     "redirectUrisRegexEnabled": true,
-    "useHighestLevelScriptIfAcrScriptNotFound": true,
+    "useHighestLevelScriptIfAcrScriptNotFound": false,
     "agamaConfiguration": {
         "enabled": true,
         "templatesPath": "/ftl",

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
@@ -394,7 +394,7 @@
     "staticKid": "%(staticKid)s",
     "forceOfflineAccessScopeToEnableRefreshToken" : false,
     "redirectUrisRegexEnabled": false,
-    "useHighestLevelScriptIfAcrScriptNotFound": true,
+    "useHighestLevelScriptIfAcrScriptNotFound": false,
     "blockWebviewAuthorizationEnabled": false,
     "dateFormatterPatterns": {
         "birthdate": "yyyy-MM-dd"


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4249

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

