### PR TITLE
fix(jans-bom): resteasy 6.2.x required weld upgrade thus reverting resteasy back to 6.0.3.Final #6787

### DIFF
--- a/jans-bom/pom.xml
+++ b/jans-bom/pom.xml
@@ -24,7 +24,7 @@
 		<httpcore.version>4.4.15</httpcore.version>
 		<httpclient.version>4.5.13</httpclient.version>
 
-		<resteasy.version>6.2.6.Final</resteasy.version>
+		<resteasy.version>6.0.3.Final</resteasy.version>
 		<richfaces.version>4.5.19-gluu.Final</richfaces.version>
 		<weld.version>4.0.3.Final</weld.version>
 	


### PR DESCRIPTION
### Description

fix(jans-bom): resteasy 6.2.x required weld upgrade thus reverting resteasy back to 6.0.3.Final 

#### Target issue
  
closes #6787

