### PR TITLE
fix(jans-tent): align hostname with redirect URI

### DIFF
--- a/demos/jans-tent/README.md
+++ b/demos/jans-tent/README.md
@@ -83,7 +83,10 @@ python main.py
 
 ### Login!
 
-Navigate your browser to `https://localhost:9090` and click the link to start.
+Navigate the browser to `https://<hostname-used-in-redirect-uri>:9090` URL to access Jans Tent home page. The hostname 
+component of the URL should match the hostname componant of redirect URI as configured by `REDIRECT_URIS` entry in the 
+`clientapp/config.py` file. By default, Jans Tent uses the string `localhost` as hostname in the redirect URI. 
+So, `https://localhost:9090` should be used.  
 
 ## Manual client configuration
 

--- a/demos/jans-tent/main.py
+++ b/demos/jans-tent/main.py
@@ -1,6 +1,9 @@
 from clientapp import create_app
+from clientapp import config as cfg
+from urllib.parse import urlparse
 
 if __name__ == '__main__':
     app = create_app()
     app.debug = True
-    app.run(host='0.0.0.0', ssl_context=('cert.pem', 'key.pem'), port=9090, use_reloader=False)
+    redirect_host_name = urlparse(cfg.REDIRECT_URIS[0]).hostname
+    app.run(host=redirect_host_name, ssl_context=('cert.pem', 'key.pem'), port=9090, use_reloader=False)


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

This PR updates the README to highlight the fact that hostname should me same as the one used in redirect URI. PR also updates the code so that Tent server starts using the same hostname alias as used in redirect URI. As a result, when the server starts the logs will only show the URL using which the user can get the right response and won't get CSRF error. See before-after result below:

**Before** (showing three URLs where server is running)

![image](https://user-images.githubusercontent.com/343411/232811175-982f1273-36d3-4d6b-bee7-e2cc9ac1daf4.png)

**After** (only showing URL with hostname same as the one used in redirect URI in config.py)

![image](https://user-images.githubusercontent.com/343411/232811701-512a256e-951a-41b1-9491-b489b86ae967.png)



#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4617 



-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

