### PR TITLE
feat(tent): add `scope` in DCR request

### DIFF
--- a/demos/jans-tent/.gitignore
+++ b/demos/jans-tent/.gitignore
@@ -1,5 +1,6 @@
 #jans-tent-specific
 client_info.json
+*.log.*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/demos/jans-tent/README.md
+++ b/demos/jans-tent/README.md
@@ -111,21 +111,25 @@ to download and install a new OP TLS certificate
 
 ## Other Tent endpoints
 
-**Auto-register endpoint**
+### Auto-register endpoint
 
 Sending a `POST` request to Jans Tent `/register` endpoint containing a `JSON`
 with the OP/AS url and client url, like this:
 
 ```json
 {
-    "op_url": "https://OP_HOSTNAME",
-    "client_url": "https://localhost:9090"
+  "op_url": "https://OP_HOSTNAME",
+  "client_url": "https://localhost:9090",
+  "additional_params": {
+    "scope": "openid mail profile"
+  }
 }
 ```
+Please notice that `additional_params` is not required by endpoint.
 
-This endpoint response will return the registered client id and client secret
+The response will return the registered client id and client secret 
 
-**Auto-config endpoint**
+### Auto-config endpoint
 
 Sending a `POST` request to the Tent `/configuration` endpoint, containing the
 client id, client secret, and metadata endpoint will fetch data from OP metadata

--- a/demos/jans-tent/clientapp/__init__.py
+++ b/demos/jans-tent/clientapp/__init__.py
@@ -129,9 +129,11 @@ def create_app():
                 status = 400
 
             else:
+                additional_metadata = {}
+                if 'additional_params' in content.keys():
+                    additional_metadata = content['additional_params']
                 client_handler = ClientHandler(
-                    content['op_url'],
-                    content['redirect_uris']
+                   content['op_url'], content['redirect_uris'], additional_metadata
                 )
                 data = client_handler.get_client_dict()
                 status = 200

--- a/demos/jans-tent/clientapp/config.py
+++ b/demos/jans-tent/clientapp/config.py
@@ -1,6 +1,6 @@
 # REQUIRED
 # Replace op_hostname
