### PR TITLE
fix(docker-jans-auth-server): avoid crashes on Agama serialization

### DIFF
--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -51,7 +51,7 @@ RUN /opt/jython/bin/pip uninstall -y pip setuptools
 # ===========
 
 ENV CN_VERSION=1.0.21-SNAPSHOT
-ENV CN_BUILD_DATE='2023-11-14 10:53'
+ENV CN_BUILD_DATE='2023-11-23 08:24'
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-auth-server/${CN_VERSION}/jans-auth-server-${CN_VERSION}.war
 
 # Install Jans Auth

--- a/docker-jans-auth-server/scripts/entrypoint.sh
+++ b/docker-jans-auth-server/scripts/entrypoint.sh
@@ -19,7 +19,7 @@ move_builtin_jars() {
     # twilio, jsmpp, casa-config, jans-fido2-client
     for src in /opt/jans/jetty/jans-auth/_libs/*.jar; do
         fname=$(basename "$src")
-        cp "$src" "/opt/jans/jetty/jans-auth/custom/libs/$fname"
+        mv "$src" "/opt/jans/jetty/jans-auth/custom/libs/$fname"
     done
 }
 
@@ -70,6 +70,7 @@ python3 "$basedir/auth_conf.py"
 cd /opt/jans/jetty/jans-auth
 # shellcheck disable=SC2046
 exec java \
+    --add-opens java.base/java.lang=ALL-UNNAMED \
     -server \
     -XX:+DisableExplicitGC \
     -XX:+UseContainerSupport \


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #6619

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

