### PR TITLE
feat(jans-cli-tui): device verification url with code

### DIFF
--- a/jans-cli-tui/cli_tui/cli/config_cli.py
+++ b/jans-cli-tui/cli_tui/cli/config_cli.py
@@ -625,11 +625,10 @@ class JCA_CLI:
 
             result = response.json()
 
-            if 'verification_uri' in result and 'user_code' in result:
+            if 'verification_uri_complete' in result and 'user_code' in result:
 
-                msg = "Please visit verification url {} and enter user code {} within {} secods".format(
-                        self.colored_text(result['verification_uri'], success_color),
-                        self.colored_text(result['user_code'], bold_color),
+                msg = "Please visit verification url {} and authorize this device within {} secods".format(
+                        self.colored_text(result['verification_uri_complete'], success_color),
                         result['expires_in']
                         )
                 print(msg)

--- a/jans-cli-tui/cli_tui/jans_cli_tui.py
+++ b/jans-cli-tui/cli_tui/jans_cli_tui.py
@@ -305,8 +305,8 @@ class JansCliApp(Application):
                 response = self.cli_object.get_device_verification_code()
                 result = response.json()
 
-                msg = _("Please visit verification url %s and enter user code %s within %d seconds.")
-                body = HSplit([Label(msg % (result['verification_uri'], result['user_code'], result['expires_in']),style='class:jans-main-verificationuri.text')],style='class:jans-main-verificationuri')
+                msg = _("Please visit verification url {} and authorize this device within {} seconds.")
+                body = HSplit([Label(msg.format(result['verification_uri_complete'], result['expires_in']), style='class:jans-main-verificationuri.text')], style='class:jans-main-verificationuri')
                 dialog = JansGDialog(self, title=_("Waiting Response"), body=body)
 
                 async def coroutine():


### PR DESCRIPTION
closes #4316

In this PR, TUI displays complete verification url as follows

![auth_code](https://user-images.githubusercontent.com/6398752/228215894-3e8e15ac-614c-4cce-a46f-b03f39e4b17f.png)
