### PR TITLE
fix(jans-linux-setup): change oxtrust to Janssen

### DIFF
--- a/jans-linux-setup/jans_setup/templates/base.ldif
+++ b/jans-linux-setup/jans_setup/templates/base.ldif
@@ -1,5 +1,5 @@
 dn: o=jans
-description: Welcome to oxTrust!
+description: Welcome to Janssen!
 displayName: %(orgName)s
 jansOrgShortName: %(orgName)s
 jansThemeColor: 166309


### PR DESCRIPTION
closes #6383