### PR TITLE
fix: registration_uri for super gluu script defaults to an /identity

### DIFF
--- a/docs/script-catalog/person_authentication/super-gluu-external-authenticator/SuperGluuExternalAuthenticator.py
+++ b/docs/script-catalog/person_authentication/super-gluu-external-authenticator/SuperGluuExternalAuthenticator.py
@@ -62,7 +62,9 @@ class PersonAuthentication(PersonAuthenticationType):
 
         self.registrationUri = None
         if configurationAttributes.containsKey("registration_uri"):
-            self.registrationUri = configurationAttributes.get("registration_uri").getValue2()
+            registrationUriValue = configurationAttributes.get("registration_uri").getValue2()
+            if StringHelper.isNotEmptyString(registrationUriValue):
+                self.registrationUri = registrationUriValue
 
         authentication_mode = configurationAttributes.get("authentication_mode").getValue2()
         if StringHelper.isEmpty(authentication_mode):

--- a/jans-linux-setup/jans_setup/templates/scripts.ldif
+++ b/jans-linux-setup/jans_setup/templates/scripts.ldif
@@ -305,7 +305,7 @@ jansConfProperty: {"value1":"AS_CLIENT_ID","value2":"","hide":false,"description
 jansConfProperty: {"value1":"AS_CLIENT_SECRET","value2":"","hide":false,"description":""}
 jansConfProperty: {"value1":"qr_options","value2":"{ size: 500, mSize: 0.05 }","description":""}
 jansConfProperty: {"value1":"label","value2":"Super Gluu","description":""}
-jansConfProperty: {"value1":"registration_uri","value2":"https://%(hostname)s/identity/register","description":""}
+jansConfProperty: {"value1":"registration_uri","value2":"","description":""}
 jansConfProperty: {"value1":"authentication_mode","value2":"two_step","description":""}
 jansConfProperty: {"value1":"notification_service_mode","value2":"jans","description":""}
 jansConfProperty: {"value1":"credentials_file","value2":"/etc/certs/super_gluu_creds.json","description":""}


### PR DESCRIPTION
Please edit this.
Closes #6370, 