### PR TITLE
fix: mailservice should send non signed emails, if keystore isn't defined (update);

### DIFF
--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -7652,6 +7652,8 @@ components:
           type: string
         description:
           type: string
+        version:
+          type: string
         configs:
           type: object
           additionalProperties:
@@ -7879,19 +7881,19 @@ components:
           $ref: '#/components/schemas/AttributeValidation'
         tooltip:
           type: string
-        adminCanAccess:
-          type: boolean
         adminCanView:
-          type: boolean
-        adminCanEdit:
           type: boolean
         userCanAccess:
           type: boolean
+        adminCanAccess:
+          type: boolean
+        adminCanEdit:
+          type: boolean
         userCanView:
           type: boolean
-        whitePagesCanView:
-          type: boolean
         userCanEdit:
+          type: boolean
+        whitePagesCanView:
           type: boolean
         baseDn:
           type: string
@@ -9431,10 +9433,10 @@ components:
           type: array
           items:
             type: object
-        displayValue:
-          type: string
         value:
           type: object
+        displayValue:
+          type: string
         clientAuthMapSchema:
           type: object
           additionalProperties:

--- a/jans-config-api/plugins/docs/user-mgt-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/user-mgt-plugin-swagger.yaml
@@ -826,10 +826,10 @@ components:
           type: array
           items:
             type: object
-        displayValue:
-          type: string
         value:
           type: object
+        displayValue:
+          type: string
         clientAuthMapSchema:
           type: object
           additionalProperties:

--- a/jans-core/service/src/main/java/io/jans/service/MailService.java
+++ b/jans-core/service/src/main/java/io/jans/service/MailService.java
@@ -94,10 +94,16 @@ public class MailService {
         mc.addMailcap("multipart/*;; x-java-content-handler=com.sun.mail.handlers.multipart_mixed");
         mc.addMailcap("message/rfc822;; x-java-content- handler=com.sun.mail.handlers.message_rfc822");
 
-        String keystoreFile = smtpConfiguration.getKeyStore();
-        String keystoreSecret = smtpConfiguration.getKeyStorePasswordDecrypted();
-
         try {
+            String keystoreFile = smtpConfiguration.getKeyStore();
+            String keystoreSecret = smtpConfiguration.getKeyStorePasswordDecrypted();
+            String keystoreAlias = smtpConfiguration.getKeyStoreAlias();
+            String keystoreSigningAlgorithm = smtpConfiguration.getSigningAlgorithm();
+
+            if(keystoreFile == null || keystoreSecret == null || keystoreAlias == null || keystoreSigningAlgorithm == null) {
+                return;
+            }
+
             SecurityProviderUtility.KeyStorageType keystoreType = SecurityProviderUtility.solveKeyStorageType(keystoreFile);
 
             InputStream is = new FileInputStream(keystoreFile);
@@ -118,15 +124,15 @@ public class MailService {
             }
             keyStore.load(is, keystoreSecret.toCharArray());
             Certificate[] certificates = null;
-            privateKey = (PrivateKey)keyStore.getKey(smtpConfiguration.getKeyStoreAlias(), smtpConfiguration.getKeyStorePasswordDecrypted().toCharArray());
-            certificates = keyStore.getCertificateChain(smtpConfiguration.getKeyStoreAlias());
+            privateKey = (PrivateKey)keyStore.getKey(keystoreAlias, keystoreSecret.toCharArray());
+            certificates = keyStore.getCertificateChain(keystoreAlias);
             if (certificates != null) {
                 x509Certificates = new X509Certificate[certificates.length];
                 for (int i = 0; i < certificates.length; i++) {
                     x509Certificates[i] = (X509Certificate)certificates[i];
                 }
             }
-            isReadyForSign = (privateKey != null && x509Certificates != null && smtpConfiguration.getSigningAlgorithm() != null);             
+            isReadyForSign = (privateKey != null && x509Certificates != null && keystoreSigningAlgorithm != null);
         }
         catch (Exception ex) {
             isReadyForSign = false;

--- a/jans-core/util/src/main/java/io/jans/model/SmtpConfiguration.java
+++ b/jans-core/util/src/main/java/io/jans/model/SmtpConfiguration.java
@@ -23,51 +23,51 @@ public class SmtpConfiguration implements java.io.Serializable {
     private static final long serialVersionUID = -5675038049444038755L;
 
     @JsonProperty("host")
-    private String host;
+    private String host = null;
 
     @JsonProperty("port")
-    private int port;
+    private int port = 0;
     
     @JsonProperty("connect_protection")
-    private SmtpConnectProtectionType connectProtection;
+    private SmtpConnectProtectionType connectProtection = null;
 
     @JsonProperty("trust_host")
-    private boolean serverTrust;
+    private boolean serverTrust = false;
 
     @JsonProperty("from_name")
-    private String fromName;
+    private String fromName = null;
 
     @JsonProperty("from_email_address")
-    private String fromEmailAddress;
+    private String fromEmailAddress = null;
 
     @JsonProperty("requires_authentication")
-    private boolean requiresAuthentication;
+    private boolean requiresAuthentication = false;
 
     @JsonProperty("smtp_authentication_account_username")
-    private String smtpAuthenticationAccountUsername;
+    private String smtpAuthenticationAccountUsername = null;
 
     @JsonProperty("smtp_authentication_account_password")
-    private String smtpAuthenticationAccountPassword;
+    private String smtpAuthenticationAccountPassword = null;
 
     @Transient
     @JsonIgnore
-    private String smtpAuthenticationAccountPasswordDecrypted;
+    private String smtpAuthenticationAccountPasswordDecrypted = null;
 
     @JsonProperty("key_store")
-    private String keyStore;
+    private String keyStore = null;
 
     @JsonProperty("key_store_password")
-    private String keyStorePassword;
+    private String keyStorePassword = null;
 
     @Transient
     @JsonIgnore
-    private String keyStorePasswordDecrypted;
+    private String keyStorePasswordDecrypted = null;
 
     @JsonProperty("key_store_alias")
-    private String keyStoreAlias;
+    private String keyStoreAlias = null;
 
     @JsonProperty("signing_algorithm")
-    private String signingAlgorithm;
+    private String signingAlgorithm = null;
 
     public String getHost() {
         return host;


### PR DESCRIPTION
-------------------

### Description

This PR should fix the problem, described here:
https://github.com/JanssenProject/jans/issues/4121#issuecomment-1502033407
.

As it seems, this code generates exception in jython (py scripts):
```
            String keystoreFile = smtpConfiguration.getKeyStore();
            String keystoreSecret = smtpConfiguration.getKeyStorePasswordDecrypted();
```   
if keystore parameters isn't defined in smtp configuration.  
I.e. if we use, for example, this JSON for configuring of smtp:
```

{
    "connectProtectionList": [
        "None",
        "StartTls",
        "SslTls"
    ],
    "trust_host": true,
    "connect_protection": "SslTls",
    "host": "smtp.gmail.com",
    "port": 465,
    "smtp_authentication_account_username": "sman2dev@gmail.com",
    "from_name": "Sergey Man",
    "from_email_address": "sman2dev@gmail.com",
    "requires_authentication": true,
    "smtp_authentication_account_password":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
}
```
.

Issue: #4121.
