### PR TITLE
refactor(docker): avoid context collision on custom log4j2.xml

### DIFF
--- a/docker-jans-auth-server/jetty/log4j2.xml
+++ b/docker-jans-auth-server/jetty/log4j2.xml
@@ -2,7 +2,7 @@
 
 <Configuration packages="io.jans.log">
     <Properties>
-        <Property name="log.console.prefix" value="auth" />
+        <Property name="auth.log.console.prefix" value="auth" />
     </Properties>
 	<Appenders>
 		<Console name="STDOUT" target="SYSTEM_OUT">
@@ -103,66 +103,66 @@
 		<Logger name="org.hibernate" level="error" />
 
 		<Logger name="io.jans.as.server.audit.debug" level="$http_log_level" additivity="false">
-            <Property name="log.console.group">-http</Property>
+            <Property name="auth.log.console.group">-http</Property>
 			<AppenderRef ref="$http_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="auth.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</Logger>
 
 		<Logger name="com.unboundid.ldap.sdk.LDAPConnection" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="auth.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</Logger>
 		<logger name="com.couchbase.client" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="auth.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</logger>
 
 		<Logger name="io.jans.orm.ldap.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="auth.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm.couchbase.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="auth.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="auth.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.as.server.service.status.ldap" level="$ldap_stats_log_level" additivity="false">
-            <Property name="log.console.group">-ldap-stats</Property>
+            <Property name="auth.log.console.group">-ldap-stats</Property>
 			<AppenderRef ref="$ldap_stats_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.service.PythonService" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="auth.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.service.custom.script" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="auth.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.as.server.service.custom" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="auth.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.agama.engine.script.LogUtils" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="auth.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.as.server.audit.ApplicationAuditLogger" level="$audit_log_level" additivity="false">
-            <Property name="log.console.group">-audit</Property>
+            <Property name="auth.log.console.group">-audit</Property>
 			<AppenderRef ref="$audit_log_target" />
 		</Logger>
 

--- a/docker-jans-auth-server/scripts/bootstrap.py
+++ b/docker-jans-auth-server/scripts/bootstrap.py
@@ -202,8 +202,11 @@ def configure_logging():
         if config[key] == "FILE":
             config[key] = value
 
-    if as_boolean(custom_config.get("enable_stdout_log_prefix")):
-        config["log_prefix"] = "${sys:log.console.prefix}%X{log.console.group} - "
+    if any([
+        as_boolean(custom_config.get("enable_stdout_log_prefix")),
+        as_boolean(os.environ.get("CN_ENABLE_STDOUT_LOG_PREFIX"))
+    ]):
+        config["log_prefix"] = "${sys:auth.log.console.prefix}%X{auth.log.console.group} - "
 
     with open("/app/templates/log4j2.xml") as f:
         txt = f.read()

--- a/docker-jans-config-api/jetty/log4j2.xml
+++ b/docker-jans-config-api/jetty/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="ERROR">
     <Properties>
-        <Property name="log.console.prefix" value="config-api" />
+        <Property name="config_api.log.console.prefix" value="config-api" />
     </Properties>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
@@ -73,62 +73,62 @@
         </Logger>
 
         <Logger name="audit" level="$audit_log_level" additivity="false">
-            <Property name="log.console.group">-audit</Property>
+            <Property name="config_api.log.console.group">-audit</Property>
             <AppenderRef ref="$audit_log_target" />
         </Logger>
 
         <Logger name="io.jans.orm" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="config_api.log.console.group">-persistence</Property>
             <AppenderRef ref="$persistence_log_target" />
         </Logger>
 
         <Logger name="com.unboundid.ldap.sdk.LDAPConnection" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="config_api.log.console.group">-persistence</Property>
             <AppenderRef ref="$persistence_log_target" />
         </Logger>
 
         <Logger name="com.couchbase.client" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="config_api.log.console.group">-persistence</Property>
             <AppenderRef ref="$persistence_log_target" />
         </Logger>
 
         <Logger name="io.jans.orm.ldap.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="config_api.log.console.group">-persistence-duration</Property>
             <AppenderRef ref="$persistence_duration_log_target" />
         </Logger>
 
         <Logger name="io.jans.orm.couchbase.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="config_api.log.console.group">-persistence-duration</Property>
             <AppenderRef ref="$persistence_duration_log_target" />
         </Logger>
 
         <Logger name="io.jans.orm.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="config_api.log.console.group">-persistence-duration</Property>
             <AppenderRef ref="$persistence_duration_log_target" />
         </Logger>
 
         <Logger name="io.jans.as.server.service.status.ldap" level="$ldap_stats_log_level" additivity="false">
-            <Property name="log.console.group">-ldap-stats</Property>
+            <Property name="config_api.log.console.group">-ldap-stats</Property>
             <AppenderRef ref="$ldap_stats_log_target" />
         </Logger>
 
         <Logger name="io.jans.service.PythonService" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="config_api.log.console.group">-script</Property>
             <AppenderRef ref="$script_log_target" />
         </Logger>
 
         <Logger name="io.jans.service.custom.script" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="config_api.log.console.group">-script</Property>
             <AppenderRef ref="$script_log_target" />
         </Logger>
 
         <Logger name="io.jans.as.server.service.custom" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="config_api.log.console.group">-script</Property>
             <AppenderRef ref="$script_log_target" />
         </Logger>
 
         <Logger name="io.jans.service.external" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="config_api.log.console.group">-script</Property>
             <AppenderRef ref="$script_log_target" />
         </Logger>
 

