### PR TITLE
fix(jans-fido2):move appleWebauthnRootCa to Fido2 configurations issue#4744

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/AttestationCertificateService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/AttestationCertificateService.java
@@ -11,10 +11,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -159,8 +156,26 @@ public class AttestationCertificateService {
 		}
 	}
 
+	/**
+	 * Get root certificates by subjectDN
+	 *
+	 * @param subjectDN subjectDN
+	 * @return List with certificates or empty
+	 */
+	public List<X509Certificate> getRootCertificatesBySubjectDN(String subjectDN) {
+		if (rootCertificatesMap == null || rootCertificatesMap.isEmpty() || subjectDN == null || subjectDN.isEmpty()) {
+			return Collections.emptyList();
+		}
+		List<X509Certificate> certificates = new ArrayList<>();
+		rootCertificatesMap.forEach((s, x509Certificate) -> {
+			if (s.equals(subjectDN)) {
+				certificates.add(x509Certificate);
+			}
+		});
+		return certificates;
+	}
+
 	private KeyStore getCertificationKeyStore(String aaguid, List<X509Certificate> certificates) {
 		return keyStoreCreator.createKeyStore(aaguid, certificates);
 	}
-
 }

--- a/jans-linux-setup/jans_setup/setup_app/installers/fido.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/fido.py
@@ -80,7 +80,7 @@ class FidoInstaller(JettyInstaller):
 
         # copy Apple_WebAuthn_Root_CA
         if os.path.exists(self.source_files[1][0]):
-            target_dir = os.path.join(self.fido2ConfigFolder, 'apple')
+            target_dir = os.path.join(self.fido2ConfigFolder, 'authenticator_cert')
             self.run([paths.cmd_mkdir, '-p', target_dir])
             self.copyFile(self.source_files[1][0], target_dir)
 


### PR DESCRIPTION
### Prepare

- [X] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [X] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Moving the harcoded value, to Fido2 configurations
#### Target issue
https://github.com/JanssenProject/jans/issues/4744

closes #4744

#### Implementation Details
Property was implemented
docs were updated
installer was updated including default value

-------------------
### Test and Document the changes
- [X] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [X] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

