### PR TITLE
fix(jans-auth-server): Device Flow fails if web session already exists #3388

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/DeviceAuthorizationRestWebService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/DeviceAuthorizationRestWebService.java
@@ -26,7 +26,6 @@ import jakarta.ws.rs.core.SecurityContext;
  */
 public interface DeviceAuthorizationRestWebService {
 
-
     /**
      * Device Authorization Request [RFC8628 3.1].
      * Generates user_code, device_code and data needed to follow the device authorization flow
@@ -44,5 +43,4 @@ public interface DeviceAuthorizationRestWebService {
             @Context HttpServletRequest httpRequest,
             @Context HttpServletResponse httpResponse,
             @Context SecurityContext securityContext);
-
 }


### PR DESCRIPTION
### Description

fix(jans-auth-server): Device Flow fails if web session already exists 

#### Target issue
  
closes #3388

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed

