### PR TITLE
chore: avoid duplicy in logging when jans-lock is part of jans-auth-server

### DIFF
--- a/jans-lock/server/src/main/resources/log4j2.xml
+++ b/jans-lock/server/src/main/resources/log4j2.xml
@@ -4,6 +4,46 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{dd-MM-yyyy HH:mm:ss.SSS} %-5p %C{4} %F:%L- %m%n" />
         </Console>
+
+		<RollingFile name="JANS_LOCK_PERSISTENCE_FILE" fileName="${sys:log.base}/logs/jans-lock_persistence.log" filePattern="${sys:log.base}/logs/jans-lock_persistence-%d{yyyy-MM-dd}-%i.log">
+			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
+
+			<Policies>
+				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
+				<SizeBasedTriggeringPolicy size="5 MB" />
+			</Policies>
+			<DefaultRolloverStrategy max="30" />
+		</RollingFile>
+
+		<RollingFile name="JANS_LOCK_PERSISTENCE_DURATION_FILE" fileName="${sys:log.base}/logs/jans-lock_persistence_duration.log" filePattern="${sys:log.base}/logs/jans-lock_persistence_duration-%d{yyyy-MM-dd}-%i.log">
+			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
+
+			<Policies>
+				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
+				<SizeBasedTriggeringPolicy size="5 MB" />
+			</Policies>
+			<DefaultRolloverStrategy max="30" />
+		</RollingFile>
+
+		<RollingFile name="JANS_LOCK_PERSISTENCE_LDAP_STATISTICS_FILE" fileName="${sys:log.base}/logs/jans-lock_persistence_ldap_statistics.log" filePattern="${sys:log.base}/logs/jans-lock_persistence_ldap_statistics-%d{yyyy-MM-dd}-%i.log">
+			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
+
+			<Policies>
+				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
+				<SizeBasedTriggeringPolicy size="5 MB" />
+			</Policies>
+			<DefaultRolloverStrategy max="30" />
+		</RollingFile>
+
+		<RollingFile name="JANS_LOCK_SCRIPT_LOG_FILE" fileName="${sys:log.base}/logs/jans-lock_script.log" filePattern="${sys:log.base}/logs/jans-lock_script-%d{yyyy-MM-dd}-%i.log">
+			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
+
+			<Policies>
+				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
+				<SizeBasedTriggeringPolicy size="5 MB" />
+			</Policies>
+			<DefaultRolloverStrategy max="30" />
+		</RollingFile>
     </Appenders>
 
     <Loggers>
@@ -11,7 +51,49 @@
 			<AppenderRef ref="JANS_LOCK_FILE" />
 			<AppenderRef ref="Console" />
         </Root>
+
+		<Logger name="io.jans.orm" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_PERSISTENCE_FILE" />
+		</Logger>
+
+		<Logger name="com.unboundid.ldap.sdk.LDAPConnection" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_PERSISTENCE_FILE" />
+		</Logger>
+		<logger name="com.couchbase.client" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_PERSISTENCE_FILE" />
+		</logger>
+
+		<Logger name="io.jans.orm.ldap.operation.watch" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_PERSISTENCE_DURATION_FILE" />
+		</Logger>
+
+		<Logger name="io.jans.orm.couchbase.operation.watch" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_PERSISTENCE_DURATION_FILE" />
+		</Logger>
+
+		<Logger name="io.jans.orm.watch" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_PERSISTENCE_DURATION_FILE" />
+		</Logger>
+
+		<Logger name="io.jans.as.server.service.status.ldap" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_PERSISTENCE_LDAP_STATISTICS_FILE" />
+		</Logger>
+
+		<Logger name="io.jans.service.PythonService" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_SCRIPT_LOG_FILE" />
+		</Logger>
+
+		<Logger name="io.jans.service.custom.script" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_SCRIPT_LOG_FILE" />
+		</Logger>
+
+		<Logger name="io.jans.as.server.service.custom" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_SCRIPT_LOG_FILE" />
+		</Logger>
 		
+		<logger name="io.jans.service.external" level="${log4j.default.log.level}" additivity="false">
+			<AppenderRef ref="JANS_LOCK_SCRIPT_LOG_FILE" />
+		</logger>
     </Loggers>
 
 </Configuration>

