### PR TITLE
fix(jans-auth-server): simple_password_auth is missed in acr_values_supported #4258

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
@@ -21,6 +21,7 @@ import io.jans.as.server.service.external.ExternalDiscoveryService;
 import io.jans.as.server.service.external.ExternalDynamicScopeService;
 import io.jans.as.server.util.ServerUtil;
 import io.jans.model.GluuAttribute;
+import io.jans.util.OxConstants;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -159,7 +160,7 @@ public class OpenIdConfiguration extends HttpServlet {
 
             jsonObj.put(AUTH_LEVEL_MAPPING, createAuthLevelMapping());
 
-            Util.putArray(jsonObj, externalAuthenticationService.getAcrValuesList(), ACR_VALUES_SUPPORTED);
+            Util.putArray(jsonObj, getAcrValuesList(), ACR_VALUES_SUPPORTED);
 
             Util.putArray(jsonObj, appConfiguration.getSubjectTypesSupported(), SUBJECT_TYPES_SUPPORTED);
 
@@ -247,6 +248,17 @@ public class OpenIdConfiguration extends HttpServlet {
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }
+    }
+
+    public List<String> getAcrValuesList() {
+        return getAcrValuesList(externalAuthenticationService.getAcrValuesList());
+    }
+
+    public static List<String> getAcrValuesList(final List<String> scriptAliases) {
+        if (!scriptAliases.contains(OxConstants.SCRIPT_TYPE_INTERNAL_RESERVED_NAME)) {
+            scriptAliases.add(OxConstants.SCRIPT_TYPE_INTERNAL_RESERVED_NAME);
+        }
+        return scriptAliases;
     }
 
     @SuppressWarnings("java:S3776")

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/servlet/OpenIdConfigurationTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/servlet/OpenIdConfigurationTest.java
@@ -4,6 +4,9 @@ import io.jans.as.model.configuration.AppConfiguration;
 import org.json.JSONObject;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertFalse;
 
@@ -11,6 +14,12 @@ import static org.testng.AssertJUnit.assertFalse;
  * @author Yuriy Z
  */
 public class OpenIdConfigurationTest {
+
+    @Test
+    public void getAcrValuesList_whenCalled_shouldContainInternalAuthnAlias() {
+        final List<String> acrValuesList = OpenIdConfiguration.getAcrValuesList(new ArrayList<>());
+        assertTrue(acrValuesList.contains("simple_password_auth"));
+    }
 
     @Test
     public void filterOutKeys_whenKeyIsInDentiedList_mustRemoveThemFromJson() {


### PR DESCRIPTION
### Description

fix(jans-auth-server): simple_password_auth is missed in acr_values_supported #4258

#### Target issue
  
closes #4258

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

