### PR TITLE
fix(jans-linux-setup): default keystore type pkcs12

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/config.py
+++ b/jans-linux-setup/jans_setup/setup_app/config.py
@@ -95,7 +95,7 @@ class Config:
             self.ldap_base_dir = os.path.join(base.snap_common, 'opendj')
             self.jetty_user = 'root'
 
-        self.default_store_type = 'JKS'
+        self.default_store_type = 'PKCS12'
 
         #create dummy progress bar that logs to file in case not defined
         progress_log_file = os.path.join(LOG_DIR, 'progress-bar.log')
@@ -252,7 +252,7 @@ class Config:
         self.encoded_ldapTrustStorePass = None
 
         self.ldapCertFn = self.opendj_cert_fn = os.path.join(self.certFolder, 'opendj.crt')
-        self.ldapTrustStoreFn = self.opendj_p12_fn = os.path.join(self.certFolder, 'opendj.p12')
+        self.ldapTrustStoreFn = self.opendj_p12_fn = os.path.join(self.certFolder, 'opendj.pkcs12')
 
         self.oxd_package = base.determine_package(os.path.join(self.dist_jans_dir, 'oxd-server*.tgz'))
 
@@ -315,7 +315,7 @@ class Config:
         self.default_enc_key_algs = 'RSA1_5 RSA-OAEP ECDH-ES'
         self.default_key_expiration = 365
 
-        self.smtp_jks_fn = os.path.join(self.certFolder, 'smtp-keys.p12')
+        self.smtp_jks_fn = os.path.join(self.certFolder, 'smtp-keys.' + self.default_store_type.lower())
         self.smtp_alias = 'smtp_sig_ec256'
         self.smtp_signing_alg = 'SHA256withECDSA'
 

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -586,7 +586,7 @@ class JansInstaller(BaseInstaller, SetupUtils):
                         '-groupname', 'secp256r1',
                         '-sigalg', Config.smtp_signing_alg,
                         '-validity', '3650',
-                        '-storetype', 'PKCS12',
+                        '-storetype', Config.default_store_type,
                         '-keystore', Config.smtp_jks_fn,
                         '-keypass', Config.smtp_jks_pass,
                         '-storepass', Config.smtp_jks_pass,

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans_auth.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans_auth.py
@@ -71,9 +71,14 @@ class JansAuthInstaller(JettyInstaller):
         Config.encoded_admin_password = self.ldap_encode(Config.admin_password)
 
         self.logIt("Generating OAuth openid keys", pbar=self.service_name)
-        sig_keys = 'RS256 RS384 RS512 ES256 ES256K ES384 ES512 PS256 PS384 PS512'
-        enc_keys = 'RSA1_5 RSA-OAEP ECDH-ES'
-        jwks = self.gen_openid_jwks_jks_keys(self.oxauth_openid_jks_fn, Config.oxauth_openid_jks_pass, key_expiration=2, key_algs=sig_keys, enc_keys=enc_keys)
+
+        jwks = self.gen_openid_jwks_jks_keys(
+                    jks_path=self.oxauth_openid_jks_fn,
+                    jks_pwd=Config.oxauth_openid_jks_pass,
+                    key_expiration=2,
+                    key_algs=Config.default_sig_key_algs,
+                    enc_keys=Config.default_enc_key_algs
+                    )
         self.write_openid_keys(self.oxauth_openid_jwks_fn, jwks)
 
         if Config.get('use_external_key'):

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans_auth.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans_auth.py
@@ -42,7 +42,7 @@ class JansAuthInstaller(JettyInstaller):
         self.oxauth_static_conf_json = os.path.join(self.templates_folder, 'jans-auth-static-conf.json')
         self.oxauth_error_json = os.path.join(self.templates_folder, 'jans-auth-errors.json')
         self.oxauth_openid_jwks_fn = os.path.join(self.output_folder, 'jans-auth-keys.json')
-        self.oxauth_openid_jks_fn = os.path.join(Config.certFolder, 'jans-auth-keys.p12')
+        self.oxauth_openid_jks_fn = os.path.join(Config.certFolder, 'jans-auth-keys.' + Config.default_store_type.lower())
         self.ldif_people = os.path.join(self.output_folder, 'people.ldif')
         self.ldif_groups = os.path.join(self.output_folder, 'groups.ldif')
         self.agama_root = os.path.join(self.jetty_base, self.service_name, 'agama')


### PR DESCRIPTION
closes #4787