### PR TITLE
fix(jans-auth-server): forced clientWhiteList when session is valid for post_logout_redirect_uri (allowPostLogoutRedirectWithoutValidation=true ) #4672

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/session/ws/rs/EndSessionService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/session/ws/rs/EndSessionService.java
@@ -1,0 +1,26 @@
+package io.jans.as.server.session.ws.rs;
+
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.util.URLPatternList;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.slf4j.Logger;
+
+/**
+ * @author Yuriy Z
+ */
+@Named
+public class EndSessionService {
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private AppConfiguration appConfiguration;
+
+    public boolean isUrlWhiteListed(String url) {
+        final boolean result = new URLPatternList(appConfiguration.getClientWhiteList()).isUrlListed(url);
+        log.trace("White listed result: {}, url: {}", result, url);
+        return result;
+    }
+}

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/session/ws/rs/EndSessionServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/session/ws/rs/EndSessionServiceTest.java
@@ -1,0 +1,48 @@
+package io.jans.as.server.session.ws.rs;
+
+import com.google.common.collect.Lists;
+import io.jans.as.model.configuration.AppConfiguration;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class EndSessionServiceTest {
+
+    @InjectMocks
+    private EndSessionService endSessionService;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Test
+    public void isUrlWhiteListed_whenClientWhiteListAllows_shouldReturnTrue() {
+        when(appConfiguration.getClientWhiteList()).thenReturn(Lists.newArrayList("white.com"));
+
+        assertTrue(endSessionService.isUrlWhiteListed("https://white.com/path"));
+        assertTrue(endSessionService.isUrlWhiteListed("https://white.com/path?param=value"));
+        assertTrue(endSessionService.isUrlWhiteListed("http://white.com/path?param=value"));
+    }
+
+    @Test
+    public void isUrlWhiteListed_whenClientWhiteListDoesNotAllow_shouldReturnFalse() {
+        when(appConfiguration.getClientWhiteList()).thenReturn(Lists.newArrayList("some.com"));
+
+        assertFalse(endSessionService.isUrlWhiteListed("https://white.com/path"));
+        assertFalse(endSessionService.isUrlWhiteListed("https://white.com/path?param=value"));
+        assertFalse(endSessionService.isUrlWhiteListed("http://white.com/path?param=value"));
+    }
+}

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -29,6 +29,7 @@
             <class name="io.jans.as.server.authorize.ws.rs.AuthorizeActionTest" />
             <class name="io.jans.as.server.register.ws.rs.SsaValidationConfigServiceTest" />
             <class name="io.jans.as.server.session.ws.rs.EndSessionRestWebServiceImplTest" />
+            <class name="io.jans.as.server.session.ws.rs.EndSessionServiceTest" />
         </classes>
     </test>
 


### PR DESCRIPTION
### Description

fix(jans-auth-server): forced clientWhiteList when session is valid for post_logout_redirect_uri (allowPostLogoutRedirectWithoutValidation=true ) 

#### Target issue
  
closes #4672

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

