### PR TITLE
feat(jans-linux-setup): make jans_stat a default oauth scope #5393

### DIFF
--- a/jans-linux-setup/jans_setup/templates/scopes.ldif
+++ b/jans-linux-setup/jans_setup/templates/scopes.ldif
@@ -191,7 +191,7 @@ dn: inum=C4F7,ou=scopes,o=jans
 jansId: jans_stat
 inum: C4F7
 description: This scope is required for calling Statistic Endpoint
-jansDefScope: false
+jansDefScope: true
 jansAttrs: {"spontaneousClientId":"","spontaneousClientScopes":[],"showInConfigurationEndpoint":false}
 jansScopeTyp: oauth
 objectClass: top


### PR DESCRIPTION
### Description

feat(jans-linux-setup): make jans_stat a default oauth scope

#### Target issue
  
closes  #5393


