### PR TITLE
feat(jans-linux-setup): option for java version

### DIFF
--- a/jans-linux-setup/jans_setup/app_info.json
+++ b/jans-linux-setup/jans_setup/app_info.json
@@ -2,7 +2,7 @@
   "JANS_APP_VERSION": "1.0.17",
   "JANS_BUILD": "-SNAPSHOT",
   "JETTY_VERSION": "11.0.15",
-  "AMAZON_CORRETTO_VERSION": "17.0.8.7.1",
+  "AMAZON_CORRETTO_VERSION": "11",
   "JYTHON_VERSION": "2.7.3",
   "OPENDJ_VERSION": "4.5.0",
   "JANS_MAVEN": "https://jenkins.jans.io",

--- a/jans-linux-setup/jans_setup/jans_setup.py
+++ b/jans-linux-setup/jans_setup/jans_setup.py
@@ -44,6 +44,7 @@ from setup_app.utils import arg_parser
 
 argsp = arg_parser.get_parser()
 
+
 # first import paths and make changes if necassary
 from setup_app import paths
 
@@ -92,6 +93,9 @@ base.argsp = argsp
 
 if 'SETUP_BRANCH' not in base.current_app.app_info:
     base.current_app.app_info['SETUP_BRANCH'] = argsp.setup_branch
+
+if argsp.java_version:
+    base.current_app.app_info['AMAZON_CORRETTO_VERSION'] = argsp.java_version
 
 base.current_app.app_info['ox_version'] = base.current_app.app_info['JANS_APP_VERSION'] + base.current_app.app_info['JANS_BUILD']
 

--- a/jans-linux-setup/jans_setup/setup_app/installers/jre.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jre.py
@@ -14,7 +14,7 @@ from setup_app.pylib.jproperties import Properties
 
 class JreInstaller(BaseInstaller, SetupUtils):
 
-    amazon_corretto_link = 'https://corretto.aws/downloads/resources/{0}/amazon-corretto-{0}-linux-x64.tar.gz'.format(base.current_app.app_info['AMAZON_CORRETTO_VERSION'])
+    amazon_corretto_link = 'https://corretto.aws/downloads/latest/amazon-corretto-{}-x64-linux-jdk.tar.gz'.format(base.current_app.app_info['AMAZON_CORRETTO_VERSION'])
     source_files = [
             (os.path.join(Config.dist_app_dir, os.path.basename(amazon_corretto_link)), amazon_corretto_link),
             ]

--- a/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
@@ -65,6 +65,9 @@ parser.add_argument('--import-ldif', help="Render ldif templates from directory 
 parser.add_argument('-enable-script', action='append', help="inum of script to enable", required=False)
 parser.add_argument('-disable-script', action='append', help="inum of script to disable", required=False)
 
+parser.add_argument('-java-version', help="Version of Amazon Corretto", choices=['11', '17'], required=False)
+
+
 if PROFILE != OPENBANKING_PROFILE:
 
     parser.add_argument('-stm', '--enable-scim-test-mode', help="Enable Scim Test Mode", action='store_true')


### PR DESCRIPTION
closes #5828

You can specify java version with option `-java-version`, it can be either 11 or 17. Default is 11