### PR TITLE
fix(jans-auth-server): common-text upgrade 1.11.0 leads to class initialization problems #6826

### DIFF
--- a/jans-bom/pom.xml
+++ b/jans-bom/pom.xml
@@ -482,7 +482,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-text</artifactId>
-				<version>1.11.0</version>
+				<version>1.10.0</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-beanutils</groupId>


### PR DESCRIPTION
### Description

fix(jans-auth-server): common-text upgrade 1.11.0 leads to class initialization problems 

#### Target issue
  
closes #6826

