### PR TITLE
feat(jans-auth-server): allow revoke any token - explicitly allow by config and scope #6381

### DIFF
--- a/docs/admin/auth-server/endpoints/token-revocation.md
+++ b/docs/admin/auth-server/endpoints/token-revocation.md
@@ -53,6 +53,7 @@ navigate via `Auth Server`->`Properties`.
 
 - [mtlstokenrevocationendpoint](../../reference/json/properties/janssenauthserver-properties.md#mtlstokenrevocationendpoint)
 - [tokenRevocationEndpoint](../../reference/json/properties/janssenauthserver-properties.md#tokenrevocationendpoint)
+- [allowRevokeForOtherClients](../../reference/json/properties/janssenauthserver-properties.md#allowrevokeforotherclients)
 
 ## Revoke all tokens by `client_id`
 
@@ -61,6 +62,15 @@ To remove all tokens for given `client_id` it's required:
 - pass in request parameter `token_type_hint=all`
 
 `client` is identified by Client Authentication performed by AS to grant access to `/revoke` endpoint.
+
+## Revoke tokens of other clients
+
+By default Revoke Endpoint allows revoke only own client's tokens. 
+However it is possible to allow revoking of any token (which is issued with other client).
+
+For this it is required:
+- set global AS configuration property `allowRevokeForOtherClients` to `true`
+- add `revoke_any_token` scope to `client` which performs revoke call  
 
 ## Revoke Interception Script
 

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -143,6 +143,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Boolean value true allow all value for revoke endpoint", defaultValue = "false")
     private Boolean allowAllValueForRevokeEndpoint = false;
 
+    @DocProperty(description = "Boolean value true allows revoking of any token for any client. False value allows remove only tokens issued by client used at Revoke Endpoint", defaultValue = "false")
+    private Boolean allowRevokeForOtherClients = false;
+
     @DocProperty(description = "Sector Identifier cache lifetime in minutes", defaultValue = "1440")
     private int sectorIdentifierCacheLifetimeInMinutes = 1440;
 
@@ -936,6 +939,15 @@ public class AppConfiguration implements Configuration {
 
     public void setAllowAllValueForRevokeEndpoint(Boolean allowAllValueForRevokeEndpoint) {
         this.allowAllValueForRevokeEndpoint = allowAllValueForRevokeEndpoint;
+    }
+
+    public Boolean getAllowRevokeForOtherClients() {
+        if (allowRevokeForOtherClients == null) allowRevokeForOtherClients = false;
+        return allowRevokeForOtherClients;
+    }
+
+    public void setAllowRevokeForOtherClients(Boolean allowRevokeForOtherClients) {
+        this.allowRevokeForOtherClients = allowRevokeForOtherClients;
     }
 
     public Boolean getReturnDeviceSecretFromAuthzEndpoint() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/config/Constants.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/config/Constants.java
@@ -29,6 +29,7 @@ public final class Constants {
     public static final String OX_AUTH_SCOPE_TYPE_OPENID = "openid";
     public static final String REVOKE_SESSION_SCOPE = "revoke_session";
     public static final String AUTHORIZATION_CHALLENGE_SCOPE = "authorization_challenge";
+    public static final String REVOKE_ANY_TOKEN_SCOPE = "revoke_any_token";
 
     public static final String REMOTE_IP = "remote_ip";
     public static final String AUTHENTICATED_USER = "auth_user";

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/revoke/RevokeRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/revoke/RevokeRestWebServiceImpl.java
@@ -126,41 +126,45 @@ public class RevokeRestWebServiceImpl implements RevokeRestWebService {
             throw new WebApplicationException(Response
                     .status(Response.Status.BAD_REQUEST.getStatusCode())
                     .type(MediaType.APPLICATION_JSON_TYPE)
-                    .entity(errorResponseFactory.errorAsJson(TokenRevocationErrorResponseType.INVALID_REQUEST, "Failed to validate token."))
+                    .entity(errorResponseFactory.errorAsJson(TokenRevocationErrorResponseType.INVALID_REQUEST, "Failed to validate token"))
                     .build());
         }
 
-        boolean isSingle = tokens.length == 1;
         for (String token : tokens) {
-            final Response removeTokenResponse = removeToken(token, executionContext, tth, oAuth2AuditLog, isSingle);
-            if (removeTokenResponse != null) {
-                return removeTokenResponse;
-            }
+            removeToken(token, executionContext, tth);
         }
 
         return response(builder, oAuth2AuditLog);
     }
 
-    private Response removeToken(String token, ExecutionContext executionContext, TokenTypeHint tth, OAuth2AuditLog oAuth2AuditLog, boolean single) {
+    private void removeToken(String token, ExecutionContext executionContext, TokenTypeHint tth) {
         final Client client = executionContext.getClient();
-        AuthorizationGrant authorizationGrant = findAuthorizationGrant(client, token, tth);
-
-        if (authorizationGrant == null && !single) {
-            log.trace("Unable to find token.");
-            return response(executionContext.getResponseBuilder(), oAuth2AuditLog);
+        AuthorizationGrant authorizationGrant = findAuthorizationGrant(token, tth);
+        if (log.isTraceEnabled()) {
+            String msg = authorizationGrant != null ? authorizationGrant.getGrantId() : "not";
+            log.trace("Grant {} found for token {}", msg, token);
         }
 
-        if (!single && !authorizationGrant.getClientId().equals(client.getClientId())) {
-            log.trace("Token was issued with client {} but revoke is requested with client {}. Skip revoking.", authorizationGrant.getClientId(), client.getClientId());
-            return response(executionContext.getResponseBuilder(), oAuth2AuditLog);
+        if (authorizationGrant == null) {
+            log.trace("Unable to find grant for token {}", token);
+            return;
         }
 
-        if (authorizationGrant != null) {
-            grantService.removeAllByGrantId(authorizationGrant.getGrantId());
-            log.trace("Revoked successfully token {}", token);
-        }
+        validateSameClient(authorizationGrant, client);
 
-        return null;
+        grantService.removeAllByGrantId(authorizationGrant.getGrantId());
+        log.trace("Revoked successfully token {}", token);
+    }
+
+    public void validateSameClient(AuthorizationGrant grant, Client client) {
+        if (!grant.getClientId().equals(client.getClientId()) && !appConfiguration.getAllowRevokeForOtherClients()) {
+            log.trace("Token was issued with client {} but revoke is requested with client {}. Skip revoking.", grant.getClientId(), client.getClientId());
+            throw new WebApplicationException(Response
+                    .status(Response.Status.BAD_REQUEST.getStatusCode())
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .entity(errorResponseFactory.errorAsJson(TokenRevocationErrorResponseType.INVALID_REQUEST, "Failed to validate token."))
+                    .build());
+        }
     }
 
     private void removeAllTokens(TokenTypeHint tth, ExecutionContext executionContext) {
@@ -174,20 +178,13 @@ public class RevokeRestWebServiceImpl implements RevokeRestWebService {
         }
     }
 
-    private AuthorizationGrant findAuthorizationGrant(Client client, String token, TokenTypeHint tth) {
+    private AuthorizationGrant findAuthorizationGrant(String token, TokenTypeHint tth) {
         if (tth == TokenTypeHint.ACCESS_TOKEN) {
             return authorizationGrantList.getAuthorizationGrantByAccessToken(token);
-        } else if (tth == TokenTypeHint.REFRESH_TOKEN) {
-            return authorizationGrantList.getAuthorizationGrantByRefreshToken(client.getClientId(), token);
-        } else {
-            // Since the hint about the type of the token submitted for revocation is optional. Jans Auth will
-            // search it as Access Token then as Refresh Token.
-            AuthorizationGrant authorizationGrant = authorizationGrantList.getAuthorizationGrantByAccessToken(token);
-            if (authorizationGrant == null) {
-                authorizationGrant = authorizationGrantList.getAuthorizationGrantByRefreshToken(client.getClientId(), token);
-            }
-            return authorizationGrant;
         }
+
+        final TokenEntity grantByCode = grantService.getGrantByCode(token);
+        return authorizationGrantList.asGrant(grantByCode);
     }
 
     private void validateToken(String token) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/revoke/RevokeRestWebServiceImplTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/revoke/RevokeRestWebServiceImplTest.java
@@ -1,0 +1,105 @@
+package io.jans.as.server.revoke;
+
+import io.jans.as.common.model.common.User;
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.server.audit.ApplicationAuditLogger;
+import io.jans.as.server.model.common.AuthorizationGrant;
+import io.jans.as.server.model.common.AuthorizationGrantList;
+import io.jans.as.server.model.common.AuthorizationGrantType;
+import io.jans.as.server.model.common.SimpleAuthorizationGrant;
+import io.jans.as.server.security.Identity;
+import io.jans.as.server.service.ClientService;
+import io.jans.as.server.service.GrantService;
+import io.jans.as.server.service.external.ExternalRevokeTokenService;
+import jakarta.ws.rs.WebApplicationException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class RevokeRestWebServiceImplTest {
+
+    @InjectMocks
+    @Spy
+    private RevokeRestWebServiceImpl service;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private ApplicationAuditLogger applicationAuditLogger;
+
+    @Mock
+    private Identity identity;
+
+    @Mock
+    private AuthorizationGrantList authorizationGrantList;
+
+    @Mock
+    private GrantService grantService;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private ClientService clientService;
+
+    @Mock
+    private ExternalRevokeTokenService externalRevokeTokenService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Test
+    public void validateSameClient_whenClientIsSame_shouldNotRaiseException() {
+        final Client client = new Client();
+        client.setClientId(UUID.randomUUID().toString());
+
+        AuthorizationGrant grant = new SimpleAuthorizationGrant();
+        grant.init(new User(), AuthorizationGrantType.AUTHORIZATION_CODE, client, new Date());
+        service.validateSameClient(grant, client);
+    }
+
+    @Test(expectedExceptions = WebApplicationException.class)
+    public void validateSameClient_whenClientIsNotSame_shouldRaiseException() {
+        Mockito.doReturn(false).when(appConfiguration).getAllowRevokeForOtherClients();
+
+        final Client client = new Client();
+        client.setClientId(UUID.randomUUID().toString());
+
+        final Client anotherClient = new Client();
+        anotherClient.setClientId(UUID.randomUUID().toString());
+
+        AuthorizationGrant grant = new SimpleAuthorizationGrant();
+        grant.init(new User(), AuthorizationGrantType.AUTHORIZATION_CODE, client, new Date());
+        service.validateSameClient(grant, anotherClient);
+    }
+
+    @Test
+    public void validateSameClient_whenClientIsNotSameButAllowedByConfig_shouldNotRaiseException() {
+        Mockito.doReturn(true).when(appConfiguration).getAllowRevokeForOtherClients();
+
+        final Client client = new Client();
+        client.setClientId(UUID.randomUUID().toString());
+
+        final Client anotherClient = new Client();
+        anotherClient.setClientId(UUID.randomUUID().toString());
+
+        AuthorizationGrant grant = new SimpleAuthorizationGrant();
+        grant.init(new User(), AuthorizationGrantType.AUTHORIZATION_CODE, client, new Date());
+        service.validateSameClient(grant, anotherClient);
+    }
+}

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/revoke/RevokeRestWebServiceImplTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/revoke/RevokeRestWebServiceImplTest.java
@@ -26,6 +26,8 @@ import org.testng.annotations.Test;
 import java.util.Date;
 import java.util.UUID;
 
+import static io.jans.as.server.model.config.Constants.REVOKE_ANY_TOKEN_SCOPE;
+
 /**
  * @author Yuriy Z
  */
@@ -101,5 +103,44 @@ public class RevokeRestWebServiceImplTest {
         AuthorizationGrant grant = new SimpleAuthorizationGrant();
         grant.init(new User(), AuthorizationGrantType.AUTHORIZATION_CODE, client, new Date());
         service.validateSameClient(grant, anotherClient);
+    }
+
+    @Test
+    public void validateScope_whenClientHasRevokeAnyTokenClient_shouldPassSuccessfully() {
+        final Client client = new Client();
+        client.setClientId(UUID.randomUUID().toString());
+        client.setScopes(new String[] {REVOKE_ANY_TOKEN_SCOPE});
+
+        final Client anotherClient = new Client();
+        anotherClient.setClientId(UUID.randomUUID().toString());
+
+        AuthorizationGrant grant = new SimpleAuthorizationGrant();
+        grant.init(new User(), AuthorizationGrantType.AUTHORIZATION_CODE, anotherClient, new Date());
+        service.validateScope(grant, client);
+    }
+
+    @Test(expectedExceptions = WebApplicationException.class)
+    public void validateScope_whenClientHasNoRevokeAnyTokenScope_shouldFail() {
+        final Client client = new Client();
+        client.setClientId(UUID.randomUUID().toString());
+        client.setScopes(new String[] {"openid"});
+
+        final Client anotherClient = new Client();
+        anotherClient.setClientId(UUID.randomUUID().toString());
+
+        AuthorizationGrant grant = new SimpleAuthorizationGrant();
+        grant.init(new User(), AuthorizationGrantType.AUTHORIZATION_CODE, anotherClient, new Date());
+        service.validateScope(grant, client);
+    }
+
+    @Test
+    public void validateScope_whenClientHasNoRevokeAnyTokenScopeButRevokeOwnToken_shouldPassSuccessfully() {
+        final Client client = new Client();
+        client.setClientId(UUID.randomUUID().toString());
+        client.setScopes(new String[] {"openid"});
+
+        AuthorizationGrant grant = new SimpleAuthorizationGrant();
+        grant.init(new User(), AuthorizationGrantType.AUTHORIZATION_CODE, client, new Date());
+        service.validateScope(grant, client);
     }
 }

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -28,11 +28,16 @@
             <class name="io.jans.as.server.token.ws.rs.TokenExchangeServiceTest" />
             <class name="io.jans.as.server.token.ws.rs.TokenRestWebServiceValidatorTest" />
             <class name="io.jans.as.server.ws.rs.stat.MonthsTest" />
+
+            <!-- AUTHORIZE -->
             <class name="io.jans.as.server.authorize.ws.rs.AuthorizeRestWebServiceValidatorTest" />
             <class name="io.jans.as.server.authorize.ws.rs.AuthorizeRestWebServiceImplTest" />
             <class name="io.jans.as.server.authorize.ws.rs.AuthorizeActionTest" />
             <class name="io.jans.as.server.authorize.ws.rs.AuthorizationChallengeValidatorTest" />
             <class name="io.jans.as.server.authorize.ws.rs.AuthzRequestTest" />
+
+            <!-- REVOKE -->
+            <class name="io.jans.as.server.revoke.RevokeRestWebServiceImplTest" />
 
             <!-- REGISTER -->
             <class name="io.jans.as.server.register.ws.rs.SsaValidationConfigServiceTest" />

--- a/jans-linux-setup/jans_setup/templates/scopes.ldif
+++ b/jans-linux-setup/jans_setup/templates/scopes.ldif
@@ -152,6 +152,17 @@ jansScopeTyp: openid
 objectClass: top
 objectClass: jansScope
 
+dn: inum=7D91,ou=scopes,o=jans
+description: Revoke Any Token (including tokens of other clients)
+displayName: revoke_any_token
+inum: 7D91
+jansAttrs: {"spontaneousClientId":"","spontaneousClientScopes":[],"showInConfigurationEndpoint":true}
+jansDefScope: false
+jansId: revoke_any_token
+jansScopeTyp: oauth
+objectClass: top
+objectClass: jansScope
+
 dn: inum=8A01,ou=scopes,o=jans
 description: View your mobile phone number.
 displayName: view_mobile_phone_number


### PR DESCRIPTION
### Description

feat(jans-auth-server): allow revoke any token - explicitly allow by config and scope #6381

#### Target issue
  
closes #6381

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

