### PR TITLE
feat(jans-auth-server): archived jwks

### DIFF
--- a/docs/admin/auth-server/crypto/keys.md
+++ b/docs/admin/auth-server/crypto/keys.md
@@ -29,6 +29,12 @@ Gets list of JSON Web Key (JWK) used by server. JWK is a JSON data structure tha
 
 ***Let's see some example of JWT public keys used in janssen.***
 
+When jwk is expired, it is archived and can be access by following url:
+
+```https://<your_server>/jans-auth/restv1/jwks/archived/{kid}``` 
+
+More info about archived jwks can be found [here](../endpoints/archived-jwks-uri.md)
+
 ### Example-1
 
 The "kty" (Key Type) of this key is RSA. This key is "use" (Public Key Use) for "sig" (Signature) on data. The "alg" (Algorithm) intended with this key is "RS256".

--- a/docs/admin/auth-server/endpoints/archived-jwks-uri.md
+++ b/docs/admin/auth-server/endpoints/archived-jwks-uri.md
@@ -1,0 +1,45 @@
+---
+tags:
+- administration
+- auth-server
+- jwks
+- json-web-key-set
+- endpoint
+---
+
+# Overview
+
+Janssen Server supports `/jwks/archived/{kid}` metadata endpoint and publishes its Archived JSON Web Keys (JWKs) at this endpoint. This 
+endpoint publishes expired signing keys as well as expired encryption keys used by Janssen Server. RP can use these keys to validate
+signatures from Janssen Server, and also to perform encryption and decryption if keys are no longer present in `/jwks` endpoint. 
+Like other metadata endpoints, this is not a secure endpoint.
+
+URL to access archived jwks endpoint on Janssen Server is listed in the response of Janssen Server's well-known
+[configuration endpoint](./configuration.md) given below.
+
+```text
+https://janssen.server.host/jans-auth/.well-known/openid-configuration
+```
+
+`archived_jwks_uri` claim in the response specifies the URL for archived jwks endpoint. By default, the archived jwks endpoint looks like below:
+
+```
+https://janssen.server.host/jans-auth/restv1/jwks/archived/{kid}
+```
+
+This endpoint is always enabled and can not be disabled using feature flags.
+
+## Configuration Properties
+
+Archived JWKs endpoint can be further configured using Janssen Server configuration properties listed below. When using
+[Janssen Text-based UI(TUI)](../../config-guide/config-tools/jans-tui/README.md) to configure the properties,
+navigate via `Auth Server`->`Properties`.
+
+- [archivedJwksUri](../../reference/json/properties/janssenauthserver-properties.md#archivedjwksuri)
+- [archivedJwkLifetimeInSeconds](../../reference/json/properties/janssenauthserver-properties.md#archivedjwklifetimeinseconds)
+
+If `archivedJwkLifetimeInSeconds` is not set then AS falls back to one year expiration. After archived jwk lifetime is passed, jwk is removed from archive.
+
+## Want to contribute?
+
+If you have content you'd like to contribute to this page in the meantime, you can get started with our [Contribution guide](https://docs.jans.io/head/CONTRIBUTING/).

--- a/jans-auth-server/client/src/main/java/io/jans/as/client/OpenIdConfigurationClient.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/OpenIdConfigurationClient.java
@@ -113,6 +113,7 @@ public class OpenIdConfigurationClient extends BaseClient<OpenIdConfigurationReq
         response.setCheckSessionIFrame(jsonObj.optString(CHECK_SESSION_IFRAME, null));
         response.setEndSessionEndpoint(jsonObj.optString(END_SESSION_ENDPOINT, null));
         response.setJwksUri(jsonObj.optString(JWKS_URI, null));
+        response.setArchivedJwksUri(jsonObj.optString(ARCHIVED_JWKS_URI, null));
         response.setRegistrationEndpoint(jsonObj.optString(REGISTRATION_ENDPOINT, null));
         response.setIntrospectionEndpoint(jsonObj.optString(INTROSPECTION_ENDPOINT, null));
         response.setParEndpoint(jsonObj.optString(PAR_ENDPOINT, null));

--- a/jans-auth-server/client/src/main/java/io/jans/as/client/OpenIdConfigurationResponse.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/OpenIdConfigurationResponse.java
@@ -36,6 +36,7 @@ public class OpenIdConfigurationResponse extends BaseResponse implements Seriali
     private String checkSessionIFrame;
     private String endSessionEndpoint;
     private String jwksUri;
+    private String archivedJwksUri;
     private String registrationEndpoint;
     private String introspectionEndpoint;
     private String parEndpoint;
@@ -375,6 +376,24 @@ public class OpenIdConfigurationResponse extends BaseResponse implements Seriali
      */
     public void setJwksUri(String jwksUri) {
         this.jwksUri = jwksUri;
+    }
+
+    /**
+     * Gets the URL of the OP's Archived JSON Web Key Set (JWK) document.
+     *
+     * @return The URL of the OP's Archived JSON Web Key Set (JWK) document.
+     */
+    public String getArchivedJwksUri() {
+        return archivedJwksUri;
+    }
+
+    /**
+     * Sets the URL of the OP's Archived JSON Web Key Set (JWK) document.
+     *
+     * @param archivedJwksUri The URL of the OP's Archived JSON Web Key Set (JWK) document.
+     */
+    public void setArchivedJwksUri(String archivedJwksUri) {
+        this.archivedJwksUri = archivedJwksUri;
     }
 
     /**
@@ -1229,6 +1248,7 @@ public class OpenIdConfigurationResponse extends BaseResponse implements Seriali
                 ", checkSessionIFrame='" + checkSessionIFrame + '\'' +
                 ", endSessionEndpoint='" + endSessionEndpoint + '\'' +
                 ", jwksUri='" + jwksUri + '\'' +
+                ", archivedJwksUri='" + archivedJwksUri + '\'' +
                 ", registrationEndpoint='" + registrationEndpoint + '\'' +
                 ", introspectionEndpoint='" + introspectionEndpoint + '\'' +
                 ", deviceAuthzEndpoint='" + deviceAuthzEndpoint + '\'' +

--- a/jans-auth-server/client/src/test/java/io/jans/as/client/BaseTest.java
+++ b/jans-auth-server/client/src/test/java/io/jans/as/client/BaseTest.java
@@ -99,6 +99,7 @@ public abstract class BaseTest {
     protected String checkSessionIFrame;
     protected String endSessionEndpoint;
     protected String jwksUri;
+    protected String archivedJwksUri;
     protected String registrationEndpoint;
     protected String configurationEndpoint;
     protected String introspectionEndpoint;
@@ -356,6 +357,14 @@ public abstract class BaseTest {
 
     public void setJwksUri(String jwksUri) {
         this.jwksUri = jwksUri;
+    }
+
+    public String getArchivedJwksUri() {
+        return archivedJwksUri;
+    }
+
+    public void setArchivedJwksUri(String archivedJwksUri) {
+        this.archivedJwksUri = archivedJwksUri;
     }
 
     public String getRegistrationEndpoint() {
@@ -988,6 +997,7 @@ public abstract class BaseTest {
             checkSessionIFrame = response.getCheckSessionIFrame();
             endSessionEndpoint = response.getEndSessionEndpoint();
             jwksUri = response.getJwksUri();
+            archivedJwksUri = response.getArchivedJwksUri();
             registrationEndpoint = response.getRegistrationEndpoint();
             introspectionEndpoint = response.getIntrospectionEndpoint();
             parEndpoint = response.getParEndpoint();
@@ -1010,6 +1020,7 @@ public abstract class BaseTest {
             checkSessionIFrame = context.getCurrentXmlTest().getParameter("checkSessionIFrame");
             endSessionEndpoint = context.getCurrentXmlTest().getParameter("endSessionEndpoint");
             jwksUri = context.getCurrentXmlTest().getParameter("jwksUri");
+            archivedJwksUri = context.getCurrentXmlTest().getParameter("archivedJwksUri");
             registrationEndpoint = context.getCurrentXmlTest().getParameter("registrationEndpoint");
             configurationEndpoint = context.getCurrentXmlTest().getParameter("configurationEndpoint");
             introspectionEndpoint = context.getCurrentXmlTest().getParameter("introspectionEndpoint");

--- a/jans-auth-server/common/src/main/java/io/jans/as/common/model/common/ArchivedJwk.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/model/common/ArchivedJwk.java
@@ -1,0 +1,99 @@
+package io.jans.as.common.model.common;
+
+import io.jans.orm.annotation.*;
+import io.jans.orm.model.base.DeletableEntity;
+import org.json.JSONObject;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * @author Yuriy Z
+ */
+@DataEntry
+@ObjectClass(value = "jansArchJwk")
+public class ArchivedJwk extends DeletableEntity implements Serializable {
+
+    @DN
+    private String dn;
+
+    @AttributeName(name = "jansId")
+    private String id;
+
+    @AttributeName(name = "creationDate")
+    private Date creationDate = new Date();
+
+    @JsonObject
+    @AttributeName(name = "jansData")
+    private JSONObject data;
+
+    @AttributeName(name = "attr")
+    @JsonObject
+    private ArchivedKeyAttributes attributes;
+
+    @Expiration
+    private int ttl;
+
+    @Override
+    public String getDn() {
+        return dn;
+    }
+
+    @Override
+    public void setDn(String dn) {
+        this.dn = dn;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public JSONObject getData() {
+        return data;
+    }
+
+    public void setData(JSONObject data) {
+        this.data = data;
+    }
+
+    public ArchivedKeyAttributes getAttributes() {
+        if (attributes == null) attributes = new ArchivedKeyAttributes();
+        return attributes;
+    }
+
+    public void setAttributes(ArchivedKeyAttributes attributes) {
+        this.attributes = attributes;
+    }
+
+    public int getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(int ttl) {
+        this.ttl = ttl;
+    }
+
+    @Override
+    public String toString() {
+        return "ArchivedKey{" +
+                "dn='" + dn + '\'' +
+                ", id='" + id + '\'' +
+                ", creationDate=" + creationDate +
+                ", data=" + data +
+                ", attributes=" + attributes +
+                ", ttl=" + ttl +
+                "} " + super.toString();
+    }
+}

--- a/jans-auth-server/common/src/main/java/io/jans/as/common/model/common/ArchivedKeyAttributes.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/model/common/ArchivedKeyAttributes.java
@@ -1,0 +1,36 @@
+package io.jans.as.common.model.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Yuriy Z
+ */
+@JsonIgnoreProperties(
+        ignoreUnknown = true
+)
+public class ArchivedKeyAttributes implements Serializable {
+
+    @JsonProperty("attributes")
+    private Map<String, String> attributes;
+
+    public Map<String, String> getAttributes() {
+        if (attributes == null) attributes = new HashMap<>();
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String toString() {
+        return "ArchivedKeyAttributes{" +
+                "attributes=" + attributes +
+                '}';
+    }
+}

--- a/jans-auth-server/docs/swagger.yaml
+++ b/jans-auth-server/docs/swagger.yaml
@@ -1227,6 +1227,51 @@ paths:
                       $ref: '#/components/schemas/JsonWebKey'
         500:
           $ref: '#/components/responses/InternalServerError'
+  /jwks/archived:
+    get:
+      tags:
+        - Archived JWK - Archived JSON Web Key (JWK)
+      summary: An archived JSON Web Key (JWK) used by server. JWK is a JSON data structure that represents a set of public keys as a JSON object [RFC4627].
+      description: Provides archived JWK used by server.
+      operationId: archived-jwk
+      parameters:
+        - name: kid
+          in: query
+          description: Key ID.
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                title: JsonWebKey
+                type: object
+                description: JSON Web Key (JWK) - A JSON object that represents a JWK.
+                $ref: '#/components/schemas/JsonWebKey'
+        400:
+          description: Error codes for archived jwk endpoint.
+          content:
+            application/json:
+              schema:
+                title: Error
+                type: object
+                required:
+                  - error
+                  - error_description
+                properties:
+                  error:
+                    type: string
+                    format: enum
+                    example:
+                      - invalid_request
+                  error_description:
+                    type: string
+                  details:
+                    type: string
+        500:
+          $ref: '#/components/responses/InternalServerError'
   /register:
     post:
       tags:

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/config/BaseDnConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/config/BaseDnConfiguration.java
@@ -65,6 +65,16 @@ public class BaseDnConfiguration {
 	private String fido2Attestation;
 	@XmlElement(name = "fido2Assertion")
 	private String fido2Assertion;
+    @XmlElement(name = "archivedJwks")
+    private String archivedJwks;
+
+    public String getArchivedJwks() {
+        return archivedJwks;
+    }
+
+    public void setArchivedJwks(String archivedJwks) {
+        this.archivedJwks = archivedJwks;
+    }
 
     public String getStat() {
         return stat;

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -152,6 +152,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Sector Identifier cache lifetime in minutes", defaultValue = "1440")
     private int sectorIdentifierCacheLifetimeInMinutes = 1440;
 
+    @DocProperty(description = "Archived JWK lifetime in seconds")
+    private int archivedJwkLifetimeInSeconds;
+
     @DocProperty(description = "UMA Configuration endpoint URL")
     private String umaConfigurationEndpoint;
 
@@ -887,6 +890,14 @@ public class AppConfiguration implements Configuration {
 
     @DocProperty(description = "Force Authentication Filtker to process OPTIONS request", defaultValue = "true")
     private Boolean skipAuthenticationFilterOptionsMethod = true;
+
+    public int getArchivedJwkLifetimeInSeconds() {
+        return archivedJwkLifetimeInSeconds;
+    }
+
+    public void setArchivedJwkLifetimeInSeconds(int archivedJwkLifetimeInSeconds) {
+        this.archivedJwkLifetimeInSeconds = archivedJwkLifetimeInSeconds;
+    }
 
     public Boolean getDpopJktForceForAuthorizationCode() {
         return dpopJktForceForAuthorizationCode;

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -68,6 +68,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "URL of the OP's JSON Web Key Set (JWK) document. This contains the signing key(s) the RP uses to validate signatures from the OP")
     private String jwksUri;
 
+    @DocProperty(description = "URL of the OP's Archived JSON Web Key Set (JWK) document. This contains the signing key(s) the RP uses to validate signatures from the OP")
+    private String archivedJwksUri;
+
     @DocProperty(description = "Registration endpoint URL")
     private String registrationEndpoint;
 
@@ -1734,6 +1737,24 @@ public class AppConfiguration implements Configuration {
      */
     public void setJwksUri(String jwksUri) {
         this.jwksUri = jwksUri;
+    }
+
+    /**
+     * Gets the URL of the OP's Archived JSON Web Key Set (JWK) document.
+     *
+     * @return The URL of the OP's Archived JSON Web Key Set (JWK) document.
+     */
+    public String getArchivedJwksUri() {
+        return archivedJwksUri;
+    }
+
+    /**
+     * Sets the URL of the OP's Archived JSON Web Key Set (JWK) document.
+     *
+     * @param archivedJwksUri The URL of the OP's Archived JSON Web Key Set (JWK) document.
+     */
+    public void setArchivedJwksUri(String archivedJwksUri) {
+        this.archivedJwksUri = archivedJwksUri;
     }
 
     /**

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/ConfigurationResponseClaim.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/ConfigurationResponseClaim.java
@@ -26,6 +26,7 @@ public final class ConfigurationResponseClaim {
     public static final String CHECK_SESSION_IFRAME = "check_session_iframe";
     public static final String END_SESSION_ENDPOINT = "end_session_endpoint";
     public static final String JWKS_URI = "jwks_uri";
+    public static final String ARCHIVED_JWKS_URI = "archived_jwks_uri";
     public static final String REGISTRATION_ENDPOINT = "registration_endpoint";
     public static final String ID_GENERATION_ENDPOINT = "id_generation_endpoint";
     public static final String INTROSPECTION_ENDPOINT = "introspection_endpoint";

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/JSONWebKeySet.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/jwk/JSONWebKeySet.java
@@ -70,14 +70,23 @@ public class JSONWebKeySet {
     public String toString() {
         try {
             JSONObject jwks = toJSONObject();
-            return toPrettyJson(jwks).replace("\\/", "/");
+            return toPrettyString(jwks);
+        } catch (JSONException e) {
+            LOG.error(e.getMessage(), e);
+            return "";
+        }
+    }
+
+    public static String toPrettyString(JSONObject json) {
+        try {
+            return toPrettyJson(json).replace("\\/", "/");
         } catch (JSONException | JsonProcessingException e) {
             LOG.error(e.getMessage(), e);
             return "";
         }
     }
 
-    private String toPrettyJson(JSONObject jsonObject) throws JsonProcessingException {
+    public static String toPrettyJson(JSONObject jsonObject) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JsonOrgModule());
         return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);

--- a/jans-auth-server/server/conf/jans-config.json
+++ b/jans-auth-server/server/conf/jans-config.json
@@ -12,6 +12,7 @@
     "checkSessionIFrame":"${config.oxauth.contextPath}/opiframe.htm",
     "endSessionEndpoint":"${config.oxauth.contextPath}/restv1/end_session",
     "jwksUri":"${config.oxauth.contextPath}/restv1/jwks",
+    "archivedJwksUri":"${config.oxauth.contextPath}/restv1/jwks/archived",
     "registrationEndpoint":"${config.oxauth.contextPath}/restv1/register",
     "openIdDiscoveryEndpoint":"${config.oxauth.issuer}/.well-known/webfinger",
     "openIdConfigurationEndpoint":"${config.oxauth.issuer}/.well-known/openid-configuration",

--- a/jans-auth-server/server/conf/jans-static-conf.json
+++ b/jans-auth-server/server/conf/jans-static-conf.json
@@ -17,6 +17,7 @@
         "sectorIdentifiers": "ou=sector_identifiers,o=jans",
         "ciba": "ou=ciba,o=jans",
         "stat": "ou=stat,o=jans",
-        "par": "ou=par,o=jans"
+        "par": "ou=par,o=jans",
+        "archivedJwks": "ou=archived_jwks,o=jans"
     }
 }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/jwk/ws/rs/ArchivedJwksService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/jwk/ws/rs/ArchivedJwksService.java
@@ -1,0 +1,95 @@
+package io.jans.as.server.jwk.ws.rs;
+
+import io.jans.as.common.model.common.ArchivedJwk;
+import io.jans.as.model.authorize.AuthorizeErrorResponseType;
+import io.jans.as.model.config.StaticConfiguration;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.jwk.JSONWebKeySet;
+import io.jans.orm.PersistenceEntryManager;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+
+/**
+ * @author Yuriy Z
+ */
+@Named
+public class ArchivedJwksService {
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private AppConfiguration appConfiguration;
+
+    @Inject
+    private PersistenceEntryManager persistenceEntryManager;
+
+    @Inject
+    private StaticConfiguration staticConfiguration;
+
+    @Inject
+    private ErrorResponseFactory errorResponseFactory;
+
+    public String buildDn(String id) {
+        return String.format("jansId=%s,%s", id, staticConfiguration.getBaseDn().getArchivedJwks());
+    }
+
+    public ArchivedJwk getArchivedJwkByDn(String dn) {
+        try {
+            return persistenceEntryManager.find(ArchivedJwk.class, dn);
+        } catch (Exception e) {
+            log.trace(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    public Response requestArchivedKid(String kid) {
+        log.debug("Requesting archived kid {} ...", kid);
+
+        final ArchivedJwk archivedJwk = getArchivedJwk(kid);
+
+        if (archivedJwk == null) {
+            log.trace("Unable to find archived jwk by kid {}", kid);
+            throw new WebApplicationException(Response
+                    .status(Response.Status.BAD_REQUEST)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .entity(errorResponseFactory.errorAsJson(AuthorizeErrorResponseType.INVALID_REQUEST, ""))
+                    .build());
+        }
+
+        final String entity = JSONWebKeySet.toPrettyString(archivedJwk.getData());
+
+        if (log.isTraceEnabled()) {
+            log.trace("Returned archived jwk, kid: {}, entity: {}", kid, entity);
+        }
+
+        return Response.ok()
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .entity(entity)
+                .build();
+    }
+
+    public ArchivedJwk getArchivedJwk(String kid) {
+        if (StringUtils.isNotBlank(kid)) {
+            ArchivedJwk result = getArchivedJwkByDn(buildDn(kid));
+            log.debug("Found {} entries for ArchivedJwk id = {}", result != null ? 1 : 0, kid);
+
+            return result;
+        }
+        return null;
+    }
+
+    public void persist(ArchivedJwk entity) {
+        persistenceEntryManager.persist(entity);
+    }
+
+    public void merge(ArchivedJwk entity) {
+        persistenceEntryManager.merge(entity);
+    }
+}

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/jwk/ws/rs/ArchivedJwksService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/jwk/ws/rs/ArchivedJwksService.java
@@ -5,6 +5,7 @@ import io.jans.as.model.authorize.AuthorizeErrorResponseType;
 import io.jans.as.model.config.StaticConfiguration;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.jwk.JSONWebKey;
 import io.jans.as.model.jwk.JSONWebKeySet;
 import io.jans.orm.PersistenceEntryManager;
 import jakarta.inject.Inject;
@@ -13,13 +14,25 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.jans.as.model.jwk.JWKParameter.JSON_WEB_KEY_SET;
+import static io.jans.as.model.jwk.JWKParameter.KEY_ID;
 
 /**
  * @author Yuriy Z
  */
 @Named
 public class ArchivedJwksService {
+
+    public static final int SECONDS_IN_ONE_YEAR = 31536000;
 
     @Inject
     private Logger log;
@@ -91,5 +104,94 @@ public class ArchivedJwksService {
 
     public void merge(ArchivedJwk entity) {
         persistenceEntryManager.merge(entity);
+    }
+
+    public void archiveJwk(JSONObject keyAsJson) {
+        if (keyAsJson == null) {
+            log.trace("JWK is null, skip archiving.");
+            return;
+        }
+
+        try {
+            JSONWebKey jwk = JSONWebKey.fromJSONObject(keyAsJson);
+
+            final String kid = jwk.getKid();
+
+            final ArchivedJwk existing = getArchivedJwk(kid);
+            if (existing != null) {
+                log.debug("JWK {} already archived.", kid);
+                return;
+            }
+
+            log.debug("Trying to archive jwk {} ...", kid);
+
+            ArchivedJwk archivedJwk = new ArchivedJwk();
+            archivedJwk.setDn(buildDn(kid));
+            archivedJwk.setId(kid);
+            archivedJwk.setData(keyAsJson);
+            archivedJwk.setCreationDate(new Date());
+            archivedJwk.setDeletable(true);
+            archivedJwk.setExpirationDate(getExpirationDate());
+            archivedJwk.setTtl(getLifetimeInSeconds());
+
+            persist(archivedJwk);
+
+            log.debug("Archived jwk {} successfully.", kid);
+        } catch (Exception e) {
+            log.error("Failed to archive jwk: {}", keyAsJson);
+        }
+    }
+
+    public int getLifetimeInSeconds() {
+        final int lifetimeFromConfig = appConfiguration.getArchivedJwkLifetimeInSeconds();
+        if (lifetimeFromConfig > 0) {
+            return lifetimeFromConfig;
+        }
+        return SECONDS_IN_ONE_YEAR;
+    }
+
+    private Date getExpirationDate() {
+        int lifetimeInSeconds = getLifetimeInSeconds();
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, lifetimeInSeconds);
+        return calendar.getTime();
+    }
+
+    public Map<String, JSONObject> findRemovedKeys(JSONObject existingJwks, JSONObject newJwks) {
+        Map<String, JSONObject> existingMap = createKidToKeyMap(existingJwks);
+        Map<String, JSONObject> newMap = createKidToKeyMap(newJwks);
+
+        for (String kid : newMap.keySet()) {
+            existingMap.remove(kid);
+        }
+
+        return existingMap;
+    }
+
+    public void archiveRemovedKeys(JSONObject existingJwks, JSONObject newJwks) {
+        Map<String, JSONObject> removedKeys = findRemovedKeys(existingJwks, newJwks);
+
+
+        for (Map.Entry<String, JSONObject> entry : removedKeys.entrySet()) {
+            if (entry.getValue() == null) {
+                continue;
+            }
+
+            archiveJwk(entry.getValue());
+        }
+    }
+
+    public static Map<String, JSONObject> createKidToKeyMap(JSONObject jwks) {
+        Map<String, JSONObject> map = new HashMap<>();
+
+        JSONArray keys = jwks.getJSONArray(JSON_WEB_KEY_SET);
+        for (int i = 0; i < keys.length(); i++) {
+            JSONObject key = keys.getJSONObject(i);
+            final String kid = key.optString(KEY_ID);
+            map.put(kid, key);
+        }
+
+        return map;
     }
 }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/jwk/ws/rs/ArchivedJwksWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/jwk/ws/rs/ArchivedJwksWebServiceImpl.java
@@ -1,0 +1,30 @@
+package io.jans.as.server.jwk.ws.rs;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.slf4j.Logger;
+
+/**
+ * @author Yuriy Z
+ */
+@Path("/")
+public class ArchivedJwksWebServiceImpl {
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private ArchivedJwksService archivedJwksService;
+
+    @GET
+    @Path("/jwks/archived")
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response requestArchivedKid(@QueryParam("kid") String kid) {
+        return archivedJwksService.requestArchivedKid(kid);
+    }
+}

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/CleanerTimer.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/CleanerTimer.java
@@ -6,26 +6,17 @@
 
 package io.jans.as.server.service;
 
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Maps;
-
+import io.jans.as.common.model.common.ArchivedJwk;
 import io.jans.as.common.model.registration.Client;
 import io.jans.as.common.model.session.SessionId;
 import io.jans.as.model.config.StaticConfiguration;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.uma.persistence.UmaResource;
+import io.jans.as.persistence.model.ClientAuthorization;
 import io.jans.as.persistence.model.Par;
 import io.jans.as.persistence.model.Scope;
-import io.jans.as.persistence.model.ClientAuthorization;
 import io.jans.as.server.model.ldap.TokenEntity;
 import io.jans.as.server.uma.authorization.UmaPCT;
 import io.jans.as.server.uma.service.UmaPctService;
@@ -46,6 +37,14 @@ import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.slf4j.Logger;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Yuriy Zabrovarnyy
@@ -193,6 +192,7 @@ public class CleanerTimer {
         cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getScopes(), Scope.class);
         cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getSessions(), SessionId.class);
         cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getPar(), Par.class);
+        cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getArchivedJwks(), ArchivedJwk.class);
 
         return cleanServiceBaseDns;
     }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/ResteasyInitializer.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/ResteasyInitializer.java
@@ -14,6 +14,7 @@ import io.jans.as.server.bcauthorize.ws.rs.BackchannelDeviceRegistrationRestWebS
 import io.jans.as.server.clientinfo.ws.rs.ClientInfoRestWebServiceImpl;
 import io.jans.as.server.introspection.ws.rs.IntrospectionWebService;
 import io.jans.as.server.jans.ws.rs.JansConfigurationWS;
+import io.jans.as.server.jwk.ws.rs.ArchivedJwksWebServiceImpl;
 import io.jans.as.server.jwk.ws.rs.JwkRestWebServiceImpl;
 import io.jans.as.server.par.ws.rs.ParRestWebService;
 import io.jans.as.server.register.ws.rs.RegisterRestWebServiceImpl;
@@ -54,6 +55,7 @@ public class ResteasyInitializer extends Application {
         classes.add(RevokeRestWebServiceImpl.class);
         classes.add(RevokeSessionRestWebService.class);
         classes.add(JwkRestWebServiceImpl.class);
+        classes.add(ArchivedJwksWebServiceImpl.class);
         classes.add(IntrospectionWebService.class);
         classes.add(ParRestWebService.class);
         classes.add(SessionRestWebService.class);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/FapiOpenIdConfiguration.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/FapiOpenIdConfiguration.java
@@ -206,6 +206,7 @@ public class FapiOpenIdConfiguration extends HttpServlet {
             jsonObj.put(CHECK_SESSION_IFRAME, appConfiguration.getCheckSessionIFrame());
             jsonObj.put(END_SESSION_ENDPOINT, appConfiguration.getEndSessionEndpoint());
             jsonObj.put(JWKS_URI, appConfiguration.getJwksUri());
+            jsonObj.put(ARCHIVED_JWKS_URI, appConfiguration.getArchivedJwksUri());
             jsonObj.put(REGISTRATION_ENDPOINT, appConfiguration.getRegistrationEndpoint());
             jsonObj.put(ID_GENERATION_ENDPOINT, appConfiguration.getIdGenerationEndpoint());
             jsonObj.put(INTROSPECTION_ENDPOINT, appConfiguration.getIntrospectionEndpoint());

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/OpenIdConfiguration.java
@@ -109,6 +109,7 @@ public class OpenIdConfiguration extends HttpServlet {
             jsonObj.put(AUTHORIZATION_CHALLENGE_ENDPOINT, appConfiguration.getAuthorizationChallengeEndpoint());
             jsonObj.put(TOKEN_ENDPOINT, appConfiguration.getTokenEndpoint());
             jsonObj.put(JWKS_URI, appConfiguration.getJwksUri());
+            jsonObj.put(ARCHIVED_JWKS_URI, appConfiguration.getArchivedJwksUri());
             jsonObj.put(CHECK_SESSION_IFRAME, appConfiguration.getCheckSessionIFrame());
 
             if (appConfiguration.isFeatureEnabled(FeatureFlagType.REVOKE_TOKEN))

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/jwk/ws/rs/ArchivedJwksServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/jwk/ws/rs/ArchivedJwksServiceTest.java
@@ -1,0 +1,98 @@
+package io.jans.as.server.jwk.ws.rs;
+
+import io.jans.as.model.config.BaseDnConfiguration;
+import io.jans.as.model.config.StaticConfiguration;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.orm.PersistenceEntryManager;
+import org.json.JSONObject;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class ArchivedJwksServiceTest {
+
+    @InjectMocks
+    private ArchivedJwksService archivedJwksService;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private PersistenceEntryManager persistenceEntryManager;
+
+    @Mock
+    private StaticConfiguration staticConfiguration;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Test
+    public void buildDn_whenCalled_shouldReturnCorrectValue() {
+        BaseDnConfiguration baseDnConfiguration = new BaseDnConfiguration();
+        baseDnConfiguration.setArchivedJwks("ou=archived_jwks,o=gluu");
+
+        when(staticConfiguration.getBaseDn()).thenReturn(baseDnConfiguration);
+
+        assertEquals("jansId=kid,ou=archived_jwks,o=gluu", archivedJwksService.buildDn("kid"));
+    }
+
+    @Test
+    public void getLifetimeInSeconds_whenConfigIsAbsent_shouldReturnOneYear() {
+        assertEquals(ArchivedJwksService.SECONDS_IN_ONE_YEAR, archivedJwksService.getLifetimeInSeconds());
+    }
+
+    @Test
+    public void getLifetimeInSeconds_whenConfigIsSet_shouldReturnValueFromConfig() {
+        when(appConfiguration.getArchivedJwkLifetimeInSeconds()).thenReturn(10);
+
+        assertEquals(10, archivedJwksService.getLifetimeInSeconds());
+    }
+
+    @Test
+    public void findRemovedKeys_whenCalled_shouldReturnCorrectValues() {
+        JSONObject existing = new JSONObject("{\n" +
+                "  \"keys\" : [ {\n" +
+                "    \"kty\" : \"RSA\",\n" +
+                "    \"e\" : \"AQAB\",\n" +
+                "    \"use\" : \"sig\",\n" +
+                "    \"kid\" : \"b302e936-b14d-4b04-b3b8-c1793f827d9a_sig_rs256\"\n" +
+                "  }, {\n" +
+                "    \"kid\" : \"3d5bb406-a0ee-447a-babe-2c86df27fb96_sig_rs384\",\n" +
+                "    \"exp\" : 1699400350705,\n" +
+                "    \"alg\" : \"RS384\"\n" +
+                "  }\n" +
+                "]\n" +
+                "}");
+        JSONObject newKeys = new JSONObject("{\n" +
+                "  \"keys\" : [ {\n" +
+                "    \"kty\" : \"RSA\",\n" +
+                "    \"e\" : \"AQAB\",\n" +
+                "    \"use\" : \"sig\",\n" +
+                "    \"kid\" : \"b302e936-b14d-4b04-b3b8-c1793f827d9a_sig_rs256\"\n" +
+                "  }" +
+                "]\n" +
+                "}");
+
+        final Map<String, JSONObject> removedKeys = archivedJwksService.findRemovedKeys(existing, newKeys);
+        final JSONObject jsonObject = removedKeys.get("3d5bb406-a0ee-447a-babe-2c86df27fb96_sig_rs384");
+        assertNotNull(jsonObject);
+        assertEquals(1, removedKeys.size());
+    }
+}

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/TestResteasyInitializer.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/TestResteasyInitializer.java
@@ -11,6 +11,7 @@ import io.jans.as.server.authorize.ws.rs.AuthorizeRestWebServiceImpl;
 import io.jans.as.server.clientinfo.ws.rs.ClientInfoRestWebServiceImpl;
 import io.jans.as.server.introspection.ws.rs.IntrospectionWebService;
 import io.jans.as.server.jans.ws.rs.JansConfigurationWS;
+import io.jans.as.server.jwk.ws.rs.ArchivedJwksWebServiceImpl;
 import io.jans.as.server.jwk.ws.rs.JwkRestWebServiceImpl;
 import io.jans.as.server.register.ws.rs.RegisterRestWebServiceImpl;
 import io.jans.as.server.session.ws.rs.EndSessionRestWebServiceImpl;
@@ -48,6 +49,7 @@ public class TestResteasyInitializer extends Application {
         classes.add(IntrospectionWebService.class);
         classes.add(ClientInfoRestWebServiceImpl.class);
         classes.add(JwkRestWebServiceImpl.class);
+        classes.add(ArchivedJwksWebServiceImpl.class);
         classes.add(EndSessionRestWebServiceImpl.class);
 
         classes.add(UmaPermissionRegistrationWS.class);

--- a/jans-linux-setup/jans_setup/schema/jans_schema.json
+++ b/jans-linux-setup/jans_setup/schema/jans_schema.json
@@ -4012,6 +4012,28 @@
     {
       "kind": "STRUCTURAL",
       "may": [
+        "jansId",
+        "creationDate",
+        "exp",
+        "del",
+        "jansData",
+        "attr"
+      ],
+      "must": [
+        "objectclass"
+      ],
+      "names": [
+        "jansArchJwk"
+      ],
+      "oid": "jansObjClass",
+      "sup": [
+        "top"
+      ],
+      "x_origin": "Jans created objectclass"
+    },
+    {
+      "kind": "STRUCTURAL",
+      "may": [
         "displayName",
         "inum",
         "owner",

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -10,6 +10,7 @@
     "checkSessionIFrame":"https://%(hostname)s/jans-auth/opiframe.htm",
     "endSessionEndpoint":"https://%(hostname)s/jans-auth/restv1/end_session",
     "jwksUri":"https://%(hostname)s/jans-auth/restv1/jwks",
+    "archivedJwksUri":"https://%(hostname)s/jans-auth/restv1/jwks/archived",
     "registrationEndpoint":"https://%(hostname)s/jans-auth/restv1/register",
     "openIdDiscoveryEndpoint":"https://%(hostname)s/.well-known/webfinger",
     "openIdConfigurationEndpoint":"https://%(hostname)s/.well-known/openid-configuration",

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-static-conf.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-static-conf.json
@@ -16,6 +16,7 @@
         "umaPolicy":"ou=policies,ou=uma,o=jans",
         "metric":"ou=statistic,o=metric",
         "sectorIdentifiers": "ou=sector_identifiers,o=jans",
+        "archivedJwks": "ou=archived_jwks,o=jans",
         "ciba": "ou=ciba,o=jans",
         "ssa": "ou=ssa,o=jans"
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,6 +198,7 @@ nav:
       - End Session: admin/auth-server/endpoints/end-session.md
       - Clientinfo: admin/auth-server/endpoints/clientinfo.md
       - JWKS URI: admin/auth-server/endpoints/jwks-uri.md
+      - Archived JWKS URI: admin/auth-server/endpoints/archived-jwks-uri.md
       - Introspection: admin/auth-server/endpoints/introspection.md
       - Device Authorization: admin/auth-server/endpoints/device-authorization.md
       - PAR: admin/auth-server/endpoints/par.md


### PR DESCRIPTION
### Description

Archived jwks:

1. When key is rotated, public part must be archived
2. It is possible to fetch it `https://as.com/jwks/archived/{kid}`
3. Added configuration property for `exp` of archived keys. Default value 1 year. After it's passed archived key is removed from DB.

#### Target issue
  
closes #6437

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

