### PR TITLE
feat(fido2): validate acceptable status when loading MDS

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/TocService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/TocService.java
@@ -224,6 +224,7 @@ public class TocService {
 				if (metadataEntry.hasNonNull("aaguid")) {
 					String aaguid = metadataEntry.get("aaguid").asText();
 					try {
+						certificateVerifier.verifyStatusAcceptable(aaguid, metadataEntry);
 						JsonNode metaDataStatement = dataMapperService
 								.readTree(metadataEntry.get("metadataStatement").toPrettyString());
 						if (metaDataStatement != null) {
@@ -234,6 +235,8 @@ public class TocService {
 
 					} catch (IOException e) {
 						log.error("Error parsing the metadata statement", e);
+					} catch (Fido2RuntimeException e) {
+						log.error("Failed to verify acceptable status: {}", e.getMessage());
 					}
 
 				} else if (metadataEntry.hasNonNull("aaid")) {


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
- Added method for validating acceptable status
- Validation of acceptable status during MDS load process
  
closes #5191
