### PR TITLE
feat(jans-auth-server): increase sessionIdUnauthenticatedUnusedLifetime value in setup #4445

### DIFF
--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.json
@@ -350,7 +350,7 @@
         }
     ],
     "sessionIdUnusedLifetime":86400,
-    "sessionIdUnauthenticatedUnusedLifetime":120,
+    "sessionIdUnauthenticatedUnusedLifetime":7200,
     "changeSessionIdOnAuthentication":true,
     "returnClientSecretOnRead": true,
     "sessionIdPersistOnPromptNone":true,

--- a/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
+++ b/docker-jans-persistence-loader/templates/jans-auth/jans-auth-config.ob.json
@@ -269,7 +269,7 @@
     "clientAuthenticationFilters":[
     ],
     "sessionIdUnusedLifetime":86400,
-    "sessionIdUnauthenticatedUnusedLifetime":120,
+    "sessionIdUnauthenticatedUnusedLifetime":7200,
     "changeSessionIdOnAuthentication":true,
     "returnClientSecretOnRead": true,
     "sessionIdPersistOnPromptNone":true,

--- a/docs/admin/config-guide/jans-cli/cli-jans-authorization-server.md
+++ b/docs/admin/config-guide/jans-cli/cli-jans-authorization-server.md
@@ -411,7 +411,7 @@ It returns all the information of the Jans Authorization server.
     }
   ],
   "sessionIdUnusedLifetime": 86400,
-  "sessionIdUnauthenticatedUnusedLifetime": 120,
+  "sessionIdUnauthenticatedUnusedLifetime": 7200,
   "sessionIdPersistOnPromptNone": true,
   "sessionIdRequestParameterEnabled": false,
   "changeSessionIdOnAuthentication": true,

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -431,7 +431,7 @@ public class AppConfiguration implements Configuration {
     private int sessionIdUnusedLifetime;
 
     @DocProperty(description = "The lifetime for unused unauthenticated session states")
-    private int sessionIdUnauthenticatedUnusedLifetime = 120; // 120 seconds
+    private int sessionIdUnauthenticatedUnusedLifetime = 7200; // 2h
 
     @DocProperty(description = "Boolean value specifying whether to persist session ID on prompt none")
     private Boolean sessionIdPersistOnPromptNone;

--- a/jans-auth-server/server/conf/jans-config.json
+++ b/jans-auth-server/server/conf/jans-config.json
@@ -322,7 +322,7 @@
     ],
     "applianceInum":"${config.oxauth.appliance}",
     "sessionIdUnusedLifetime":86400,
-    "sessionIdUnauthenticatedUnusedLifetime":60,
+    "sessionIdUnauthenticatedUnusedLifetime":7200,
     "sessionIdEnabled":true,
     "sessionIdPersistOnPromptNone":true,
     "sessionIdLifetime":86400,

--- a/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/openbanking/templates/jans-auth/jans-auth-config.json
@@ -269,7 +269,7 @@
     "clientAuthenticationFilters":[
     ],
     "sessionIdUnusedLifetime":86400,
-    "sessionIdUnauthenticatedUnusedLifetime":120,
+    "sessionIdUnauthenticatedUnusedLifetime":7200,
     "changeSessionIdOnAuthentication":true,
     "returnClientSecretOnRead": true,
     "sessionIdPersistOnPromptNone":true,

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -355,7 +355,7 @@
         }
     ],
     "sessionIdUnusedLifetime":86400,
-    "sessionIdUnauthenticatedUnusedLifetime":120,
+    "sessionIdUnauthenticatedUnusedLifetime":7200,
     "changeSessionIdOnAuthentication":true,
     "returnClientSecretOnRead": true,
     "sessionIdPersistOnPromptNone":true,


### PR DESCRIPTION
### Description

feat(jans-auth-server): increase sessionIdUnauthenticatedUnusedLifetime value in setup

#### Target issue
  
closes #4445


-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

