### PR TITLE
chore(deps): bump nimbus-jose-jwt from 9.11.1 to 9.28

### DIFF
--- a/jans-config-api/pom.xml
+++ b/jans-config-api/pom.xml
@@ -252,7 +252,7 @@
 			<dependency>
 				<groupId>com.nimbusds</groupId>
 				<artifactId>nimbus-jose-jwt</artifactId>
-				<version>9.11.1</version>
+				<version>9.28</version>
 			</dependency>
 			<dependency>
 				<groupId>org.bitbucket.b_c</groupId>


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Security vulnerability reported in `jans-config-api` due to json-smart.
json-smart is shaded dependency on in `nimbus-jose-jwt`
Bump nimbus-jose-jwt version to resolve vulnerability


#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4842

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

