### PR TITLE
feat(jans-auth-server): invalidate discovery cache if some scripts are (re)loaded #4500

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/LocalResponseCache.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/LocalResponseCache.java
@@ -6,12 +6,12 @@ import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.server.service.cdi.event.AuthConfigurationEvent;
 import io.jans.service.cdi.async.Asynchronous;
 import io.jans.service.cdi.event.Scheduled;
-import org.json.JSONObject;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.json.JSONObject;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,6 +39,10 @@ public class LocalResponseCache {
 
     private int currentDiscoveryLifetime = DEFAULT_DISCOVERY_LIFETIME;
     private int currentSectorIdentifierLifetime = DEFAULT_SECTOR_IDENTIFIER_LIFETIME;
+
+    public void invalidateDiscoveryCache() {
+        discoveryCache.invalidate(DISCOVERY_CACHE_KEY);
+    }
 
     @Asynchronous
     public void reloadConfigurationTimerEvent(@Observes @Scheduled AuthConfigurationEvent authConfigurationEvent) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalAuthenticationService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalAuthenticationService.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.jans.as.common.service.common.ApplicationFactory;
 import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.server.service.LocalResponseCache;
 import io.jans.as.server.service.cdi.event.ReloadAuthScript;
 import io.jans.as.server.service.external.internal.InternalDefaultPersonAuthenticationType;
 import io.jans.model.AuthenticationScriptUsageType;
@@ -24,12 +25,12 @@ import io.jans.model.ldap.GluuLdapConfiguration;
 import io.jans.service.custom.script.ExternalScriptService;
 import io.jans.util.OxConstants;
 import io.jans.util.StringHelper;
-import org.apache.commons.lang.StringUtils;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.apache.commons.lang.StringUtils;
+
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -52,6 +53,9 @@ public class ExternalAuthenticationService extends ExternalScriptService {
 
     @Inject
     private AppConfiguration appConfiguration;
+
+    @Inject
+    private LocalResponseCache localResponseCache;
 
     private static final long serialVersionUID = 7339887464253044927L;
 
@@ -89,6 +93,9 @@ public class ExternalAuthenticationService extends ExternalScriptService {
 
         // Determine default authenticator for every usage type
         this.defaultExternalAuthenticators = determineDefaultCustomScriptConfigurationsMap(this.customScriptConfigurationsNameMap);
+
+        // invalidate discovery cache
+        localResponseCache.invalidateDiscoveryCache();
     }
 
     private HashMap<String, String> buildScriptAliases() {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/LocalResponseCacheTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/LocalResponseCacheTest.java
@@ -1,0 +1,40 @@
+package io.jans.as.server.service;
+
+import io.jans.as.model.configuration.AppConfiguration;
+import org.json.JSONObject;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class LocalResponseCacheTest {
+
+    @InjectMocks
+    private LocalResponseCache localResponseCache;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Test
+    public void invalidateDiscoveryCache_whenCalled_shouldInvalidateCache() {
+        localResponseCache.putDiscoveryResponse(new JSONObject());
+        assertNotNull(localResponseCache.getDiscoveryResponse());
+
+        localResponseCache.invalidateDiscoveryCache();
+        assertNull(localResponseCache.getDiscoveryResponse());
+    }
+
+    @Test
+    public void putDiscoveryResponse_whenCalled_shouldContainCache() {
+        localResponseCache.putDiscoveryResponse(new JSONObject());
+        assertNotNull(localResponseCache.getDiscoveryResponse());
+    }
+}

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -20,6 +20,7 @@
             <class name="io.jans.as.server.servlet.OpenIdConfigurationTest" />
             <class name="io.jans.as.server.service.net.UriServiceTest" />
             <class name="io.jans.as.server.service.GrantServiceTest" />
+            <class name="io.jans.as.server.service.LocalResponseCacheTest" />
 
             <class name="io.jans.as.server.token.ws.rs.TokenExchangeServiceTest" />
             <class name="io.jans.as.server.token.ws.rs.TokenRestWebServiceValidatorTest" />


### PR DESCRIPTION
### Description

feat(jans-auth-server): invalidate discovery cache if some scripts are (re)loaded 

#### Target issue
  
closes #4500


-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

