### PR TITLE
feat(tent): log registered client info

### DIFF
--- a/demos/jans-tent/clientapp/helpers/client_handler.py
+++ b/demos/jans-tent/clientapp/helpers/client_handler.py
@@ -77,6 +77,7 @@ class ClientHandler:
         :return: [client information including client-id and secret]
         :rtype: dict
         """
+        logger.debug('called ClientHandler´s register_client method')
         registration_args = {'redirect_uris': redirect_uris,
                              'response_types': ['code'],
                              'grant_types': ['authorization_code'],
@@ -86,7 +87,7 @@ class ClientHandler:
                              **self.__additional_metadata
                              }
         reg_info = self.clientAdapter.register(op_data['registration_endpoint'], **registration_args)
-
+        logger.info('register_client - reg_info = %s', json.dumps(reg_info.to_dict(), indent=2))
         return reg_info
 
     def discover(self, op_url: Optional[str] = __op_url) -> ASConfigurationResponse:


### PR DESCRIPTION
### Description
Log registered client info. (pyoic `ResponseRequest` allowed params) as example:

```json
{
  "allow_spontaneous_scopes": false,
  "application_type": "web",
  "rpt_as_jwt": false,
  "registration_client_uri": "https://myop.gluu.info/jans-auth/restv1/register?client_id=7393015e-1967-4dbf-add6-3c42419e1732",
  "run_introspection_script_before_jwt_creation": false,
  "registration_access_token": "32ec646c-878b-43b5-97dc-e97df12d8414",
  "client_id": "7393015e-1967-4dbf-add6-3c42419e1744",
  "token_endpoint_auth_method": "client_secret_post",
  "scope": "openid",
  "client_secret": "c80c52ef-1bde-4d1f-9291-0ad4c022d375",
  "client_id_issued_at": 1682953380,
  "backchannel_logout_session_required": false,
  "client_name": "Jans Tent",
  "par_lifetime": 600,
  "spontaneous_scopes": [],
  "id_token_signed_response_alg": "RS256",
  "access_token_as_jwt": false,
  "grant_types": [
    "authorization_code"
  ],
  "subject_type": "pairwise",
  "additional_token_endpoint_auth_methods": [],
  "keep_client_authorization_after_expiration": false,
  "require_par": false,
  "redirect_uris": [
    "https://localhost:9090/oidc_callback"
  ],
  "additional_audience": [],
  "frontchannel_logout_session_required": false,
  "client_secret_expires_at": 0,
  "access_token_signing_alg": "RS256",
  "response_types": [
    "code"
  ]
}
```

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4769 

