### PR TITLE
fix(jans-linux-setup): load test data with setup.properties

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -208,6 +208,9 @@ class PropertiesUtils(SetupUtils):
         if p.get('enable-script'):
             base.argsp.enable_script = p['enable-script'].split()
 
+        if p.get('loadTestData'):
+            base.argsp.t = True
+
         if p.get('rdbm_type') == 'pgsql' and not p.get('rdbm_port'):
             p['rdbm_port'] = '5432'
 


### PR DESCRIPTION
closes #5722