### PR TITLE
chore(tent): remove source licensing copyright notice

### DIFF
--- a/demos/jans-tent/clientapp/__init__.py
+++ b/demos/jans-tent/clientapp/__init__.py
@@ -1,7 +1,7 @@
 '''
 Project: Test Auth Client
 Author: Christian Hawk
-Copyright 2023 Christian Hawk
+
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.
@@ -26,13 +26,17 @@ from flask import (Flask, jsonify, redirect, render_template, request, session,
 
 from . import config as cfg
 from .client_handler import ClientHandler
+from flask.logging import default_handler
+
 
 oauth = OAuth()
-
+logging.getLogger("flask-oidc")
 logging.basicConfig(
     level=logging.DEBUG,
     format='[%(asctime)s] %(levelname)s %(name)s in %(module)s : %(message)s',
     filename='test-client.log')
+root = logging.getLogger()
+root.addHandler(default_handler)
 '''
 dictConfig({
     'version': 1,

--- a/demos/jans-tent/clientapp/client_handler.py
+++ b/demos/jans-tent/clientapp/client_handler.py
@@ -1,7 +1,7 @@
 '''
 Project: Test Auth Client
 Author: Christian Hawk
-Copyright 2023 Christian Hawk
+
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.
@@ -73,8 +73,8 @@ class ClientHandler:
         """Discover op information on .well-known/open-id-configuration
         :param op_url: [description], defaults to __op_url
         :type op_url: str, optional
-        :param discovery: [flask_oidc.discovery injection], defaults to discovery
-        :type discovery: discovery, optional
+        :param disc: [flask_oidc.discovery injection], defaults to discovery
+        :type disc: discovery, optional
         :return: [data retrieved from OP url]
         :rtype: dict3
         """

--- a/demos/jans-tent/clientapp/config.py
+++ b/demos/jans-tent/clientapp/config.py
@@ -1,7 +1,6 @@
 '''
 Project: Test Auth Client
 Author: Christian Hawk
-Copyright 2023 Christian Hawk
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.

--- a/demos/jans-tent/main.py
+++ b/demos/jans-tent/main.py
@@ -1,7 +1,6 @@
 '''
 Project: Test Auth Client
 Author: Christian Hawk
-Copyright 2023 Christian Hawk
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
As not requested by Apache 2.
Closes #4304, 