### PR TITLE
fix(jans-fido2): compilation is failing due to missed jans-doc dependency #5051

### DIFF
--- a/jans-fido2/notify-client/pom.xml
+++ b/jans-fido2/notify-client/pom.xml
@@ -27,5 +27,9 @@
 	        <groupId>org.jboss.resteasy</groupId>
 	        <artifactId>resteasy-jackson2-provider</artifactId>
 	    </dependency>
+        <dependency>
+            <groupId>io.jans</groupId>
+            <artifactId>jans-doc</artifactId>
+        </dependency>
    	</dependencies>
 </project>


### PR DESCRIPTION
### Description

fix(jans-fido2): compilation is failing due to missed jans-doc dependency 

#### Target issue
  
closes #5051