--- a/docker-jans-config-api/plugins/admin-ui/log4j2-adminui.xml
+++ b/docker-jans-config-api/plugins/admin-ui/log4j2-adminui.xml
@@ -2,7 +2,7 @@
 
 <Configuration packages="io.jans.log">
     <Properties>
-        <Property name="log.console.prefix.admin-ui" value="config-api" />
+        <Property name="admin_ui.log.console.prefix" value="config-api" />
     </Properties>
     <Appenders>
         <Console name="AdminUI_Console" target="SYSTEM_OUT">
@@ -34,11 +34,11 @@
 
     <Loggers>
         <Logger name="io.jans.ca.plugin.adminui.rest.logging" level="$admin_ui_audit_log_level" additivity="false">
-            <Property name="log.console.group.admin-ui">/admin-ui-audit</Property>
+            <Property name="admin_ui.log.console.group">-admin-ui-audit</Property>
             <AppenderRef ref="$admin_ui_audit_log_target" />
         </Logger>
         <Logger name="io.jans.ca.plugin.adminui" level="$admin_ui_log_level" additivity="false">
-            <Property name="log.console.group.admin-ui">/admin-ui</Property>
+            <Property name="admin_ui.log.console.group">-admin-ui</Property>
             <AppenderRef ref="$admin_ui_log_target" />
         </Logger>
     </Loggers>

--- a/docker-jans-config-api/scripts/bootstrap.py
+++ b/docker-jans-config-api/scripts/bootstrap.py
@@ -235,8 +235,11 @@ def configure_logging():
         else:
             config[key] = file_aliases[key]
 
-    if as_boolean(custom_config.get("enable_stdout_log_prefix")):
-        config["log_prefix"] = "${sys:log.console.prefix}%X{log.console.group} - "
+    if any([
+        as_boolean(custom_config.get("enable_stdout_log_prefix")),
+        as_boolean(os.environ.get("CN_ENABLE_STDOUT_LOG_PREFIX")),
+    ]):
+        config["log_prefix"] = "${sys:config_api.log.console.prefix}%X{config_api.log.console.group} - "
 
     with open("/app/templates/log4j2.xml") as f:
         txt = f.read()
@@ -266,7 +269,7 @@ def configure_admin_ui_logging():
 
     # ensure custom config is ``dict`` type
     if not isinstance(custom_config, dict):
-        logger.warning("Invalid data type for CN_CONFIG_API_APP_LOGGERS; fallback to defaults")
+        logger.warning("Invalid data type for CN_ADMIN_UI_PLUGIN_LOGGERS; fallback to defaults")
         custom_config = {}
 
     # list of supported levels; OFF is not supported
@@ -305,8 +308,11 @@ def configure_admin_ui_logging():
         else:
             config[key] = file_aliases[key]
 
-    if as_boolean(custom_config.get("enable_stdout_log_prefix")):
-        config["log_prefix"] = "${sys:log.console.prefix.admin-ui}%X{log.console.group.admin-ui} - "
+    if any([
+        as_boolean(custom_config.get("enable_stdout_log_prefix")),
+        as_boolean(os.environ.get("CN_ENABLE_STDOUT_LOG_PREFIX")),
+    ]):
+        config["log_prefix"] = "${sys:admin_ui.log.console.prefix}%X{admin_ui.log.console.group} - "
 
     with open("/app/plugins/admin-ui/log4j2-adminui.xml") as f:
         txt = f.read()

--- a/docker-jans-fido2/jetty/log4j2.xml
+++ b/docker-jans-fido2/jetty/log4j2.xml
@@ -2,7 +2,7 @@
 
 <Configuration packages="io.jans.log">
     <Properties>
-        <Property name="log.console.prefix" value="fido2" />
+        <Property name="fido2.log.console.prefix" value="fido2" />
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
@@ -60,47 +60,47 @@
         </Logger>
 
 		<Logger name="io.jans.orm" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="fido2.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</Logger>
 
 		<Logger name="com.unboundid.ldap.sdk.LDAPConnection" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="fido2.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</Logger>
 
 		<logger name="com.couchbase.client" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="fido2.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</logger>
 
 		<Logger name="io.jans.orm.ldap.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="fido2.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm.couchbase.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="fido2.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="fido2.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.service.PythonService" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="fido2.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.service.custom.script" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="fido2.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.fido2.service.shared" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="fido2.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 

--- a/docker-jans-fido2/scripts/bootstrap.py
+++ b/docker-jans-fido2/scripts/bootstrap.py
@@ -189,8 +189,11 @@ def configure_logging():
         if config[key] == "FILE":
             config[key] = value
 
