### PR TITLE
fix(jans-auth-server): if scopes are missed in grant_type=refresh_token AS must take scopes from previous grant #5462

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
@@ -349,6 +349,7 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
         }
 
         authorizationGrant.checkScopesPolicy(scope);
+        scope = authorizationGrant.getScopesAsString();
 
         AccessToken accToken = authorizationGrant.createAccessToken(executionContext); // create token after scopes are checked
 
@@ -381,7 +382,7 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
                 accToken.getTokenType(),
                 accToken.getExpiresIn(),
                 reToken,
-                authorizationGrant.getScopesAsString(),
+                scope,
                 idToken)), auditLog);
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
@@ -348,7 +348,7 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
             }
         }
 
-        scope = authorizationGrant.checkScopesPolicy(scope);
+        authorizationGrant.checkScopesPolicy(scope);
 
         AccessToken accToken = authorizationGrant.createAccessToken(executionContext); // create token after scopes are checked
 
@@ -381,7 +381,7 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
                 accToken.getTokenType(),
                 accToken.getExpiresIn(),
                 reToken,
-                scope,
+                authorizationGrant.getScopesAsString(),
                 idToken)), auditLog);
     }
 


### PR DESCRIPTION
### Description

fix(jans-auth-server): if scopes are missed in grant_type=refresh_token AS must take scopes from previous grant 

#### Target issue
  
closes #5462

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed

