### PR TITLE
fix(jans-pycloudlib): unable to parse mysql server version

### DIFF
--- a/jans-pycloudlib/jans/pycloudlib/persistence/sql.py
+++ b/jans-pycloudlib/jans/pycloudlib/persistence/sql.py
@@ -32,7 +32,7 @@ if _t.TYPE_CHECKING:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
-SERVER_VERSION_RE = re.compile(r"\d+(.\d+)+")
+SERVER_VERSION_RE = re.compile(r"[\d.]+")
 
 
 def get_sql_password(manager: Manager) -> str:
@@ -540,8 +540,8 @@ class SqlClient(SqlSchemaMixin):
 
     def get_server_version(self) -> tuple[int, ...]:
         """Get server version as tuple."""
-        # major and minor format
-        version = [0, 0]
+        # major.minor.patch format
+        version = [0, 0, 0]
 
         pattern = SERVER_VERSION_RE.search(self.server_version)
         if pattern:

--- a/jans-pycloudlib/tests/test_persistence.py
+++ b/jans-pycloudlib/tests/test_persistence.py
@@ -930,3 +930,19 @@ def test_persistence_mapper_groups_rdn(monkeypatch):
         "sql": ["", "cache", "sessions"],
     }
     assert PersistenceMapper().groups_with_rdn() == groups
+
+
+@pytest.mark.parametrize("given, expected", [
+    ("8.0.30", (8, 0, 30)),
+    ("5.7.22-standard", (5, 7, 22)),
+    ("8.0.25-221000 MySQL Community Server", (8, 0, 25)),
+])
+def test_get_server_version(gmanager, given, expected):
+    from jans.pycloudlib.persistence.sql import SqlClient
+
+    def patched_server_version(cls):
+        return given
+
+    SqlClient.server_version = property(patched_server_version)
+    client = SqlClient(gmanager)
+    assert client.get_server_version() == expected


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #5336 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

