### PR TITLE
feat: userName -> smtpAuthenticationAccountUsername;

### DIFF
--- a/jans-auth-server/common/src/main/java/io/jans/as/common/service/common/ConfigurationService.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/service/common/ConfigurationService.java
@@ -102,10 +102,10 @@ public class ConfigurationService {
         if (smtpConfiguration == null) {
             return;
         }
-        String password = smtpConfiguration.getPassword();
+        String password = smtpConfiguration.getSmtpAuthenticationAccountPassword();
         if (StringHelper.isNotEmpty(password)) {
             try {
-                smtpConfiguration.setPasswordDecrypted(encryptionService.decrypt(password));
+                smtpConfiguration.setSmtpAuthenticationAccountPasswordDecrypted(encryptionService.decrypt(password));
             } catch (EncryptionException ex) {
                 log.error("Failed to decrypt SMTP user password", ex);
             }

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -7697,15 +7697,15 @@ components:
           type: string
         whitePagesCanView:
           type: boolean
-        userCanEdit:
-          type: boolean
-        userCanView:
-          type: boolean
         adminCanAccess:
           type: boolean
         adminCanView:
           type: boolean
         adminCanEdit:
+          type: boolean
+        userCanEdit:
+          type: boolean
+        userCanView:
           type: boolean
         userCanAccess:
           type: boolean
@@ -8432,6 +8432,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        fapi:
+          type: boolean
         allResponseTypesSupported:
           uniqueItems: true
           type: array
@@ -8441,8 +8443,6 @@ components:
             - code
             - token
             - id_token
-        fapi:
-          type: boolean
     AuthenticationFilter:
       required:
       - baseDn
@@ -8963,6 +8963,8 @@ components:
         ttl:
           type: integer
           format: int32
+        displayName:
+          type: string
         authenticationMethod:
           type: string
           enum:
@@ -8988,8 +8990,6 @@ components:
             - tls_client_auth
             - self_signed_tls_client_auth
             - none
-        displayName:
-          type: string
         baseDn:
           type: string
         inum:
@@ -9219,6 +9219,8 @@ components:
     SmtpConfiguration:
       type: object
       properties:
+        valid:
+          type: boolean
         connectProtectionList:
           type: array
           items:
@@ -9227,8 +9229,6 @@ components:
             - None
             - StartTls
             - SslTls
-        valid:
-          type: boolean
         host:
           type: string
         port:
@@ -9248,9 +9248,9 @@ components:
           type: string
         requires_authentication:
           type: boolean
-        user_name:
+        smtp_authentication_account_username:
           type: string
-        password:
+        smtp_authentication_account_password:
           type: string
         key-store:
           type: string

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/ConfigSmtpResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/ConfigSmtpResource.java
@@ -146,7 +146,7 @@ public class ConfigSmtpResource extends ConfigBaseResource {
         log.debug("smtpTest:{}", smtpTest);
         SmtpConfiguration smtpConfiguration = configurationService.getConfiguration().getSmtpConfiguration();
         log.debug(SMTP_CONFIGURATION + ":{}", smtpConfiguration);
-        smtpConfiguration.setPasswordDecrypted(encryptionService.decrypt(smtpConfiguration.getPassword()));
+        smtpConfiguration.setSmtpAuthenticationAccountPasswordDecrypted(encryptionService.decrypt(smtpConfiguration.getSmtpAuthenticationAccountPassword()));
         smtpConfiguration.setKeyStorePasswordDecrypted(encryptionService.decrypt(smtpConfiguration.getKeyStorePassword()));
         boolean status = false;
         if (smtpTest.getSign()) {
@@ -185,13 +185,13 @@ public class ConfigSmtpResource extends ConfigBaseResource {
         if (smtpConfiguration == null) {
             return smtpConfiguration;
         }
-        String password = smtpConfiguration.getPassword();
+        String password = smtpConfiguration.getSmtpAuthenticationAccountPassword();
         if (password != null && !password.isEmpty()) {
             try {
                 encryptionService.decrypt(password);
             } catch (Exception ex) {
                 log.error("Exception while decryption of smtpConfiguration password hence will encrypt it!!!");
-                smtpConfiguration.setPassword(encryptionService.encrypt(password));
+                smtpConfiguration.setSmtpAuthenticationAccountPassword(encryptionService.encrypt(password));
             }
         }
         password = smtpConfiguration.getKeyStorePassword();
@@ -208,9 +208,9 @@ public class ConfigSmtpResource extends ConfigBaseResource {
 
     private SmtpConfiguration decryptPassword(SmtpConfiguration smtpConfiguration) throws EncryptionException {
         if (smtpConfiguration != null) {
-            String password = smtpConfiguration.getPassword();
+            String password = smtpConfiguration.getSmtpAuthenticationAccountPassword();
             if (password != null && !password.isEmpty()) {
-                smtpConfiguration.setPasswordDecrypted(encryptionService.decrypt(password));
+                smtpConfiguration.setSmtpAuthenticationAccountPasswordDecrypted(encryptionService.decrypt(password));
             }
             password = smtpConfiguration.getKeyStorePassword();
             if (password != null && !password.isEmpty()) {

--- a/jans-core/service/src/main/java/io/jans/service/MailService.java
+++ b/jans-core/service/src/main/java/io/jans/service/MailService.java
@@ -175,8 +175,8 @@ public class MailService {
         if (mailSmtpConfiguration.isRequiresAuthentication()) {
             props.put("mail.smtp.auth", "true");
 
-            final String userName = mailSmtpConfiguration.getUserName();
-            final String password = mailSmtpConfiguration.getPasswordDecrypted();
+            final String userName = mailSmtpConfiguration.getSmtpAuthenticationAccountUsername();
+            final String password = mailSmtpConfiguration.getSmtpAuthenticationAccountPasswordDecrypted();
             
             session = Session.getInstance(props, new javax.mail.Authenticator() {
                 protected PasswordAuthentication getPasswordAuthentication() {
@@ -337,8 +337,8 @@ public class MailService {
                 props.put("mail.smtp.auth", "true");
             }
 
-            final String userName = mailSmtpConfiguration.getUserName();
-            final String password = mailSmtpConfiguration.getPasswordDecrypted();
+            final String userName = mailSmtpConfiguration.getSmtpAuthenticationAccountUsername();
+            final String password = mailSmtpConfiguration.getSmtpAuthenticationAccountPasswordDecrypted();
 
             session = Session.getInstance(props, new javax.mail.Authenticator() {
                 protected PasswordAuthentication getPasswordAuthentication() {

--- a/jans-core/util/src/main/java/io/jans/model/SmtpConfiguration.java
+++ b/jans-core/util/src/main/java/io/jans/model/SmtpConfiguration.java
@@ -43,15 +43,15 @@ public class SmtpConfiguration implements java.io.Serializable {
     @JsonProperty("requires_authentication")
     private boolean requiresAuthentication;
 
-    @JsonProperty("user_name")
-    private String userName;
+    @JsonProperty("smtp_authentication_account_username")
+    private String smtpAuthenticationAccountUsername;
 
-    @JsonProperty("password")
-    private String password;
+    @JsonProperty("smtp_authentication_account_password")
+    private String smtpAuthenticationAccountPassword;
 
     @Transient
     @JsonIgnore
-    private String passwordDecrypted;
+    private String smtpAuthenticationAccountPasswordDecrypted;
     
     @JsonProperty("key-store")
     private String keyStore;
@@ -128,31 +128,31 @@ public class SmtpConfiguration implements java.io.Serializable {
     public boolean isValid() {
         return getHost() != null && getPort() != 0
                 && ((!isRequiresAuthentication())
-                || (getUserName() != null && getPassword() != null));
+                || (getSmtpAuthenticationAccountUsername() != null && getSmtpAuthenticationAccountPassword() != null));
     }
 
-    public String getUserName() {
-        return userName;
+    public String getSmtpAuthenticationAccountUsername() {
+        return smtpAuthenticationAccountUsername;
     }
 
-    public void setUserName(String userName) {
-        this.userName = userName;
+    public void setSmtpAuthenticationAccountUsername(String smtpAuthenticationAccountUsername) {
+        this.smtpAuthenticationAccountUsername = smtpAuthenticationAccountUsername;
     }
 
-    public String getPassword() {
-        return password;
+    public String getSmtpAuthenticationAccountPassword() {
+        return smtpAuthenticationAccountPassword;
     }
 
-    public void setPassword(String password) {
-        this.password = password;
+    public void setSmtpAuthenticationAccountPassword(String smtpAuthenticationAccountPassword) {
+        this.smtpAuthenticationAccountPassword = smtpAuthenticationAccountPassword;
     }
 
-    public String getPasswordDecrypted() {
-        return passwordDecrypted;
+    public String getSmtpAuthenticationAccountPasswordDecrypted() {
+        return smtpAuthenticationAccountPasswordDecrypted;
     }
 
-    public void setPasswordDecrypted(String passwordDecrypted) {
-        this.passwordDecrypted = passwordDecrypted;
+    public void setSmtpAuthenticationAccountPasswordDecrypted(String smtpAuthenticationAccountPasswordDecrypted) {
+        this.smtpAuthenticationAccountPasswordDecrypted = smtpAuthenticationAccountPasswordDecrypted;
     }
     
     public SmtpConnectProtectionType[] getConnectProtectionList() {

--- a/jans-scim/service/src/main/java/io/jans/scim/service/ConfigurationService.java
+++ b/jans-scim/service/src/main/java/io/jans/scim/service/ConfigurationService.java
@@ -215,7 +215,7 @@ public class ConfigurationService implements Serializable {
 		if (smtpConfiguration == null) {
 			return;
 		}
-		String password = smtpConfiguration.getPasswordDecrypted();
+		String password = smtpConfiguration.getSmtpAuthenticationAccountPasswordDecrypted();
 		if (StringHelper.isNotEmpty(password)) {
 			try {
 				String encryptedPassword = encryptionService.encrypt(password);

--- a/jans-scim/service/src/main/java/io/jans/scim/service/ConfigurationService.java
+++ b/jans-scim/service/src/main/java/io/jans/scim/service/ConfigurationService.java
@@ -219,7 +219,7 @@ public class ConfigurationService implements Serializable {
 		if (StringHelper.isNotEmpty(password)) {
 			try {
 				String encryptedPassword = encryptionService.encrypt(password);
-				smtpConfiguration.setPassword(encryptedPassword);
+				smtpConfiguration.setSmtpAuthenticationAccountPassword(encryptedPassword);
 			} catch (EncryptionException ex) {
 				log.error("Failed to encrypt SMTP password", ex);
 			}
@@ -230,10 +230,10 @@ public class ConfigurationService implements Serializable {
 		if (smtpConfiguration == null) {
 			return;
 		}
-		String password = smtpConfiguration.getPassword();
+		String password = smtpConfiguration.getSmtpAuthenticationAccountPassword();
 		if (StringHelper.isNotEmpty(password)) {
 			try {
-				smtpConfiguration.setPasswordDecrypted(encryptionService.decrypt(password));
+				smtpConfiguration.setSmtpAuthenticationAccountPasswordDecrypted(encryptionService.decrypt(password));
 			} catch (EncryptionException ex) {
 				log.error("Failed to decrypt SMTP password", ex);
 			}


### PR DESCRIPTION
Renamed:
userName -> smtpAuthenticationAccountUsername (json prop '**smtp_authentication_account_username**');
password -> smtpAuthenticationAccountPassword (json prop '**smtp_authentication_account_password**');
passwordDecrypted -> smtpAuthenticationAccountPasswordDecrypted;

i.e. now:
```
/opt/jans/jans-cli/cli/config_cli.py --operation-id put-config-smtp --data ./smtp.json
```
, where **smtp.json** contains:
```
{
    "connectProtectionList":
        [
            "NONE",
            "START_TLS",
            "SSL_TLS"
        ],

    "trust_host": true,
    "connect-protection": "SslTls",
    "host": "smtp.gmail.com",
    "port": 465,
    "smtp_authentication_account_username": "sman2dev@gmail.com",
    "from_name": "Sergey Man",
    "from_email_address": "sman2dev@gmail.com",
    "requires_authentication": true,
    "smtp_authentication_account_password":"******************************",
    "key-store":"/etc/certs/smtp-keys.p12",
    "key-store-password":"3afH2BnO8qHB",
    "key-store-alias":"smtp_sig_ec256",
    "signing-algorithm":"SHA256withECDSA"
}
```

Issue: #4403.

.
Closes #4402, 