### PR TITLE
fix(jans-cli-tui): save auth server logging config

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/main.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/main.py
@@ -1041,7 +1041,7 @@ class Plugin(DialogUtils):
                 data_fn=None,
                 data=pathches
                 )
-            self.app.app_configuration = response
+            self.app.app_configuration = response.json()
 
             body = HSplit([Label(_("Jans authorization server application configuration logging properties were saved."))])
 


### PR DESCRIPTION
closes #7427