### PR TITLE
fix(jans-auth-server) : Authorization with acr_values=simple_password_auth failing #4278

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -287,8 +287,7 @@ public class AuthorizeAction {
 
             List<String> acrValuesList = sessionIdService.acrValuesList(this.acrValues);
             boolean useExternalAuthenticator = externalAuthenticationService.isEnabled(AuthenticationScriptUsageType.INTERACTIVE);
-            boolean skipScript = acrValuesList.isEmpty() && BooleanUtils.isFalse(appConfiguration.getUseHighestLevelScriptIfAcrScriptNotFound())
-                    && OxConstants.SCRIPT_TYPE_INTERNAL_RESERVED_NAME.equalsIgnoreCase(defaultAuthenticationMode.getName());
+            boolean skipScript = shouldSkipScript(acrValuesList);
             if (useExternalAuthenticator && !skipScript) {
                 if (acrValuesList.isEmpty()) {
                     acrValuesList = Arrays.asList(defaultAuthenticationMode.getName());
@@ -452,6 +451,14 @@ public class AuthorizeAction {
                 return;
             }
         }
+    }
+
+    public boolean shouldSkipScript(List<String> acrValues) {
+        if (acrValues.size() == 1 && acrValues.contains(OxConstants.SCRIPT_TYPE_INTERNAL_RESERVED_NAME)) {
+            return true;
+        }
+        return acrValues.isEmpty() && BooleanUtils.isFalse(appConfiguration.getUseHighestLevelScriptIfAcrScriptNotFound())
+                && OxConstants.SCRIPT_TYPE_INTERNAL_RESERVED_NAME.equalsIgnoreCase(defaultAuthenticationMode.getName());
     }
 
     private SessionId handleAcrChange(SessionId session, List<io.jans.as.model.common.Prompt> prompts) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
@@ -1,0 +1,158 @@
+package io.jans.as.server.authorize.ws.rs;
+
+import com.google.common.collect.Lists;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.crypto.AbstractCryptoProvider;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.server.auth.Authenticator;
+import io.jans.as.server.i18n.LanguageBean;
+import io.jans.as.server.model.auth.AuthenticationMode;
+import io.jans.as.server.model.authorize.ScopeChecker;
+import io.jans.as.server.security.Identity;
+import io.jans.as.server.service.*;
+import io.jans.as.server.service.ciba.CibaRequestService;
+import io.jans.as.server.service.external.ExternalAuthenticationService;
+import io.jans.as.server.service.external.ExternalConsentGatheringService;
+import io.jans.as.server.service.external.ExternalPostAuthnService;
+import io.jans.jsf2.message.FacesMessages;
+import io.jans.jsf2.service.FacesService;
+import io.jans.service.net.NetworkService;
+import io.jans.util.OxConstants;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class AuthorizeActionTest {
+
+    @InjectMocks
+    private AuthorizeAction authorizeAction;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private ClientService clientService;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private SessionIdService sessionIdService;
+
+    @Mock
+    private RedirectionUriService redirectionUriService;
+
+    @Mock
+    private ClientAuthorizationsService clientAuthorizationsService;
+
+    @Mock
+    private ExternalAuthenticationService externalAuthenticationService;
+
+    @Mock
+    private ExternalConsentGatheringService externalConsentGatheringService;
+
+    @Mock
+    private AuthenticationMode defaultAuthenticationMode;
+
+    @Mock
+    private LanguageBean languageBean;
+
+    @Mock
+    private NetworkService networkService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private FacesService facesService;
+
+    @Mock
+    private FacesMessages facesMessages;
+
+    @Mock
+    private FacesContext facesContext;
+
+    @Mock
+    private ExternalContext externalContext;
+
+    @Mock
+    private ConsentGathererService consentGatherer;
+
+    @Mock
+    private AuthorizeService authorizeService;
+
+    @Mock
+    private RequestParameterService requestParameterService;
+
+    @Mock
+    private ScopeChecker scopeChecker;
+
+    @Mock
+    private ErrorHandlerService errorHandlerService;
+
+    @Mock
+    private AbstractCryptoProvider cryptoProvider;
+
+    @Mock
+    private CookieService cookieService;
+
+    @Mock
+    private Authenticator authenticator;
+
+    @Mock
+    private AuthenticationService authenticationService;
+
+    @Mock
+    private ExternalPostAuthnService externalPostAuthnService;
+
+    @Mock
+    private CibaRequestService cibaRequestService;
+
+    @Mock
+    private Identity identity;
+
+    @Mock
+    private AuthorizeRestWebServiceValidator authorizeRestWebServiceValidator;
+
+    @Test
+    public void shouldSkipScript_forExplicitDefaultPasswordAuth_shouldReturnTrue() {
+        final boolean skip = authorizeAction.shouldSkipScript(Lists.newArrayList(OxConstants.SCRIPT_TYPE_INTERNAL_RESERVED_NAME));
+        assertTrue(skip);
+    }
+
+    @Test
+    public void shouldSkipScript_forEmptyAcrsAndHighestFalseAndDefaultPassAuthn_shouldReturnTrue() {
+        when(appConfiguration.getUseHighestLevelScriptIfAcrScriptNotFound()).thenReturn(false);
+        when(defaultAuthenticationMode.getName()).thenReturn(OxConstants.SCRIPT_TYPE_INTERNAL_RESERVED_NAME);
+        final boolean skip = authorizeAction.shouldSkipScript(Lists.newArrayList());
+        assertTrue(skip);
+    }
+
+    @Test
+    public void shouldSkipScript_forEmptyAcrsAndHighestTrue_shouldReturnFalse() {
+        when(appConfiguration.getUseHighestLevelScriptIfAcrScriptNotFound()).thenReturn(true);
+        final boolean skip = authorizeAction.shouldSkipScript(Lists.newArrayList());
+        assertFalse(skip);
+    }
+
+    @Test
+    public void shouldSkipScript_forEmptyAcrsAndHighestFalseAndDefaultIsNotDefaultPassAuthn_shouldReturnFalse() {
+        when(appConfiguration.getUseHighestLevelScriptIfAcrScriptNotFound()).thenReturn(false);
+        when(defaultAuthenticationMode.getName()).thenReturn("some_acr");
+        final boolean skip = authorizeAction.shouldSkipScript(Lists.newArrayList());
+        assertFalse(skip);
+    }
+}

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
             <class name="io.jans.as.server.ws.rs.stat.MonthsTest" />
             <class name="io.jans.as.server.authorize.ws.rs.AuthorizeRestWebServiceValidatorTest" />
             <class name="io.jans.as.server.authorize.ws.rs.AuthorizeRestWebServiceImplTest" />
+            <class name="io.jans.as.server.authorize.ws.rs.AuthorizeActionTest" />
             <class name="io.jans.as.server.register.ws.rs.SsaValidationConfigServiceTest" />
             <class name="io.jans.as.server.session.ws.rs.EndSessionRestWebServiceImplTest" />
         </classes>


### PR DESCRIPTION
### Description

fix(jans-auth-server) : Authorization with acr_values=simple_password_auth failing 

#### Target issue
  
closes #4278

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