--- a/jans-lock/service/src/main/resources/log4j2-lock.xml
+++ b/jans-lock/service/src/main/resources/log4j2-lock.xml
@@ -9,95 +9,12 @@
 			</Policies>
 			<DefaultRolloverStrategy max="30" />
 		</RollingFile>
-
-		<RollingFile name="JANS_LOCK_PERSISTENCE_FILE" fileName="${sys:log.base}/logs/jans-lock_persistence.log" filePattern="${sys:log.base}/logs/jans-lock_persistence-%d{yyyy-MM-dd}-%i.log">
-			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
-
-			<Policies>
-				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
-				<SizeBasedTriggeringPolicy size="5 MB" />
-			</Policies>
-			<DefaultRolloverStrategy max="30" />
-		</RollingFile>
-
-		<RollingFile name="JANS_LOCK_PERSISTENCE_DURATION_FILE" fileName="${sys:log.base}/logs/jans-lock_persistence_duration.log" filePattern="${sys:log.base}/logs/jans-lock_persistence_duration-%d{yyyy-MM-dd}-%i.log">
-			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
-
-			<Policies>
-				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
-				<SizeBasedTriggeringPolicy size="5 MB" />
-			</Policies>
-			<DefaultRolloverStrategy max="30" />
-		</RollingFile>
-
-		<RollingFile name="JANS_LOCK_PERSISTENCE_LDAP_STATISTICS_FILE" fileName="${sys:log.base}/logs/jans-lock_persistence_ldap_statistics.log" filePattern="${sys:log.base}/logs/jans-lock_persistence_ldap_statistics-%d{yyyy-MM-dd}-%i.log">
-			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
-
-			<Policies>
-				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
-				<SizeBasedTriggeringPolicy size="5 MB" />
-			</Policies>
-			<DefaultRolloverStrategy max="30" />
-		</RollingFile>
-
-		<RollingFile name="JANS_LOCK_SCRIPT_LOG_FILE" fileName="${sys:log.base}/logs/jans-lock_script.log" filePattern="${sys:log.base}/logs/jans-lock_script-%d{yyyy-MM-dd}-%i.log">
-			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
-
-			<Policies>
-				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
-				<SizeBasedTriggeringPolicy size="5 MB" />
-			</Policies>
-			<DefaultRolloverStrategy max="30" />
-		</RollingFile>
     </Appenders>
 
     <Loggers>
 		<Logger name="io.jans.lock" level="${log4j.default.log.level}">
 			<AppenderRef ref="JANS_LOCK_FILE" />
 		</Logger>
-
-		<Logger name="io.jans.orm" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_PERSISTENCE_FILE" />
-		</Logger>
-
-		<Logger name="com.unboundid.ldap.sdk.LDAPConnection" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_PERSISTENCE_FILE" />
-		</Logger>
-		<logger name="com.couchbase.client" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_PERSISTENCE_FILE" />
-		</logger>
-
-		<Logger name="io.jans.orm.ldap.operation.watch" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_PERSISTENCE_DURATION_FILE" />
-		</Logger>
-
-		<Logger name="io.jans.orm.couchbase.operation.watch" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_PERSISTENCE_DURATION_FILE" />
-		</Logger>
-
-		<Logger name="io.jans.orm.watch" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_PERSISTENCE_DURATION_FILE" />
-		</Logger>
-
-		<Logger name="io.jans.as.server.service.status.ldap" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_PERSISTENCE_LDAP_STATISTICS_FILE" />
-		</Logger>
-
-		<Logger name="io.jans.service.PythonService" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_SCRIPT_LOG_FILE" />
-		</Logger>
-
-		<Logger name="io.jans.service.custom.script" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_SCRIPT_LOG_FILE" />
-		</Logger>
-
-		<Logger name="io.jans.as.server.service.custom" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_SCRIPT_LOG_FILE" />
-		</Logger>
-		
-		<logger name="io.jans.service.external" level="${log4j.default.log.level}" additivity="false">
-			<AppenderRef ref="JANS_LOCK_SCRIPT_LOG_FILE" />
-		</logger>
     </Loggers>
 
 </Configuration>


### PR DESCRIPTION
#7382