### PR TITLE
fix(jans-auth-server): redirect when session does not exist but client_id parameter is present

### DIFF
--- a/jans-auth-server/server/src/test/java/io/jans/as/server/session/ws/rs/EndSessionRestWebServiceImplTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/session/ws/rs/EndSessionRestWebServiceImplTest.java
@@ -111,14 +111,14 @@ public class EndSessionRestWebServiceImplTest {
 
     @Test
     public void validateIdTokenHint_whenIdTokenHintIsBlank_shouldGetNoError() {
-        assertNull(endSessionRestWebService.validateIdTokenHint("", null, "", "http://postlogout.com"));
+        assertNull(endSessionRestWebService.validateIdTokenHint("", null, "", "http://postlogout.com", ""));
     }
 
     @Test(expectedExceptions = WebApplicationException.class)
     public void validateIdTokenHint_whenIdTokenHintIsBlankButRequired_shouldGetError() {
         when(appConfiguration.getForceIdTokenHintPrecense()).thenReturn(true);
 
-        endSessionRestWebService.validateIdTokenHint("", null, "", "http://postlogout.com");
+        endSessionRestWebService.validateIdTokenHint("", null, "", "http://postlogout.com", "");
     }
 
     @Test(expectedExceptions = WebApplicationException.class)
@@ -126,7 +126,7 @@ public class EndSessionRestWebServiceImplTest {
         when(appConfiguration.getRejectEndSessionIfIdTokenExpired()).thenReturn(true);
         when(endSessionRestWebService.getTokenHintGrant("test")).thenReturn(null);
 
-        endSessionRestWebService.validateIdTokenHint("testToken", null, "", "http://postlogout.com");
+        endSessionRestWebService.validateIdTokenHint("testToken", null, "", "http://postlogout.com", "");
     }
 
     @Test(expectedExceptions = WebApplicationException.class)
@@ -134,7 +134,7 @@ public class EndSessionRestWebServiceImplTest {
         when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(true);
         when(endSessionRestWebService.getTokenHintGrant("notValidJwt")).thenReturn(GRANT);
 
-        endSessionRestWebService.validateIdTokenHint("notValidJwt", null, "", "http://postlogout.com");
+        endSessionRestWebService.validateIdTokenHint("notValidJwt", null, "", "http://postlogout.com", "");
     }
 
     @Test
@@ -142,7 +142,7 @@ public class EndSessionRestWebServiceImplTest {
         when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(true);
         when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(GRANT);
 
-        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "", "http://postlogout.com");
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "", "http://postlogout.com", "");
         assertNotNull(jwt);
     }
 
@@ -153,7 +153,7 @@ public class EndSessionRestWebServiceImplTest {
         when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(null);
         when(cryptoProvider.verifySignature(anyString(), anyString(), anyString(), isNull(), isNull(), any())).thenReturn(false);
 
-        assertNull(endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "", "http://postlogout.com"));
+        assertNull(endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "", "http://postlogout.com", ""));
     }
 
     @Test
@@ -163,7 +163,7 @@ public class EndSessionRestWebServiceImplTest {
         when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(null);
         when(cryptoProvider.verifySignature(anyString(), anyString(), isNull(), isNull(), isNull(), any())).thenReturn(true);
 
-        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "", "http://postlogout.com");
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "", "http://postlogout.com", "");
         assertNotNull(jwt);
     }
 
@@ -177,7 +177,7 @@ public class EndSessionRestWebServiceImplTest {
         SessionId sidSession = new SessionId();
         sidSession.setOutsideSid("1234"); // sid encoded into DUMMY_JWT
 
-        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "", "http://postlogout.com");
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "", "http://postlogout.com", "");
         assertNotNull(jwt);
     }
 
@@ -191,7 +191,7 @@ public class EndSessionRestWebServiceImplTest {
         SessionId sidSession = new SessionId();
         sidSession.setOutsideSid("12345"); // sid encoded into DUMMY_JWT
 
-        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "", "http://postlogout.com");
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "", "http://postlogout.com", "");
         assertNotNull(jwt);
     }
 }


### PR DESCRIPTION
### Description

fix(jans-auth-server): redirect when session does not exist but client_id parameter is present

#### Target issue
  
closes #5942

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

