### PR TITLE
fix(docs): remove selinux disabling instruction for RHEL Setup

### DIFF
--- a/docs/admin/install/vm-install/rhel.md
+++ b/docs/admin/install/vm-install/rhel.md
@@ -13,9 +13,6 @@ Before you install, check the [VM system requirements](vm-requirements.md).
 ## Supported versions
 - Red Hat Enterprise Linus 8 (RHEL 8)
 
-## Disable SELinux
-You can disable SELinux temporarily by executing `setenforce 0`. To disable permanently edit file `/etc/selinux/config`.
-
 ## Install the Package
 
 - Install EPEL and mod-auth-openidc as dependencies


### PR DESCRIPTION
Instead of disabling selinux, setup sets selinux policy `httpd_can_network_connect 1 -P`