### PR TITLE
feat(jans-linux-setup): config-api saml plugin

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/config.py
+++ b/jans-linux-setup/jans_setup/setup_app/config.py
@@ -206,6 +206,7 @@ class Config:
         self.install_cache_refresh = True
         self.loadTestData = False
         self.allowPreReleasedFeatures = False
+        self.install_saml_integration = False
 
         # backward compatibility
         self.os_type = base.os_type

--- a/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
@@ -25,6 +25,7 @@ class ConfigApiInstaller(JettyInstaller):
                 (os.path.join(Config.dist_jans_dir, 'user-mgt-plugin.jar'), os.path.join(base.current_app.app_info['JANS_MAVEN'], 'maven/io/jans/jans-config-api/plugins/user-mgt-plugin/{0}/user-mgt-plugin-{0}-distribution.jar').format(base.current_app.app_info['ox_version'])),
                 (os.path.join(Config.dist_jans_dir, 'fido2-plugin.jar'), os.path.join(base.current_app.app_info['JANS_MAVEN'], 'maven/io/jans/jans-config-api/plugins/fido2-plugin/{0}/fido2-plugin-{0}-distribution.jar').format(base.current_app.app_info['ox_version'])),
                 (os.path.join(Config.dist_jans_dir, 'cache-refresh-plugin.jar'), os.path.join(base.current_app.app_info['JANS_MAVEN'], 'maven/io/jans/jans-config-api/plugins/cache-refresh-plugin/{0}/cache-refresh-plugin-{0}-distribution.jar').format(base.current_app.app_info['ox_version'])),
+                (os.path.join(Config.dist_jans_dir, 'saml-plugin.jar'), os.path.join(base.current_app.app_info['JANS_MAVEN'], 'maven/io/jans/jans-config-api/plugins/saml-plugin-plugin/{0}/saml-plugin-{0}-distribution.jar').format(base.current_app.app_info['ox_version'])),
                 ]
 
     def __init__(self):
@@ -69,6 +70,9 @@ class ConfigApiInstaller(JettyInstaller):
 
         if Config.install_cache_refresh:
             self.install_plugin('cache-refresh-plugin')
+
+        if Config.install_saml_integration:
+            self.install_plugin('saml-plugin')
 
         self.enable()
 

--- a/jans-linux-setup/jans_setup/setup_app/setup_options.py
+++ b/jans-linux-setup/jans_setup/setup_app/setup_options.py
@@ -25,6 +25,7 @@ def get_setup_options():
         'loadTestDataExit': False,
         'loadData': True,
         'properties_password': None,
+        'install_saml_integration': False,
     }
 
     if not (getattr(base.argsp, 'remote_couchbase', None) or base.argsp.remote_rdbm or base.argsp.local_rdbm):
@@ -189,6 +190,8 @@ def get_setup_options():
 
     if base.argsp.no_httpd:
         setupOptions['installHTTPD'] = False
+
+    setupOptions['install_saml_integration'] = base.argsp.install_saml_integration
 
 
     return setupOptions

--- a/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
@@ -112,6 +112,9 @@ if PROFILE != OPENBANKING_PROFILE:
     parser.add_argument('-test-client-redirect-uri', help="Redirect URI for test client")
     parser.add_argument('--test-client-trusted', help="Make test client trusted", action='store_true')
 
+    parser.add_argument('--install-saml-integration', help="Installs SAML Integration", action='store_true')
+
+
 else:
     # openbanking
     parser.add_argument('--no-external-key', help="Don't use external key", action='store_true')

--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -869,6 +869,18 @@ class PropertiesUtils(SetupUtils):
 
             Config.ob_alias = self.getPrompt('  Openbanking Key Alias', Config.ob_alias)
 
+    def prompt_saml_integration(self):
+        if Config.installed_instance and Config.install_saml_integration:
+            return
+
+        prompt_for_saml_integration = self.getPrompt("Install SAML Integration?", 
+                            self.getDefaultOption(Config.install_saml_integration)
+                            )[0].lower()
+
+        Config.install_saml_integration = prompt_for_saml_integration == 'y'
+
+        if Config.installed_instance and Config.install_saml_integration:
+            Config.addPostSetupService.append('install_saml_integration')
 
     def promptForProperties(self):
 
@@ -954,6 +966,7 @@ class PropertiesUtils(SetupUtils):
             self.promptForScimServer()
             self.promptForFido2Server()
             self.prompt_for_cache_refresh()
+            self.prompt_saml_integration()
             #self.promptForEleven()
             #if (not Config.installOxd) and Config.oxd_package:
             #    self.promptForOxd()


### PR DESCRIPTION
closes #5321

- [ ] Prerequisite: Keycloak installation, Keycloak OpenID Client Creation with admin role.
- [ ] [Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)](config-api-saml-plugin: Jetty changes to configure new config-api plugin for saml-plugin)
