### PR TITLE
fix(jans-linux-setup): CR variable names and snapshot dir

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/cache_refresh.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/cache_refresh.py
@@ -42,13 +42,13 @@ class CacheRefreshInstaller(JettyInstaller):
     def render_import_templates(self):
         self.logIt("Preparing base64 encodings configuration files")
         self.renderTemplateInOut(self.config_json_fn, self.templates_folder, self.output_folder)
-        Config.templateRenderingDict['jans_auth_config_base64'] = self.generate_base64_ldap_file(
+        Config.templateRenderingDict['cache_refresh_config_base64'] = self.generate_base64_ldap_file(
                 os.path.join(
                     self.output_folder,
                     os.path.basename(self.config_json_fn)
                 )
             )
-        Config.templateRenderingDict['jans_auth_static_conf_base64'] = self.generate_base64_ldap_file(self.static_config_json_fn)
+        Config.templateRenderingDict['cache_refresh_static_conf_base64'] = self.generate_base64_ldap_file(self.static_config_json_fn)
 
         self.renderTemplateInOut(self.ldif_config_fn, self.templates_folder, self.output_folder)
 

--- a/jans-linux-setup/jans_setup/templates/jans-cache-refresh/configuration.ldif
+++ b/jans-linux-setup/jans_setup/templates/jans-cache-refresh/configuration.ldif
@@ -1,6 +1,6 @@
 dn: ou=jans-cache-refresh,ou=configuration,o=jans
-jansConfDyn::%(jans_auth_config_base64)s
-jansConfStatic::%(jans_auth_static_conf_base64)s
+jansConfDyn::%(cache_refresh_config_base64)s
+jansConfStatic::%(cache_refresh_static_conf_base64)s
 jansRevision: 1
 objectClass: top
 objectClass: jansAppConf

--- a/jans-linux-setup/jans_setup/templates/jans-cache-refresh/jans-cache-refresh-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-cache-refresh/jans-cache-refresh-config.json
@@ -66,7 +66,7 @@
       "destination": "sn"
     }
   ],
-  "snapshotFolder": "/var/cr-snapshots",
+  "snapshotFolder": "%(snapshots_dir)s",
   "snapshotMaxCount": 10,
   "baseDN": "o=jans",
   "personObjectClassTypes": [


### PR DESCRIPTION
closes #5292