### PR TITLE
feat(jans-auth-server): included org_id in the response of DCR #5787

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/register/RegisterRequestParam.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/register/RegisterRequestParam.java
@@ -93,6 +93,11 @@ public enum RegisterRequestParam {
     TOS_URI("tos_uri"),
 
     /**
+     * Organization id
+     */
+    ORG_ID("org_id"),
+
+    /**
      * URL for the Client's JSON Web Key Set (JWK) document containing key(s) that are used for signing requests to
      * the OP. The JWK Set may also contain the Client's encryption keys(s) that are used by the OP to encrypt the
      * responses to the Client.

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterJsonService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterJsonService.java
@@ -83,6 +83,7 @@ public class RegisterJsonService {
         Util.addToJSONObjectIfNotNull(responseJsonObject, CLIENT_URI.toString(), client.getClientUri());
         Util.addToJSONObjectIfNotNull(responseJsonObject, POLICY_URI.toString(), client.getPolicyUri());
         Util.addToJSONObjectIfNotNull(responseJsonObject, TOS_URI.toString(), client.getTosUri());
+        Util.addToJSONObjectIfNotNull(responseJsonObject, ORG_ID.toString(), client.getOrganization());
 
         Util.addToJSONObjectIfNotNull(responseJsonObject, CLIENT_NAME.toString(), client.getClientNameLocalized());
         Util.addToJSONObjectIfNotNull(responseJsonObject, LOGO_URI.toString(), client.getLogoUriLocalized());

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterService.java
@@ -20,6 +20,7 @@ import io.jans.as.model.json.JsonApplier;
 import io.jans.as.model.jwt.Jwt;
 import io.jans.as.model.register.ApplicationType;
 import io.jans.as.model.register.RegisterErrorResponseType;
+import io.jans.as.model.register.RegisterRequestParam;
 import io.jans.as.persistence.model.Scope;
 import io.jans.as.server.ciba.CIBARegisterClientMetadataService;
 import io.jans.as.server.service.ScopeService;
@@ -388,7 +389,7 @@ public class RegisterService {
         }
 
         if (requestObject.getJsonObject() != null) {
-            final String orgId = requestObject.getJsonObject().optString("org_id");
+            final String orgId = requestObject.getJsonObject().optString(RegisterRequestParam.ORG_ID.getName());
             if (StringUtils.isNotBlank(orgId)) {
                 client.setOrganization(orgId);
             }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterJsonServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterJsonServiceTest.java
@@ -1,0 +1,66 @@
+package io.jans.as.server.register.ws.rs;
+
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.service.AttributeService;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.server.ciba.CIBARegisterClientResponseService;
+import io.jans.as.server.service.ClientService;
+import io.jans.as.server.service.ScopeService;
+import io.jans.util.security.StringEncrypter;
+import org.json.JSONObject;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class RegisterJsonServiceTest {
+
+    @InjectMocks
+    @Spy
+    private RegisterJsonService registerJsonService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private ClientService clientService;
+
+    @Mock
+    private ScopeService scopeService;
+
+    @Mock
+    private AttributeService attributeService;
+    @Mock
+    private CIBARegisterClientResponseService cibaRegisterClientResponseService;
+
+    @Test
+    public void getJSONObject_whenOrgIdSet_shouldHaveOrgIdPresentInJson() throws StringEncrypter.EncryptionException {
+        Client client = new Client();
+        client.setOrganization("testOrgId");
+        client.setClientIdIssuedAt(new Date());
+
+        final JSONObject json = registerJsonService.getJSONObject(client);
+        assertEquals(json.get("org_id"), "testOrgId");
+    }
+
+    @Test
+    public void getJSONObject_whenOrgIdIsNotSet_shouldHaveNullOrgIdInJson() throws StringEncrypter.EncryptionException {
+        Client client = new Client();
+        client.setOrganization(null);
+        client.setClientIdIssuedAt(new Date());
+
+        final JSONObject json = registerJsonService.getJSONObject(client);
+        assertNull(json.opt("org_id"));
+    }
+}

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterJsonServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterJsonServiceTest.java
@@ -41,6 +41,7 @@ public class RegisterJsonServiceTest {
 
     @Mock
     private AttributeService attributeService;
+
     @Mock
     private CIBARegisterClientResponseService cibaRegisterClientResponseService;
 

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -38,6 +38,7 @@
             <class name="io.jans.as.server.register.ws.rs.action.RegisterCreateActionTest" />
             <class name="io.jans.as.server.register.ws.rs.RegisterServiceTest" />
             <class name="io.jans.as.server.register.ws.rs.RegisterValidatorTest" />
+            <class name="io.jans.as.server.register.ws.rs.RegisterJsonServiceTest" />
 
             <!-- SESSION -->
             <class name="io.jans.as.server.session.ws.rs.EndSessionRestWebServiceImplTest" />


### PR DESCRIPTION
### Description

feat(jans-auth-server): included org_id in the response of DCR 

#### Target issue
  
closes #5787

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

