### PR TITLE
fix(jans-cli-tui): process auth  endpoint has security constraint

### DIFF
--- a/jans-cli-tui/cli_tui/cli/config_cli.py
+++ b/jans-cli-tui/cli_tui/cli/config_cli.py
@@ -710,7 +710,8 @@ class JCA_CLI:
         return True, ''
 
     def get_access_token(self, scope):
-        if self.my_op_mode != 'auth':
+
+        if self.my_op_mode != 'auth' and scope:
             if self.use_test_client:
                 self.get_scoped_access_token(scope)
             elif not self.access_token and not self.wrapped:
@@ -801,6 +802,7 @@ class JCA_CLI:
             sys.stderr.write("Please wait while retrieving data ...\n")
 
         security = self.get_scope_for_endpoint(endpoint)
+
         self.get_access_token(security)
 
         headers=self.get_request_header({'Accept': 'application/json'})

--- a/jans-cli-tui/cli_tui/jans_cli_tui.py
+++ b/jans-cli-tui/cli_tui/jans_cli_tui.py
@@ -325,7 +325,27 @@ class JansCliApp(Application):
                 test_client=test_client
             )
 
+        print(_("Checking health of Jans Config Api Server"))
+        response = self.cli_requests({'operation_id': 'get-config-health'})
+
+        if response.status_code != 200:
+            print(_("Jans Config Api Server is not running propery"))
+            print(response.text)
+            sys.exit()
+        else:
+            result = response.json()
+            for healt_status in result:
+                if healt_status['status'] != 'UP':
+                    print(_("Jans Config Api Server is not running propery"))
+                    print(healt_status)
+                    sys.exit()
+
+        print(_("Health of Jans Config Api Server seems good"))
+
         status = self.cli_object.check_connection()
+
+
+
 
         self.invalidate()
 


### PR DESCRIPTION
- closes #4880: process auth only  endpoint has security constraint
- closes #4874: check health of config-api before start