### PR TITLE
fix(jans-linux-setup): new location of jans_test_client_keys.zip

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
+++ b/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
@@ -251,7 +251,7 @@ class TestDataLoader(BaseInstaller, SetupUtils):
         apache_user = 'www-data' if base.clone_type == 'deb' else 'apache'
 
         # Client keys deployment
-        base.download('https://raw.githubusercontent.com/JanssenProject/jans-auth-server/master/client/src/test/resources/jans_test_client_keys.zip', '/var/www/html/jans_test_client_keys.zip')
+        base.download('https://github.com/JanssenProject/jans/raw/main/jans-auth-server/client/src/test/resources/jans_test_client_keys.zip', '/var/www/html/jans_test_client_keys.zip')
         self.run([paths.cmd_unzip, '-o', '/var/www/html/jans_test_client_keys.zip', '-d', '/var/www/html/'])
         self.run([paths.cmd_rm, '-rf', 'jans_test_client_keys.zip'])
         self.run([paths.cmd_chown, '-R', 'root:'+apache_user, '/var/www/html/jans-auth-client'])


### PR DESCRIPTION
closes #5634