### PR TITLE
fix(jans-fido2): buildfix - removed stale notify-client reference after move to jans-core #5257

### DIFF
--- a/jans-fido2/pom.xml
+++ b/jans-fido2/pom.xml
@@ -70,7 +70,6 @@
 	<modules>
 		<module>model</module>
 		<module>client</module>
-		<module>notify-client</module>
 		<module>server</module>
 	</modules>
 	


### PR DESCRIPTION
### Description

fix(jans-fido2): buildfix - remove stale notify-client reference after move to jans-core 

#### Target issue
  
closes #5257

