### PR TITLE
fix(jans-linux-setup): disable agama script by default (avoid blank page) #4374

### DIFF
--- a/jans-linux-setup/jans_setup/templates/scripts.ldif
+++ b/jans-linux-setup/jans_setup/templates/scripts.ldif
@@ -539,7 +539,7 @@ displayName: agama
 inum: BADA-BADA
 jansConfProperty: {"value1":"cust_param_name","value2":"agama_flow","hide":false,"description":""}
 jansConfProperty: {"value1":"default_flow_name","value2":"","hide":false,"description":""}
-jansEnabled: true
+jansEnabled: false
 jansLevel: 10
 jansModuleProperty: {"value1":"usage_type","value2":"interactive","description":""}
 jansModuleProperty: {"value1":"location_type","value2":"db","description": ""}


### PR DESCRIPTION
### Description

fix(jans-linux-setup): disable agama script by default (avoid blank page) 

#### Target issue
  
closes #4374

