### PR TITLE
feat(tent): support RP initiated logout

### DIFF
--- a/demos/jans-tent/clientapp/__init__.py
+++ b/demos/jans-tent/clientapp/__init__.py
@@ -120,18 +120,6 @@ def create_app():
         app.logger.info('Not authorized to logout, redirecting to index')
         return redirect(url_for('index'))
 
-        #
-        # app.logger.debug('Session keys logout:')
-        # app.logger.debug(session.keys())
-        # token_hint = session.get('id_token')
-        # session.pop('id_token')
-        # session.pop('user')
-        # app.logger.debug('Session after pop:')
-        # app.logger.debug(session.keys())
-        # return redirect('https://dev2.techno24x7.com/jans-auth/restv1/end_session?post_logout_redirect_uri=https://localhost:9090&token_hint=%s' % token_hint)
-
-
-
     @app.route('/register', methods=['POST'])
     def register():
         app.logger.info('/register called')

--- a/demos/jans-tent/clientapp/__init__.py
+++ b/demos/jans-tent/clientapp/__init__.py
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 import base64
+import urllib
 import json
 import os
 from urllib.parse import urlparse
@@ -38,6 +39,7 @@ def add_config_from_json():
         cfg.SERVER_META_URL = client_info['op_metadata_url']
         cfg.CLIENT_ID = client_info['client_id']
         cfg.CLIENT_SECRET = client_info['client_secret']
+        cfg.END_SESSION_ENDPOINT = client_info['end_session_endpoint'] # separate later
 
 
 def get_preselected_provider():
@@ -98,6 +100,37 @@ def create_app():
         user = session.get('user')
         id_token = session.get('id_token')
         return render_template("home.html", user=user, id_token=id_token)
+
+    @app.route('/logout')
+    def logout():
+        app.logger.info('Called /logout')
+        if 'id_token' in session.keys():
+            app.logger.info('Cleaning session credentials')
+            token_hint = session.get('id_token')
+            session.pop('id_token')
+            session.pop('user')
+            parsed_redirect_uri = urllib.parse.urlparse(cfg.REDIRECT_URIS[0])
+            post_logout_redirect_uri = '%s://%s' % (parsed_redirect_uri.scheme, parsed_redirect_uri.netloc)
+            return redirect(
+                '%s?post_logout_redirect_uri=%s&token_hint=%s' % (
+                    cfg.END_SESSION_ENDPOINT, post_logout_redirect_uri, token_hint
+                )
+            )
+
+        app.logger.info('Not authorized to logout, redirecting to index')
+        return redirect(url_for('index'))
+
+        #
+        # app.logger.debug('Session keys logout:')
+        # app.logger.debug(session.keys())
+        # token_hint = session.get('id_token')
+        # session.pop('id_token')
+        # session.pop('user')
+        # app.logger.debug('Session after pop:')
+        # app.logger.debug(session.keys())
+        # return redirect('https://dev2.techno24x7.com/jans-auth/restv1/end_session?post_logout_redirect_uri=https://localhost:9090&token_hint=%s' % token_hint)
+
+
 
     @app.route('/register', methods=['POST'])
     def register():
@@ -194,9 +227,9 @@ def create_app():
             user = oauth.op.userinfo()
             app.logger.debug('/callback - user = %s' % user)
             session['user'] = user
+            session['id_token'] = token['userinfo']
             app.logger.debug('/callback - cookies = %s' % request.cookies)
             app.logger.debug('/callback - session = %s' % session)
-            session['id_token'] = token['userinfo']
 
             return redirect('/')
 

--- a/demos/jans-tent/clientapp/helpers/client_handler.py
+++ b/demos/jans-tent/clientapp/helpers/client_handler.py
@@ -36,6 +36,7 @@ class ClientHandler:
     __metadata_url = None
     __op_url = None
     __additional_metadata = None
+    __end_session_endpoint = None
     op_data = None
 
     def __init__(self, op_url: str, redirect_uris: list[str], additional_metadata: dict):
@@ -55,6 +56,7 @@ class ClientHandler:
         self.__metadata_url = '%s/.well-known/openid-configuration' % op_url
         self.op_data = self.discover(op_url)
         self.reg_info = self.register_client(op_data=self.op_data, redirect_uris=redirect_uris)
