### PR TITLE
feat(jans-auth-server): add client_id parameter support to /end_session #5942

### DIFF
--- a/docs/admin/auth-server/endpoints/end-session.md
+++ b/docs/admin/auth-server/endpoints/end-session.md
@@ -31,6 +31,10 @@ https://janssen.server.host/jans-auth/restv1/end_session
 Refer to [this](https://gluu.org/docs/gluu-server/4.4/operation/logout/#openid-connect-single-log-out-slo) article from 
 Gluu Server documentation to understand how end session endpoint works in Janssen Server.  
 
+More information about request and response of the end session endpoint can be found in the OpenAPI specification 
+of [jans-auth-server module](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/vreplace-janssen-version/jans-auth-server/docs/swagger.yaml).
+
+
 ## Disabling The Endpoint Using Feature Flag
 
 `/end_session` endpoint can be enabled or disable using [END_SESSION feature flag](../../reference/json/feature-flags/janssenauthserver-feature-flags.md#endsession).

--- a/jans-auth-server/docs/swagger.yaml
+++ b/jans-auth-server/docs/swagger.yaml
@@ -2523,6 +2523,11 @@ paths:
           description: Session Id
           schema:
             type: string
+        - name: client_id
+          in: query
+            description: Client Id. It can be useful to specify client id explicitly in case id_token and session are expired so AS can still validate "post_logout_redirect_uri"
+            schema:
+              type: string
       responses:
         200:
           description: OK - User redirected to logout page

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/session/ws/rs/EndSessionRestWebService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/session/ws/rs/EndSessionRestWebService.java
@@ -32,6 +32,7 @@ public interface EndSessionRestWebService {
                                @QueryParam(EndSessionRequestParam.POST_LOGOUT_REDIRECT_URI) String postLogoutRedirectUri,
                                @QueryParam(EndSessionRequestParam.STATE) String state,
                                @QueryParam("sid") String sid,
+                               @QueryParam("client_id") String clientId,
                                @Context HttpServletRequest httpRequest,
                                @Context HttpServletResponse httpResponse,
                                @Context SecurityContext securityContext);


### PR DESCRIPTION
### Description

feat(jans-auth-server): add client_id parameter support to /end_session 

#### Target issue
  
closes #5942

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