-ISSUER = 'https://christian-hawk-awake-grub.gluu.info'
+ISSUER = 'https://op_hostname'
 
 # Tent redirect uri
 REDIRECT_URIS = [
@@ -17,13 +17,13 @@ SERVER_TOKEN_AUTH_METHOD = 'client_secret_post'
 
 # ACR VALUES
 # Examples:
-ACR_VALUES = "agama"
+# ACR_VALUES = "agama"
 # ACR_VALUES = 'simple_password_auth'
-# ACR_VALUES = None
+ACR_VALUES = None
 
 # ADDITIONAL PARAMS TO CALL AUTHORIZE ENDPOINT, WITHOUT BASE64 ENCODING. USE DICT {'param': 'value'}
 # ADDITIONAL_PARAMS = {'paramOne': 'valueOne', 'paramTwo': 'valueTwo'}
-ADDITIONAL_PARAMS = {'agama_flow': 'com.chris.basic'}
+ADDITIONAL_PARAMS = None
 
 # SYSTEM SETTINGS
 # use with caution, unsecure requests, for development environments

--- a/demos/jans-tent/clientapp/config.py
+++ b/demos/jans-tent/clientapp/config.py
@@ -1,6 +1,6 @@
 # REQUIRED
 # Replace op_hostname
-ISSUER = 'https://op_hostname'
+ISSUER = 'https://christian-hawk-awake-grub.gluu.info'
 
 # Tent redirect uri
 REDIRECT_URIS = [
@@ -17,13 +17,13 @@ SERVER_TOKEN_AUTH_METHOD = 'client_secret_post'
 
 # ACR VALUES
 # Examples:
-# ACR_VALUES = "agama"
+ACR_VALUES = "agama"
 # ACR_VALUES = 'simple_password_auth'
-ACR_VALUES = None
+# ACR_VALUES = None
 
 # ADDITIONAL PARAMS TO CALL AUTHORIZE ENDPOINT, WITHOUT BASE64 ENCODING. USE DICT {'param': 'value'}
 # ADDITIONAL_PARAMS = {'paramOne': 'valueOne', 'paramTwo': 'valueTwo'}
-ADDITIONAL_PARAMS = None
+ADDITIONAL_PARAMS = {'agama_flow': 'com.chris.basic'}
 
 # SYSTEM SETTINGS
 # use with caution, unsecure requests, for development environments

--- a/demos/jans-tent/clientapp/helpers/client_handler.py
+++ b/demos/jans-tent/clientapp/helpers/client_handler.py
@@ -38,13 +38,15 @@ class ClientHandler:
     __additional_metadata = None
     op_data = None
 
-    def __init__(self, op_url: str, redirect_uris: list[str], additional_metadata: Optional[dict] = None):
+    def __init__(self, op_url: str, redirect_uris: list[str], additional_metadata: dict):
         """[initializes]
 
         :param op_url: [url from oidc provider starting with https]
         :type op_url: str
         :param redirect_uris: [url from client starting with https]
         :type redirect_uris: list
+        :param additional_metadata: additional client metadata
+        :type additional_metadata: dict
         """
         self.__additional_metadata = additional_metadata
         self.clientAdapter = Client(client_authn_method=CLIENT_AUTHN_METHOD, message_factory=CustomMessageFactory)

--- a/demos/jans-tent/clientapp/helpers/client_handler.py
+++ b/demos/jans-tent/clientapp/helpers/client_handler.py
@@ -35,9 +35,10 @@ class ClientHandler:
     __client_secret = None
     __metadata_url = None
     __op_url = None
+    __additional_metadata = None
     op_data = None
 
-    def __init__(self, op_url: str, redirect_uris: list[str]):
+    def __init__(self, op_url: str, redirect_uris: list[str], additional_metadata: Optional[dict] = None):
         """[initializes]
 
         :param op_url: [url from oidc provider starting with https]
@@ -45,6 +46,7 @@ class ClientHandler:
         :param redirect_uris: [url from client starting with https]
         :type redirect_uris: list
         """
+        self.__additional_metadata = additional_metadata
         self.clientAdapter = Client(client_authn_method=CLIENT_AUTHN_METHOD, message_factory=CustomMessageFactory)
         self.__op_url = op_url
         self.__redirect_uris = redirect_uris
@@ -79,7 +81,7 @@ class ClientHandler:
                              'application_type': 'web',
                              'client_name': 'Jans Tent',
                              'token_endpoint_auth_method': 'client_secret_post',
-                             'scope': ['openid']
+                             **self.__additional_metadata
                              }
         reg_info = self.clientAdapter.register(op_data['registration_endpoint'], **registration_args)
 

--- a/demos/jans-tent/clientapp/helpers/client_handler.py
+++ b/demos/jans-tent/clientapp/helpers/client_handler.py
@@ -23,6 +23,7 @@ from typing import Optional, Dict, Any
 from oic.oauth2 import ASConfigurationResponse
 from oic.oic import Client
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
+from .custom_msg_factory import CustomMessageFactory
 
 
 logger = logging.getLogger(__name__)
@@ -44,7 +45,7 @@ class ClientHandler:
         :param redirect_uris: [url from client starting with https]
         :type redirect_uris: list
         """
-        self.clientAdapter = Client(client_authn_method=CLIENT_AUTHN_METHOD)
+        self.clientAdapter = Client(client_authn_method=CLIENT_AUTHN_METHOD, message_factory=CustomMessageFactory)
         self.__op_url = op_url
         self.__redirect_uris = redirect_uris
         self.__metadata_url = '%s/.well-known/openid-configuration' % op_url
@@ -77,7 +78,8 @@ class ClientHandler:
                              'grant_types': ['authorization_code'],
                              'application_type': 'web',
                              'client_name': 'Jans Tent',
-                             'token_endpoint_auth_method': 'client_secret_post'
+                             'token_endpoint_auth_method': 'client_secret_post',
+                             'scope': ['openid']
                              }
         reg_info = self.clientAdapter.register(op_data['registration_endpoint'], **registration_args)
 

--- a/demos/jans-tent/clientapp/helpers/custom_msg_factory.py
+++ b/demos/jans-tent/clientapp/helpers/custom_msg_factory.py
@@ -1,3 +1,9 @@
+"""
+Custom message factory required by pyoic to add scope param
+Overrides RegistrationRequest, RegistrationResponse
+and use them to create CustomMessageFactory
+"""
+
 from oic.oic.message import OIDCMessageFactory, RegistrationRequest, RegistrationResponse, MessageTuple, OPTIONAL_LOGICAL
 from oic.oauth2.message import OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT
 
@@ -39,7 +45,7 @@ class MyRegistrationRequest(RegistrationRequest):
         "frontchannel_logout_session_required": OPTIONAL_LOGICAL,
         "backchannel_logout_uri": SINGLE_OPTIONAL_STRING,
         "backchannel_logout_session_required": OPTIONAL_LOGICAL,
-        "scope": OPTIONAL_LIST_OF_STRINGS,
+        "scope": OPTIONAL_LIST_OF_STRINGS,  # added
     }
     c_default = {"application_type": "web", "response_types": ["code"]}
     c_allowed_values = {
@@ -47,9 +53,6 @@ class MyRegistrationRequest(RegistrationRequest):
         "subject_type": ["public", "pairwise"],
     }
 
-
-# class MyRegistrationResponse(RegistrationResponse):
-#     # add the extra fields you expect the OP to send back
 
 class CustomMessageFactory(OIDCMessageFactory):
     registration_endpoint = MessageTuple(MyRegistrationRequest, RegistrationResponse)

--- a/demos/jans-tent/clientapp/helpers/custom_msg_factory.py
+++ b/demos/jans-tent/clientapp/helpers/custom_msg_factory.py
@@ -1,0 +1,56 @@
+from oic.oic.message import OIDCMessageFactory, RegistrationRequest, RegistrationResponse, MessageTuple, OPTIONAL_LOGICAL
+from oic.oauth2.message import OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT
+
+
+class MyRegistrationRequest(RegistrationRequest):
+    c_param = {
+        "redirect_uris": REQUIRED_LIST_OF_STRINGS,
+        "response_types": OPTIONAL_LIST_OF_STRINGS,
+        "grant_types": OPTIONAL_LIST_OF_STRINGS,
+        "application_type": SINGLE_OPTIONAL_STRING,
+        "contacts": OPTIONAL_LIST_OF_STRINGS,
+        "client_name": SINGLE_OPTIONAL_STRING,
+        "logo_uri": SINGLE_OPTIONAL_STRING,
+        "client_uri": SINGLE_OPTIONAL_STRING,
+        "policy_uri": SINGLE_OPTIONAL_STRING,
+        "tos_uri": SINGLE_OPTIONAL_STRING,
+        "jwks": SINGLE_OPTIONAL_STRING,
+        "jwks_uri": SINGLE_OPTIONAL_STRING,
+        "sector_identifier_uri": SINGLE_OPTIONAL_STRING,
+        "subject_type": SINGLE_OPTIONAL_STRING,
+        "id_token_signed_response_alg": SINGLE_OPTIONAL_STRING,
+        "id_token_encrypted_response_alg": SINGLE_OPTIONAL_STRING,
+        "id_token_encrypted_response_enc": SINGLE_OPTIONAL_STRING,
+        "userinfo_signed_response_alg": SINGLE_OPTIONAL_STRING,
+        "userinfo_encrypted_response_alg": SINGLE_OPTIONAL_STRING,
+        "userinfo_encrypted_response_enc": SINGLE_OPTIONAL_STRING,
+        "request_object_signing_alg": SINGLE_OPTIONAL_STRING,
+        "request_object_encryption_alg": SINGLE_OPTIONAL_STRING,
+        "request_object_encryption_enc": SINGLE_OPTIONAL_STRING,
+        "token_endpoint_auth_method": SINGLE_OPTIONAL_STRING,
+        "token_endpoint_auth_signing_alg": SINGLE_OPTIONAL_STRING,
+        "default_max_age": SINGLE_OPTIONAL_INT,
+        "require_auth_time": OPTIONAL_LOGICAL,
+        "default_acr_values": OPTIONAL_LIST_OF_STRINGS,
+        "initiate_login_uri": SINGLE_OPTIONAL_STRING,
+        "request_uris": OPTIONAL_LIST_OF_STRINGS,
+        "post_logout_redirect_uris": OPTIONAL_LIST_OF_STRINGS,
+        "frontchannel_logout_uri": SINGLE_OPTIONAL_STRING,
+        "frontchannel_logout_session_required": OPTIONAL_LOGICAL,
+        "backchannel_logout_uri": SINGLE_OPTIONAL_STRING,
+        "backchannel_logout_session_required": OPTIONAL_LOGICAL,
+        "scope": OPTIONAL_LIST_OF_STRINGS,
+    }
+    c_default = {"application_type": "web", "response_types": ["code"]}
+    c_allowed_values = {
+        "application_type": ["native", "web"],
+        "subject_type": ["public", "pairwise"],
+    }
+
+
+# class MyRegistrationResponse(RegistrationResponse):
+#     # add the extra fields you expect the OP to send back
+
+class CustomMessageFactory(OIDCMessageFactory):
+    registration_endpoint = MessageTuple(MyRegistrationRequest, RegistrationResponse)
+

--- a/demos/jans-tent/clientapp/utils/dcr_from_config.py
+++ b/demos/jans-tent/clientapp/utils/dcr_from_config.py
@@ -5,6 +5,7 @@ import json
 
 OP_URL = cfg.ISSUER
 REDIRECT_URIS = cfg.REDIRECT_URIS
+SCOPE = cfg.SCOPE
 
 
 def setup_logging() -> None:
@@ -17,8 +18,14 @@ def setup_logging() -> None:
 
 
 def register() -> None:
+    """
+    Register client with information from config and write info to client_info.json
+    :return: None
+    """
     logger = logging.getLogger(__name__)
-    client_handler = ClientHandler(OP_URL, REDIRECT_URIS)
+    scope_as_list = SCOPE.split(" ")
+    additional_params = {'scope': scope_as_list}
+    client_handler = ClientHandler(OP_URL, REDIRECT_URIS, additional_params)
     json_client_info = json.dumps(client_handler.get_client_dict(), indent=4)
     with open('client_info.json', 'w') as outfile:
         logger.info('Writing registered client information to client_info.json')

--- a/demos/jans-tent/tests/unit_integration/test_client_register_endpoint.py
+++ b/demos/jans-tent/tests/unit_integration/test_client_register_endpoint.py
@@ -110,6 +110,7 @@ class TestRegisterEndpoint(FlaskBaseTestCase):
         redirect_uris = ['https://client.com.br/oidc_calback']
         test_client_id = '1234-5678-9ten11'
         test_client_secret = 'mysuperprotectedsecret'
+        additional_params = {'param1': 'value1'}
 
         expected_keys = {'op_metadata_url', 'client_id', 'client_secret'}
 
@@ -120,7 +121,8 @@ class TestRegisterEndpoint(FlaskBaseTestCase):
         }) as get_client_dict:
             response = self.client.post(url_for('register'), json={
                 'op_url': op_url,
-                'redirect_uris': redirect_uris
+                'redirect_uris': redirect_uris,
+                'additional_params': additional_params
             })
             print(response)
             assert expected_keys <= response.json.keys(), response.json

--- a/demos/jans-tent/tests/unit_integration/test_client_register_endpoint.py
+++ b/demos/jans-tent/tests/unit_integration/test_client_register_endpoint.py
@@ -47,11 +47,26 @@ class TestRegisterEndpoint(FlaskBaseTestCase):
     def test_endpoint_should_accept_2_params(self):
         first_value = 'https://op'
         second_value = ['https://client.com.br/oidc_callback']
+
         self.client.post(url_for('register'), json={
             'op_url': first_value,
             'redirect_uris': second_value
         })
-        ClientHandler.__init__.assert_called_once_with(first_value, second_value)
+        ClientHandler.__init__.assert_called_once_with(first_value, second_value, {})
+
+    @patch('clientapp.helpers.client_handler.ClientHandler.__init__', MagicMock(return_value=None))
+    def test_endpoint_should_accept_3_params(self):
+        first_value = 'https://op'
+        second_value = ['https://client.com.br/oidc_callback']
+        third_value = {'scope': 'openid email profile'}
+
+        self.client.post(url_for('register'), json={
+            'op_url': first_value,
+            'redirect_uris': second_value,
+            'additional_params': third_value
+        })
+
+        ClientHandler.__init__.assert_called_once_with(first_value, second_value, third_value)
 
     def test_endpoint_should_return_error_code_400_if_no_data_sent(self):
         self.assertEqual(

--- a/demos/jans-tent/tests/unit_integration/test_dcr_from_config.py
+++ b/demos/jans-tent/tests/unit_integration/test_dcr_from_config.py
@@ -47,7 +47,7 @@ class TestDrcFromConfig(TestCase):
     @patch('clientapp.helpers.client_handler.ClientHandler.__init__', MagicMock(return_value=None))
     def test_register_should_call_ClientHandler_with_params(self):
         dcr_from_config.register()
-        ClientHandler.__init__.assert_called_once_with(cfg.ISSUER, cfg.REDIRECT_URIS)
+        ClientHandler.__init__.assert_called_once_with(cfg.ISSUER, cfg.REDIRECT_URIS, {'scope': cfg.SCOPE.split(" ")})
 
     def test_register_should_call_open(self):
         with patch('builtins.open', mock_open()) as open_mock:

--- a/demos/jans-tent/tests/unit_integration/test_dcr_from_config.py
+++ b/demos/jans-tent/tests/unit_integration/test_dcr_from_config.py
@@ -61,7 +61,7 @@ class TestDrcFromConfig(TestCase):
         open_mock.assert_called_once_with('client_info.json', 'w')
 
     def test_register_should_call_write_with_client_info(self):
-        client = ClientHandler(cfg.ISSUER, cfg.REDIRECT_URIS)
+        client = ClientHandler(cfg.ISSUER, cfg.REDIRECT_URIS, {})
         expected_json_client_info = json.dumps(client.get_client_dict(), indent=4)
         with patch('builtins.open', mock_open()) as open_mock:
             dcr_from_config.register()

--- a/demos/jans-tent/tests/unit_integration/test_dynamic_client_registration.py
+++ b/demos/jans-tent/tests/unit_integration/test_dynamic_client_registration.py
@@ -12,8 +12,9 @@ ClientHandler = client_handler.ClientHandler
 
 # helper
 def get_class_instance(op_url='https://t1.techno24x7.com',
-                       client_url='https://mock.test.com'):
-    client_handler_obj = ClientHandler(op_url, client_url)
+                       client_url='https://mock.test.com',
+                       additional_metadata={}):
+    client_handler_obj = ClientHandler(op_url, client_url, additional_metadata)
     return client_handler_obj
 
 
@@ -74,6 +75,7 @@ class TestDynamicClientRegistration(TestCase):
             '_ClientHandler__client_secret',
             '_ClientHandler__redirect_uris',
             '_ClientHandler__metadata_url',
+            '_ClientHandler__additional_metadata',
             'discover',  # method
             'register_client'  # method
         ]
@@ -163,7 +165,7 @@ class TestDynamicClientRegistration(TestCase):
 
         op_url = 'https://t1.techno24x7.com'
         redirect_uris = 'https://mock.test.com/oidc_callback'
-        client_handler_obj = ClientHandler(op_url, redirect_uris)
+        client_handler_obj = ClientHandler(op_url, redirect_uris, {})
 
         self.restore_stashed_mocks()
 
@@ -185,6 +187,17 @@ class TestDynamicClientRegistration(TestCase):
         self.assertEqual(
             client_handler_obj.__dict__['_ClientHandler__metadata_url'],
             expected_metadata_url)
+
+    def test_class_init_should_set_additional_params(self):
+        self.mock_methods()
+        expected_metadata = {'metakey1': 'meta value 1'}
+        client_handler_obj = get_class_instance(additional_metadata=expected_metadata)
+        self.restore_stashed_mocks()
+
+        self.assertEqual(
+            client_handler_obj.__dict__['_ClientHandler__additional_metadata'],
+            expected_metadata
+        )
 
     def test_class_init_should_have_docstring(self):
         self.assertTrue(ClientHandler.__init__.__doc__,


### PR DESCRIPTION
### Description
  As discussed in the related issue, sending `scope` in DCR request  is unusual but is allowed by specs. This PR address this issue.

Scopes added in `config.py` are now included in DCR request.

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4615




