### PR TITLE
fix(docker-jans-auth-server): compare contents before pushing otp_configuration and super_gluu_creds to secrets

### DIFF
--- a/docker-jans-auth-server/scripts/auth_conf.py
+++ b/docker-jans-auth-server/scripts/auth_conf.py
@@ -1,4 +1,4 @@
-from hashlib import md5
+from hashlib import sha256
 from pathlib import Path
 
 from jans.pycloudlib import get_manager
@@ -28,8 +28,8 @@ def push_auth_conf() -> None:
 
 
 def digest_equals(val1: str, val2: str) -> bool:
-    val1_digest = md5(val1.encode()).hexdigest()  # nosec: B234
-    val2_digest = md5(val2.encode()).hexdigest()  # nosec: B234
+    val1_digest = sha256(val1.encode()).hexdigest()
+    val2_digest = sha256(val2.encode()).hexdigest()
     return val1_digest == val2_digest
 
 

--- a/docker-jans-auth-server/scripts/auth_conf.py
+++ b/docker-jans-auth-server/scripts/auth_conf.py
@@ -1,4 +1,5 @@
-import os
+from hashlib import md5
+from pathlib import Path
 
 from jans.pycloudlib import get_manager
 
@@ -12,16 +13,24 @@ logger = logging.getLogger("entrypoint")
 manager = get_manager()
 
 
-def push_auth_conf():
+def push_auth_conf() -> None:
     conf_files = (
         "otp_configuration.json",
         "super_gluu_creds.json",
     )
     for conf_file in conf_files:
-        file_ = f"/etc/certs/{conf_file}"
-        secret_name = os.path.splitext(conf_file)[0]
-        logger.info(f"Pushing {file_} to secrets")
-        manager.secret.from_file(secret_name, file_)
+        file_ = Path(f"/etc/certs/{conf_file}")
+
+        # compare digest; if they are different, push the contents of file to secrets
+        if not digest_equals(manager.secret.get(file_.stem), file_.read_text()):
+            logger.info(f"Detected changes in {file_}; pushing changes to secrets.")
+            manager.secret.from_file(file_.stem, str(file_))
+
+
+def digest_equals(val1: str, val2: str) -> bool:
+    val1_digest = md5(val1.encode()).hexdigest()  # nosec: B234
+    val2_digest = md5(val2.encode()).hexdigest()  # nosec: B234
+    return val1_digest == val2_digest
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4797 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

