### PR TITLE
fix(jans-auth-server): cnf introspection response is null even when valid cert is send during MTLS #6343

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AbstractAuthorizationGrant.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AbstractAuthorizationGrant.java
@@ -64,7 +64,7 @@ public abstract class AbstractAuthorizationGrant implements IAuthorizationGrant 
     private IdToken idToken;
     private AuthorizationCode authorizationCode;
     private String tokenBindingHash;
-    private String x5cs256;
+    private String x5ts256;
     private String nonce;
     private String codeChallenge;
     private String codeChallengeMethod;
@@ -141,12 +141,12 @@ public abstract class AbstractAuthorizationGrant implements IAuthorizationGrant 
         this.tokenBindingHash = tokenBindingHash;
     }
 
-    public String getX5cs256() {
-        return x5cs256;
+    public String getX5ts256() {
+        return x5ts256;
     }
 
-    public void setX5cs256(String x5cs256) {
-        this.x5cs256 = x5cs256;
+    public void setX5ts256(String x5ts256) {
+        this.x5ts256 = x5ts256;
     }
 
     @Override
@@ -525,6 +525,6 @@ public abstract class AbstractAuthorizationGrant implements IAuthorizationGrant 
                 + '\'' + ", sessionDn='" + sessionDn + '\'' + ", codeChallenge='" + codeChallenge + '\''
                 + ", codeChallengeMethod='" + codeChallengeMethod + '\'' + ", authenticationTime=" + authenticationTime
                 + ", scopes=" + scopes + ", authorizationGrantType=" + authorizationGrantType + ", tokenBindingHash=" + tokenBindingHash
-                + ", x5cs256=" + x5cs256 + ", claims=" + claims + '}';
+                + ", x5ts256=" + x5ts256 + ", claims=" + claims + '}';
     }
 }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrantList.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrantList.java
@@ -333,7 +333,7 @@ public class AuthorizationGrantList implements IAuthorizationGrantList {
 
                 result.setTokenBindingHash(tokenEntity.getTokenBindingHash());
                 result.setNonce(nonce);
-                result.setX5cs256(tokenEntity.getAttributes().getX5cs256());
+                result.setX5ts256(tokenEntity.getAttributes().getX5cs256());
                 result.setDpopJkt(tokenEntity.getAttributes().getDpopJkt());
                 result.setTokenEntity(tokenEntity);
                 if (StringUtils.isNotBlank(grantId)) {
@@ -362,24 +362,29 @@ public class AuthorizationGrantList implements IAuthorizationGrantList {
                             if (result instanceof AuthorizationCodeGrant) {
                                 final AuthorizationCode code = new AuthorizationCode(tokenEntity.getTokenCode(), tokenEntity.getCreationDate(), tokenEntity.getExpirationDate());
                                 final AuthorizationCodeGrant g = (AuthorizationCodeGrant) result;
+                                code.setX5ts256(g.getX5ts256());
                                 g.setAuthorizationCode(code);
                             }
                             break;
                         case REFRESH_TOKEN:
                             final RefreshToken refreshToken = new RefreshToken(tokenEntity.getTokenCode(), tokenEntity.getCreationDate(), tokenEntity.getExpirationDate());
+                            refreshToken.setX5ts256(result.getX5ts256());
                             result.setRefreshTokens(Collections.singletonList(refreshToken));
                             break;
                         case ACCESS_TOKEN:
                             final AccessToken accessToken = new AccessToken(tokenEntity.getTokenCode(), tokenEntity.getCreationDate(), tokenEntity.getExpirationDate());
                             accessToken.setDpop(tokenEntity.getDpop());
+                            accessToken.setX5ts256(result.getX5ts256());
                             result.setAccessTokens(Collections.singletonList(accessToken));
                             break;
                         case ID_TOKEN:
                             final IdToken idToken = new IdToken(tokenEntity.getTokenCode(), tokenEntity.getCreationDate(), tokenEntity.getExpirationDate());
+                            idToken.setX5ts256(result.getX5ts256());
                             result.setIdToken(idToken);
                             break;
                         case LONG_LIVED_ACCESS_TOKEN:
                             final AccessToken longLivedAccessToken = new AccessToken(tokenEntity.getTokenCode(), tokenEntity.getCreationDate(), tokenEntity.getExpirationDate());
+                            longLivedAccessToken.setX5ts256(result.getX5ts256());
                             result.setLongLivedAccessToken(longLivedAccessToken);
                             break;
                     }


### PR DESCRIPTION

### Description

fix(jans-auth-server): cnf introspection response is null even when valid cert is send during MTLS #6343

#### Target issue
  
closes #6343

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
