### PR TITLE
fix(docker-jans-persistence-loader): data type too small for jansDevice data

### DIFF
--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -26,7 +26,7 @@ RUN python3 -m ensurepip \
 # =====================
 
 # janssenproject/jans SHA commit
-ENV JANS_SOURCE_VERSION=38653c9cb9eb992213c5f230a5f36ce1187d0197
+ENV JANS_SOURCE_VERSION=39ffb3a35b397d8cac1a7472908a6aa6d17e1a33
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 ARG JANS_SCRIPT_CATALOG_DIR=docs/script-catalog
 ARG JANS_CONFIG_API_RESOURCES=jans-config-api/server/src/main/resources

--- a/docker-jans-persistence-loader/scripts/spanner_setup.py
+++ b/docker-jans-persistence-loader/scripts/spanner_setup.py
@@ -428,6 +428,10 @@ class SpannerBackend:
             ("jansFido2AuthnEntry", "jansApp"),
             ("jansFido2RegistrationEntry", "jansApp"),
             ("adsPrjDeployment", "adsPrjDeplDetails"),
+            ("jansFido2RegistrationEntry", "jansDeviceData"),
+            ("jansDeviceRegistration", "jansDeviceData"),
+            ("jansFido2RegistrationEntry", "jansDeviceNotificationConf"),
+            ("jansDeviceRegistration", "jansDeviceNotificationConf"),
         ]:
             change_column_type(mod[0], mod[1])
 

--- a/docker-jans-persistence-loader/scripts/sql_setup.py
+++ b/docker-jans-persistence-loader/scripts/sql_setup.py
@@ -456,6 +456,10 @@ class SQLBackend:
             ("jansFido2AuthnEntry", "jansApp"),
             ("jansFido2RegistrationEntry", "jansApp"),
             ("adsPrjDeployment", "adsPrjDeplDetails"),
+            ("jansFido2RegistrationEntry", "jansDeviceData"),
+            ("jansDeviceRegistration", "jansDeviceData"),
+            ("jansFido2RegistrationEntry", "jansDeviceNotificationConf"),
+            ("jansDeviceRegistration", "jansDeviceNotificationConf"),
         ]:
             change_column_type(mod[0], mod[1])
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #5950 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

