### PR TITLE
fix(jans-core): jans-core starts to fail after dependencies upgrade #6783

### DIFF
--- a/jans-core/util/pom.xml
+++ b/jans-core/util/pom.xml
@@ -91,6 +91,10 @@
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jackson2-provider</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>


### PR DESCRIPTION
### Description

fix(jans-core): jans-core starts to fail after dependencies upgrade 

#### Target issue
  
closes #6783

