### PR TITLE
fix(jans-cli-tui): rename Message to Lock

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/main.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/main.py
@@ -265,14 +265,14 @@ class Plugin(DialogUtils):
                     entries=[
                         ('clients', 'C[l]ients'),
                         ('scopes', 'Sc[o]pes'),
-                        ('keys', '[K]eys'),
+                        ('keys', 'Ke[y]s'),
                         ('authn', 'Au[t]hn'),
                         ('properties', 'Properti[e]s'),
                         ('logging', 'Lo[g]ging'),
                         ('ssa', '[S]SA'),
                         ('agama', 'Aga[m]a'),
                         ('attributes', 'Attri[b]utes'),
-                        ('message', 'Message')
+                        ('message', 'Loc[k]')
                         ],
                     selection_changed=self.oauth_nav_selection_changed,
                     select=0,


### PR DESCRIPTION
closes #7209