### PR TITLE
fix(jans-auth-server): corrected current_sessions cookie value encoding #5262

### DIFF
--- a/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/SelectAccountHttpTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/ws/rs/SelectAccountHttpTest.java
@@ -7,11 +7,7 @@
 package io.jans.as.client.ws.rs;
 
 import com.google.common.collect.Lists;
-import io.jans.as.client.AuthorizationRequest;
-import io.jans.as.client.AuthorizationResponse;
-import io.jans.as.client.AuthorizeClient;
-import io.jans.as.client.BaseTest;
-import io.jans.as.client.RegisterResponse;
+import io.jans.as.client.*;
 import io.jans.as.client.client.AssertBuilder;
 import io.jans.as.client.page.LoginPage;
 import io.jans.as.client.page.PageConfig;
@@ -30,15 +26,12 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * @author Yuriy Zabrovarnyy
@@ -96,7 +89,11 @@ public class SelectAccountHttpTest extends BaseTest {
 
         output("4. both Account 1 and Account 2 sessions must be in current_sessions cookie");
         assertEquals(account2SessionId, assertSessionIdCookie());
-        List<Object> currentSessions = new JSONArray(driver.manage().getCookieNamed("current_sessions").getValue()).toList();
+
+        final String currentSessionsCookieValue = driver.manage().getCookieNamed("current_sessions").getValue();
+        output("current_sessions cookie value = " + currentSessionsCookieValue);
+
+        List<Object> currentSessions = new JSONArray(URLDecoder.decode(currentSessionsCookieValue, "UTF-8")).toList();
         assertTrue(currentSessions.contains(account1SessionId));
         assertTrue(currentSessions.contains(account2SessionId));
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -259,6 +259,9 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
         authzRequestService.createOauth2AuditLog(authzRequest);
 
         log.debug("Attempting to request authorization: {}", authzRequest);
+        if (log.isTraceEnabled()) {
+            log.trace("Attempting to request authorization with cookies: {}", cookieService.getCookiesAsString(servletRequest));
+        }
 
         ResponseBuilder builder;
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -259,9 +259,6 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
         authzRequestService.createOauth2AuditLog(authzRequest);
 
         log.debug("Attempting to request authorization: {}", authzRequest);
-        if (log.isTraceEnabled()) {
-            log.trace("Attempting to request authorization with cookies: {}", cookieService.getCookiesAsString(servletRequest));
-        }
 
         ResponseBuilder builder;
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -534,6 +534,9 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
 
     private void checkPromptSelectAccount(AuthzRequest authzRequest, List<Prompt> prompts) {
         if (prompts.contains(Prompt.SELECT_ACCOUNT)) {
+            if (log.isTraceEnabled()) {
+                cookieService.getCurrentSessions(authzRequest.getHttpRequest()); // force print current_sessions
+            }
             throw new WebApplicationException(redirectToSelectAccountPage(authzRequest, prompts));
         }
     }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/CookieService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/CookieService.java
@@ -167,24 +167,6 @@ public class CookieService {
         currentSessions.removeAll(toRemove);
     }
 
-    public String getCookiesAsString(HttpServletRequest request) {
-        StringBuilder result = new StringBuilder();
-        try {
-            final Cookie[] cookies = request.getCookies();
-            if (cookies != null) {
-                for (Cookie cookie : cookies) {
-                    result.append(cookie.getName());
-                    result.append("=");
-                    result.append(cookie.getValue());
-                    result.append("\n");
-                }
-            }
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-        }
-        return result.toString();
-    }
-
     public String getValueFromCookie(HttpServletRequest request, String cookieName) {
         try {
             final Cookie[] cookies = request.getCookies();

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/CookieService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/CookieService.java
@@ -153,6 +153,24 @@ public class CookieService {
         currentSessions.removeAll(toRemove);
     }
 
+    public String getCookiesAsString(HttpServletRequest request) {
+        StringBuilder result = new StringBuilder();
+        try {
+            final Cookie[] cookies = request.getCookies();
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    result.append(cookie.getName());
+                    result.append("=");
+                    result.append(cookie.getValue());
+                    result.append("\n");
+                }
+            }
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+        return result.toString();
+    }
+
     public String getValueFromCookie(HttpServletRequest request, String cookieName) {
         try {
             final Cookie[] cookies = request.getCookies();

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/CookieService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/CookieService.java
@@ -7,17 +7,12 @@
 package io.jans.as.server.service;
 
 import com.google.common.collect.Sets;
-import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.common.model.session.SessionId;
 import io.jans.as.common.model.session.SessionIdState;
+import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.server.model.config.ConfigurationFactory;
 import io.jans.orm.exception.EntryPersistenceException;
 import io.jans.service.cdi.util.CdiUtil;
-import org.apache.commons.lang.StringUtils;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.slf4j.Logger;
-
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
@@ -25,6 +20,14 @@ import jakarta.inject.Inject;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.slf4j.Logger;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -105,23 +108,34 @@ public class CookieService {
         try {
             return Sets.newHashSet(toList(new JSONArray(valueFromCookie)));
         } catch (JSONException e) {
-            log.error("Failed to parse current_sessions, value: " + valueFromCookie, e);
-            return Sets.newHashSet();
+            try {
+                String value = URLDecoder.decode(valueFromCookie, "UTF-8");
+                return Sets.newHashSet(toList(new JSONArray(value)));
+            } catch (UnsupportedEncodingException e1) {
+                log.error("Failed to parse current_sessions, value: " + valueFromCookie, e);
+            }
         }
+
+        log.debug("Return back empty current_sessions.");
+        return Sets.newHashSet();
     }
 
     public void addCurrentSessionCookie(SessionId sessionId, HttpServletRequest request, HttpServletResponse httpResponse) {
-        final Set<String> currentSessions = getCurrentSessions(request);
-        removeOutdatedCurrentSessions(currentSessions, sessionId);
-        currentSessions.add(sessionId.getId());
+        try {
+            final Set<String> currentSessions = getCurrentSessions(request);
+            removeOutdatedCurrentSessions(currentSessions, sessionId);
+            currentSessions.add(sessionId.getId());
 
-        String header = CURRENT_SESSIONS_COOKIE_NAME + "=" + new JSONArray(currentSessions).toString();
-        log.trace("on add - {}, addedValue: {}", header, sessionId.getId());
-        header += "; Path=/";
-        header += "; Secure";
-        header += "; HttpOnly";
+            String header = CURRENT_SESSIONS_COOKIE_NAME + "=" + URLEncoder.encode(new JSONArray(currentSessions).toString(), "UTF-8");
+            log.trace("on add - {}, addedValue: {}", header, sessionId.getId());
+            header += "; Path=/";
+            header += "; Secure";
+            header += "; HttpOnly";
 
-        createCookie(header, httpResponse);
+            createCookie(header, httpResponse);
+        } catch (UnsupportedEncodingException e) {
+            log.error("Failed to modify current_sessions", e);
+        }
     }
 
     private void removeOutdatedCurrentSessions(Set<String> currentSessions, SessionId session) {


### PR DESCRIPTION
### Description

fix(jans-auth-server): corrected current_sessions cookie value encoding 

#### Target issue
  
closes #5262

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
