### PR TITLE
fix(jans-auth-server): Illegal op_policy_uri parameter: - exclude entries with blank values from discovery response (oxauth counterpart) #4888

### DIFF
--- a/docs/admin/reference/json/properties/janssenauthserver-properties.md
+++ b/docs/admin/reference/json/properties/janssenauthserver-properties.md
@@ -15,6 +15,7 @@ tags:
 | activeSessionAuthorizationScope | Authorization Scope for active session | [Details](#activesessionauthorizationscope) |
 | agamaConfiguration | Engine Config which offers an alternative way to build authentication flows in Janssen server | [Details](#agamaconfiguration) |
 | allowAllValueForRevokeEndpoint | Boolean value true allow all value for revoke endpoint | [Details](#allowallvalueforrevokeendpoint) |
+| allowBlankValuesInDiscoveryResponse | Boolean value specifying whether to allow blank values in discovery response | [Details](#allowblankvaluesindiscoveryresponse) |
 | allowEndSessionWithUnmatchedSid | default value false. If true, sid check will be skipped | [Details](#allowendsessionwithunmatchedsid) |
 | allowIdTokenWithoutImplicitGrantType | Specifies if a token without implicit grant types is allowed | [Details](#allowidtokenwithoutimplicitgranttype) |
 | allowPostLogoutRedirectWithoutValidation | Allows post-logout redirect without validation for the End Session endpoint (still AS validates it against clientWhiteList url pattern property) | [Details](#allowpostlogoutredirectwithoutvalidation) |
@@ -312,6 +313,15 @@ tags:
 ### allowAllValueForRevokeEndpoint
 
 - Description: Boolean value true allow all value for revoke endpoint
+
+- Required: No
+
+- Default value: false
+
+
+### allowBlankValuesInDiscoveryResponse
+
+- Description: Boolean value specifying whether to allow blank values in discovery response
 
 - Required: No
 

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -687,6 +687,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Boolean value specifying whether to extend refresh tokens on rotation", defaultValue = "false")
     private Boolean refreshTokenExtendLifetimeOnRotation = false;
 
+    @DocProperty(description = "Boolean value specifying whether to allow blank values in discovery response", defaultValue = "false")
+    private Boolean allowBlankValuesInDiscoveryResponse;
+
     @DocProperty(description = "Check whether user exists and is active before creating RefreshToken. Set it to true if check is needed(Default value is false - don't check.", defaultValue = "false")
     private Boolean checkUserPresenceOnRefreshToken = false;
 
@@ -1036,6 +1039,15 @@ public class AppConfiguration implements Configuration {
 
     public void setRefreshTokenExtendLifetimeOnRotation(Boolean refreshTokenExtendLifetimeOnRotation) {
         this.refreshTokenExtendLifetimeOnRotation = refreshTokenExtendLifetimeOnRotation;
+    }
+
+    public Boolean getAllowBlankValuesInDiscoveryResponse() {
+        if (allowBlankValuesInDiscoveryResponse == null) allowBlankValuesInDiscoveryResponse = false;
+        return allowBlankValuesInDiscoveryResponse;
+    }
+
+    public void setAllowBlankValuesInDiscoveryResponse(Boolean allowBlankValuesInDiscoveryResponse) {
+        this.allowBlankValuesInDiscoveryResponse = allowBlankValuesInDiscoveryResponse;
     }
 
     public int getSectorIdentifierCacheLifetimeInMinutes() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
@@ -28,6 +28,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -304,6 +305,16 @@ public class OpenIdConfiguration extends HttpServlet {
     }
 
     public static void filterOutKeys(JSONObject jsonObj, AppConfiguration appConfiguration) {
+
+        // filter out keys with blank values
+        if (BooleanUtils.isFalse(appConfiguration.getAllowBlankValuesInDiscoveryResponse())) {
+            for (String key : new HashSet<>(jsonObj.keySet())) {
+                if (jsonObj.get(key) == null || StringUtils.isBlank(jsonObj.optString(key))) {
+                    jsonObj.remove(key);
+                }
+            }
+        }
+
         final List<String> denyKeys = appConfiguration.getDiscoveryDenyKeys();
         if (!denyKeys.isEmpty()) {
             for (String key : new HashSet<>(jsonObj.keySet())) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/servlet/OpenIdConfigurationTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/servlet/OpenIdConfigurationTest.java
@@ -9,11 +9,43 @@ import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Yuriy Z
  */
 public class OpenIdConfigurationTest {
+
+    @Test
+    public void filterOutKeys_withBlankValues_shouldRemoveKeys() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key1", "");
+        jsonObject.put("key2", "value2");
+        jsonObject.put("key3", "  ");
+
+        OpenIdConfiguration.filterOutKeys(jsonObject, new AppConfiguration());
+
+        assertEquals("value2", jsonObject.get("key2"));
+        assertFalse(jsonObject.has("key1"));
+        assertFalse(jsonObject.has("key3"));
+    }
+
+    @Test
+    public void filterOutKeys_withBlankValuesAndAllowedBlankValuesInConfig_shouldNotRemoveKeys() {
+        final AppConfiguration appConfiguration = new AppConfiguration();
+        appConfiguration.setAllowBlankValuesInDiscoveryResponse(true);
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key1", "");
+        jsonObject.put("key2", "value2");
+        jsonObject.put("key3", "  ");
+
+        OpenIdConfiguration.filterOutKeys(jsonObject, appConfiguration);
+
+        assertEquals("value2", jsonObject.get("key2"));
+        assertTrue(jsonObject.has("key1"));
+        assertTrue(jsonObject.has("key3"));
+    }
 
     @Test
     public void getAcrValuesList_whenCalled_shouldContainInternalAuthnAlias() {

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -8471,6 +8471,8 @@ components:
           type: boolean
         refreshTokenExtendLifetimeOnRotation:
           type: boolean
+        allowBlankValuesInDiscoveryResponse:
+          type: boolean
         checkUserPresenceOnRefreshToken:
           type: boolean
         consentGatheringScriptBackwardCompatibility:


### PR DESCRIPTION
### Description

fix(jans-auth-server): Illegal op_policy_uri parameter: - exclude entries with blank values from discovery response (oxauth counterpart) 

#### Target issue
  
closes #4888

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

