### PR TITLE
fix: openapi spec version element

### DIFF
--- a/jans-auth-server/docs/swagger.yaml
+++ b/jans-auth-server/docs/swagger.yaml
@@ -11,6 +11,7 @@ info:
   license:
     name: License
     url: https://github.com/JanssenProject/jans/blob/main/LICENSE
+  version: ""
 servers:
   - url: https://jans.local.io/jans-auth
 tags:

--- a/jans-auth-server/docs/swagger.yaml
+++ b/jans-auth-server/docs/swagger.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: License
     url: https://github.com/JanssenProject/jans/blob/main/LICENSE
-  version: ""
+  version: "OAS Version"
 servers:
   - url: https://jans.local.io/jans-auth
 tags:

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/ApiApplication.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/ApiApplication.java
@@ -31,7 +31,10 @@ import jakarta.ws.rs.core.Application;
 @OpenAPIDefinition(info = @Info(title = "Jans Config API", contact =
 @Contact(name = "Contact", url = "https://github.com/JanssenProject/jans/discussions"),
 
-        license = @License(name = "License", url = "https://github.com/JanssenProject/jans/blob/main/LICENSE")),
+        license = @License(name = "License", url = "https://github" +
+                ".com/JanssenProject/jans/blob/main/LICENSE"),
+
+        version = "OAS Version"),
 
         tags = { @Tag(name = "Attribute"), @Tag(name = "Default Authentication Method"),
                 @Tag(name = "Cache Configuration"), @Tag(name = "Cache Configuration – Memcached"),

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: License
     url: https://github.com/JanssenProject/jans/blob/main/LICENSE
-  version: ""
+  version: "OAS Version"
 servers:
   - url: https://jans.local.io
 tags:

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -11,6 +11,7 @@ info:
   license:
     name: License
     url: https://github.com/JanssenProject/jans/blob/main/LICENSE
+  version: ""
 servers:
   - url: https://jans.local.io
 tags:

--- a/jans-scim/server/src/main/resources/jans-scim-openapi.yaml
+++ b/jans-scim/server/src/main/resources/jans-scim-openapi.yaml
@@ -10,6 +10,7 @@ info:
   license:
     name: License
     url: https://github.com/JanssenProject/jans/blob/main/LICENSE
+  version: ""
 servers:
 - url: https://jans.local.io/jans-scim/restv1/v2
 tags:

--- a/jans-scim/server/src/main/resources/jans-scim-openapi.yaml
+++ b/jans-scim/server/src/main/resources/jans-scim-openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: License
     url: https://github.com/JanssenProject/jans/blob/main/LICENSE
-  version: ""
+  version: "OAS Version"
 servers:
 - url: https://jans.local.io/jans-scim/restv1/v2
 tags:


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Since we do not want to use the `info`->`version` element but we have to because the `editor.swagger.io` shows warning otherwise.

Ideal solution is to put `vreplace-janssen-version` in there and let the release process fill in the right version number. But at the moment yaml files are not covered in this replacement process. So as a stop-gap, I have added version with static value of `OAS Version` as it looks logical on screen :point_down: and doesn't have to be replaced.

![image](https://github.com/JanssenProject/jans/assets/343411/fa480a8f-3080-47fb-973d-760d6bb52737)

closes #6622 
-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

