### PR TITLE
test(jans-auth-server): embedded tests are failing after testng upgrade to 7.8.0 #6837

### DIFF
--- a/jans-auth-server/server/pom.xml
+++ b/jans-auth-server/server/pom.xml
@@ -589,6 +589,7 @@
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
 			<scope>test</scope>
+            <version>6.14.3</version> <!-- we need 6.14.3 due to Arquillian -->
 		</dependency>
 		<dependency>
             <groupId>jakarta.websocket</groupId>

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/ConfigurableTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/ConfigurableTest.java
@@ -9,13 +9,9 @@ package io.jans.as.server;
 import io.jans.as.server.util.Deployments;
 import io.jans.util.StringHelper;
 import io.jans.util.properties.FileConfiguration;
-import jakarta.servlet.Servlet;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
 import org.apache.commons.io.IOUtils;
 import org.eu.ingwar.tools.arquillian.extension.suite.annotations.ArquillianSuiteDeployment;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.testng.ITestContext;
@@ -24,13 +20,10 @@ import org.testng.annotations.BeforeSuite;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-
-import static org.omnifaces.util.Faces.getServletContext;
 
 /**
  * Base class for all seam test which require external configuration
@@ -56,6 +49,7 @@ public abstract class ConfigurableTest extends Arquillian {
         if (initialized) {
             return;
         }
+        System.setProperty("testng.ignore.callback.skip", "true");
 
         Reporter.log("Invoked init test suite method", true);
 


### PR DESCRIPTION
### Description

test(jans-auth-server): embedded tests are failing after testng upgrade to 7.8.0 

#### Target issue
  
closes #6837

