### PR TITLE
chore(docker-jans-fido2): move location of downloaded Apple WebAuthn Root CA file

### DIFF
--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -46,7 +46,7 @@ RUN wget -q https://maven.jans.io/maven/io/jans/jython-installer/${JYTHON_VERSIO
 # =====
 
 ENV CN_VERSION=1.0.14-SNAPSHOT
-ENV CN_BUILD_DATE='2023-05-10 08:26'
+ENV CN_BUILD_DATE='2023-06-08 17:15'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-fido2-server/${CN_VERSION}/jans-fido2-server-${CN_VERSION}.war
 
 # Install FIDO2
@@ -65,7 +65,7 @@ RUN mkdir -p ${JETTY_BASE}/jans-fido2/webapps \
 # jans-linux-setup sync
 # =====================
 
-ENV JANS_SOURCE_VERSION=49054ae66d17d2e7d34febd31ac7ab25be3acdc4
+ENV JANS_SOURCE_VERSION=16001859895d5aa5d840cfc9d425d0ee95149979
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)
@@ -103,7 +103,7 @@ RUN rm -rf /tmp/jans
 
 # download external files
 ARG MDS_DOWNLOAD_DATE='2022-10-03'
-RUN wget -q https://www.apple.com/certificateauthority/Apple_WebAuthn_Root_CA.pem -P /etc/jans/conf/fido2/apple/ \
+RUN wget -q https://www.apple.com/certificateauthority/Apple_WebAuthn_Root_CA.pem -P /etc/jans/conf/fido2/authenticator_cert/ \
     && wget -q https://mds.fidoalliance.org/ -O /etc/jans/conf/fido2/mds/toc/toc.jwt \
     && wget -q http://secure.globalsign.com/cacert/root-r3.crt -P /etc/jans/conf/fido2/mds/cert/
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #5189 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

