### PR TITLE
fix(docker-jans-loadtesting-jmeter): rename incorrect reference to OCI image

### DIFF
--- a/demos/benchmarking/docker-jans-loadtesting-jmeter/Dockerfile
+++ b/demos/benchmarking/docker-jans-loadtesting-jmeter/Dockerfile
@@ -67,7 +67,7 @@ RUN mkdir -p /root/.bzt/jmeter-taurus \
     && tar zxvf /scripts/apache-jmeter-5.5.tgz -C /root/.bzt/jmeter-taurus \
     && mv /root/.bzt/jmeter-taurus/apache-jmeter-5.5 /root/.bzt/jmeter-taurus/5.5
 
-LABEL org.opencontainers.image.url="ghcr.io/janssenproject/jans/demo_loadtesting" \
+LABEL org.opencontainers.image.url="ghcr.io/janssenproject/jans/loadtesting-jmeter" \
     org.opencontainers.image.authors="Janssen Project <support@jans.io>" \
     org.opencontainers.image.vendor="Janssen Project" \
     org.opencontainers.image.version="1.0.13" \

--- a/demos/benchmarking/docker-jans-loadtesting-jmeter/Makefile
+++ b/demos/benchmarking/docker-jans-loadtesting-jmeter/Makefile
@@ -1,5 +1,5 @@
 CN_VERSION?=1.0.13-SNAPSHOT
-IMAGE_NAME=ghcr.io/janssenproject/jans/demo_loadtesting
+IMAGE_NAME=ghcr.io/janssenproject/jans/loadtesting-jmeter
 DEV_VERSION?=$(shell echo ${CN_VERSION} | cut -d '-' -f 1)_dev
 
 # pass extra build args, i.e. `make build-dev BUILD_ARGS="--no-cache"`

--- a/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-test/load_test_auth_code.yaml
+++ b/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-test/load_test_auth_code.yaml
@@ -36,7 +36,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: load-testing-cm
-        image: janssenproject/demo_loadtesting:1.0.12_dev
+        image: ghcr.io/janssenproject/jans/loadtesting-jmeter:1.0.13_dev
         imagePullPolicy: Always
         name: load-testing
         resources:

--- a/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_couchbase_job.yaml
+++ b/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_couchbase_job.yaml
@@ -31,7 +31,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: load-users-cb-cm
-        image: janssenproject/demo_loadtesting:1.0.12_dev
+        image: ghcr.io/janssenproject/jans/loadtesting-jmeter:1.0.13_dev
         name: load-users
         resources:
           limits:

--- a/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_ldap_job.yaml
+++ b/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_ldap_job.yaml
@@ -31,7 +31,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: load-users-ldap-cm
-        image: janssenproject/demo_loadtesting:1.0.12_dev
+        image: ghcr.io/janssenproject/jans/loadtesting-jmeter:1.0.13_dev
         name: load-users
         resources:
           limits:

--- a/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_rdbms_job.yaml
+++ b/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_rdbms_job.yaml
@@ -34,7 +34,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: load-users-mysql-cm
-        image: janssenproject/demo_loadtesting:1.0.12_dev
+        image: ghcr.io/janssenproject/jans/loadtesting-jmeter:1.0.13_dev
         name: load-users-mysql
         resources:
           limits:

--- a/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_spanner_job.yaml
+++ b/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_spanner_job.yaml
@@ -38,7 +38,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: load-users-spanner-cm
-        image: janssenproject/demo_loadtesting:1.0.12_dev
+        image: ghcr.io/janssenproject/jans/loadtesting-jmeter:1.0.13_dev
         volumeMounts:
         - mountPath: /etc/certs/google_service_account.json
           name: google-sa

--- a/docs/admin/planning/benchmarking.md
+++ b/docs/admin/planning/benchmarking.md
@@ -58,8 +58,8 @@ justified.
 **Prerequisite**
 
 1. Create OpenID Connect client with 
-   1. Response Types: ['code', 'id_token]
-   1. Grant Types: ['authorization_code', `implicit`, 'refresh_token']
+   1. Response Types: `['code', 'id_token']`
+   1. Grant Types: `['authorization_code', 'implicit', 'refresh_token']`
    1. Redirect Uri: valid redirect uri which is resolvable by machine which runs this load test
 Change the `FQDN` below and execute:
 ```bash
@@ -106,7 +106,7 @@ Download or build [config-cli-tui](../config-guide/jans-tui/README.md) and run:
 ```
 
 1. Create users by pattern:
-Set the following [env vars](../../../demos/benchmarking/docker-jans-loadtesting-jmeter/README.md#loading-users) 
+Set the following [env vars](https://github.com/JanssenProject/jans/blob/vreplace-janssen-version/demos/benchmarking/docker-jans-loadtesting-jmeter/README.md#loading-users) 
 
 | ENV                          | Example            |
 |------------------------------|--------------------|
@@ -120,7 +120,7 @@ Set the following [env vars](../../../demos/benchmarking/docker-jans-loadtesting
 | `USER_NUMBER_ENDING_POINT`   | 10000              |
 
 
-Run the following script [add_sequenced_jans_user_rdbm.py](../../../demos/benchmarking/docker-jans-loadtesting-jmeter/scripts/add_users_rdbm.py)
+Run the following script [load_users_rdbms_job.py](https://github.com/JanssenProject/jans/blob/vreplace-janssen-version/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_rdbms_job.yaml)
 
 
 **Threads&RampUp**
@@ -140,7 +140,7 @@ jmeter -n -t Authorization_Code_Flow_jans.jmx
 
 ### Authorization Code Flow jmeter test
 
-For load testing with Authorization Code Flow jmeter test is used located [here](https://github.com/JanssenProject/jans/blob/main/demos/load-testing/jmeter/test/Authorization%20Code%20Flow_jans.jmx)
+For load testing with Authorization Code Flow jmeter test is used located [here](https://github.com/JanssenProject/jans/blob/vreplace-janssen-version/demos/benchmarking/docker-jans-loadtesting-jmeter/scripts/tests/authorization_code_flow.jmx)
 
 1. Configure Script
    1. Open jmeter script by GUI
@@ -163,7 +163,7 @@ If everything was done correctly you should see:
 
 ### Resource Owner Password Grant (ROPC) Flow jmeter test
 
-For load testing with Resource Owner Password Grant (ROPC) Flow jmeter test is used located [here](https://github.com/JanssenProject/jans/blob/main/demos/load-testing/jmeter/test/ResourceOwnerPasswordCredentials_jans.jmx)
+For load testing with Resource Owner Password Grant (ROPC) Flow jmeter test is used located [here](https://github.com/JanssenProject/jans/blob/vreplace-janssen-version/demos/benchmarking/docker-jans-loadtesting-jmeter/scripts/tests/resource_owner_password_credentials.jmx)
 
 1. Configure Script
    1. Open jmeter script by GUI

--- a/docs/admin/recipes/benchmark.md
+++ b/docs/admin/recipes/benchmark.md
@@ -90,7 +90,7 @@ A Kubernetes cluster can be created with three nodes or more in one region and t
    ```yaml
    config:
       image:
-        repository: janssenproject/configurator
+        repository: ghcr.io/janssenproject/jans/configurator
         tag: 1.0.13_dev 
       countryCode: US
       email: support@gluu.org
@@ -134,17 +134,17 @@ A Kubernetes cluster can be created with three nodes or more in one region and t
    auth-server:
      image:
        pullPolicy: IfNotPresent
-       repository: janssenproject/auth-server
+       repository: ghcr.io/janssenproject/jans/auth-server
        tag: 1.0.13_dev
    config-api:
      image:
        pullPolicy: IfNotPresent
-       repository: janssenproject/config-api
+       repository: ghcr.io/janssenproject/jans/config-api
        tag: 1.0.13_dev
    persistence:
      image:
        pullPolicy: IfNotPresent
-       repository: janssenproject/persistence-loader
+       repository: ghcr.io/janssenproject/jans/persistence-loader
        tag: 1.0.13_dev 
    nginx-ingress:
      ingress:
@@ -178,6 +178,7 @@ Loading users requires a hefty but temporary amount of resources. By default, th
     ```bash
     mkdir add_users && cd add_users
     ```
+
 2. Copy the following [yaml](https://github.com/JanssenProject/jans/blob/vreplace-janssen-version/demos/benchmarking/docker-jans-loadtesting-jmeter/yaml/load-users/load_users_rdbms_job.yaml) into the folder under the name `load_users.yaml`.
 
 3. Open the file and modify the sql connection parameters. To speed the loading process increase the CPU requests and limits.


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #4906 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