-    if as_boolean(custom_config.get("enable_stdout_log_prefix")):
-        config["log_prefix"] = "${sys:log.console.prefix}%X{log.console.group} - "
+    if any([
+        as_boolean(custom_config.get("enable_stdout_log_prefix")),
+        as_boolean(os.environ.get("CN_ENABLE_STDOUT_LOG_PREFIX")),
+    ]) :
+        config["log_prefix"] = "${sys:fido2.log.console.prefix}%X{fido2.log.console.group} - "
 
     with open("/app/templates/log4j2.xml") as f:
         txt = f.read()

--- a/docker-jans-link/jetty/log4j2.xml
+++ b/docker-jans-link/jetty/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
     <Properties>
-        <Property name="log.console.prefix" value="link" />
+        <Property name="link.log.console.prefix" value="link" />
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
@@ -64,56 +64,56 @@
         </Logger>
 
 		<Logger name="io.jans.orm" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="link.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</Logger>
 
 		<Logger name="com.unboundid.ldap.sdk.LDAPConnection" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="link.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</Logger>
 		<logger name="com.couchbase.client" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="link.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</logger>
 
 		<Logger name="io.jans.orm.ldap.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="link.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm.couchbase.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="link.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="link.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.as.server.service.status.ldap" level="$ldap_stats_log_level" additivity="false">
-            <Property name="log.console.group">-ldap-stats</Property>
+            <Property name="link.log.console.group">-ldap-stats</Property>
 			<AppenderRef ref="$ldap_stats_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.service.PythonService" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="link.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.service.custom.script" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="link.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.as.server.service.custom" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="link.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<logger name="io.jans.service.external" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="link.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</logger>
 

--- a/docker-jans-link/scripts/bootstrap.py
+++ b/docker-jans-link/scripts/bootstrap.py
@@ -202,8 +202,11 @@ def configure_logging():
         if config[key] == "FILE":
             config[key] = value
 
-    if as_boolean(custom_config.get("enable_stdout_log_prefix")):
-        config["log_prefix"] = "${sys:log.console.prefix}%X{log.console.group} - "
+    if any([
+        as_boolean(custom_config.get("enable_stdout_log_prefix")),
+        as_boolean(os.environ.get("CN_ENABLE_STDOUT_LOG_PREFIX")),
+    ]):
+        config["log_prefix"] = "${sys:link.log.console.prefix}%X{link.log.console.group} - "
 
     with open("/app/templates/log4j2.xml") as f:
         txt = f.read()

--- a/docker-jans-scim/jetty/log4j2.xml
+++ b/docker-jans-scim/jetty/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="ERROR">
     <Properties>
-        <Property name="log.console.prefix" value="scim" />
+        <Property name="scim.log.console.prefix" value="scim" />
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
@@ -65,56 +65,56 @@
 
 
 		<Logger name="io.jans.orm" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="scim.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</Logger>
 
 		<Logger name="com.unboundid.ldap.sdk.LDAPConnection" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="scim.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</Logger>
 		<logger name="com.couchbase.client" level="$persistence_log_level" additivity="false">
-            <Property name="log.console.group">-persistence</Property>
+            <Property name="scim.log.console.group">-persistence</Property>
 			<AppenderRef ref="$persistence_log_target" />
 		</logger>
 
 		<Logger name="io.jans.orm.ldap.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="scim.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm.couchbase.operation.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="scim.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.orm.watch" level="$persistence_duration_log_level" additivity="false">
-            <Property name="log.console.group">-persistence-duration</Property>
+            <Property name="scim.log.console.group">-persistence-duration</Property>
 			<AppenderRef ref="$persistence_duration_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.as.server.service.status.ldap" level="$ldap_stats_log_level" additivity="false">
-            <Property name="log.console.group">-ldap-stats</Property>
+            <Property name="scim.log.console.group">-ldap-stats</Property>
 			<AppenderRef ref="$ldap_stats_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.service.PythonService" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="scim.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.service.custom.script" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="scim.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<Logger name="io.jans.as.server.service.custom" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="scim.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</Logger>
 
 		<logger name="io.jans.service.external" level="$script_log_level" additivity="false">
-            <Property name="log.console.group">-script</Property>
+            <Property name="scim.log.console.group">-script</Property>
 			<AppenderRef ref="$script_log_target" />
 		</logger>
 

--- a/docker-jans-scim/scripts/bootstrap.py
+++ b/docker-jans-scim/scripts/bootstrap.py
@@ -206,8 +206,11 @@ def configure_logging():
         if config[key] == "FILE":
             config[key] = value
 
-    if as_boolean(custom_config.get("enable_stdout_log_prefix")):
-        config["log_prefix"] = "${sys:log.console.prefix}%X{log.console.group} - "
+    if any([
+        as_boolean(custom_config.get("enable_stdout_log_prefix")),
+        as_boolean(os.environ.get("CN_ENABLE_STDOUT_LOG_PREFIX")),
+    ]):
+        config["log_prefix"] = "${sys:scim.log.console.prefix}%X{scim.log.console.group} - "
 
     with open("/app/templates/log4j2.xml") as f:
         txt = f.read()


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

The changeset sets namespaced context for `log.console.*` in `log4j2.xml`.

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #5616 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

