### PR TITLE
test(jans-auth-server): IntrospectionWsHttpTest.bearerWithResponseAsJwt fail because it was not adapted to latest JWT changes #4358

### DIFF
--- a/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/IntrospectionWsHttpTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/IntrospectionWsHttpTest.java
@@ -50,7 +50,7 @@ public class IntrospectionWsHttpTest extends BaseTest {
         final IntrospectionService introspectionService = ClientFactory.instance().createIntrospectionService(introspectionEndpoint, engine);
         final String jwtAsString = introspectionService.introspectTokenWithResponseAsJwt("Bearer " + authorization.getAccessToken(), tokenToIntrospect.getAccessToken(), true);
         final Jwt jwt = Jwt.parse(jwtAsString);
-        assertTrue(Boolean.parseBoolean(jwt.getClaims().getClaimAsString("active")));
+        assertTrue(jwt.getClaims().getClaimAsJSON("token_introspection").getBoolean("active"));
     }
 
     @Test


### PR DESCRIPTION
### Description

test(jans-auth-server): IntrospectionWsHttpTest.bearerWithResponseAsJwt fail because it was not adapted to latest JWT changes 

#### Target issue
  
closes #4358

