### PR TITLE
fix(jans-cli-tui): fromisoformat function for py < 3.7

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/agama.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/agama.py
@@ -15,7 +15,7 @@ from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.widgets import Button
 
 from utils.multi_lang import _
-from utils.utils import DialogUtils
+from utils.utils import DialogUtils, fromisoformat
 from utils.static import cli_style, common_strings
 from wui_components.jans_vetrical_nav import JansVerticalNav
 from wui_components.jans_path_browser import jans_file_browser_dialog, BrowseType
@@ -100,7 +100,7 @@ class Agama(DialogUtils):
                 if search_str not in project_str:
                     continue
 
-            dt_object = datetime.fromisoformat(agama['createdAt'])
+            dt_object = fromisoformat(agama['createdAt'])
             if agama.get('finishedAt'):
                 status = _("Pending")
                 error = ''

--- a/jans-cli-tui/cli_tui/utils/utils.py
+++ b/jans-cli-tui/cli_tui/utils/utils.py
@@ -1,3 +1,5 @@
+import datetime
+
 from types import SimpleNamespace
 from typing import Optional
 
@@ -83,3 +85,12 @@ class DialogUtils:
             return False
 
         return True
+
+
+def fromisoformat(dt_str):
+    dt, _, us = dt_str.partition(".")
+    dt = datetime.datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S")
+    if us:
+        us = int(us.rstrip("Z"), 10)
+        dt = dt + datetime.timedelta(microseconds=us)
+    return dt


### PR DESCRIPTION
closes #4355

SUSE 15 uses Python 3.6 whose **datetime** library does not have `fromisoformat()`