+        self.__end_session_endpoint = self.op_data['end_session_endpoint']
         self.__client_id = self.reg_info['client_id']
         self.__client_secret = self.reg_info['client_secret']
 
@@ -62,7 +64,8 @@ class ClientHandler:
         r = {
             'op_metadata_url': self.__metadata_url,
             'client_id': self.__client_id,
-            'client_secret': self.__client_secret
+            'client_secret': self.__client_secret,
+            'end_session_endpoint': self.__end_session_endpoint
         }
 
         return r
@@ -86,6 +89,7 @@ class ClientHandler:
                              'token_endpoint_auth_method': 'client_secret_post',
                              **self.__additional_metadata
                              }
+        logger.info('calling register with registration_args: %s', json.dumps(registration_args, indent=2))
         reg_info = self.clientAdapter.register(op_data['registration_endpoint'], **registration_args)
         logger.info('register_client - reg_info = %s', json.dumps(reg_info.to_dict(), indent=2))
         return reg_info

--- a/demos/jans-tent/clientapp/helpers/client_handler.py
+++ b/demos/jans-tent/clientapp/helpers/client_handler.py
@@ -77,6 +77,7 @@ class ClientHandler:
         :return: [client information including client-id and secret]
         :rtype: dict
         """
+        logger.debug('called ClientHandler´s register_client method')
         registration_args = {'redirect_uris': redirect_uris,
                              'response_types': ['code'],
                              'grant_types': ['authorization_code'],
@@ -86,7 +87,7 @@ class ClientHandler:
                              **self.__additional_metadata
                              }
         reg_info = self.clientAdapter.register(op_data['registration_endpoint'], **registration_args)
-
+        logger.info('register_client - reg_info = %s', json.dumps(reg_info.to_dict(), indent=2))
         return reg_info
 
     def discover(self, op_url: Optional[str] = __op_url) -> ASConfigurationResponse:

--- a/demos/jans-tent/clientapp/utils/dcr_from_config.py
+++ b/demos/jans-tent/clientapp/utils/dcr_from_config.py
@@ -1,11 +1,16 @@
 import logging
+import urllib.parse
+
 from clientapp import config as cfg
 from clientapp.helpers.client_handler import ClientHandler
 import json
+from urllib import parse
 
 OP_URL = cfg.ISSUER
 REDIRECT_URIS = cfg.REDIRECT_URIS
 SCOPE = cfg.SCOPE
+parsed_redirect_uri = urllib.parse.urlparse(cfg.REDIRECT_URIS[0])
+POST_LOGOUT_REDIRECT_URI = '%s://%s' % (parsed_redirect_uri.scheme, parsed_redirect_uri.netloc)
 
 
 def setup_logging() -> None:
@@ -24,7 +29,10 @@ def register() -> None:
     """
     logger = logging.getLogger(__name__)
     scope_as_list = SCOPE.split(" ")
-    additional_params = {'scope': scope_as_list}
+    additional_params = {
+        'scope': scope_as_list,
+        'post_logout_redirect_uris': [POST_LOGOUT_REDIRECT_URI]
+    }
     client_handler = ClientHandler(OP_URL, REDIRECT_URIS, additional_params)
     json_client_info = json.dumps(client_handler.get_client_dict(), indent=4)
     with open('client_info.json', 'w') as outfile:

--- a/demos/jans-tent/tests/unit_integration/helper.py
+++ b/demos/jans-tent/tests/unit_integration/helper.py
@@ -17,6 +17,7 @@ class FlaskBaseTestCase(TestCase):
         clientapp.cfg.CLIENT_ID = 'any-client-id-stub'
         clientapp.cfg.CLIENT_SECRET = 'any-client-secret-stub'
         clientapp.cfg.SERVER_META_URL = 'https://ophostname.com/server/meta/url'
+        clientapp.cfg.END_SESSION_ENDPOINT = 'https://ophostname.com/end_session_endpoint'
         clientapp.add_config_from_json = MagicMock(name='add_config_from_json')
         clientapp.add_config_from_json.return_value(None)
         self.stashed_discover = ClientHandler.discover

