### PR TITLE
fix(docker-jans-persistence-loader): disable agama engine by default

### DIFF
--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -226,7 +226,7 @@ def _transform_auth_dynamic_config(conf):
                 "templatesPath": "/ftl",
                 "scriptsPath": "/scripts",
                 "serializerType": "KRYO",
-                "maxItemsLoggedInCollections": 3,
+                "maxItemsLoggedInCollections": 9,
                 "pageMismatchErrorPage": "mismatch.ftl",
                 "interruptionErrorPage": "timeout.ftl",
                 "crashErrorPage": "crash.ftl",

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
@@ -479,7 +479,7 @@
     "redirectUrisRegexEnabled": true,
     "useHighestLevelScriptIfAcrScriptNotFound": false,
     "agamaConfiguration": {
-        "enabled": true,
+        "enabled": false,
         "templatesPath": "/ftl",
         "scriptsPath": "/scripts",
         "serializerType": "KRYO",


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4399 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

