### PR TITLE
fix(jans-cli-tui): use -dev isntead of -SNAPSHOT in build version

### DIFF
--- a/jans-cli-tui/setup.py
+++ b/jans-cli-tui/setup.py
@@ -60,6 +60,7 @@ def find_version(*file_paths):
     here = os.path.abspath(os.path.dirname(__file__))
     with codecs.open(os.path.join(here, *file_paths), 'r') as f:
         version_file = f.read()
+    version_file = version_file.replace('-SNAPSHOT', '-dev')
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)
     if version_match:


### PR DESCRIPTION
closes #4357