### PR TITLE
fix(docker-jans-monolith): add support for using /opt/dist/scripts

### DIFF
--- a/automation/startjanssenmonolithdemo.sh
+++ b/automation/startjanssenmonolithdemo.sh
@@ -50,11 +50,16 @@ sudo apt-get update
 sudo python3 -m pip install --upgrade pip
 pip3 install setuptools --upgrade
 pip3 install dockerfile-parse ruamel.yaml
+
+# switching to version defined by JANS_BUILD_COMMIT
 if [[ "$JANS_BUILD_COMMIT" ]]; then
   python3 -c "from dockerfile_parse import DockerfileParser ; dfparser = DockerfileParser('/tmp/jans/docker-jans-monolith') ; dfparser.envs['JANS_SOURCE_VERSION'] = '$JANS_BUILD_COMMIT'"
+
+  # as JANS_SOURCE_VERSION is changed, allow docker compose to rebuild image on-the-fly
+  # and use the respective image instead of the default image
+  python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/jans/docker-jans-monolith/jans-mysql-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['jans']['build'] = '.' ; del data['services']['jans']['image'] ; yaml.dump(data, compose)"
+  python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/jans/docker-jans-monolith/jans-postgres-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['jans']['build'] = '.' ; del data['services']['jans']['image'] ; yaml.dump(data, compose)"
 fi
-python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/jans/docker-jans-monolith/jans-mysql-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['jans']['build'] = '.' ; del data['services']['jans']['image'] ; yaml.dump(data, compose)"
-python3 -c "from pathlib import Path ; import ruamel.yaml ; compose = Path('/tmp/jans/docker-jans-monolith/jans-postgres-compose.yml') ; yaml = ruamel.yaml.YAML() ; data = yaml.load(compose) ; data['services']['jans']['build'] = '.' ; del data['services']['jans']['image'] ; yaml.dump(data, compose)"
 # --
 if [[ $JANS_PERSISTENCE == "MYSQL" ]]; then
   docker compose -f /tmp/jans/docker-jans-monolith/jans-mysql-compose.yml up -d

--- a/docker-jans-monolith/Dockerfile
+++ b/docker-jans-monolith/Dockerfile
@@ -38,7 +38,7 @@ EXPOSE 443 8080 1636
 # jans-linux-setup
 # =====================
 
-ENV JANS_SOURCE_VERSION=86c4feedd696db0271022e4de0a7ad8092d31738
+ENV JANS_SOURCE_VERSION=461d96b9fda237c924d074f8ef2bbc98f19c429e
 
 # cleanup
 RUN rm -rf /tmp/jans

--- a/docker-jans-monolith/scripts/entrypoint.sh
+++ b/docker-jans-monolith/scripts/entrypoint.sh
@@ -92,7 +92,8 @@ start_services() {
 check_installed_jans
 start_services
 
-tail -f /opt/jans/jetty/jans-auth/logs/*.log \
--f /opt/jans/jetty/jans-config-api/logs/*.log \
--f /opt/jans/jetty/jans-fido2/logs/*.log \
--f /opt/jans/jetty/jans-scim/logs/*.log
+# use -F option to follow (and retry) logs
+tail -F /opt/jans/jetty/jans-auth/logs/*.log \
+  /opt/jans/jetty/jans-config-api/logs/*.log \
+  /opt/jans/jetty/jans-fido2/logs/*.log \
+  /opt/jans/jetty/jans-scim/logs/*.log


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

1. Add support for running processes using scripts under `/opt/dist/scripts` directory (for example: `/opt/dist/scripts/opendj start`)
2. allow build mode (instead of pulling image) only if `JANS_BUILD_COMMIT` passed to `automation/startjanssenmonolithdemo.sh`

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4809 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

