### PR TITLE
fix(docker-jans-configurator): use longer expiration time for initial jwks

### DIFF
--- a/docker-jans-configurator/scripts/bootstrap.py
+++ b/docker-jans-configurator/scripts/bootstrap.py
@@ -295,8 +295,8 @@ class CtxGenerator:
         enc_keys = " ".join(enc_keys)
         self.set_config("auth_enc_keys", enc_keys)
 
-        # default exp = 2 hours + token lifetime (in hour)
-        exp = int(2 + (3600 / 3600))
+        # default exp = 48 hours + token lifetime (in hour)
+        exp = int(48 + (3600 / 3600))
 
         _, err, retcode = generate_openid_keys_hourly(
             self.get_secret("auth_openid_jks_pass"),


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #5991 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

