### PR TITLE
fix(jans-auth-server): upgraded jettison, 1.5.2 -> 1.5.4 #4591

### DIFF
--- a/jans-auth-server/pom.xml
+++ b/jans-auth-server/pom.xml
@@ -27,7 +27,7 @@
 		<jakarta.jms.api.version>2.0.3</jakarta.jms.api.version>
 		<activemq.version>5.15.14</activemq.version>
 
-		<jettison.version>1.5.2</jettison.version>
+		<jettison.version>1.5.4</jettison.version>
 
 		<slf4j.version>1.7.25</slf4j.version>
 


### PR DESCRIPTION
### Description

fix(jans-auth-server): upgraded jettison, 1.5.2 -> 1.5.4 

#### Target issue
  
closes #4591

