### PR TITLE
fix(keycloak-integration): Keycloak startup issue #7123

### DIFF
--- a/jans-keycloak-integration/pom.xml
+++ b/jans-keycloak-integration/pom.xml
@@ -20,7 +20,7 @@
       <maven.min-version>3.3.9</maven.min-version>
       <maven.compiler.source>17</maven.compiler.source>
       <maven.compiler.target>17</maven.compiler.target>
-      <keycloak-server.version>23.0.1</keycloak-server.version>
+      <keycloak-server.version>23.0.3</keycloak-server.version>
       <nimbus.oauth-sdk.version>10.11</nimbus.oauth-sdk.version>
       <nimbus.oauth2-oidc-sdk.version>10.11</nimbus.oauth2-oidc-sdk.version>
       <jackson.coreutils.version>1.8</jackson.coreutils.version>
@@ -250,7 +250,18 @@
                   jakarta.servlet,
                   jakarta.validation,
                   jakarta.xml.bind,
-                  org.jboss.resteasy
+                  org.jboss.resteasy,
+                  org.jboss.spec.javax.ws.rs,
+                  com.fasterxml.jackson.core,
+                  commons-codec,
+                  commons-lang3,
+                  commons-lang,
+                  commons-collections4,
+                  commons-io,
+                  commons-logging,
+                  commons-text,
+                  org.apache.commons,
+                  commons-configuration
                 </excludeGroupIds>
               </configuration>
             </execution>


### PR DESCRIPTION
Excluded libraries causing `kc-storage-plugin` to prevent Keycloak from starting.