### PR TITLE
fix(jans-auth-server): ignore custom OC for non-LDAP during client merge

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientService.java
@@ -94,6 +94,7 @@ public class ClientService {
     }
 
     public void merge(Client client) {
+        ignoreCustomObjectClassesForNonLDAP(client);
         ldapEntryManager.merge(client);
         removeFromCache(client);
     }


### PR DESCRIPTION
### Description

fix(jans-auth-server): ignore custom OC for non-LDAP during client merge

#### Target issue

closes #5977

