### PR TITLE
fix(jans-auth-server): authz challenge session attributes are overwritten after external script run #6933

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeService.java
@@ -189,10 +189,16 @@ public class AuthorizationChallengeService {
         Map<String, String> requestParameterMap = requestParameterService.getAllowedParameters(parameterMap);
 
         SessionId sessionUser = sessionIdService.generateAuthenticatedSessionId(authzRequest.getHttpRequest(), user.getDn(), authzRequest.getPrompt());
-        sessionUser.setSessionAttributes(requestParameterMap);
+        final Set<String> sessionAttributesKeySet = sessionUser.getSessionAttributes().keySet();
+        requestParameterMap.forEach((key, value) -> {
+            if (!sessionAttributesKeySet.contains(key)) {
+                sessionUser.getSessionAttributes().put(key, value);
+            }
+        });
 
         cookieService.createSessionIdCookie(sessionUser, authzRequest.getHttpRequest(), authzRequest.getHttpResponse(), false);
         sessionIdService.updateSessionId(sessionUser);
+        log.trace("Session updated with {}", sessionUser);
 
         return sessionUser;
     }


### PR DESCRIPTION
### Description

fix(jans-auth-server): authz challenge session attributes are overwritten after external script run 

#### Target issue
  
closes #6933

