### PR TITLE
fix(jans-fido2): jansPublicKeyId updated to 256 characters

### DIFF
--- a/jans-fido2/server/profiles/default/config-build.properties
+++ b/jans-fido2/server/profiles/default/config-build.properties
@@ -1,0 +1,5 @@
+jakarta.faces.PROJECT_STAGE=Production
+jakarta.faces.FACELETS_REFRESH_PERIOD=10
+
+log4j.default.log.level=DEBUG
+weld.debug=false

--- a/jans-linux-setup/jans_setup/static/rdbm/sql_data_types.json
+++ b/jans-linux-setup/jans_setup/static/rdbm/sql_data_types.json
@@ -261,11 +261,11 @@
   },
   "jansPublicKeyId": {
     "mysql": {
-      "size": 96,
+      "size": 256,
       "type": "VARCHAR"
     },
     "spanner": {
-      "size": 96,
+      "size": 256,
       "type": "STRING"
     }
   },


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
- jansPublicKeyId field size update to 256 characters
- Updating the fido config-build.properties file
  
closes #7114

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

