### PR TITLE
refactor(docker-jans-persistence-loader): reusable assets for custom image

### DIFF
--- a/docker-jans-persistence-loader/scripts/couchbase_setup.py
+++ b/docker-jans-persistence-loader/scripts/couchbase_setup.py
@@ -11,7 +11,7 @@ from utils import prepare_template_ctx
 from hooks import get_ldif_mappings_hook
 
 logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger("couchbase_setup")
+logger = logging.getLogger("persistence-loader")
 
 
 def get_bucket_mappings(manager):

--- a/docker-jans-persistence-loader/scripts/entrypoint.sh
+++ b/docker-jans-persistence-loader/scripts/entrypoint.sh
@@ -1,5 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
 set -e
 
-python3 /app/scripts/wait.py
-exec python3 /app/scripts/bootstrap.py
+# get script directory
+basedir=$(dirname "$(readlink -f -- "$0")")
+
+python3 "$basedir/wait.py"
+exec python3 "$basedir/bootstrap.py"

--- a/docker-jans-persistence-loader/scripts/ldap_setup.py
+++ b/docker-jans-persistence-loader/scripts/ldap_setup.py
@@ -13,7 +13,7 @@ from utils import prepare_template_ctx
 from hooks import get_ldif_mappings_hook
 
 logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger("ldap_setup")
+logger = logging.getLogger("persistence-loader")
 
 
 class LDAPBackend:

--- a/docker-jans-persistence-loader/scripts/settings.py
+++ b/docker-jans-persistence-loader/scripts/settings.py
@@ -17,35 +17,10 @@ LOGGING_CONFIG = {
             "level": "INFO",
             "propagate": True,
         },
-        "entrypoint": {
+        "persistence-loader": {
             "handlers": ["console"],
             "level": "INFO",
             "propagate": False,
         },
-        "ldap_setup": {
-            "handlers": ["console"],
-            "level": "INFO",
-            "propagate": False,
-        },
-        "sql_setup": {
-            "handlers": ["console"],
-            "level": "INFO",
-            "propagate": False,
-        },
-        "spanner_setup": {
-            "handlers": ["console"],
-            "level": "INFO",
-            "propagate": False,
-        },
-        "couchbase_setup": {
-            "handlers": ["console"],
-            "level": "INFO",
-            "propagate": False,
-        },
-
     },
-    # "root": {
-    #     "level": "INFO",
-    #     "handlers": ["console"],
-    # },
 }

--- a/docker-jans-persistence-loader/scripts/spanner_setup.py
+++ b/docker-jans-persistence-loader/scripts/spanner_setup.py
@@ -13,7 +13,7 @@ from hooks import get_ldif_mappings_hook
 FIELD_RE = re.compile(r"[^0-9a-zA-Z\s]+")
 
 logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger("spanner_setup")
+logger = logging.getLogger("persistence-loader")
 
 
 class SpannerBackend:

--- a/docker-jans-persistence-loader/scripts/sql_setup.py
+++ b/docker-jans-persistence-loader/scripts/sql_setup.py
@@ -17,7 +17,7 @@ from hooks import get_ldif_mappings_hook
 FIELD_RE = re.compile(r"[^0-9a-zA-Z\s]+")
 
 logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger("sql_setup")
+logger = logging.getLogger("persistence-loader")
 
 
 class SQLBackend:

--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -21,7 +21,7 @@ from utils import get_role_scope_mappings
 from hooks import transform_auth_dynamic_config_hook
 
 logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger("entrypoint")
+logger = logging.getLogger("persistence-loader")
 
 Entry = namedtuple("Entry", ["id", "attrs"])
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #5791 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

Point 1: change logger prefix to persistence-loader

The prefix of entrypoint has been changed from:

```
INFO - entrypoint - 2023-08-04 18:02:33,256 - Creating tables (if not exist)
INFO - entrypoint - 2023-08-04 18:02:33,327 - Updating schema (if required)
INFO - entrypoint - 2023-08-04 18:02:33,461 - Creating indexes (if not exist)
INFO - entrypoint - 2023-08-04 18:02:33,676 - Importing builtin LDIF files
```

to

```
INFO - persistence-loader - 2023-08-04 18:02:33,256 - Creating tables (if not exist)
INFO - persistence-loader - 2023-08-04 18:02:33,327 - Updating schema (if required)
INFO - persistence-loader - 2023-08-04 18:02:33,461 - Creating indexes (if not exist)
INFO - persistence-loader - 2023-08-04 18:02:33,676 - Importing builtin LDIF files
```

Point no. 2: allow executing entrypoint.sh from any directory or by using symlink

The `entrypoint.sh` can be executed from any directory. Also it support symlink, for example:

```
ln -s /app/scripts/entrypoint.sh /app/bin/persistence-loader-entrypoint.sh
sh /app/bin/persistence-loader-entrypoint.sh
```

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

