### PR TITLE
feat(fido2): make mds and attestation optional

### DIFF
--- a/docs/admin/fido/config.md
+++ b/docs/admin/fido/config.md
@@ -26,18 +26,20 @@ tags:
 
 #### Fido2Configuration structure
 
-| Field named                     | Example                                                                          | Description                                                                               |
-|---------------------------------|----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| authenticatorCertsFolder        | /etc/jans/conf/fido2/authenticator_cert                                          | Authenticators certificates fodler.                                                       |
-| mdsCertsFolder                  | /etc/jans/conf/fido2/mds/cert                                                    | MDS TOC root certificates folder.                                                         |
-| mdsTocsFolder                   | /etc/jans/conf/fido2/mds/toc                                                     | MDS TOC files folder.                                                                     |
-| serverMetadataFolder            | /etc/jans/conf/fido2/server_metadata                                             | Authenticators metadata in json format. Example: virtual devices.                         |
-| metadataUrlsProvider            | https://mds3.fido.tools                                                          | String value to provide source of URLs with external metadata.                            |
-| requestedCredentialTypes        | ["RS256","ES256"]                                                                |                                                                                           |
-| requestedParties                | [{"name":"https://my-jans-server.jans.io","domains":["my-jans-server.jans.io"]}] | Requested party name.                                                                     |
-| userAutoEnrollment              | false                                                                            | Allow to enroll users on enrollment/authentication requests. (Useful while running tests) |
-| unfinishedRequestExpiration     | 180                                                                              | Expiration time in seconds for pending enrollment/authentication requests                 |
-| authenticationHistoryExpiration | 1296000                                                                          | Expiration time in seconds for approved authentication requests.                          |
+| Field named                         | Example                                                                          | Description                                                                               |
+|-------------------------------------|----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| authenticatorCertsFolder            | /etc/jans/conf/fido2/authenticator_cert                                          | Authenticators certificates fodler.                                                       |
+| mdsCertsFolder                      | /etc/jans/conf/fido2/mds/cert                                                    | MDS TOC root certificates folder.                                                         |
+| mdsTocsFolder                       | /etc/jans/conf/fido2/mds/toc                                                     | MDS TOC files folder.                                                                     |
+| serverMetadataFolder                | /etc/jans/conf/fido2/server_metadata                                             | Authenticators metadata in json format. Example: virtual devices.                         |
+| metadataUrlsProvider                | https://mds3.fido.tools                                                          | String value to provide source of URLs with external metadata.                            |
+| requestedCredentialTypes            | ["RS256","ES256"]                                                                |                                                                                           |
+| requestedParties                    | [{"name":"https://my-jans-server.jans.io","domains":["my-jans-server.jans.io"]}] | Requested party name.                                                                     |
+| userAutoEnrollment                  | false                                                                            | Allow to enroll users on enrollment/authentication requests. (Useful while running tests) |
+| unfinishedRequestExpiration         | 180                                                                              | Expiration time in seconds for pending enrollment/authentication requests                 |
+| authenticationHistoryExpiration     | 1296000                                                                          | Expiration time in seconds for approved authentication requests.                          |
+| skipDownloadMdsEnabled              | false                                                                            | Boolean value indicating whether the MDS download should be omitted                       |
+| skipValidateMdsInAttestationEnabled | false                                                                            | Boolean value indicating whether MDS validation should be omitted during attestation      |
 
 ### Configuring the FIDO2 server:
 #### 1. Read Configuration parameters:
@@ -76,6 +78,8 @@ Response:
     "authenticationHistoryExpiration": 1296000,
     "serverMetadataFolder": "/etc/jans/conf/fido2/server_metadata",
     "metadataUrlsProvider": "",
