### PR TITLE
chore: fix dependecies to guava lib

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientService.java
@@ -30,7 +30,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.apache.commons.lang3.BooleanUtils;
 import org.json.JSONArray;
-import org.python.jline.internal.Preconditions;
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 
 import java.util.*;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/SpontaneousScopeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/SpontaneousScopeService.java
@@ -17,7 +17,7 @@ import io.jans.as.persistence.model.Scope;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import org.python.google.common.collect.Sets;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 
 import java.util.*;

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/uma/service/UmaValidationService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/uma/service/UmaValidationService.java
@@ -41,7 +41,7 @@ import io.jans.orm.exception.EntryPersistenceException;
 import io.jans.util.StringHelper;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.python.google.common.collect.Iterables;
+import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 
 import jakarta.ejb.Stateless;


### PR DESCRIPTION
Use guava instead of internal jython classes.
Closes #6570, 