### PR TITLE
fix(jans-cli-tui): ruamel.yaml<0.18.0

### DIFF
--- a/jans-cli-tui/setup.py
+++ b/jans-cli-tui/setup.py
@@ -83,7 +83,7 @@ setup(
     package_data={'': ['*.yaml', '.enabled']},
     zip_safe=False,
     install_requires=[
-        "ruamel.yaml>=0.16.5",
+        "ruamel.yaml>=0.16.5,<0.18.0",
         "PyJWT==2.4.0",
         "pygments",
         "prompt_toolkit==3.0.33",


### PR DESCRIPTION
closes #6408