### PR TITLE
fix(jans-cli-tui): set seleted to zero in JansVerticalNav when cleared

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/agama.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/agama.py
@@ -251,7 +251,7 @@ class Agama(DialogUtils):
                     ))
 
         if not data_display and self.app.current_page == 'agama' and search_str:
-            self.app.show_message(_("Oops"), _(common_strings.no_matching_result), tobefocused = self.main_container)
+            self.app.show_message(_("Oops"), _(common_strings.no_matching_result), tobefocused=self.main_container)
             return
 
         self.working_container.hide_headers = False
@@ -353,8 +353,8 @@ class Agama(DialogUtils):
             continue_upload()
         else:
             continue_button = Button(_("Continue!"), handler=continue_upload)
-            buttons = [Button('Back'), continue_button]
-            self.app.show_message(_("Action must be taken"),_("Agama is not enabled"), buttons=buttons)
+            buttons = [Button('Back'), continue_button] 
+            self.app.show_message(_("Action must be taken"), _("Agama is not enabled"), buttons=buttons, tobefocused=self.main_container)
 
     def search_agama_project(self, tbuffer:Buffer) -> None:
         if 'entries' in self.data:

--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/attributes.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/attributes.py
@@ -204,6 +204,8 @@ class Attributes(DialogUtils):
                 await get_event_loop().run_in_executor(self.app.executor, self.app.cli_requests, cli_args)
                 self.app.stop_progressing()
                 self.get_attributes()
+                common_data.claims_retreived = False
+
             asyncio.ensure_future(coroutine())
 
 
@@ -310,6 +312,7 @@ class Attributes(DialogUtils):
                 await get_event_loop().run_in_executor(self.app.executor, self.app.cli_requests, cli_args)
                 self.app.stop_progressing()
                 self.get_attributes()
+                common_data.claims_retreived = False
 
             asyncio.ensure_future(coroutine())
 

--- a/jans-cli-tui/cli_tui/plugins/070_users/edit_user_dialog.py
+++ b/jans-cli-tui/cli_tui/plugins/070_users/edit_user_dialog.py
@@ -171,9 +171,8 @@ class EditUserDialog(JansGDialog, DialogUtils):
                 )
 
             elif claim_prop.get('dataType') == 'boolean':
-                checked = get_custom_attribute(ca['value']).lower() == 'true'
                 self.edit_user_content.insert(-1, 
-                    self.app.getTitledCheckBox(_(claim_prop['displayName']), name=ca['name'], checked=checked, style='class:script-checkbox', jans_help=self.app.get_help_from_schema(self.schema, ca['name']))
+                    self.app.getTitledCheckBox(_(claim_prop['displayName']), name=ca['name'], checked=ca['value'], style='class:script-checkbox', jans_help=self.app.get_help_from_schema(self.schema, ca['name']))
                 )
 
         self.edit_user_container = ScrollablePane(content=HSplit(self.edit_user_content, width=D()),show_scrollbar=False)

--- a/jans-cli-tui/cli_tui/plugins/070_users/main.py
+++ b/jans-cli-tui/cli_tui/plugins/070_users/main.py
@@ -314,7 +314,7 @@ class Plugin(DialogUtils):
     def get_claims(self) -> None:
         """This method for getting claims
         """
-        if hasattr(common_data.users, 'claims'):
+        if hasattr(common_data.users, 'claims') and getattr(common_data, 'claims_retreived', False):
             return
         async def coroutine():
             cli_args = {'operation_id': 'get-attributes', 'endpoint_args':'limit:200,status:active'}
@@ -323,6 +323,7 @@ class Plugin(DialogUtils):
             self.app.stop_progressing()
             result = response.json()
             common_data.users.claims = result['entries']
+            common_data.claims_retreived = True
 
         asyncio.ensure_future(coroutine())
 

--- a/jans-cli-tui/cli_tui/wui_components/jans_vetrical_nav.py
+++ b/jans-cli-tui/cli_tui/wui_components/jans_vetrical_nav.py
@@ -321,6 +321,7 @@ class JansVerticalNav():
     def clear(self) -> None:
         self.data = []
         self.container_content[-1].height = self.max_height
+        self.selectes = 0
 
     def _get_key_bindings(self) -> KeyBindingsBase:
         """All key binding for the Dialog with Navigation bar

--- a/jans-cli-tui/cli_tui/wui_components/jans_vetrical_nav.py
+++ b/jans-cli-tui/cli_tui/wui_components/jans_vetrical_nav.py
@@ -320,7 +320,7 @@ class JansVerticalNav():
 
     def clear(self) -> None:
         self.data = []
-        self.container_content[-1].height = self.max_height
+        self.list_box.height = 0
         self.selectes = 0
 
     def _get_key_bindings(self) -> KeyBindingsBase:


### PR DESCRIPTION
 - closes #4793: set selection to zero in JansVerticalNav when cleared
 - closes #4795: update claims list on edit user page if attribute is saved/deleted
 - closes #4796: checked state of user custom attribute
 - closes #4800: When hit return to select < back > ...  cannot use the tab anymore to navigate and had to ctrl-c