--- a/demos/jans-tent/tests/unit_integration/test_dcr_from_config.py
+++ b/demos/jans-tent/tests/unit_integration/test_dcr_from_config.py
@@ -47,7 +47,12 @@ class TestDrcFromConfig(TestCase):
     @patch('clientapp.helpers.client_handler.ClientHandler.__init__', MagicMock(return_value=None))
     def test_register_should_call_ClientHandler_with_params(self):
         dcr_from_config.register()
-        ClientHandler.__init__.assert_called_once_with(cfg.ISSUER, cfg.REDIRECT_URIS, {'scope': cfg.SCOPE.split(" ")})
+        ClientHandler.__init__.assert_called_once_with(
+            cfg.ISSUER, cfg.REDIRECT_URIS, {
+                'scope': cfg.SCOPE.split(" "),
+                "post_logout_redirect_uris": ['https://localhost:9090']
+            }
+        )
 
     def test_register_should_call_open(self):
         with patch('builtins.open', mock_open()) as open_mock:

--- a/demos/jans-tent/tests/unit_integration/test_logout_endpoint.py
+++ b/demos/jans-tent/tests/unit_integration/test_logout_endpoint.py
@@ -1,0 +1,65 @@
+import clientapp
+from helper import FlaskBaseTestCase, app_endpoints
+from flask import url_for, session
+from urllib import parse
+from clientapp import config as cfg
+
+class TestLogoutEndpoint(FlaskBaseTestCase):
+    def authenticated_session_mock(self):
+        with self.client.session_transaction() as session:
+            session['id_token'] = 'id_token_stub'
+
+    def test_endpoint_exists(self):
+        self.assertIn(
+            'logout',
+            app_endpoints(clientapp.create_app())
+        )
+
+    def test_endpoint_should_require_authentication(self):
+        ...
+    def test_logout_endpoint_should_redirect_to_home_if_unauthenticated(self):
+        # print(self.client.get(url_for('logout')).response)
+        response = self.client.get(url_for('logout'))
+        assert(response.status_code == 302)
+        assert(response.location == url_for('index'))
+
+
+    def test_logout_endpoint_should_clear_session(self):
+        with self.client.session_transaction() as sess:
+            sess['id_token'] = 'id_token_stub'
+            sess['user'] = 'userinfo stub'
+
+        with self.client:
+            self.client.get(url_for('logout'))
+            assert 'id_token' not in session
+            assert 'user' not in session
+
+    def test_endpoint_should_redirect_to_end_session_endpoint(self):
+        with self.client.session_transaction() as session:
+            session['id_token'] = 'id_token_stub'
+            session['user'] = 'userinfo stub'
+
+        response = self.client.get(url_for('logout'))
+
+        parsed_location = parse.urlparse(response.location)
+        assert parsed_location.scheme == 'https'
+        assert parsed_location.netloc == 'ophostname.com'
+        assert parsed_location.path == '/end_session_endpoint'
+
+
+
+    def test_endpoint_should_redirect_to_end_session_endpoint_with_params(self):
+        token_stub = 'id_token_stub'
+        with self.client.session_transaction() as session:
+            session['id_token'] = token_stub
+            session['user'] = 'userinfo stub'
+
+        parsed_redirect_uri = parse.urlparse(cfg.REDIRECT_URIS[0])
+        post_logout_uri = '%s://%s' % (parsed_redirect_uri.scheme, parsed_redirect_uri.netloc)
+
+        expected_query = 'post_logout_redirect_uri=%s&token_hint=%s' % (post_logout_uri, token_stub)
+        response = self.client.get(url_for('logout'))
+
+        parsed_location = parse.urlparse(response.location)
+        assert parsed_location.query == expected_query
+


### PR DESCRIPTION
Logout using Session Management. Kill session and redirects to `end_session_endpoint`

Details:

1. `post_logout_redirect_uris` is now sent in `DCR`, parsed from `redirect_uris` (localhost:9090).
2. `end_session_endpoint` is persisted to `client-info.json` for now.
3. `logout` endpoint requires authentication to be accessed, clear session and redirect to `end_session_endpoint` with the following query string params: `token_hint` , `post_logout_redirect_uri`

Tests:
https://github.com/JanssenProject/jans/commit/4addca2526bd5559520574bbb00c27fe48601009 provides integration tests that ensures item 3 mentioned above.


Closes #4727 , 