### PR TITLE
fix(tent): remove print calls

### DIFF
--- a/demos/jans-tent/clientapp/__init__.py
+++ b/demos/jans-tent/clientapp/__init__.py
@@ -65,7 +65,6 @@ def get_provider_host():
 
 def ssl_verify(ssl_verify=cfg.SSL_VERIFY):
     if ssl_verify is False:
-        print("Here!")
         os.environ['CURL_CA_BUNDLE'] = ""
 
 
@@ -110,11 +109,9 @@ def create_app():
             status = 400
             # message = 'No json data posted'
         elif 'op_url' and 'redirect_uris' not in content:
-            print('needed keys NOT found in json')
             status = 400
             # message = 'Not needed keys found in json'
         else:
-            print('else')
             app.logger.info('Trying to register client %s on %s' %
                             (content['redirect_uris'], content['op_url']))
             op_url = content['op_url']
@@ -201,8 +198,6 @@ def create_app():
             return redirect('/')
 
         except Exception as error:
-            print('exception!')
-            print(error)
             app.logger.error(str(error))
             return {'error': str(error)}, 400
 


### PR DESCRIPTION
### Description
Debug information was being printed to console calling `print` function.


Closes #4588, 