### PR TITLE
fix(jans-auth-server) - client registration request defaults to code flow #4296

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/registration/RegisterParamsValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/registration/RegisterParamsValidator.java
@@ -284,9 +284,7 @@ public class RegisterParamsValidator {
                         case WEB:
                             if (HTTP.equalsIgnoreCase(uri.getScheme())) {
                                 if (!LOCALHOST.equalsIgnoreCase(uri.getHost()) && !LOOPBACK.equalsIgnoreCase(uri.getHost())) {
-                                    log.debug("Invalid protocol for redirect_uri: " +
-                                            redirectUri +
-                                            " (only https protocol is allowed for application_type=web or localhost/127.0.0.1 for http)");
+                                    log.debug("Invalid protocol for redirect_uri: {} (only https protocol is allowed for application_type=web or localhost/127.0.0.1 for http)", redirectUri);
                                     valid = false;
                                 }
                             }
@@ -304,6 +302,7 @@ public class RegisterParamsValidator {
                                 grantTypes.contains(GrantType.CLIENT_CREDENTIALS)))
                 && !responseTypes.contains(ResponseType.TOKEN) && !responseTypes.contains(ResponseType.ID_TOKEN);
 
+        log.trace("Validating redirect uris ... valid: {}, redirectUris: {}, grantTypes: {}, subjectType: {}", valid, redirectUris, grantTypes, subjectType);
 
         /*
          * Providers that use pairwise sub (subject) values SHOULD utilize the sector_identifier_uri value
@@ -388,6 +387,10 @@ public class RegisterParamsValidator {
      * All the Redirect Uris must match to return true.
      */
     private boolean checkWhiteListRedirectUris(List<String> redirectUris) {
+        if (redirectUris == null || redirectUris.isEmpty()) {
+            return true;
+        }
+
         boolean valid = true;
         List<String> whiteList = appConfiguration.getClientWhiteList();
         URLPatternList urlPatternList = new URLPatternList(whiteList);
@@ -403,6 +406,10 @@ public class RegisterParamsValidator {
      * None of the Redirect Uris must match to return true.
      */
     private boolean checkBlackListRedirectUris(List<String> redirectUris) {
+        if (redirectUris == null || redirectUris.isEmpty()) {
+            return true;
+        }
+
         boolean valid = true;
         List<String> blackList = appConfiguration.getClientBlackList();
         URLPatternList urlPatternList = new URLPatternList(blackList);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterService.java
@@ -81,6 +81,88 @@ public class RegisterService {
         return null;
     }
 
+    public Set<ResponseType> identifyResponseTypes(Collection<ResponseType> requestResponseTypes, Collection<GrantType> requestGrantTypes) {
+        Set<ResponseType> result = new HashSet<>(requestResponseTypes);
+
+        if (result.isEmpty()) { // fallback to "code", spec: If omitted, the default is that the Client will use only the code Response Type.
+            result.add(ResponseType.CODE);
+        }
+
+        if (isTrue(appConfiguration.getGrantTypesAndResponseTypesAutofixEnabled())) {
+            if (isTrue(appConfiguration.getClientRegDefaultToCodeFlowWithRefresh())) {
+                if (result.isEmpty()) {
+                    result.add(ResponseType.CODE);
+                }
+
+                if (requestGrantTypes.contains(GrantType.AUTHORIZATION_CODE)) {
+                    result.add(ResponseType.CODE);
+                }
+            }
+            if (requestGrantTypes.contains(GrantType.IMPLICIT)) {
+                result.add(ResponseType.TOKEN);
+            }
+        }
+
+        result.retainAll(appConfiguration.getAllResponseTypesSupported());
+        return result;
+    }
+
+    public Set<GrantType> identifyGrantTypes(Collection<ResponseType> identifiedResponseTypes, Collection<GrantType> requestGrantTypes) {
+        Set<GrantType> result = new HashSet<>(requestGrantTypes);
+
+        if (result.isEmpty()) {
+            result.add(GrantType.AUTHORIZATION_CODE);
+        }
+
+        if (isTrue(appConfiguration.getGrantTypesAndResponseTypesAutofixEnabled())) {
+            if (isTrue(appConfiguration.getClientRegDefaultToCodeFlowWithRefresh())) {
+                if (identifiedResponseTypes.contains(ResponseType.CODE)) {
+                    result.add(GrantType.AUTHORIZATION_CODE);
+                    result.add(GrantType.REFRESH_TOKEN);
+                }
+                if (result.contains(GrantType.AUTHORIZATION_CODE)) {
+                    identifiedResponseTypes.add(ResponseType.CODE);
+                    result.add(GrantType.REFRESH_TOKEN);
+                }
+            }
+
+            if (identifiedResponseTypes.contains(ResponseType.TOKEN) || identifiedResponseTypes.contains(ResponseType.ID_TOKEN)) {
+                result.add(GrantType.IMPLICIT);
+            }
+            if (result.contains(GrantType.IMPLICIT)) {
+                identifiedResponseTypes.add(ResponseType.TOKEN);
+            }
+        }
+
+        result.retainAll(appConfiguration.getGrantTypesSupported());
+        result.retainAll(appConfiguration.getDynamicGrantTypeDefault());
+
+        return result;
+    }
+
+    private void assignResponseTypesAndGrantTypes(Client client, RegisterRequest requestObject, boolean update) {
+        final Set<ResponseType> identifiedResponseTypes = identifyResponseTypes(requestObject.getResponseTypes(), requestObject.getGrantTypes());
+        final Set<GrantType> identifiedGrantTypes = identifyGrantTypes(identifiedResponseTypes, requestObject.getGrantTypes());
+
+        final boolean isNewClient = !update;
+
+        if (isNewClient || !requestObject.getResponseTypes().isEmpty()) {
+            client.setResponseTypes(identifiedResponseTypes.toArray(new ResponseType[0]));
+        }
+
+        if (isNewClient || (isTrue(appConfiguration.getEnableClientGrantTypeUpdate()) && !requestObject.getGrantTypes().isEmpty())) {
+            client.setGrantTypes(identifiedGrantTypes.toArray(new GrantType[0]));
+        }
+
+        log.trace("Updating client with responseTypes: {}, grantTypes: {}, isNewClient: {}", identifiedResponseTypes, identifiedGrantTypes, isNewClient);
+    }
+
+    @SuppressWarnings("java:S1168")
+    public static String[] listAsArrayWithoutDuplicates(List<String> list) {
+        List<String> result = new ArrayList<>(new HashSet<>(list)); // Remove repeated elements
+        return result.toArray(new String[0]);
+    }
+
     // yuriyz - ATTENTION : this method is used for both registration and update client metadata cases, therefore any logic here
     // will be applied for both cases.
     @SuppressWarnings("java:S3776")
@@ -91,13 +173,12 @@ public class RegisterService {
 
         List<String> redirectUris = requestObject.getRedirectUris();
         if (redirectUris != null && !redirectUris.isEmpty()) {
-            redirectUris = new ArrayList<>(new HashSet<>(redirectUris)); // Remove repeated elements
-            client.setRedirectUris(redirectUris.toArray(new String[0]));
+            client.setRedirectUris(listAsArrayWithoutDuplicates(redirectUris));
         }
+
         List<String> claimsRedirectUris = requestObject.getClaimsRedirectUris();
         if (claimsRedirectUris != null && !claimsRedirectUris.isEmpty()) {
-            claimsRedirectUris = new ArrayList<>(new HashSet<>(claimsRedirectUris)); // Remove repeated elements
-            client.setClaimRedirectUris(claimsRedirectUris.toArray(new String[0]));
+            client.setClaimRedirectUris(listAsArrayWithoutDuplicates(claimsRedirectUris));
         }
 
         client.setApplicationType(requestObject.getApplicationType() != null ? requestObject.getApplicationType() : ApplicationType.WEB);
@@ -106,48 +187,11 @@ public class RegisterService {
             client.setSectorIdentifierUri(requestObject.getSectorIdentifierUri());
         }
 
-        Set<ResponseType> responseTypeSet = new HashSet<>(requestObject.getResponseTypes());
-        Set<GrantType> grantTypeSet = new HashSet<>(requestObject.getGrantTypes());
-
-        if (isTrue(appConfiguration.getGrantTypesAndResponseTypesAutofixEnabled())) {
-            if (isTrue(appConfiguration.getClientRegDefaultToCodeFlowWithRefresh())) {
-                if (responseTypeSet.isEmpty() && grantTypeSet.isEmpty()) {
-                    responseTypeSet.add(ResponseType.CODE);
-                }
-                if (responseTypeSet.contains(ResponseType.CODE)) {
-                    grantTypeSet.add(GrantType.AUTHORIZATION_CODE);
-                    grantTypeSet.add(GrantType.REFRESH_TOKEN);
-                }
-                if (grantTypeSet.contains(GrantType.AUTHORIZATION_CODE)) {
-                    responseTypeSet.add(ResponseType.CODE);
-                    grantTypeSet.add(GrantType.REFRESH_TOKEN);
-                }
-            }
-            if (responseTypeSet.contains(ResponseType.TOKEN) || responseTypeSet.contains(ResponseType.ID_TOKEN)) {
-                grantTypeSet.add(GrantType.IMPLICIT);
-            }
-            if (grantTypeSet.contains(GrantType.IMPLICIT)) {
-                responseTypeSet.add(ResponseType.TOKEN);
-            }
-        }
-
-        responseTypeSet.retainAll(appConfiguration.getAllResponseTypesSupported());
-        grantTypeSet.retainAll(appConfiguration.getGrantTypesSupported());
-
-        Set<GrantType> dynamicGrantTypeDefault = appConfiguration.getDynamicGrantTypeDefault();
-        grantTypeSet.retainAll(dynamicGrantTypeDefault);
-
-        if (!update || !requestObject.getResponseTypes().isEmpty()) {
-            client.setResponseTypes(responseTypeSet.toArray(new ResponseType[0]));
-        }
-        if (!update || (isTrue(appConfiguration.getEnableClientGrantTypeUpdate()) && !requestObject.getGrantTypes().isEmpty())) {
-            client.setGrantTypes(grantTypeSet.toArray(new GrantType[0]));
-        }
+        assignResponseTypesAndGrantTypes(client, requestObject, update);
 
         List<String> contacts = requestObject.getContacts();
         if (contacts != null && !contacts.isEmpty()) {
-            contacts = new ArrayList<>(new HashSet<>(contacts)); // Remove repeated elements
-            client.setContacts(contacts.toArray(new String[0]));
+            client.setContacts(listAsArrayWithoutDuplicates(contacts));
         }
 
         for (String key : requestObject.getClientNameLanguageTags()) {
@@ -282,8 +326,7 @@ public class RegisterService {
         }
         List<String> defaultAcrValues = requestObject.getDefaultAcrValues();
         if (defaultAcrValues != null && !defaultAcrValues.isEmpty()) {
-            defaultAcrValues = new ArrayList<>(new HashSet<>(defaultAcrValues)); // Remove repeated elements
-            client.setDefaultAcrValues(defaultAcrValues.toArray(new String[defaultAcrValues.size()]));
+            client.setDefaultAcrValues(listAsArrayWithoutDuplicates(defaultAcrValues));
         }
         if (StringUtils.isNotBlank(requestObject.getInitiateLoginUri())) {
             client.setInitiateLoginUri(requestObject.getInitiateLoginUri());
@@ -304,13 +347,12 @@ public class RegisterService {
 
         final List<String> groups = requestObject.getGroups();
         if (groups != null && !groups.isEmpty()) {
-            client.setGroups(new HashSet<>(groups).toArray(new String[0])); // remove duplicates
+            client.setGroups(listAsArrayWithoutDuplicates(groups));
         }
 
         List<String> postLogoutRedirectUris = requestObject.getPostLogoutRedirectUris();
         if (postLogoutRedirectUris != null && !postLogoutRedirectUris.isEmpty()) {
-            postLogoutRedirectUris = new ArrayList<>(new HashSet<>(postLogoutRedirectUris)); // Remove repeated elements
-            client.setPostLogoutRedirectUris(postLogoutRedirectUris.toArray(new String[postLogoutRedirectUris.size()]));
+            client.setPostLogoutRedirectUris(listAsArrayWithoutDuplicates(postLogoutRedirectUris));
         }
 
         if (StringUtils.isNotBlank(requestObject.getFrontChannelLogoutUri())) {
@@ -325,18 +367,16 @@ public class RegisterService {
 
         List<String> requestUris = requestObject.getRequestUris();
         if (requestUris != null && !requestUris.isEmpty()) {
-            requestUris = new ArrayList<>(new HashSet<>(requestUris)); // Remove repeated elements
-            client.setRequestUris(requestUris.toArray(new String[requestUris.size()]));
+            client.setRequestUris(listAsArrayWithoutDuplicates(requestUris));
         }
 
         List<String> authorizedOrigins = requestObject.getAuthorizedOrigins();
         if (authorizedOrigins != null && !authorizedOrigins.isEmpty()) {
-            authorizedOrigins = new ArrayList<>(new HashSet<>(authorizedOrigins)); // Remove repeated elements
-            client.setAuthorizedOrigins(authorizedOrigins.toArray(new String[authorizedOrigins.size()]));
+            client.setAuthorizedOrigins(listAsArrayWithoutDuplicates(authorizedOrigins));
         }
 
         List<String> scopes = requestObject.getScope();
-        if (grantTypeSet.contains(GrantType.RESOURCE_OWNER_PASSWORD_CREDENTIALS) && !appConfiguration.getDynamicRegistrationAllowedPasswordGrantScopes().isEmpty()) {
+        if (Arrays.asList(client.getGrantTypes()).contains(GrantType.RESOURCE_OWNER_PASSWORD_CREDENTIALS) && !appConfiguration.getDynamicRegistrationAllowedPasswordGrantScopes().isEmpty()) {
             scopes = Lists.newArrayList(scopes);
             scopes.retainAll(appConfiguration.getDynamicRegistrationAllowedPasswordGrantScopes());
         }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterServiceTest.java
@@ -4,7 +4,9 @@ import com.beust.jcommander.internal.Lists;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 import io.jans.as.common.service.AttributeService;
+import io.jans.as.model.common.ResponseType;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
 import io.jans.as.server.ciba.CIBARegisterClientMetadataService;
@@ -17,6 +19,9 @@ import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.Logger;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Set;
 
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
@@ -48,6 +53,14 @@ public class RegisterServiceTest {
 
     @Mock
     private CIBARegisterClientMetadataService cibaRegisterClientMetadataService;
+
+    @Test
+    public void identifyResponseType_whenResponseTypeIsBlank_shouldFallbackToCodeValue() {
+        when(appConfiguration.getAllResponseTypesSupported()).thenReturn(Sets.newHashSet(ResponseType.values()));
+
+        final Set<ResponseType> result = registerService.identifyResponseTypes(new ArrayList<>(), new ArrayList<>());
+        assertTrue(result.contains(ResponseType.CODE));
+    }
 
     @Test
     public void addDefaultCustomAttributes_whenCalledWithExistingConfigurationData_shouldPopulateRequestObject() throws JsonProcessingException {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterServiceTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import io.jans.as.common.service.AttributeService;
+import io.jans.as.model.common.GrantType;
 import io.jans.as.model.common.ResponseType;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
@@ -60,6 +61,80 @@ public class RegisterServiceTest {
 
         final Set<ResponseType> result = registerService.identifyResponseTypes(new ArrayList<>(), new ArrayList<>());
         assertTrue(result.contains(ResponseType.CODE));
+    }
+
+    @Test
+    public void identifyResponseType_whenResponseTypeIsNotSupported_shouldRemoveIt() {
+        when(appConfiguration.getAllResponseTypesSupported()).thenReturn(Sets.newHashSet());
+
+        final Set<ResponseType> result = registerService.identifyResponseTypes(new ArrayList<>(), new ArrayList<>());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void identifyResponseType_whenResponseTypeIsAbsentButAutofixEnabledForAuthorizationCode_shouldFix() {
+        when(appConfiguration.getAllResponseTypesSupported()).thenReturn(Sets.newHashSet(ResponseType.values()));
+        when(appConfiguration.getGrantTypesAndResponseTypesAutofixEnabled()).thenReturn(true);
+
+        final Set<ResponseType> result = registerService.identifyResponseTypes(new ArrayList<>(), Lists.newArrayList(GrantType.AUTHORIZATION_CODE));
+        assertTrue(result.contains(ResponseType.CODE));
+    }
+
+    @Test
+    public void identifyResponseType_whenResponseTypeIsAbsentButAutofixEnabledForToken_shouldFix() {
+        when(appConfiguration.getAllResponseTypesSupported()).thenReturn(Sets.newHashSet(ResponseType.values()));
+        when(appConfiguration.getGrantTypesAndResponseTypesAutofixEnabled()).thenReturn(true);
+
+        final Set<ResponseType> result = registerService.identifyResponseTypes(new ArrayList<>(), Lists.newArrayList(GrantType.IMPLICIT));
+        assertTrue(result.contains(ResponseType.TOKEN));
+    }
+
+    @Test
+    public void identifyGrantType_whenGrantTypeIsBlank_shouldFallbackToCodeValue() {
+        when(appConfiguration.getGrantTypesSupported()).thenReturn(Sets.newHashSet(GrantType.values()));
+        when(appConfiguration.getDynamicGrantTypeDefault()).thenReturn(Sets.newHashSet(GrantType.values()));
+
+        final Set<GrantType> result = registerService.identifyGrantTypes(new ArrayList<>(), new ArrayList<>());
+        assertTrue(result.contains(GrantType.AUTHORIZATION_CODE));
+    }
+
+    @Test
+    public void identifyGrantType_whenGrantTypeIsNotSupported_shouldRemoveIt() {
+        when(appConfiguration.getGrantTypesSupported()).thenReturn(Sets.newHashSet());
+        when(appConfiguration.getDynamicGrantTypeDefault()).thenReturn(Sets.newHashSet(GrantType.values()));
+
+        final Set<GrantType> result = registerService.identifyGrantTypes(new ArrayList<>(), new ArrayList<>());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void identifyGrantType_whenGrantTypeIsAbsentButAutofixEnabledForAuthorizationCode_shouldFix() {
+        when(appConfiguration.getGrantTypesSupported()).thenReturn(Sets.newHashSet(GrantType.values()));
+        when(appConfiguration.getDynamicGrantTypeDefault()).thenReturn(Sets.newHashSet(GrantType.values()));
+        when(appConfiguration.getGrantTypesAndResponseTypesAutofixEnabled()).thenReturn(true);
+
+        final Set<GrantType> result = registerService.identifyGrantTypes(Lists.newArrayList(ResponseType.CODE), new ArrayList<>());
+        assertTrue(result.contains(GrantType.AUTHORIZATION_CODE));
+    }
+
+    @Test
+    public void identifyGrantType_whenGrantTypeIsAbsentButAutofixEnabledForToken_shouldFix() {
+        when(appConfiguration.getGrantTypesSupported()).thenReturn(Sets.newHashSet(GrantType.values()));
+        when(appConfiguration.getDynamicGrantTypeDefault()).thenReturn(Sets.newHashSet(GrantType.values()));
+        when(appConfiguration.getGrantTypesAndResponseTypesAutofixEnabled()).thenReturn(true);
+
+        final Set<GrantType> result = registerService.identifyGrantTypes(Lists.newArrayList(ResponseType.TOKEN), new ArrayList<>());
+        assertTrue(result.contains(GrantType.IMPLICIT));
+    }
+
+    @Test
+    public void identifyGrantType_whenGrantTypeIsAbsentButAutofixEnabledForIdToken_shouldFix() {
+        when(appConfiguration.getGrantTypesSupported()).thenReturn(Sets.newHashSet(GrantType.values()));
+        when(appConfiguration.getDynamicGrantTypeDefault()).thenReturn(Sets.newHashSet(GrantType.values()));
+        when(appConfiguration.getGrantTypesAndResponseTypesAutofixEnabled()).thenReturn(true);
+
+        final Set<GrantType> result = registerService.identifyGrantTypes(Lists.newArrayList(ResponseType.ID_TOKEN), new ArrayList<>());
+        assertTrue(result.contains(GrantType.IMPLICIT));
     }
 
     @Test


### PR DESCRIPTION
### Description

fix(jans-auth-server) - client registration request defaults to code flow 

>> response_types
OPTIONAL. JSON array containing a list of the OAuth 2.0 response_type values that the Client is declaring that it will restrict itself to using. **If omitted, the default is that the Client will use only the code Response Type.**

>> grant_types
OPTIONAL. JSON array containing a list of the OAuth 2.0 Grant Types that the Client is declaring that it will restrict itself to using.  **If omitted, the default is that the Client will use only the authorization_code Grant Type.**

https://openid.net/specs/openid-connect-registration-1_0.html

#### Target issue
  
closes #4296

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

