### PR TITLE
feat(jans-tarp): on registering client the scope parameter should be space separated string #5259

### DIFF
--- a/demos/jans-tarp/src/options/oidcClientDetails.tsx
+++ b/demos/jans-tarp/src/options/oidcClientDetails.tsx
@@ -101,7 +101,7 @@ const OIDCClientDetails = (data) => {
             if (!!result.oidcClient) {
 
                 let options: ILooseObject = {
-                    scope: result?.oidcClient?.scope.join(['+']),
+                    scope: result?.oidcClient?.scope,
                     response_type: result?.oidcClient?.response_type[0],
                     redirect_uri: redirectUrl,
                     client_id: result?.oidcClient?.client_id,
@@ -155,14 +155,14 @@ const OIDCClientDetails = (data) => {
                             resolve(JSON.stringify(result));
                         });
                     });
-
+                    
                     const tokenReqData = qs.stringify({
                         redirect_uri: redirectUrl,
                         grant_type: 'authorization_code',
                         code_verifier: secret,
                         client_id: result.oidcClient.client_id,
                         code,
-                        scope: result.oidcClient.scope.join(['+'])
+                        scope: result.oidcClient.scope
                     })
 
                     const tokenReqOptions = {

--- a/demos/jans-tarp/src/options/registerForm.tsx
+++ b/demos/jans-tarp/src/options/registerForm.tsx
@@ -133,7 +133,7 @@ const RegisterForm = (data) => {
             const opConfigurationEndpoint = generateOpenIdConfigurationURL(issuerOption.map((iss) => iss.value)[0]);
             const opConfigurationEndpointURL = new URL(opConfigurationEndpoint);
             const issuer = opConfigurationEndpointURL.protocol + '//' + opConfigurationEndpointURL.hostname;
-            const scope = scopeOption.map((ele) => ele.value);
+            const scope = scopeOption.map((ele) => ele.value).join(" ");
             const openapiConfig = await getOpenidConfiguration(opConfigurationEndpoint);
 
             if (openapiConfig != undefined) {


### PR DESCRIPTION

closes #5259
