### PR TITLE
fix(fido2): tests are failing due to NoClassDefFoundError: javax/xml/bind/annotation/XmlElement #6865

### DIFF
--- a/jans-fido2/server/pom.xml
+++ b/jans-fido2/server/pom.xml
@@ -140,6 +140,10 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+        </dependency>
 
         <!-- Weld -->
         <dependency>


### PR DESCRIPTION
### Description

fix(fido2): tests are failing due to NoClassDefFoundError: javax/xml/bind/annotation/XmlElement 

https://jenkins.jans.io/jenkins/job/jans-fido2/3555/testReport/junit/io.jans.fido2.service.sg/FullFlowAndroidTest/testFinishAttestationTwoStepAndroid_String__String__String_/

#### Target issue
  
closes #6865

