### PR TITLE
fix: jsonvalue has been added;

### DIFF
--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -7652,6 +7652,8 @@ components:
           type: string
         description:
           type: string
+        version:
+          type: string
         configs:
           type: object
           additionalProperties:
@@ -7879,19 +7881,19 @@ components:
           $ref: '#/components/schemas/AttributeValidation'
         tooltip:
           type: string
-        adminCanAccess:
+        whitePagesCanView:
           type: boolean
         adminCanView:
           type: boolean
+        adminCanAccess:
+          type: boolean
         adminCanEdit:
+          type: boolean
+        userCanEdit:
           type: boolean
         userCanAccess:
           type: boolean
         userCanView:
-          type: boolean
-        whitePagesCanView:
-          type: boolean
-        userCanEdit:
           type: boolean
         baseDn:
           type: string
@@ -8632,8 +8634,6 @@ components:
           type: object
           additionalProperties:
             type: string
-        fapi:
-          type: boolean
         allResponseTypesSupported:
           uniqueItems: true
           type: array
@@ -8643,6 +8643,8 @@ components:
             - code
             - token
             - id_token
+        fapi:
+          type: boolean
         clientAuthMapSchema:
           type: object
           additionalProperties:
@@ -9431,10 +9433,10 @@ components:
           type: array
           items:
             type: object
-        value:
-          type: object
         displayValue:
           type: string
+        value:
+          type: object
         clientAuthMapSchema:
           type: object
           additionalProperties:
@@ -9602,8 +9604,6 @@ components:
     SmtpConfiguration:
       type: object
       properties:
-        valid:
-          type: boolean
         connectProtectionList:
           type: array
           items:
@@ -9612,6 +9612,8 @@ components:
             - None
             - StartTls
             - SslTls
+        valid:
+          type: boolean
         host:
           type: string
         port:

--- a/jans-core/util/src/main/java/io/jans/model/SmtpConnectProtectionType.java
+++ b/jans-core/util/src/main/java/io/jans/model/SmtpConnectProtectionType.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.jans.orm.annotation.AttributeEnum;
 
@@ -63,9 +64,9 @@ public enum SmtpConnectProtectionType implements AttributeEnum {
         return getByValue(value);
     }
 
+    @JsonValue
     @Override
     public String toString() {
         return value;
     }
-	
 }


### PR DESCRIPTION
-------------------

### Description

```
/opt/jans/jans-cli/cli/config_cli.py --operation-id get-config-smtp
```
doesn't return "connect_protection" property.

Response should contain property:
"connect_protection": "xxxxxxxx".
Ldap Db contains in **jansSmtpConf**:

...
"connectProtectionList":["NONE","START_TLS","SSL_TLS"],
"connect_protection":"SSL_TLS"
...

After fix:
Ldap Db contains in **jansSmtpConf**:

```
"connectProtectionList":["None","StartTls","SslTls"],
"connect_protection":"SslTls"
```
.

Issue: #4602