### PR TITLE
chore(deps): remove jwcrypto dependency from jans-all-in-one image

### DIFF
--- a/docker-jans-all-in-one/app/requirements.txt
+++ b/docker-jans-all-in-one/app/requirements.txt
@@ -6,6 +6,5 @@ marshmallow==3.20.1
 fqdn==1.5.1
 ruamel.yaml==0.18.5
 supervisor==4.2.5
-jwcrypto==1.4.2
 pluggy==1.3.0
 git+https://github.com/JanssenProject/jans@25633cf9ab019fdf60a65d2c27f2665c359abab7#egg=jans-pycloudlib&subdirectory=jans-pycloudlib


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Remove `jwcrypto` library from requirements as the dependant `flex-all-in-one` image has been adding the library directly.

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #6835 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

