### PR TITLE
feat(jans-auth-server): add configuration property to AS which will allow to bypass basic client authentication restriction to query only own tokens #6307

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -566,6 +566,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Specifies if authorization to be skipped for introspection")
     private Boolean introspectionSkipAuthorization;
 
+    @DocProperty(description = "If True, allow client request only own tokens. Otherwise allow to introspect all tokens.", defaultValue = "false")
+    private Boolean introspectionRestrictBasicAuthnToOwnTokens = false;
+
     @DocProperty(description = "Choose whether to accept access tokens to call end_session endpoint")
     private Boolean endSessionWithAccessToken;
 
@@ -1455,6 +1458,15 @@ public class AppConfiguration implements Configuration {
 
     public void setIntrospectionSkipAuthorization(Boolean introspectionSkipAuthorization) {
         this.introspectionSkipAuthorization = introspectionSkipAuthorization;
+    }
+
+    public Boolean getIntrospectionRestrictBasicAuthnToOwnTokens() {
+        if (introspectionRestrictBasicAuthnToOwnTokens == null) introspectionRestrictBasicAuthnToOwnTokens = false;
+        return introspectionRestrictBasicAuthnToOwnTokens;
+    }
+
+    public void setIntrospectionRestrictBasicAuthnToOwnTokens(Boolean introspectionRestrictBasicAuthnToOwnTokens) {
+        this.introspectionRestrictBasicAuthnToOwnTokens = introspectionRestrictBasicAuthnToOwnTokens;
     }
 
     public Boolean getUmaRptAsJwt() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/introspection/ws/rs/IntrospectionWebService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/introspection/ws/rs/IntrospectionWebService.java
@@ -280,7 +280,7 @@ public class IntrospectionWebService {
         String password = URLDecoder.decode(token.substring(delim + 1), Util.UTF8_STRING_ENCODING);
         if (clientService.authenticate(clientId, password)) {
             AuthorizationGrant grant = authorizationGrantList.getAuthorizationGrantByAccessToken(accessToken);
-            if (grant != null && !grant.getClientId().equals(clientId)) {
+            if (BooleanUtils.isTrue(appConfiguration.getIntrospectionRestrictBasicAuthnToOwnTokens()) && grant != null && !grant.getClientId().equals(clientId)) {
                 log.trace("Failed to match grant object clientId and client id provided during authentication.");
                 return EMPTY;
             }


### PR DESCRIPTION
### Description

feat(jans-auth-server): add configuration property to AS which will allow to bypass basic client authentication restriction to query only own tokens 

#### Target issue
  
closes #6307

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

