### PR TITLE
fix(jans-linux-setup): modification date of MANIFEST.MF in war file is build date

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/printVersion.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/printVersion.py
@@ -8,6 +8,7 @@ import sys
 import os
 import json
 import argparse
+import datetime
 
 try:
     from urllib.request import urlopen
@@ -28,8 +29,9 @@ def get_latest_commit(service):
 
 def get_war_info(war_fn):
     retDict = {'title':'', 'version':'', 'build':'', 'buildDate':'', 'branch':''}
-    war_zip = zipfile.ZipFile(war_fn,"r")
-    menifest = war_zip.read('META-INF/MANIFEST.MF')
+    war_zip = zipfile.ZipFile(war_fn, 'r')
+    menifest_fn = 'META-INF/MANIFEST.MF'
+    menifest = war_zip.read(menifest_fn)
 
     for l in menifest.splitlines():
         ls = l.strip().decode('utf-8')
@@ -43,16 +45,10 @@ def get_war_info(war_fn):
                 branch = branch.split('/')[1]
 
             retDict['branch'] = branch
-            
 
-    for f in war_zip.filelist:
-        if f.filename.startswith('META-INF/maven/org.jans') and f.filename.endswith('pom.properties'):
-            pom_prop = war_zip.read(f.filename)
-            for l in pom_prop.splitlines():
-                build_date = re.findall("\w{3}\s\w{3}\s{1,2}\w{1,2}\s\w{2}:\w{2}:\w{2}\s[+\w]{3}\s\w{4}", l.decode('utf-8'))
-                if build_date:
-                    retDict['buildDate'] =  build_date[0]
-                    break
+    menifest_info = war_zip.getinfo(menifest_fn)
+    retDict['buildDate'] = str(datetime.datetime(*menifest_info.date_time))
+
 
     return retDict
 


### PR DESCRIPTION
closes #7451

With this fix:

```
# /opt/jans/printVersion.py
Title: Jans authentication server
Version: 1.0.22-SNAPSHOT
Builddate: 2024-01-18 18:59:18
Build: 39b609640aa290f7607089950ac3525ab09e6d1f

Title: SCIM API Server
Version: 1.0.22-SNAPSHOT
Builddate: 2023-12-18 12:08:48
Build: 07e078bb4457800296ba74f3cadf70a639f39c79

Title: jans-config-api-server
Version: 1.0.22-SNAPSHOT
Builddate: 2024-01-18 20:31:16
Build: 39b609640aa290f7607089950ac3525ab09e6d1f

root@myjans:/opt/jans# /opt/jans/printVersion.py
Title: Jans authentication server
Version: 1.0.22-SNAPSHOT
Builddate: 2024-01-18 18:59:18
Build: 39b609640aa290f7607089950ac3525ab09e6d1f

Title: SCIM API Server
Version: 1.0.22-SNAPSHOT
Builddate: 2023-12-18 12:08:48
Build: 07e078bb4457800296ba74f3cadf70a639f39c79

Title: jans-config-api-server
Version: 1.0.22-SNAPSHOT
Builddate: 2024-01-18 20:31:16
Build: 39b609640aa290f7607089950ac3525ab09e6d1f
```