+    "skipDownloadMdsEnabled": false,
+    "skipValidateMdsInAttestationEnabled": false,
     "requestedCredentialTypes": [
       "RS256",
       "ES256"

--- a/docs/admin/fido/vendor-metadata.md
+++ b/docs/admin/fido/vendor-metadata.md
@@ -16,195 +16,195 @@ Janssen's FIDO server has a [configuration parameter](./config.md) called `serve
 Example of authenticator metadata:
 ```
 {
-			"aaguid": "83c44309-....-8be444b573cb",
-			"metadataStatement": {
-				"legalHeader": "Submission of this statement and retrieval and use of this statement indicates acceptance of the appropriate agreement located at https://fidoalliance.org/metadata/metadata-legal-terms/.",
-				"aaguid": "83c44309-....-8be444b573cb",
-				"description": "Just an example",
-				"authenticatorVersion": 448962,
-				"protocolFamily": "fido2",
-				"schema": 3,
-				"upv": [
-					{
-						"major": 1,
-						"minor": 0
-					},
-					{
-						"major": 1,
-						"minor": 1
-					}
-				],
-				"authenticationAlgorithms": [
-					"ed25519_eddsa_sha512_raw",
-					"secp256r1_ecdsa_sha256_raw"
-				],
-				"publicKeyAlgAndEncodings": [
-					"cose"
-				],
-				"attestationTypes": [
-					"basic_full"
-				],
-				"userVerificationDetails": [
-					[
-						{
-							"userVerificationMethod": "passcode_external",
-							"caDesc": {
-								"base": 64,
-								"minLength": 4,
-								"maxRetries": 8,
-								"blockSlowdown": 0
-							}
-						},
-						{
-							"userVerificationMethod": "presence_internal"
-						}
-					],
-					[
-						{
-							"userVerificationMethod": "passcode_external",
-							"caDesc": {
-								"base": 64,
-								"minLength": 4,
-								"maxRetries": 8,
-								"blockSlowdown": 0
-							}
-						}
-					],
-					[
-						{
-							"userVerificationMethod": "fingerprint_internal",
-							"baDesc": {
-								"selfAttestedFRR": 0,
-								"selfAttestedFAR": 0,
-								"maxTemplates": 5,
-								"maxRetries": 5,
-								"blockSlowdown": 0
-							}
-						},
-						{
-							"userVerificationMethod": "presence_internal"
-						}
-					],
-					[
-						{
-							"userVerificationMethod": "none"
-						}
-					],
-					[
-						{
-							"userVerificationMethod": "fingerprint_internal",
-							"baDesc": {
-								"selfAttestedFRR": 0,
-								"selfAttestedFAR": 0,
-								"maxTemplates": 5,
-								"maxRetries": 5,
-								"blockSlowdown": 0
-							}
-						}
-					],
-					[
-						{
-							"userVerificationMethod": "presence_internal"
-						}
-					]
-				],
-				"keyProtection": [
-					"hardware",
-					"secure_element"
-				],
-				"matcherProtection": [
-					"on_chip"
-				],
-				"cryptoStrength": 128,
-				"attachmentHint": [
-					"external",
-					"wired"
-				],
-				"tcDisplay": [],
-				"attestationRootCertificates": [
-					"MII....psmyPzK+Vsgw2jeRQ5JlKDyqE0hebfC1tvFu0CCrJFcw=="
-				],
-				"icon": "data:image/png;base64,iVBORw0KGgoAAAA....k5+36hF7vXAAAAAElFTkSuQmCC",
-				"authenticatorGetInfo": {
-					"versions": [
-						"FIDO_2_0",
-						"FIDO_2_1_PRE",
-						"FIDO_2_1"
-					],
-					"extensions": [
-						"credProtect",
-						"hmac-secret",
-						"largeBlobKey",
-						"credBlob",
-						"minPinLength"
-					],
-					"aaguid": "83c.....73cb",
-					"options": {
-						"plat": false,
-						"rk": true,
-						"clientPin": true,
-						"up": true,
-						"uv": false,
-						"pinUvAuthToken": true,
-						"largeBlobs": true,
-						"ep": false,
-						"bioEnroll": false,
-						"userVerificationMgmtPreview": false,
-						"authnrCfg": true,
-						"credMgmt": true,
-						"credentialMgmtPreview": true,
-						"setMinPINLength": true,
-						"makeCredUvNotRqd": false,
-						"alwaysUv": true
-					},
-					"maxMsgSize": 1200,
-					"pinUvAuthProtocols": [
-						2,
-						1
-					],
-					"maxCredentialCountInList": 8,
-					"maxCredentialIdLength": 128,
-					"transports": [
-						"usb"
-					],
-					"algorithms": [
-						{
-							"type": "public-key",
-							"alg": -7
-						},
-						{
-							"type": "public-key",
-							"alg": -8
-						}
-					],
-					"maxSerializedLargeBlobArray": 1024,
-					"forcePINChange": false,
-					"minPINLength": 4,
-					"firmwareVersion": 328965,
-					"maxCredBlobLength": 32,
-					"maxRPIDsForSetMinPINLength": 1,
-					"preferredPlatformUvAttempts": 3,
-					"uvModality": 2,
-					"remainingDiscoverableCredentials": 25
-				}
-			},
-			"statusReports": [
-				{
-					"status": "FIDO_CERTIFIED_L1",
-					"effectiveDate": "2021-08-06",
-					"url": "www.yubico.com",
-					"certificationDescriptor": "An example",
-					"certificateNumber": "FIDO2.....001",
-					"certificationPolicyVersion": "1.3",
-					"certificationRequirementsVersion": "1.4"
-				},
-				{
-					"status": "FIDO_CERTIFIED",
-					"effectiveDate": "2021-08-06"
-				}
-			],
-			"timeOfLastStatusChange": "2021-08-16"
-		}
+    "aaguid": "83c44309-....-8be444b573cb",
+    "metadataStatement": {
+        "legalHeader": "Submission of this statement and retrieval and use of this statement indicates acceptance of the appropriate agreement located at https://fidoalliance.org/metadata/metadata-legal-terms/.",
+        "aaguid": "83c44309-....-8be444b573cb",
+        "description": "Just an example",
+        "authenticatorVersion": 448962,
+        "protocolFamily": "fido2",
+        "schema": 3,
+        "upv": [
+            {
+                "major": 1,
+                "minor": 0
+            },
+            {
+                "major": 1,
+                "minor": 1
+            }
+        ],
+        "authenticationAlgorithms": [
+            "ed25519_eddsa_sha512_raw",
+            "secp256r1_ecdsa_sha256_raw"
+        ],
+        "publicKeyAlgAndEncodings": [
+            "cose"
+        ],
+        "attestationTypes": [
+            "basic_full"
+        ],
+        "userVerificationDetails": [
+            [
+                {
+                    "userVerificationMethod": "passcode_external",
+                    "caDesc": {
+                        "base": 64,
+                        "minLength": 4,
+                        "maxRetries": 8,
+                        "blockSlowdown": 0
+                    }
+                },
+                {
+                    "userVerificationMethod": "presence_internal"
+                }
+            ],
+            [
+                {
+                    "userVerificationMethod": "passcode_external",
+                    "caDesc": {
+                        "base": 64,
+                        "minLength": 4,
+                        "maxRetries": 8,
+                        "blockSlowdown": 0
+                    }
+                }
+            ],
+            [
+                {
+                    "userVerificationMethod": "fingerprint_internal",
+                    "baDesc": {
+                        "selfAttestedFRR": 0,
+                        "selfAttestedFAR": 0,
+                        "maxTemplates": 5,
+                        "maxRetries": 5,
+                        "blockSlowdown": 0
+                    }
+                },
+                {
+                    "userVerificationMethod": "presence_internal"
+                }
+            ],
+            [
+                {
+                    "userVerificationMethod": "none"
+                }
+            ],
+            [
+                {
+                    "userVerificationMethod": "fingerprint_internal",
+                    "baDesc": {
+                        "selfAttestedFRR": 0,
+                        "selfAttestedFAR": 0,
+                        "maxTemplates": 5,
+                        "maxRetries": 5,
+                        "blockSlowdown": 0
+                    }
+                }
+            ],
+            [
+                {
+                    "userVerificationMethod": "presence_internal"
+                }
+            ]
+        ],
+        "keyProtection": [
+            "hardware",
+            "secure_element"
+        ],
+        "matcherProtection": [
+            "on_chip"
+        ],
+        "cryptoStrength": 128,
+        "attachmentHint": [
+            "external",
+            "wired"
+        ],
+        "tcDisplay": [],
+        "attestationRootCertificates": [
+            "MII....psmyPzK+Vsgw2jeRQ5JlKDyqE0hebfC1tvFu0CCrJFcw=="
+        ],
+        "icon": "data:image/png;base64,iVBORw0KGgoAAAA....k5+36hF7vXAAAAAElFTkSuQmCC",
+        "authenticatorGetInfo": {
+            "versions": [
+                "FIDO_2_0",
+                "FIDO_2_1_PRE",
+                "FIDO_2_1"
+            ],
+            "extensions": [
+                "credProtect",
+                "hmac-secret",
+                "largeBlobKey",
+                "credBlob",
+                "minPinLength"
+            ],
+            "aaguid": "83c.....73cb",
+            "options": {
+                "plat": false,
+                "rk": true,
+                "clientPin": true,
+                "up": true,
+                "uv": false,
+                "pinUvAuthToken": true,
+                "largeBlobs": true,
+                "ep": false,
+                "bioEnroll": false,
+                "userVerificationMgmtPreview": false,
+                "authnrCfg": true,
+                "credMgmt": true,
+                "credentialMgmtPreview": true,
+                "setMinPINLength": true,
+                "makeCredUvNotRqd": false,
+                "alwaysUv": true
+            },
+            "maxMsgSize": 1200,
+            "pinUvAuthProtocols": [
+                2,
+                1
+            ],
+            "maxCredentialCountInList": 8,
+            "maxCredentialIdLength": 128,
+            "transports": [
+                "usb"
+            ],
+            "algorithms": [
+                {
+                    "type": "public-key",
+                    "alg": -7
+                },
+                {
+                    "type": "public-key",
+                    "alg": -8
+                }
+            ],
+            "maxSerializedLargeBlobArray": 1024,
+            "forcePINChange": false,
+            "minPINLength": 4,
+            "firmwareVersion": 328965,
+            "maxCredBlobLength": 32,
+            "maxRPIDsForSetMinPINLength": 1,
+            "preferredPlatformUvAttempts": 3,
+            "uvModality": 2,
+            "remainingDiscoverableCredentials": 25
+        }
+    },
+    "statusReports": [
+        {
+            "status": "FIDO_CERTIFIED_L1",
+            "effectiveDate": "2021-08-06",
+            "url": "www.yubico.com",
+            "certificationDescriptor": "An example",
+            "certificateNumber": "FIDO2.....001",
+            "certificationPolicyVersion": "1.3",
+            "certificationRequirementsVersion": "1.4"
+        },
+        {
+            "status": "FIDO_CERTIFIED",
+            "effectiveDate": "2021-08-06"
+        }
+    ],
+    "timeOfLastStatusChange": "2021-08-16"
+}
 ```
 
 
@@ -228,9 +228,21 @@ Janssen's FIDO2 server -
 1.  Re-downloads the metadata BLOB when it expires.
 1.  Provides trust root certificates for verifying attestation statements during credential registrations.
 
-
 ### 3. Skip metadata validation
-Metadata validation is recommended but not mandatory as per FIDO2 specifications. As per the current implementation, there is no provision in the jans-fido2 server to turn this feature off. However, the intention is to implement it in the future.
+
+Metadata validation is recommended but not mandatory as per FIDO2 specifications.
+In FIDO2 we can disable this validation by setting the `skipValidateMdsInAttestationEnabled` parameter (default is
+false).
+
+It should look something like this:
+
+```
+"fido2Configuration": {
+  ...,
+  "skipValidateMdsInAttestationEnabled": true,
+  ...
+}
+```
 
 ### 4. How Apple does it differently
 

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
@@ -45,6 +45,10 @@ public class Fido2Configuration {
     private List<RequestedParty> requestedParties = new ArrayList<RequestedParty>();
     @DocProperty(description = "String value to provide source of URLs with external metadata")
     private String metadataUrlsProvider;
+    @DocProperty(description = "Boolean value indicating whether the MDS download should be omitted")
+    private boolean skipDownloadMdsEnabled = false;
+    @DocProperty(description = "Boolean value indicating whether MDS validation should be omitted during attestation")
+    private boolean skipValidateMdsInAttestationEnabled = false;
 
     public String getAuthenticatorCertsFolder() {
         return authenticatorCertsFolder;
@@ -140,5 +144,21 @@ public class Fido2Configuration {
 
     public void setMetadataUrlsProvider(String metadataUrlsProvider) {
         this.metadataUrlsProvider = metadataUrlsProvider;
+    }
+
+    public boolean isSkipDownloadMdsEnabled() {
+        return skipDownloadMdsEnabled;
+    }
+
+    public void setSkipDownloadMdsEnabled(boolean skipDownloadMdsEnabled) {
+        this.skipDownloadMdsEnabled = skipDownloadMdsEnabled;
+    }
+
+    public boolean isSkipValidateMdsInAttestationEnabled() {
+        return skipValidateMdsInAttestationEnabled;
+    }
+
+    public void setSkipValidateMdsInAttestationEnabled(boolean skipValidateMdsInAttestationEnabled) {
+        this.skipValidateMdsInAttestationEnabled = skipValidateMdsInAttestationEnabled;
     }
 }

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/app/MDS3UpdateTimer.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/app/MDS3UpdateTimer.java
@@ -57,6 +57,10 @@ public class MDS3UpdateTimer {
 	@Asynchronous
 	public void process(@Observes @Scheduled MDS3UpdateEvent mds3UpdateEvent) {
 		LocalDate nextUpdate = tocService.getNextUpdateDate();
+		if (nextUpdate == null) {
+			log.info("NextUpdate is null");
+			return;
+		}
 		if (nextUpdate.equals(LocalDate.now()) || nextUpdate.isBefore(LocalDate.now())) {
 			log.info("Downloading the latest TOC from https://mds.fidoalliance.org/");
 			try {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/AttestationCertificateService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/AttestationCertificateService.java
@@ -124,7 +124,7 @@ public class AttestationCertificateService {
 				
 				return getAttestationRootCertificates(metadata, attestationCertificates);
 			} catch (Fido2RuntimeException ex) {
-				log.warn("Failed to get metadata from Fido2 meta-data server");
+				log.warn("Failed to get metadata from Fido2 meta-data server: {}", ex.getMessage(), ex);
 				
 				metadataForAuthenticator = dataMapperService.createObjectNode();
 			}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/TocService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/TocService.java
@@ -97,11 +97,14 @@ public class TocService {
 		loadMetadataServiceExternalProvider();
     }
 
-    public void refresh()
-    {
-    	this.tocEntries = Collections.synchronizedMap(new HashMap<String, JsonNode>());
-        tocEntries.putAll(parseTOCs());
-    }
+    public void refresh() {
+		this.tocEntries = Collections.synchronizedMap(new HashMap<String, JsonNode>());
+		if (appConfiguration.getFido2Configuration().isSkipDownloadMdsEnabled()) {
+			log.debug("SkipDownloadMds is enabled");
+		}  else {
+			tocEntries.putAll(parseTOCs());
+		}
+	}
     
 	private Map<String, JsonNode> parseTOCs() {
 		Fido2Configuration fido2Configuration = appConfiguration.getFido2Configuration();

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/AndroidSafetyNetAttestationProcessor.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/AndroidSafetyNetAttestationProcessor.java
@@ -24,6 +24,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
 import io.jans.fido2.model.attestation.AttestationErrorResponseType;
+import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.error.ErrorResponseFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -32,6 +33,7 @@ import javax.net.ssl.X509TrustManager;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import io.jans.fido2.ctap.AttestationFormat;
+import io.jans.fido2.exception.Fido2RuntimeException;
 import io.jans.fido2.google.safetynet.AttestationStatement;
 import io.jans.fido2.google.safetynet.OfflineVerify;
 import io.jans.fido2.model.auth.AuthData;
@@ -65,6 +67,9 @@ public class AndroidSafetyNetAttestationProcessor implements AttestationFormatPr
     private Base64Service base64Service;
 
     @Inject
+    private AppConfiguration appConfiguration;
+
+    @Inject
     private ErrorResponseFactory errorResponseFactory;
 
     @Inject
@@ -77,49 +82,43 @@ public class AndroidSafetyNetAttestationProcessor implements AttestationFormatPr
 
     @Override
     public void process(JsonNode attStmt, AuthData authData, Fido2RegistrationData credential, byte[] clientDataHash,
-            CredAndCounterData credIdAndCounters) {
+                        CredAndCounterData credIdAndCounters) {
 
         commonVerifiers.verifyThatNonEmptyString(attStmt, "ver");
         String response = attStmt.get("response").asText();
         String aaguid = Hex.encodeHexString(authData.getAaguid());
         log.debug("Android safetynet payload {} {}", aaguid, new String(base64Service.decode(response)));
 
-        X509TrustManager tm = attestationCertificateService.populateTrustManager(authData, null);
-        AttestationStatement stmt;
-        try {
-            stmt = offlineVerify.parseAndVerify(new String(base64Service.decode(response)), tm);
-        } catch (Exception e) {
-            log.error("Error on parse and verify: {}", e.getMessage(), e);
-            throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation " + e.getMessage());
+        if (appConfiguration.getFido2Configuration().isSkipValidateMdsInAttestationEnabled()) {
+            log.warn("SkipValidateMdsInAttestation is enabled");
+        } else {
+            X509TrustManager tm = attestationCertificateService.populateTrustManager(authData, null);
+            AttestationStatement stmt = offlineVerify.parseAndVerify(new String(base64Service.decode(response)), tm);
+            if (stmt == null) {
+                throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, stmt is null");
+            }
+            byte[] b1 = authData.getAuthDataDecoded();
+            byte[] b2 = clientDataHash;
+            byte[] buffer = ByteBuffer.allocate(b1.length + b2.length).put(b1).put(b2).array();
+            byte[] hashedBuffer = DigestUtils.getSha256Digest().digest(buffer);
+            byte[] nonce = stmt.getNonce();
+            if (!Arrays.equals(hashedBuffer, nonce)) {
+                throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, hashed and nonce are not equals");
+            }
+
+            if (!stmt.isCtsProfileMatch()) {
+                throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, cts profile match is false");
+            }
+
+            Instant timestamp = Instant.ofEpochMilli(stmt.getTimestampMs());
+            if (timestamp.isAfter(Instant.now())) {
+                throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, timestamp is after now");
+            }
+
+            if (timestamp.isBefore(Instant.now().minus(1, ChronoUnit.MINUTES))) {
+                throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, timestamp is before now minus 1 minutes");
+            }
         }
-
-        if (stmt == null) {
-            throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, stmt is null");
-        }
-
-        byte[] b1 = authData.getAuthDataDecoded();
-        byte[] b2 = clientDataHash;
-        byte[] buffer = ByteBuffer.allocate(b1.length + b2.length).put(b1).put(b2).array();
-        byte[] hashedBuffer = DigestUtils.getSha256Digest().digest(buffer);
-        byte[] nonce = stmt.getNonce();
-        if (!Arrays.equals(hashedBuffer, nonce)) {
-            throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, hashed and nonce are not equals");
-        }
-
-        if (!stmt.isCtsProfileMatch()) {
-            throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, cts profile match is false");
-        }
-
-        Instant timestamp = Instant.ofEpochMilli(stmt.getTimestampMs());
-
-        if (timestamp.isAfter(Instant.now())) {
-            throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, timestamp is after now");
-        }
-
-        if (timestamp.isBefore(Instant.now().minus(1, ChronoUnit.MINUTES))) {
-            throw errorResponseFactory.badRequestException(AttestationErrorResponseType.ANDROID_SAFETYNET_ERROR, "Invalid safety net attestation, timestamp is before now minus 1 minutes");
-        }
-
         credIdAndCounters.setAttestationType(getAttestationFormat().getFmt());
         credIdAndCounters.setCredId(base64Service.urlEncodeToString(authData.getCredId()));
         credIdAndCounters.setUncompressedEcPoint(base64Service.urlEncodeToString(authData.getCosePublicKey()));

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/AppleAttestationProcessor.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/AppleAttestationProcessor.java
@@ -2,7 +2,6 @@ package io.jans.fido2.service.processor.attestation;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -10,22 +9,21 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import io.jans.fido2.exception.Fido2RuntimeException;
 import io.jans.fido2.model.attestation.AttestationErrorResponseType;
+import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.service.util.AppleUtilService;
+import io.jans.fido2.service.util.CommonUtilService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.kerby.asn1.parse.Asn1Container;
-import org.apache.kerby.asn1.parse.Asn1ParseResult;
-import org.apache.kerby.asn1.parse.Asn1Parser;
-import org.apache.kerby.asn1.type.Asn1OctetString;
 
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.jans.fido2.ctap.AttestationFormat;
-import io.jans.fido2.exception.Fido2MissingAttestationCertException;
 import io.jans.fido2.model.auth.AuthData;
 import io.jans.fido2.model.auth.CredAndCounterData;
 import io.jans.orm.model.fido2.Fido2RegistrationData;
@@ -63,9 +61,16 @@ public class AppleAttestationProcessor implements AttestationFormatProcessor {
 	private CertificateService certificateService;
 
 	@Inject
+	private AppConfiguration appConfiguration;
+
+	@Inject
 	private ErrorResponseFactory errorResponseFactory;
 
-    private static final String KEY_DESCRIPTION_OID = "1.2.840.113635.100.8.2";
+	@Inject
+	private CommonUtilService commonUtilService;
+
+	@Inject
+	private AppleUtilService appleUtilService;
 
 	private static final String SUBJECT_DN = "st=california, o=apple inc., cn=apple webauthn root ca";
 
@@ -95,20 +100,28 @@ public class AppleAttestationProcessor implements AttestationFormatProcessor {
 				certificates.add(cert);
 			}
 
+			if (certificates.isEmpty()) {
+				throw errorResponseFactory.badRequestException(AttestationErrorResponseType.APPLE_ERROR, "x5c certificates is empty");
+			}
+
 			// the first certificate in x5c
 			X509Certificate credCert = certificates.get(0);
 
-            List<X509Certificate> trustAnchorCertificates = attestationCertificateService.getRootCertificatesBySubjectDN(SUBJECT_DN);
-            try {
-                log.debug("APPLE_WEBAUTHN_ROOT_CA root certificate" + trustAnchorCertificates.size());
-                X509Certificate verifiedCert = certificateVerifier.verifyAttestationCertificates(certificates,
-                        trustAnchorCertificates);
-                log.info("Step 1 completed  ");
-			} catch (Fido2MissingAttestationCertException ex) {
-				X509Certificate certificate = certificates.get(0);
-				String issuerDN = certificate.getIssuerDN().getName();
-				log.warn("Failed to find attestation validation signature public certificate with DN: '{}'", issuerDN);
-
+			if (appConfiguration.getFido2Configuration().isSkipValidateMdsInAttestationEnabled()) {
+				log.warn("SkipValidateMdsInAttestation is enabled");
+			} else {
+				try {
+					List<X509Certificate> trustAnchorCertificates = attestationCertificateService.getRootCertificatesBySubjectDN(SUBJECT_DN);
+					log.debug("APPLE_WEBAUTHN_ROOT_CA root certificate: " + trustAnchorCertificates.size());
+					X509Certificate verifiedCert = certificateVerifier.verifyAttestationCertificates(certificates, trustAnchorCertificates);
+					log.info("Step 1 completed");
+				} catch (Fido2RuntimeException e) {
+//					X509Certificate certificate = certificates.get(0);
+					String issuerDN = credCert.getIssuerDN().getName();
+					log.warn("Failed to find attestation validation signature public certificate with DN: '{}'", issuerDN);
+					throw errorResponseFactory.badRequestException(AttestationErrorResponseType.APPLE_ERROR,
+							"Failed to find attestation validation signature public certificate with DN: " + issuerDN);
+				}
 			}
 
 			// 2. Concatenate |authenticatorData| and |clientDataHash| to form
@@ -118,13 +131,12 @@ public class AppleAttestationProcessor implements AttestationFormatProcessor {
 			// byte[] nonceToHash = new byte[authDataInBytes.length +
 			// clientDataHash.length];
 
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			ByteArrayOutputStream baos;
 			try {
-				baos.write(authDataInBytes);
-				baos.write(clientDataHash);
+				baos = commonUtilService.writeOutputStreamByteList(Arrays.asList(authDataInBytes, clientDataHash));
 			} catch (IOException e) {
 				throw errorResponseFactory.badRequestException(AttestationErrorResponseType.APPLE_ERROR,
-						"Concatenate |authenticatorData| and |clientDataHash| to form |nonceToHash|." + e.getMessage());
+						"Concatenate |authenticatorData| and |clientDataHash| to form |nonceToHash| : " + e.getMessage());
 			}
 
 			byte[] nonceToHash = baos.toByteArray();
@@ -137,7 +149,7 @@ public class AppleAttestationProcessor implements AttestationFormatProcessor {
 			// 4. Verify |nonce| matches the value of the extension with OID (
 			// 1.2.840.113635.100.8.2 ) in |credCert|.
 
-			byte[] attestationChallenge = getExtension(credCert);
+			byte[] attestationChallenge = appleUtilService.getExtension(credCert);
 
 			if (!Arrays.equals(nonce, attestationChallenge)) {
 				throw errorResponseFactory.badRequestException(AttestationErrorResponseType.APPLE_ERROR, "Certificate 1.2.840.113635.100.8.2 extension does not match nonce");
@@ -166,57 +178,6 @@ public class AppleAttestationProcessor implements AttestationFormatProcessor {
 			// log.info("attStmt.get(\"alg\")"+attStmt.get("alg"));
 			int alg = -7;// commonVerifiers.verifyAlgorithm(attStmt.get("alg"), authData.getKeyType());
 			credIdAndCounters.setSignatureAlgorithm(alg);
-		}
-
-	}
-
-	/*-
-	[
-	   {
-	       "type": "OBJECT_IDENTIFIER",
-	       "data": "1.2.840.113635.100.8.2"
-	   },
-	   {
-	       "type": "OCTET_STRING",
-	       "data": [
-	           {
-	               "type": "SEQUENCE",
-	               "data": [
-	                   {
-	                       "type": "[1]",
-	                       "data": [
-	                           {
-	                               "type": "OCTET_STRING",
-	                               "data": {
-	                                   "type": "Buffer",
-	                                   "data": [92, 219, 157, 144, 115, 64, 69, 91, 99, 115, 230, 117, 43, 115, 252, 54, 132, 83, 96, 34, 21, 250, 234, 187, 124, 22, 95, 11, 173, 172, 7, 204]
-	                               }
-	                           }
-	                       ]
-	                   }
-	               ]
-	           }
-	       ]
-	   }
-	]
-	*/
-
-	public byte[] getExtension(X509Certificate attestationCert) {
-		byte[] extensionValue = attestationCert.getExtensionValue(KEY_DESCRIPTION_OID);
-		byte[] extracted;
-		try {
-			Asn1OctetString extensionEnvelope = new Asn1OctetString();
-			extensionEnvelope.decode(extensionValue);
-			extensionEnvelope.getValue();
-			byte[] extensionEnvelopeValue = extensionEnvelope.getValue();
-			Asn1Container container = (Asn1Container) Asn1Parser.parse(ByteBuffer.wrap(extensionEnvelopeValue));
-			Asn1ParseResult firstElement = container.getChildren().get(0);
-			Asn1OctetString octetString = new Asn1OctetString();
-			octetString.decode(firstElement);
-			extracted = octetString.getValue();
-			return extracted;
-		} catch (IOException | RuntimeException e) {
-			throw errorResponseFactory.badRequestException(AttestationErrorResponseType.APPLE_ERROR, "Failed to extract nonce from Apple anonymous attestation statement.");
 		}
 	}
 }

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/util/AppleUtilService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/util/AppleUtilService.java
@@ -1,0 +1,71 @@
+package io.jans.fido2.service.util;
+
+import io.jans.fido2.model.attestation.AttestationErrorResponseType;
+import io.jans.fido2.model.error.ErrorResponseFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.kerby.asn1.parse.Asn1Container;
+import org.apache.kerby.asn1.parse.Asn1ParseResult;
+import org.apache.kerby.asn1.parse.Asn1Parser;
+import org.apache.kerby.asn1.type.Asn1OctetString;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.cert.X509Certificate;
+
+@ApplicationScoped
+public class AppleUtilService {
+
+    private static final String KEY_DESCRIPTION_OID = "1.2.840.113635.100.8.2";
+
+    @Inject
+    private ErrorResponseFactory errorResponseFactory;
+
+    /*-
+	[
+	   {
+	       "type": "OBJECT_IDENTIFIER",
+	       "data": "1.2.840.113635.100.8.2"
+	   },
+	   {
+	       "type": "OCTET_STRING",
+	       "data": [
+	           {
+	               "type": "SEQUENCE",
+	               "data": [
+	                   {
+	                       "type": "[1]",
+	                       "data": [
+	                           {
+	                               "type": "OCTET_STRING",
+	                               "data": {
+	                                   "type": "Buffer",
+	                                   "data": [92, 219, 157, 144, 115, 64, 69, 91, 99, 115, 230, 117, 43, 115, 252, 54, 132, 83, 96, 34, 21, 250, 234, 187, 124, 22, 95, 11, 173, 172, 7, 204]
+	                               }
+	                           }
+	                       ]
+	                   }
+	               ]
+	           }
+	       ]
+	   }
+	]
+	*/
+    public byte[] getExtension(X509Certificate attestationCert) {
+        byte[] extensionValue = attestationCert.getExtensionValue(KEY_DESCRIPTION_OID);
+        byte[] extracted;
+        try {
+            Asn1OctetString extensionEnvelope = new Asn1OctetString();
+            extensionEnvelope.decode(extensionValue);
+            byte[] extensionEnvelopeValue = extensionEnvelope.getValue();
+            Asn1Container container = (Asn1Container) Asn1Parser.parse(ByteBuffer.wrap(extensionEnvelopeValue));
+            Asn1ParseResult firstElement = container.getChildren().get(0);
+            Asn1OctetString octetString = new Asn1OctetString();
+            octetString.decode(firstElement);
+            extracted = octetString.getValue();
+            return extracted;
+        } catch (IOException | RuntimeException e) {
+            throw errorResponseFactory.badRequestException(AttestationErrorResponseType.APPLE_ERROR, "Failed to extract nonce from Apple anonymous attestation statement.");
+        }
+    }
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/util/CommonUtilService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/util/CommonUtilService.java
@@ -1,0 +1,22 @@
+package io.jans.fido2.service.util;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+@ApplicationScoped
+public class CommonUtilService {
+
+    public ByteArrayOutputStream writeOutputStreamByteList(List<byte[]> list) throws IOException {
+        if (list.isEmpty()) {
+            throw new IOException("List is empty");
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        for (byte[] bytes : list) {
+            baos.write(bytes);
+        }
+        return baos;
+    }
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/CommonVerifiers.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/CommonVerifiers.java
@@ -39,6 +39,8 @@ import io.jans.util.StringHelper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import tss.tpm.TPMS_ATTEST;
+import tss.tpm.TPMT_PUBLIC;
 
 /**
  * @author Yuriy Movchan
@@ -497,5 +499,13 @@ public class CommonVerifiers {
         if ((node == null) || node.isNull()) {
             throw errorResponseFactory.invalidRequest("Invalid data, value is null");
         }
+    }
+
+    public TPMT_PUBLIC tpmParseToPublic(byte[] value) {
+        return TPMT_PUBLIC.fromTpm(value);
+    }
+
+    public TPMS_ATTEST tpmParseToAttest(byte[] value) {
+        return TPMS_ATTEST.fromTpm(value);
     }
 }

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/AndroidKeyAttestationProcessorTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/AndroidKeyAttestationProcessorTest.java
@@ -2,9 +2,13 @@ package io.jans.fido2.service.processor.attestation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.jans.fido2.androind.AndroidKeyUtils;
+import io.jans.fido2.exception.Fido2RuntimeException;
 import io.jans.fido2.model.auth.AuthData;
 import io.jans.fido2.model.auth.CredAndCounterData;
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
 import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.service.Base64Service;
 import io.jans.fido2.service.CertificateService;
 import io.jans.fido2.service.mds.AttestationCertificateService;
 import io.jans.fido2.service.verifier.AuthenticatorDataVerifier;
@@ -13,6 +17,7 @@ import io.jans.fido2.service.verifier.CommonVerifiers;
 import io.jans.orm.model.fido2.Fido2RegistrationData;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Sequence;
@@ -24,7 +29,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -59,6 +66,89 @@ class AndroidKeyAttestationProcessorTest {
     @Mock
     private ErrorResponseFactory errorResponseFactory;
 
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private Base64Service base64Service;
+
+    @Test
+    void getAttestationFormat_valid_androidKey() {
+        String fmt = androidKeyAttestationProcessor.getAttestationFormat().getFmt();
+        assertNotNull(fmt);
+        assertEquals(fmt, "android-key");
+    }
+
+    @Test
+    void process_ifSkipValidateMdsInAttestationEnabledIsTrue_valid() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.emptyIterator());
+        List<X509Certificate> certificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(certificates);
+        List<X509Certificate> trustAnchorCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getAttestationRootCertificates(authData, certificates)).thenReturn(trustAnchorCertificates);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(true);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(base64Service.urlEncodeToString(any())).thenReturn("test-credId");
+
+        androidKeyAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters);
+
+        verify(log).debug(eq("Android-key payload"));
+        verify(attestationCertificateService).getAttestationRootCertificates(authData, certificates);
+        verify(appConfiguration).getFido2Configuration();
+        verify(log).warn(eq("SkipValidateMdsInAttestation is enabled"));
+        verify(base64Service, times(2)).urlEncodeToString(any());
+        verifyNoMoreInteractions(log);
+        verifyNoInteractions(certificateVerifier, errorResponseFactory, androidKeyUtils, commonVerifiers, authenticatorDataVerifier);
+    }
+
+    @Test
+    void process_ifVerifyAttestationCertificatesThrownError_badRequestException() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.emptyIterator());
+        List<X509Certificate> certificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(certificates);
+        List<X509Certificate> trustAnchorCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getAttestationRootCertificates(authData, certificates)).thenReturn(trustAnchorCertificates);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        Fido2RuntimeException fido2RuntimeException = new Fido2RuntimeException("test exception");
+        when(certificateVerifier.verifyAttestationCertificates(certificates, trustAnchorCertificates)).thenThrow(fido2RuntimeException);
+        when(errorResponseFactory.badRequestException(any(), any())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> androidKeyAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(log).debug(eq("Android-key payload"));
+//        verify(certificateService).getCertificates(anyList());
+        verify(attestationCertificateService).getAttestationRootCertificates(authData, certificates);
+        verify(appConfiguration).getFido2Configuration();
+        verify(certificateVerifier).verifyAttestationCertificates(certificates, trustAnchorCertificates);
+        verify(log).error("Error on verify attestation certificates: {}", fido2RuntimeException.getMessage(), fido2RuntimeException);
+        verify(errorResponseFactory).badRequestException(any(), any());
+        verifyNoMoreInteractions(log, errorResponseFactory);
+        verifyNoInteractions(base64Service, androidKeyUtils, commonVerifiers, authenticatorDataVerifier);
+    }
+
     @Test
     void process_ifClientDataHashNotEqualsToAttestationChallenge_badRequestException() throws Exception {
         JsonNode attStmt = mock(JsonNode.class);
@@ -70,6 +160,13 @@ class AndroidKeyAttestationProcessorTest {
         JsonNode x5cNode = mock(JsonNode.class);
         when(attStmt.get("x5c")).thenReturn(x5cNode);
         when(x5cNode.elements()).thenReturn(Collections.emptyIterator());
+        List<X509Certificate> certificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(certificates);
+        List<X509Certificate> trustAnchorCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getAttestationRootCertificates(authData, certificates)).thenReturn(trustAnchorCertificates);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
         when(certificateVerifier.verifyAttestationCertificates(any(), any())).thenReturn(mock(X509Certificate.class));
         ASN1Sequence extensionData = mock(ASN1Sequence.class);
         when(androidKeyUtils.extractAttestationSequence(any())).thenReturn(extensionData);
@@ -89,13 +186,17 @@ class AndroidKeyAttestationProcessorTest {
         assertEquals(res.getResponse().getEntity(), "test exception");
 
         verify(log).debug(eq("Android-key payload"));
-        verify(log).warn(contains("Problem with android key"), anyString());
-        verify(errorResponseFactory, times(2)).badRequestException(any(), any());
-        verifyNoInteractions(commonVerifiers, authenticatorDataVerifier);
+        verify(attestationCertificateService).getAttestationRootCertificates(authData, certificates);
+        verify(appConfiguration).getFido2Configuration();
+        verify(certificateVerifier).verifyAttestationCertificates(certificates, trustAnchorCertificates);
+        verify(androidKeyUtils).extractAttestationSequence(any());
+        verify(errorResponseFactory).badRequestException(any(), eq("Invalid android key attestation"));
+        verifyNoMoreInteractions(log, errorResponseFactory);
+        verifyNoInteractions(base64Service, commonVerifiers, authenticatorDataVerifier);
     }
 
     @Test
-    void process_ifCertificateServiceThrowException_badRequestException() throws Exception {
+    void process_ifCertificateServiceThrowError_badRequestException() throws Exception {
         JsonNode attStmt = mock(JsonNode.class);
         AuthData authData = mock(AuthData.class);
         Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
@@ -105,6 +206,13 @@ class AndroidKeyAttestationProcessorTest {
         JsonNode x5cNode = mock(JsonNode.class);
         when(attStmt.get("x5c")).thenReturn(x5cNode);
         when(x5cNode.elements()).thenReturn(Collections.emptyIterator());
+        List<X509Certificate> certificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(certificates);
+        List<X509Certificate> trustAnchorCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getAttestationRootCertificates(authData, certificates)).thenReturn(trustAnchorCertificates);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
         when(androidKeyUtils.extractAttestationSequence(any())).thenThrow(new Exception("test exception"));
         when(errorResponseFactory.badRequestException(any(), any())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
 
@@ -115,9 +223,61 @@ class AndroidKeyAttestationProcessorTest {
         assertEquals(res.getResponse().getEntity(), "test exception");
 
         verify(log).debug(eq("Android-key payload"));
+        verify(attestationCertificateService).getAttestationRootCertificates(authData, certificates);
+        verify(appConfiguration).getFido2Configuration();
+        verify(certificateVerifier).verifyAttestationCertificates(certificates, trustAnchorCertificates);
         verify(log).warn(contains("Problem with android key"), anyString());
-        verify(errorResponseFactory).badRequestException(any(), any());
+        verify(errorResponseFactory).badRequestException(any(), eq("Problem with android key"));
         verifyNoInteractions(commonVerifiers, authenticatorDataVerifier);
-        verifyNoMoreInteractions(errorResponseFactory);
+        verifyNoMoreInteractions(log, errorResponseFactory);
+    }
+
+    @Test
+    void process_ifX5cContainsValues_valid() throws Exception {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test-octets".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        when(authData.getKeyType()).thenReturn(1);
+        JsonNode x5cNode = mock(JsonNode.class);
+        List<JsonNode> elements = Arrays.asList(mock(JsonNode.class), mock(JsonNode.class));
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(elements.iterator());
+        List<X509Certificate> certificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(certificates);
+        List<X509Certificate> trustAnchorCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getAttestationRootCertificates(authData, certificates)).thenReturn(trustAnchorCertificates);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        X509Certificate verifiedCert = mock(X509Certificate.class);
+        when(certificateVerifier.verifyAttestationCertificates(any(), any())).thenReturn(verifiedCert);
+        ASN1Sequence extensionData = mock(ASN1Sequence.class);
+        when(androidKeyUtils.extractAttestationSequence(any())).thenReturn(extensionData);
+        ASN1Integer asn1Integer = new ASN1Integer(1L);
+        when(extensionData.getObjectAt(AndroidKeyUtils.ATTESTATION_VERSION_INDEX)).thenReturn(asn1Integer);
+        when(extensionData.getObjectAt(AndroidKeyUtils.ATTESTATION_SECURITY_LEVEL_INDEX)).thenReturn(asn1Integer);
+        when(extensionData.getObjectAt(AndroidKeyUtils.KEYMASTER_SECURITY_LEVEL_INDEX)).thenReturn(asn1Integer);
+        ASN1OctetString asn1OctetString = mock(ASN1OctetString.class);
+        when(extensionData.getObjectAt(AndroidKeyUtils.ATTESTATION_CHALLENGE_INDEX)).thenReturn(asn1OctetString);
+        when(asn1OctetString.getOctets()).thenReturn("test-octets".getBytes());
+        ASN1Sequence asn1Sequence = mock(ASN1Sequence.class);
+        when(extensionData.getObjectAt(AndroidKeyUtils.SW_ENFORCED_INDEX)).thenReturn(asn1Sequence);
+        when(extensionData.getObjectAt(AndroidKeyUtils.TEE_ENFORCED_INDEX)).thenReturn(asn1Sequence);
+        when(asn1Sequence.toArray()).thenReturn(new ASN1Encodable[]{mock(ASN1Encodable.class)});
+        when(commonVerifiers.verifyBase64String(any())).thenReturn("test-signature");
+
+        androidKeyAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters);
+
+        verify(log).debug(eq("Android-key payload"));
+        verify(attestationCertificateService).getAttestationRootCertificates(authData, certificates);
+        verify(appConfiguration).getFido2Configuration();
+        verify(certificateVerifier).verifyAttestationCertificates(certificates, trustAnchorCertificates);
+        verify(androidKeyUtils).extractAttestationSequence(any());
+        verify(authenticatorDataVerifier).verifyAttestationSignature(authData, clientDataHash, "test-signature", verifiedCert, 1);
+        verifyNoInteractions(errorResponseFactory);
+        verifyNoMoreInteractions(log);
     }
 }

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/AppleAttestationProcessorTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/AppleAttestationProcessorTest.java
@@ -1,0 +1,348 @@
+package io.jans.fido2.service.processor.attestation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.jans.fido2.exception.Fido2RuntimeException;
+import io.jans.fido2.model.auth.AuthData;
+import io.jans.fido2.model.auth.CredAndCounterData;
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
+import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.service.Base64Service;
+import io.jans.fido2.service.CertificateService;
+import io.jans.fido2.service.CoseService;
+import io.jans.fido2.service.mds.AttestationCertificateService;
+import io.jans.fido2.service.util.AppleUtilService;
+import io.jans.fido2.service.util.CommonUtilService;
+import io.jans.fido2.service.verifier.CertificateVerifier;
+import io.jans.orm.model.fido2.Fido2RegistrationData;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.http.auth.BasicUserPrincipal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AppleAttestationProcessorTest {
+
+    @InjectMocks
+    private AppleAttestationProcessor appleAttestationProcessor;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private AttestationCertificateService attestationCertificateService;
+
+    @Mock
+    private CertificateVerifier certificateVerifier;
+
+    @Mock
+    private CoseService coseService;
+
+    @Mock
+    private Base64Service base64Service;
+
+    @Mock
+    private CertificateService certificateService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private CommonUtilService commonUtilService;
+
+    @Mock
+    private AppleUtilService appleUtilService;
+
+    @Test
+    void getAttestationFormat_valid_apple() {
+        String fmt = appleAttestationProcessor.getAttestationFormat().getFmt();
+        assertNotNull(fmt);
+        assertEquals(fmt, "apple");
+    }
+
+    @Test
+    void process_ifCertificatesIsEmpty_badRequestException() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test_clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        when(attStmt.asText()).thenReturn("test_att_stmt");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.emptyIterator());
+        when(errorResponseFactory.badRequestException(any(), anyString())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> appleAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(log).info(eq("AttStmt: test_att_stmt"));
+        verifyNoInteractions(certificateService, appConfiguration, attestationCertificateService, certificateVerifier, coseService, base64Service);
+        verifyNoMoreInteractions(log, errorResponseFactory);
+    }
+
+    @Test
+    void process_ifGetRootCertificatesBySubjectDN_badRequestException() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test_clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        when(attStmt.asText()).thenReturn("test_att_stmt");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("x5c item")).iterator());
+        X509Certificate credCert = mock(X509Certificate.class);
+        when(certificateService.getCertificate(anyString())).thenReturn(credCert);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenThrow(new Fido2RuntimeException("test exception"));
+        when(credCert.getIssuerDN()).thenReturn(new BasicUserPrincipal("test issuer dn"));
+        when(errorResponseFactory.badRequestException(any(), anyString())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> appleAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(log).info(eq("AttStmt: test_att_stmt"));
+        verify(certificateService).getCertificate(eq("x5c item"));
+        verify(appConfiguration).getFido2Configuration();
+        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(log).warn(eq("Failed to find attestation validation signature public certificate with DN: '{}'"), eq("test issuer dn"));
+        verify(errorResponseFactory).badRequestException(any(), eq("Failed to find attestation validation signature public certificate with DN: test issuer dn"));
+        verifyNoMoreInteractions(log, errorResponseFactory);
+        verifyNoInteractions(certificateVerifier, coseService, base64Service);
+    }
+
+    @Test
+    void process_ifByArrayOutputStreamThrownError_badRequestException() throws IOException {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test_clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        when(attStmt.asText()).thenReturn("test_att_stmt");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("x5c item")).iterator());
+        X509Certificate credCert = mock(X509Certificate.class);
+        when(certificateService.getCertificate(anyString())).thenReturn(credCert);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        List<X509Certificate> rootCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenReturn(rootCertificates);
+        when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(mock(X509Certificate.class));
+        when(authData.getAuthDataDecoded()).thenReturn("test decoded".getBytes());
+        when(commonUtilService.writeOutputStreamByteList(anyList())).thenThrow(new IOException("test ioexception"));
+        when(errorResponseFactory.badRequestException(any(), anyString())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> appleAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(log).info(eq("AttStmt: test_att_stmt"));
+        verify(certificateService).getCertificate(eq("x5c item"));
+        verify(appConfiguration).getFido2Configuration();
+        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(log).debug(eq("APPLE_WEBAUTHN_ROOT_CA root certificate: 1"));
+        verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
+        verify(log).info(eq("Step 1 completed"));
+        verify(commonUtilService).writeOutputStreamByteList(anyList());
+        verify(errorResponseFactory).badRequestException(any(), eq("Concatenate |authenticatorData| and |clientDataHash| to form |nonceToHash| : test ioexception"));
+        verifyNoMoreInteractions(log, errorResponseFactory);
+        verifyNoInteractions(coseService, base64Service);
+    }
+
+    @Test
+    void process_ifNonceAndAttestationChallengeAreNotEquals_badRequestException() throws IOException {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test_clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        when(attStmt.asText()).thenReturn("test_att_stmt");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("x5c item")).iterator());
+        X509Certificate credCert = mock(X509Certificate.class);
+        when(certificateService.getCertificate(anyString())).thenReturn(credCert);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        List<X509Certificate> rootCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenReturn(rootCertificates);
+        when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(mock(X509Certificate.class));
+        when(authData.getAuthDataDecoded()).thenReturn("test decoded".getBytes());
+        ByteArrayOutputStream baos = mock(ByteArrayOutputStream.class);
+        when(commonUtilService.writeOutputStreamByteList(anyList())).thenReturn(baos);
+        when(baos.toByteArray()).thenReturn("test baos".getBytes());
+        when(appleUtilService.getExtension(any())).thenReturn("test_challenge".getBytes());
+        when(errorResponseFactory.badRequestException(any(), anyString())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> appleAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(log).info(eq("AttStmt: test_att_stmt"));
+        verify(certificateService).getCertificate(eq("x5c item"));
+        verify(appConfiguration).getFido2Configuration();
+        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(log).debug(eq("APPLE_WEBAUTHN_ROOT_CA root certificate: 1"));
+        verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
+        verify(log).info(eq("Step 1 completed"));
+        verify(commonUtilService).writeOutputStreamByteList(anyList());
+        verify(log).info(eq("Step 2 completed"));
+        verify(log).info(eq("Step 3 completed"));
+        verify(appleUtilService).getExtension(any());
+        verify(errorResponseFactory).badRequestException(any(), eq("Certificate 1.2.840.113635.100.8.2 extension does not match nonce"));
+        verifyNoMoreInteractions(log, errorResponseFactory);
+        verifyNoInteractions(coseService, base64Service);
+    }
+
+    @Test
+    void process_ifPublicKeyAuthDataAndPublicCredCertAreNotEquals_badRequestException() throws IOException {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test_clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        when(attStmt.asText()).thenReturn("test_att_stmt");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("x5c item")).iterator());
+        X509Certificate credCert = mock(X509Certificate.class);
+        when(certificateService.getCertificate(anyString())).thenReturn(credCert);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        List<X509Certificate> rootCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenReturn(rootCertificates);
+        when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(mock(X509Certificate.class));
+        when(authData.getAuthDataDecoded()).thenReturn("test decoded".getBytes());
+        ByteArrayOutputStream baos = mock(ByteArrayOutputStream.class);
+        when(commonUtilService.writeOutputStreamByteList(anyList())).thenReturn(baos);
+        when(baos.toByteArray()).thenReturn("test baos".getBytes());
+        when(appleUtilService.getExtension(any())).thenReturn(DigestUtils.getSha256Digest().digest("test baos".getBytes()));
+        when(coseService.getPublicKeyFromUncompressedECPoint(any())).thenReturn(mock(PublicKey.class));
+        when(credCert.getPublicKey()).thenReturn(mock(PublicKey.class));
+        when(errorResponseFactory.badRequestException(any(), anyString())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> appleAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(log).info(eq("AttStmt: test_att_stmt"));
+        verify(certificateService).getCertificate(eq("x5c item"));
+        verify(appConfiguration).getFido2Configuration();
+        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(log).debug(eq("APPLE_WEBAUTHN_ROOT_CA root certificate: 1"));
+        verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
+        verify(log).info(eq("Step 1 completed"));
+        verify(commonUtilService).writeOutputStreamByteList(anyList());
+        verify(log).info(eq("Step 2 completed"));
+        verify(log).info(eq("Step 3 completed"));
+        verify(log).info(eq("Step 4 completed"));
+        verify(appleUtilService).getExtension(any());
+        verify(coseService).getPublicKeyFromUncompressedECPoint(any());
+        verify(errorResponseFactory).badRequestException(any(), eq("The public key in the first certificate in x5c doesn't matches the credentialPublicKey in the attestedCredentialData in authenticatorData."));
+        verifyNoMoreInteractions(log, errorResponseFactory);
+        verifyNoInteractions(base64Service);
+    }
+
+    @Test
+    void process_validData_success() throws IOException {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData credential = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = "test_clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+
+        when(attStmt.asText()).thenReturn("test_att_stmt");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("x5c item")).iterator());
+        X509Certificate credCert = mock(X509Certificate.class);
+        when(certificateService.getCertificate(anyString())).thenReturn(credCert);
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        List<X509Certificate> rootCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenReturn(rootCertificates);
+        when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(mock(X509Certificate.class));
+        when(authData.getAuthDataDecoded()).thenReturn("test decoded".getBytes());
+        ByteArrayOutputStream baos = mock(ByteArrayOutputStream.class);
+        when(commonUtilService.writeOutputStreamByteList(anyList())).thenReturn(baos);
+        when(baos.toByteArray()).thenReturn("test baos".getBytes());
+        when(appleUtilService.getExtension(any())).thenReturn(DigestUtils.getSha256Digest().digest("test baos".getBytes()));
+        PublicKey publicKey = mock(PublicKey.class);
+        when(coseService.getPublicKeyFromUncompressedECPoint(any())).thenReturn(publicKey);
+        when(credCert.getPublicKey()).thenReturn(publicKey);
+        when(authData.getCredId()).thenReturn("test_cred_id".getBytes());
+        when(authData.getCosePublicKey()).thenReturn("test_cose_public_key".getBytes());
+        when(base64Service.urlEncodeToString(any(byte[].class))).thenReturn("test_cred_id", "test_uncompressed_ec_point");
+
+        appleAttestationProcessor.process(attStmt, authData, credential, clientDataHash, credIdAndCounters);
+
+        verify(log).info(eq("AttStmt: test_att_stmt"));
+        verify(certificateService).getCertificate(eq("x5c item"));
+        verify(appConfiguration).getFido2Configuration();
+        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(log).debug(eq("APPLE_WEBAUTHN_ROOT_CA root certificate: 1"));
+        verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
+        verify(log).info(eq("Step 1 completed"));
+        verify(commonUtilService).writeOutputStreamByteList(anyList());
+        verify(log).info(eq("Step 2 completed"));
+        verify(log).info(eq("Step 3 completed"));
+        verify(log).info(eq("Step 4 completed"));
+        verify(log).info(eq("Step 5 completed"));
+        verify(appleUtilService).getExtension(any());
+        verify(coseService).getPublicKeyFromUncompressedECPoint(any());
+        verify(base64Service, times(2)).urlEncodeToString(any());
+        verifyNoMoreInteractions(log);
+        verifyNoInteractions(errorResponseFactory);
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/PackedAttestationProcessorTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/PackedAttestationProcessorTest.java
@@ -1,0 +1,322 @@
+package io.jans.fido2.service.processor.attestation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.jans.fido2.model.auth.AuthData;
+import io.jans.fido2.model.auth.CredAndCounterData;
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
+import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.service.Base64Service;
+import io.jans.fido2.service.CertificateService;
+import io.jans.fido2.service.CoseService;
+import io.jans.fido2.service.mds.AttestationCertificateService;
+import io.jans.fido2.service.verifier.AuthenticatorDataVerifier;
+import io.jans.fido2.service.verifier.CertificateVerifier;
+import io.jans.fido2.service.verifier.CommonVerifiers;
+import io.jans.orm.model.fido2.Fido2RegistrationData;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+
+import static io.jans.util.TestUtil.instanceMapper;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PackedAttestationProcessorTest {
+
+    @InjectMocks
+    private PackedAttestationProcessor packedAttestationProcessor;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private CommonVerifiers commonVerifiers;
+
+    @Mock
+    private AuthenticatorDataVerifier authenticatorDataVerifier;
+
+    @Mock
+    private CertificateVerifier certificateVerifier;
+
+    @Mock
+    private CoseService coseService;
+
+    @Mock
+    private Base64Service base64Service;
+
+    @Mock
+    private AttestationCertificateService attestationCertificateService;
+
+    @Mock
+    private CertificateService certificateService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Test
+    void getAttestationFormat_valid_packed() {
+        String fmt = packedAttestationProcessor.getAttestationFormat().getFmt();
+        assertNotNull(fmt);
+        assertEquals(fmt, "packed");
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationEnabledIsFalseAndTrustManagerIsNull_badRequestException() throws DecoderException {
+        ObjectNode attStmt = instanceMapper().createObjectNode();
+        ArrayNode x5cArray = instanceMapper().createArrayNode();
+        x5cArray.add("certPath1");
+        attStmt.set("x5c", x5cArray);
+        attStmt.put("alg", -7);
+        attStmt.put("sig", "test-signature");
+        AuthData authData = new AuthData();
+        authData.setKeyType(-7);
+        String hexAaguid = "6161677569642d74657374";
+        authData.setAaguid(Hex.decodeHex(hexAaguid.toCharArray()));
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> packedAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(commonVerifiers).verifyAlgorithm(any(JsonNode.class), any(Integer.class));
+        verify(commonVerifiers).verifyBase64String(any(JsonNode.class));
+        verify(attestationCertificateService).populateTrustManager(any(AuthData.class), anyList());
+        verifyNoInteractions(certificateVerifier, coseService, authenticatorDataVerifier, base64Service);
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationEnabledIsFalseAndTrustManagerAndAcceptedIssuersLengthIsZero_fido2RuntimeException() throws DecoderException {
+        ObjectNode attStmt = instanceMapper().createObjectNode();
+        ArrayNode x5cArray = instanceMapper().createArrayNode();
+        x5cArray.add("certPath1");
+        attStmt.set("x5c", x5cArray);
+        attStmt.put("alg", -7);
+        attStmt.put("sig", "test-signature");
+        AuthData authData = new AuthData();
+        authData.setKeyType(-7);
+        String hexAaguid = "6161677569642d74657374";
+        authData.setAaguid(Hex.decodeHex(hexAaguid.toCharArray()));
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        List<X509Certificate> certificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(certificates);
+        X509TrustManager tm = mock(X509TrustManager.class);
+        when(attestationCertificateService.populateTrustManager(authData, certificates)).thenReturn(tm);
+        when(tm.getAcceptedIssuers()).thenReturn(new X509Certificate[]{});
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> packedAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(commonVerifiers).verifyAlgorithm(any(JsonNode.class), any(Integer.class));
+        verify(commonVerifiers).verifyBase64String(any(JsonNode.class));
+        verify(attestationCertificateService).populateTrustManager(any(AuthData.class), anyList());
+        verifyNoInteractions(certificateVerifier, coseService, authenticatorDataVerifier, base64Service);
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationEnabledIsFalseAndTrustManagerAndIsSelfSignedTrue_badRequestException() throws DecoderException {
+        ObjectNode attStmt = instanceMapper().createObjectNode();
+        ArrayNode x5cArray = instanceMapper().createArrayNode();
+        x5cArray.add("certPath1");
+        attStmt.set("x5c", x5cArray);
+        int alg = -7;
+        attStmt.put("alg", alg);
+        attStmt.put("sig", "test-signature");
+        AuthData authData = new AuthData();
+        authData.setKeyType(alg);
+        String hexAaguid = "6161677569642d74657374";
+        authData.setAaguid(Hex.decodeHex(hexAaguid.toCharArray()));
+        authData.setAuthDataDecoded("test-AuthDataDecoded".getBytes());
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        String signature = "test-signature";
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(commonVerifiers.verifyAlgorithm(any(), anyInt())).thenReturn(alg);
+        when(commonVerifiers.verifyBase64String(any())).thenReturn(signature);
+        List<X509Certificate> certificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(certificates);
+        X509TrustManager tm = mock(X509TrustManager.class);
+        when(attestationCertificateService.populateTrustManager(authData, certificates)).thenReturn(tm);
+        X509Certificate verifiedCert = mock(X509Certificate.class);
+        when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(verifiedCert);
+        when(tm.getAcceptedIssuers()).thenReturn(new X509Certificate[]{mock(X509Certificate.class)});
+        when(certificateVerifier.isSelfSigned(any())).thenReturn(true);
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> packedAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(commonVerifiers).verifyAlgorithm(any(JsonNode.class), any(Integer.class));
+        verify(commonVerifiers).verifyBase64String(any(JsonNode.class));
+        verify(attestationCertificateService).populateTrustManager(any(AuthData.class), anyList());
+        verify(authenticatorDataVerifier).verifyPackedAttestationSignature(authData.getAuthDataDecoded(), clientDataHash, signature, verifiedCert, alg);
+        verifyNoMoreInteractions(authenticatorDataVerifier);
+        verifyNoInteractions(coseService, base64Service);
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationEnabledIsFalseAndTrustManagerAndIsSelfSignedTrue_success() throws DecoderException {
+        ObjectNode attStmt = instanceMapper().createObjectNode();
+        ArrayNode x5cArray = instanceMapper().createArrayNode();
+        x5cArray.add("certPath1");
+        attStmt.set("x5c", x5cArray);
+        int alg = -7;
+        attStmt.put("alg", alg);
+        attStmt.put("sig", "test-signature");
+        AuthData authData = new AuthData();
+        authData.setKeyType(alg);
+        String hexAaguid = "6161677569642d74657374";
+        authData.setAaguid(Hex.decodeHex(hexAaguid.toCharArray()));
+        authData.setAuthDataDecoded("test-AuthDataDecoded".getBytes());
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        String signature = "test-signature";
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(commonVerifiers.verifyAlgorithm(any(), anyInt())).thenReturn(alg);
+        when(commonVerifiers.verifyBase64String(any())).thenReturn(signature);
+        List<X509Certificate> certificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(certificates);
+        X509TrustManager tm = mock(X509TrustManager.class);
+        when(attestationCertificateService.populateTrustManager(authData, certificates)).thenReturn(tm);
+        X509Certificate verifiedCert = mock(X509Certificate.class);
+        when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(verifiedCert);
+        when(tm.getAcceptedIssuers()).thenReturn(new X509Certificate[]{mock(X509Certificate.class)});
+        when(certificateVerifier.isSelfSigned(any())).thenReturn(false);
+
+        packedAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters);
+        verify(commonVerifiers).verifyAlgorithm(any(JsonNode.class), any(Integer.class));
+        verify(commonVerifiers).verifyBase64String(any(JsonNode.class));
+        verify(attestationCertificateService).populateTrustManager(any(AuthData.class), anyList());
+        verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
+        verify(authenticatorDataVerifier).verifyPackedAttestationSignature(authData.getAuthDataDecoded(), clientDataHash, signature, verifiedCert, alg);
+        verify(certificateVerifier).isSelfSigned(any(X509Certificate.class));
+        verify(base64Service, times(2)).urlEncodeToString(any());
+        verifyNoInteractions(log, coseService);
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationEnabledIsTrue_success() {
+        ObjectNode attStmt = instanceMapper().createObjectNode();
+        ArrayNode x5cArray = instanceMapper().createArrayNode();
+        x5cArray.add("certPath1");
+        attStmt.set("x5c", x5cArray);
+        int alg = -7;
+        attStmt.put("alg", alg);
+        attStmt.put("sig", "test-signature");
+        AuthData authData = new AuthData();
+        authData.setKeyType(alg);
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        String signature = "test-signature";
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(true);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(commonVerifiers.verifyAlgorithm(any(), anyInt())).thenReturn(alg);
+        when(commonVerifiers.verifyBase64String(any())).thenReturn(signature);
+
+        packedAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters);
+        verify(commonVerifiers).verifyAlgorithm(any(JsonNode.class), any(Integer.class));
+        verify(commonVerifiers).verifyBase64String(any(JsonNode.class));
+        verify(log).warn(eq("SkipValidateMdsInAttestation is enabled"));
+        verify(base64Service, times(2)).urlEncodeToString(any());
+        verifyNoInteractions(authenticatorDataVerifier, certificateService, attestationCertificateService, certificateVerifier, coseService);
+        verifyNoMoreInteractions(log);
+    }
+
+    @Test
+    void process_ifAttStmtHasEcdaaKey_badRequestException() {
+        ObjectNode attStmt = instanceMapper().createObjectNode();
+        String ecdaaKeyId = "test-ecdaaKeyId";
+        attStmt.put("ecdaaKeyId", ecdaaKeyId);
+        int alg = -7;
+        attStmt.put("alg", alg);
+        attStmt.put("sig", "test-signature");
+        AuthData authData = new AuthData();
+        authData.setKeyType(alg);
+        authData.setAuthDataDecoded("test-AuthDataDecoded".getBytes());
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        when(commonVerifiers.verifyAlgorithm(any(), anyInt())).thenReturn(alg);
+        when(commonVerifiers.verifyBase64String(any())).thenReturn("test-signature");
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> packedAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(commonVerifiers).verifyAlgorithm(any(JsonNode.class), any(Integer.class));
+        verify(commonVerifiers).verifyBase64String(any(JsonNode.class));
+        verifyNoInteractions(attestationCertificateService, appConfiguration, log, certificateVerifier, certificateService, coseService, authenticatorDataVerifier, base64Service);
+    }
+
+    @Test
+    void process_ifAttStmtIsNotX5cOrEcdaaKey_valid() {
+        ObjectNode attStmt = instanceMapper().createObjectNode();
+        int alg = -7;
+        attStmt.put("alg", alg);
+        attStmt.put("sig", "test-signature");
+        AuthData authData = new AuthData();
+        authData.setKeyType(alg);
+        authData.setAuthDataDecoded("test-AuthDataDecoded".getBytes());
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        String signature = "test-signature";
+        when(commonVerifiers.verifyAlgorithm(any(), anyInt())).thenReturn(alg);
+        when(commonVerifiers.verifyBase64String(any())).thenReturn(signature);
+
+        packedAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters);
+        verify(commonVerifiers).verifyAlgorithm(any(JsonNode.class), any(Integer.class));
+        verify(commonVerifiers).verifyBase64String(any(JsonNode.class));
+        verify(base64Service, times(2)).urlEncodeToString(any());
+        verifyNoInteractions(certificateService, attestationCertificateService, appConfiguration, log, certificateVerifier);
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/TPMProcessorTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/TPMProcessorTest.java
@@ -1,0 +1,237 @@
+package io.jans.fido2.service.processor.attestation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.jans.fido2.model.auth.AuthData;
+import io.jans.fido2.model.auth.CredAndCounterData;
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
+import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.service.Base64Service;
+import io.jans.fido2.service.CertificateService;
+import io.jans.fido2.service.DataMapperService;
+import io.jans.fido2.service.mds.AttestationCertificateService;
+import io.jans.fido2.service.verifier.CertificateVerifier;
+import io.jans.fido2.service.verifier.CommonVerifiers;
+import io.jans.fido2.service.verifier.SignatureVerifier;
+import io.jans.orm.model.fido2.Fido2RegistrationData;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import tss.tpm.TPMS_ATTEST;
+import tss.tpm.TPMT_PUBLIC;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TPMProcessorTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @InjectMocks
+    private TPMProcessor tpmProcessor;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private CertificateService certificateService;
+
+    @Mock
+    private CommonVerifiers commonVerifiers;
+
+    @Mock
+    private AttestationCertificateService attestationCertificateService;
+
+    @Mock
+    private SignatureVerifier signatureVerifier;
+
+    @Mock
+    private CertificateVerifier certificateVerifier;
+
+    @Mock
+    private DataMapperService dataMapperService;
+
+    @Mock
+    private Base64Service base64Service;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Test
+    void getAttestationFormat_valid_tpm() {
+        String fmt = tpmProcessor.getAttestationFormat().getFmt();
+        assertNotNull(fmt);
+        assertEquals(fmt, "tpm");
+    }
+
+    @Test
+    void process_ifCborReadTreeThrowError_fido2RuntimeException() throws IOException {
+        ObjectNode attStmt = mapper.createObjectNode();
+        AuthData authData = new AuthData();
+        authData.setCosePublicKey("test-cosePublicKey".getBytes());
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        when(dataMapperService.cborReadTree(any())).thenThrow(new IOException("test IOException"));
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> tpmProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(dataMapperService).cborReadTree(any(byte[].class));
+        verify(errorResponseFactory).badRequestException(any(), eq("Problem with TPM attestation: test IOException"));
+        verifyNoInteractions(base64Service, certificateService, attestationCertificateService, certificateVerifier, appConfiguration, log, commonVerifiers, signatureVerifier);
+    }
+
+    @Test
+    void process_ifX5cIsEmpty_badRequestException() throws IOException {
+        ObjectNode attStmt = mapper.createObjectNode();
+        ArrayNode x5cArray = mapper.createArrayNode();
+        attStmt.set("x5c", x5cArray);
+        attStmt.put("pubArea", "test-pubArea");
+        attStmt.put("certInfo", "test-certInfo");
+        attStmt.put("ver", "2.0");
+        attStmt.put("alg", -256);
+        AuthData authData = new AuthData();
+        authData.setCosePublicKey("test-cosePublicKey".getBytes());
+        authData.setAttestationBuffer("test-attestationBuffer".getBytes());
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        ObjectNode cborPublicKey = mapper.createObjectNode();
+        cborPublicKey.put("-1", "test-PublicKey");
+        when(dataMapperService.cborReadTree(any())).thenReturn(cborPublicKey);
+        MessageDigest messageDigest = mock(MessageDigest.class);
+        when(signatureVerifier.getDigest(-256)).thenReturn(messageDigest);
+        when(messageDigest.digest()).thenReturn("test-hashedBuffer".getBytes());
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> tpmProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(dataMapperService).cborReadTree(any(byte[].class));
+        verify(base64Service).decode(any(String.class));
+        verifyNoInteractions(certificateService, attestationCertificateService, certificateVerifier, appConfiguration, commonVerifiers);
+    }
+
+    @Test
+    void process_ifX5cAndSkipValidateMdsInAttestationIsFalseAndVerifyAttestationCertificatesThrowError_badRequestException() throws IOException {
+        ObjectNode attStmt = mapper.createObjectNode();
+        ArrayNode x5cArray = mapper.createArrayNode();
+        x5cArray.add("certPath1");
+        attStmt.set("x5c", x5cArray);
+        attStmt.put("pubArea", "test-pubArea");
+        attStmt.put("certInfo", "test-certInfo");
+        attStmt.put("ver", "2.0");
+        attStmt.put("alg", -256);
+        AuthData authData = new AuthData();
+        authData.setCosePublicKey("test-cosePublicKey".getBytes());
+        authData.setAttestationBuffer("test-attestationBuffer".getBytes());
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        ObjectNode cborPublicKey = mapper.createObjectNode();
+        cborPublicKey.put("-1", "test-PublicKey");
+        when(dataMapperService.cborReadTree(any())).thenReturn(cborPublicKey);
+        MessageDigest messageDigest = mock(MessageDigest.class);
+        when(signatureVerifier.getDigest(-256)).thenReturn(messageDigest);
+        when(messageDigest.digest()).thenReturn("test-hashedBuffer".getBytes());
+        List<X509Certificate> aikCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(Collections.emptyList());
+        when(certificateService.getCertificates(anyList())).thenReturn(aikCertificates);
+        when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> tpmProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(log, never()).warn("SkipValidateMdsInAttestation is enabled");
+        verify(dataMapperService).cborReadTree(any(byte[].class));
+        verify(base64Service).decode(any(String.class));
+        verify(attestationCertificateService).getAttestationRootCertificates(authData, aikCertificates);
+        verify(certificateVerifier).verifyAttestationCertificates(any(), any());
+        verifyNoInteractions(commonVerifiers);
+    }
+
+    @Test
+    void process_ifX5cAndSkipValidateMdsInAttestationIsFalseAndVerifyAttestationCertificatesIsValid_success() throws IOException {
+        ObjectNode attStmt = mapper.createObjectNode();
+        ArrayNode x5cArray = mapper.createArrayNode();
+        x5cArray.add("certPath1");
+        attStmt.set("x5c", x5cArray);
+        String pubArea = "AAEACwAGBHIAIJ3/y/NsODrmmfuYaNxty4nXFTiEvigDkiwSQVi/rSKuABAAEAgAAAAAAAEAss+GHGDpvFEbV+MsBvJsXWTC4MKkyZoOFYCM2EF05SNlFZs4PMQWX1b13Rg0jz77aH3sMO2YmqOSmU00l6/yRabVSiRoAtmRl5pY3HJ+WRsjl//zaJmeHi3EWxUFPA7xAE+qecX7s4HW6aDDQZZgFAfSh95exV1CStYT3s9YvBg/PT3C6355hfK2TAdMqTGXvKRolqmQ8+hO8qMg9b73MXLneMEAp0d2vjufcH8nVvtcu72z9cke7yqmsKRuWg8BpV0r36Ji2UvzPElcdzylAm1n2oGn/POdkf8bQcCI48oc5QRAUoDiSOTuXlybUF0iIi/jOUFfhGnTB6vkwRNZ3w==";
+        String certInfo = "/1RDR4AXACIACxHmjtRNtTcuFCluL4Ssx4OYdRiBkh4w/CKgb4tzx5RTACAzhxi3W0HuExVoYbtvYBWeg7Bli9xEDJvw2AMqf60mywAAAAFHcBdIVWl7S8aFYKUBc375jTRWVfsAIgALzYHYUq0K55IskuzIfukQ/H/o1LOOjz7EoGnTf6Yy8toAIgALfXLmQ1rhTAPBOQeQbAQQYPqvbON0RO/9OtVFOrp7UV4=";
+        attStmt.put("pubArea", pubArea);
+        attStmt.put("certInfo", certInfo);
+        attStmt.put("ver", "2.0");
+        attStmt.put("alg", -256);
+        AuthData authData = new AuthData();
+        authData.setCosePublicKey("test-cosePublicKey".getBytes());
+        authData.setAttestationBuffer("test-attestationBuffer".getBytes());
+        Fido2RegistrationData registration = new Fido2RegistrationData();
+        byte[] clientDataHash = "test-clientDataHash".getBytes();
+        CredAndCounterData credIdAndCounters = new CredAndCounterData();
+        byte[] certInfoBuffer = Base64.getDecoder().decode(certInfo);
+        byte[] pubAreaBuffer = Base64.getDecoder().decode(pubArea);
+        TPMS_ATTEST tpmsAttest = TPMS_ATTEST.fromTpm(certInfoBuffer);
+        TPMT_PUBLIC tpmtPublic = TPMT_PUBLIC.fromTpm(pubAreaBuffer);
+        ObjectNode cborPublicKey = mapper.createObjectNode();
+        cborPublicKey.put("-1", "test-PublicKey");
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setSkipValidateMdsInAttestationEnabled(false);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(dataMapperService.cborReadTree(any())).thenReturn(cborPublicKey);
+        MessageDigest messageDigest = mock(MessageDigest.class);
+        when(signatureVerifier.getDigest(-256)).thenReturn(messageDigest);
+        when(messageDigest.digest()).thenReturn(tpmsAttest.extraData);
+        List<X509Certificate> aikCertificates = Collections.singletonList(mock(X509Certificate.class));
+        when(certificateService.getCertificates(anyList())).thenReturn(Collections.emptyList());
+        when(certificateService.getCertificates(anyList())).thenReturn(aikCertificates);
+        X509Certificate verifiedCert = mock(X509Certificate.class);
+        when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(verifiedCert);
+        when(commonVerifiers.verifyBase64String(any())).thenReturn("test-signature");
+        when(base64Service.decode(any(String.class))).thenReturn(Arrays.copyOfRange(tpmtPublic.unique.toTpm(), 2, tpmtPublic.unique.toTpm().length), certInfoBuffer, pubAreaBuffer);
+        when(commonVerifiers.tpmParseToPublic(any())).thenReturn(tpmtPublic);
+        when(commonVerifiers.tpmParseToAttest(any())).thenReturn(tpmsAttest);
+
+        tpmProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters);
+        verify(dataMapperService).cborReadTree(any(byte[].class));
+        verify(base64Service, times(3)).decode(anyString());
+        verify(certificateService, times(2)).getCertificates(anyList());
+        verify(attestationCertificateService).getAttestationRootCertificates(any(AuthData.class), anyList());
+        verify(appConfiguration).getFido2Configuration();
+        verify(log).trace("TPM attStmt 'alg': {}", -256);
+        verify(base64Service, times(2)).urlEncodeToString(any());
+        verifyNoMoreInteractions(log);
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/U2FAttestationProcessorTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/U2FAttestationProcessorTest.java
@@ -1,0 +1,284 @@
+package io.jans.fido2.service.processor.attestation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.jans.fido2.exception.Fido2MissingAttestationCertException;
+import io.jans.fido2.model.auth.AuthData;
+import io.jans.fido2.model.auth.CredAndCounterData;
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
+import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.service.Base64Service;
+import io.jans.fido2.service.CertificateService;
+import io.jans.fido2.service.CoseService;
+import io.jans.fido2.service.mds.AttestationCertificateService;
+import io.jans.fido2.service.verifier.AuthenticatorDataVerifier;
+import io.jans.fido2.service.verifier.CertificateVerifier;
+import io.jans.fido2.service.verifier.CommonVerifiers;
+import io.jans.fido2.service.verifier.UserVerificationVerifier;
+import io.jans.orm.model.fido2.Fido2RegistrationData;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import java.nio.file.attribute.UserPrincipal;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class U2FAttestationProcessorTest {
+
+    @InjectMocks
+    private U2FAttestationProcessor u2FAttestationProcessor;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private CommonVerifiers commonVerifiers;
+
+    @Mock
+    private AuthenticatorDataVerifier authenticatorDataVerifier;
+
+    @Mock
+    private UserVerificationVerifier userVerificationVerifier;
+
+    @Mock
+    private AttestationCertificateService attestationCertificateService;
+
+    @Mock
+    private CertificateVerifier certificateVerifier;
+
+    @Mock
+    private CoseService coseService;
+
+    @Mock
+    private Base64Service base64Service;
+
+    @Mock
+    private CertificateService certificateService;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Test
+    void getAttestationFormat_valid_fidoU2f() {
+        String fmt = u2FAttestationProcessor.getAttestationFormat().getFmt();
+        assertNotNull(fmt);
+        assertEquals(fmt, "fido-u2f");
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationIsFalseAndVerifyAttestationThrowErrorAndCertificatesIsEmpty_fido2MissingAttestationCertException() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData registration = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = new byte[]{};
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+        Fido2Configuration fido2Configuration = mock(Fido2Configuration.class);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(registration.getDomain()).thenReturn("test-domain");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.emptyIterator());
+        when(attStmt.get("sig")).thenReturn(mock(JsonNode.class));
+        when(commonVerifiers.verifyBase64String(any())).thenReturn("test-signature");
+        when(certificateVerifier.verifyAttestationCertificates(any(), any())).thenThrow(new Fido2MissingAttestationCertException("test missing"));
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(fido2Configuration.isSkipValidateMdsInAttestationEnabled()).thenReturn(false);
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> u2FAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+//        assertNotNull(ex);
+//        assertEquals(ex.getMessage(), "test missing");
+
+        verify(commonVerifiers).verifyAAGUIDZeroed(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(commonVerifiers).verifyRpIdHash(authData, "test-domain");
+        verify(certificateService).getCertificates(anyList());
+        verify(attestationCertificateService).getAttestationRootCertificates((JsonNode) eq(null), anyList());
+        verify(appConfiguration).getFido2Configuration();
+        verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
+        verify(authenticatorDataVerifier, never()).verifyU2FAttestationSignature(any(AuthData.class), any(byte[].class), any(String.class), any(X509Certificate.class), any(Integer.class));
+        verify(log, never()).warn(contains("Failed to find attestation validation signature public certificate with DN"), anyString());
+        verifyNoInteractions(log, authenticatorDataVerifier, coseService, base64Service);
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationIsFalseAndVerifyAttestationThrowErrorAndCertificatesIsNotEmpty_badRequestException() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData registration = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = new byte[]{};
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+        Fido2Configuration fido2Configuration = mock(Fido2Configuration.class);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(registration.getDomain()).thenReturn("test-domain");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("cert1")).iterator());
+        when(attStmt.get("sig")).thenReturn(mock(JsonNode.class));
+        when(commonVerifiers.verifyBase64String(any())).thenReturn("test-signature");
+        when(certificateVerifier.verifyAttestationCertificates(any(), any())).thenThrow(new Fido2MissingAttestationCertException("test missing"));
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(fido2Configuration.isSkipValidateMdsInAttestationEnabled()).thenReturn(false);
+        X509Certificate publicCert1 = mock(X509Certificate.class);
+        when(certificateService.getCertificates(anyList())).thenReturn(Collections.singletonList(publicCert1));
+        when(publicCert1.getIssuerDN()).thenReturn((UserPrincipal) () -> "test-issuer");
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> u2FAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(commonVerifiers).verifyAAGUIDZeroed(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(commonVerifiers).verifyRpIdHash(authData, "test-domain");
+        verify(certificateService).getCertificates(anyList());
+        verify(attestationCertificateService).getAttestationRootCertificates((JsonNode) eq(null), anyList());
+        verify(appConfiguration).getFido2Configuration();
+        verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
+        verify(authenticatorDataVerifier, never()).verifyU2FAttestationSignature(any(AuthData.class), any(byte[].class), any(String.class), any(X509Certificate.class), any(Integer.class));
+        verify(log).warn("Failed to find attestation validation signature public certificate with DN: '{}'", "test-issuer");
+        verifyNoInteractions(authenticatorDataVerifier, coseService, base64Service);
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationIsFalseAndCertificatesIsNotEmptyAndVerifyAttestationIsValid_success() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData registration = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = new byte[]{};
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+        Fido2Configuration fido2Configuration = mock(Fido2Configuration.class);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(registration.getDomain()).thenReturn("test-domain");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("cert1")).iterator());
+        when(attStmt.get("sig")).thenReturn(mock(JsonNode.class));
+        X509Certificate verifiedCert = mock(X509Certificate.class);
+        when(commonVerifiers.verifyBase64String(any())).thenReturn("test-signature");
+        when(certificateVerifier.verifyAttestationCertificates(any(), any())).thenReturn(verifiedCert);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(fido2Configuration.isSkipValidateMdsInAttestationEnabled()).thenReturn(false);
+
+        u2FAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters);
+        verify(commonVerifiers).verifyAAGUIDZeroed(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(commonVerifiers).verifyRpIdHash(authData, "test-domain");
+        verify(certificateService).getCertificates(anyList());
+        verify(attestationCertificateService).getAttestationRootCertificates((JsonNode) eq(null), anyList());
+        verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
+        verify(authenticatorDataVerifier).verifyU2FAttestationSignature(any(AuthData.class), any(byte[].class), any(String.class), any(X509Certificate.class), any(Integer.class));
+        verify(base64Service, times(2)).urlEncodeToString(any());
+        verifyNoInteractions(log, coseService);
+    }
+
+    @Test
+    void process_ifAttStmtHasX5cAndSkipValidateMdsInAttestationIsTrue_success() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData registration = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = new byte[]{};
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+        Fido2Configuration fido2Configuration = mock(Fido2Configuration.class);
+        JsonNode x5cNode = mock(JsonNode.class);
+        when(registration.getDomain()).thenReturn("test-domain");
+        when(attStmt.hasNonNull("x5c")).thenReturn(true);
+        when(attStmt.get("x5c")).thenReturn(x5cNode);
+        when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("cert1")).iterator());
+        when(attStmt.get("sig")).thenReturn(mock(JsonNode.class));
+        when(commonVerifiers.verifyBase64String(any())).thenReturn("test-signature");
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(fido2Configuration.isSkipValidateMdsInAttestationEnabled()).thenReturn(true);
+
+        u2FAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters);
+        verify(commonVerifiers).verifyAAGUIDZeroed(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(commonVerifiers).verifyRpIdHash(authData, "test-domain");
+        verify(certificateService).getCertificates(anyList());
+        verify(attestationCertificateService).getAttestationRootCertificates((JsonNode) eq(null), anyList());
+        verify(log).warn(eq("SkipValidateMdsInAttestation is enabled"));
+        verifyNoMoreInteractions(log);
+        verify(base64Service, times(2)).urlEncodeToString(any());
+        verifyNoInteractions(certificateVerifier, authenticatorDataVerifier, coseService);
+    }
+
+    @Test
+    void process_ifAttStmtHasEcdaaKeyId_badRequestException() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData registration = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = new byte[]{};
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+        when(registration.getDomain()).thenReturn("test-domain");
+        when(attStmt.get("sig")).thenReturn(mock(JsonNode.class));
+        when(attStmt.hasNonNull("x5c")).thenReturn(false);
+        when(attStmt.hasNonNull("ecdaaKeyId")).thenReturn(true);
+        when(attStmt.get("ecdaaKeyId")).thenReturn(new TextNode("test-ecdaaKeyId"));
+        when(errorResponseFactory.badRequestException(any(), any())).thenReturn(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class, () -> u2FAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters));
+        assertNotNull(res);
+        assertNotNull(res.getResponse());
+        assertEquals(res.getResponse().getStatus(), 400);
+        assertEquals(res.getResponse().getEntity(), "test exception");
+
+        verify(commonVerifiers).verifyBase64String(any());
+        verify(commonVerifiers).verifyAAGUIDZeroed(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(commonVerifiers).verifyRpIdHash(authData, "test-domain");
+        verify(log).warn("Fido-U2F unsupported EcdaaKeyId: {}", "test-ecdaaKeyId");
+        verifyNoMoreInteractions(log);
+        verifyNoInteractions(certificateService, certificateVerifier, appConfiguration, attestationCertificateService, authenticatorDataVerifier, coseService, base64Service);
+    }
+
+    @Test
+    void process_ifAttStmtNotIsX5cOrEcdaaKeyId_success() {
+        JsonNode attStmt = mock(JsonNode.class);
+        AuthData authData = mock(AuthData.class);
+        Fido2RegistrationData registration = mock(Fido2RegistrationData.class);
+        byte[] clientDataHash = new byte[]{};
+        CredAndCounterData credIdAndCounters = mock(CredAndCounterData.class);
+        when(registration.getDomain()).thenReturn("test-domain");
+        when(authData.getAuthDataDecoded()).thenReturn("test-decoded".getBytes());
+        when(attStmt.get("sig")).thenReturn(mock(JsonNode.class));
+        when(commonVerifiers.verifyBase64String(any())).thenReturn("test-signature");
+        when(attStmt.hasNonNull("x5c")).thenReturn(false);
+        when(attStmt.hasNonNull("ecdaaKeyId")).thenReturn(false);
+        PublicKey publicKey = mock(PublicKey.class);
+        when(coseService.getPublicKeyFromUncompressedECPoint(any())).thenReturn(publicKey);
+
+        u2FAttestationProcessor.process(attStmt, authData, registration, clientDataHash, credIdAndCounters);
+        verify(commonVerifiers).verifyBase64String(any());
+        verify(commonVerifiers).verifyAAGUIDZeroed(authData);
+        verify(userVerificationVerifier).verifyUserPresent(authData);
+        verify(commonVerifiers).verifyRpIdHash(authData, "test-domain");
+        verify(coseService).getPublicKeyFromUncompressedECPoint(any());
+        verify(authenticatorDataVerifier).verifyPackedSurrogateAttestationSignature(authData.getAuthDataDecoded(), clientDataHash, "test-signature", publicKey, -7);
+        verifyNoInteractions(log, certificateService, certificateVerifier, appConfiguration, attestationCertificateService);
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/util/CommonUtilServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/util/CommonUtilServiceTest.java
@@ -1,0 +1,15 @@
+package io.jans.fido2.service.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class CommonUtilServiceTest {
+
+    @Test
+    void writeOutputStreamByteList() {
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/util/TestUtil.java
+++ b/jans-fido2/server/src/test/java/io/jans/util/TestUtil.java
@@ -1,0 +1,22 @@
+package io.jans.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestUtil {
+
+    private static final TestUtil testUtil = new TestUtil();
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static TestUtil instanceTestUtil() {
+        return testUtil;
+    }
+
+    public static ObjectMapper instanceMapper() {
+        return instanceTestUtil().getMapper();
+    }
+
+    public ObjectMapper getMapper() {
+        return mapper;
+    }
+}

--- a/jans-linux-setup/jans_setup/templates/jans-fido2/dynamic-conf.json
+++ b/jans-linux-setup/jans_setup/templates/jans-fido2/dynamic-conf.json
@@ -38,6 +38,8 @@
       "userAutoEnrollment":false,
       "unfinishedRequestExpiration":180,
       "authenticationHistoryExpiration":1296000,
-      "metadataUrlsProvider":""
+      "metadataUrlsProvider":"",
+      "skipDownloadMdsEnabled":false,
+      "skipValidateMdsInAttestationEnabled":false
    }
 }


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
- Added 2 new configuration parameters: 
  * `skipDownloadMdsEnabled`: Boolean value indicating whether the MDS download should be omitted
  * `skipValidateMdsInAttestationEnabled`: Boolean value indicating whether MDS validation should be omitted during attestation
- Skip MDS validation in attestation for `packet`, `fido-u2f`, `tpm`, `android-key`, `android-safetynet` and `apple`

closes #5171
