### PR TITLE
chore: use bc-fips <= 1.0.2.4

### DIFF
--- a/jans-bom/pom.xml
+++ b/jans-bom/pom.xml
@@ -287,7 +287,7 @@
 			<dependency>
 				<groupId>org.bouncycastle</groupId>
 				<artifactId>bc-fips</artifactId>
-				<version>1.0.2.3</version>
+				<version>(,1.0.2.4]</version>
 			</dependency>
 			<dependency>
 				<groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Please edit this.
Closes #6004, 