### PR TITLE
chore(jans-core): notify-client is not included in parent pom.xml #5511

### DIFF
--- a/jans-core/pom.xml
+++ b/jans-core/pom.xml
@@ -62,6 +62,7 @@
 		<module>demo-cdi</module>
 		<module>doc</module>
 		<module>uma-rs-core</module>
+		<module>notify-client</module>
 	</modules>
 
 	<dependencyManagement>


### PR DESCRIPTION
### Description

chore(jans-core): notify-client is not included in parent pom.xml 

#### Target issue
  
closes #5511
