### PR TITLE
feat(jans-cli-tui): custom validation for attrbiutes

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/attributes.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/attributes.py
@@ -61,6 +61,37 @@ class Attributes(DialogUtils):
         """
         data = params['data']
 
+        def get_custom_validation_container(cb=None):
+            if getattr(cb, 'checked', False) or data.get('attributeValidation'):
+                self.custom_validation_container = HSplit([
+                                self.app.getTitledText(
+                                    title=_("    Regular Exprrssion"),
+                                    name='regexp',
+                                    value=data.get('attributeValidation',{}).get('regexp', ''),
+                                    style=cli_style.edit_text
+                                ),
+                                self.app.getTitledText(
+                                    title=_("    Minumum Lenght"),
+                                    name='minLength',
+                                    value=data.get('attributeValidation',{}).get('minLength', 8),
+                                    text_type='integer',
+                                    style=cli_style.edit_text
+                                ),
+                                self.app.getTitledText(
+                                    title=_("    Maximum Lenght"),
+                                    name='maxLength',
+                                    value=data.get('attributeValidation',{}).get('maxLength', 10),
+                                    text_type='integer',
+                                    style=cli_style.edit_text
+                                ),
+                                ],
+                                width=D()
+                            )
+            else:
+                self.custom_validation_container = HSplit([], width=D())
+
+        get_custom_validation_container()
+
         body = HSplit([
 
                 self.app.getTitledText(
@@ -163,6 +194,17 @@ class Attributes(DialogUtils):
                     style=cli_style.edit_text
                 ),
 
+                self.app.getTitledCheckBox(
+                    _("Enable Custom Validation"),
+                    name='enableCustomValidation',
+                    checked=bool(data.get('attributeValidation')),
+                    on_selection_changed=get_custom_validation_container,
+                    jans_help=_("Check this to enable custom validation"),
+                    style=cli_style.check_box
+                ),
+
+                DynamicContainer(lambda: self.custom_validation_container)
+
             ])
 
         save_button = Button(_("Save"), handler=self.save_attribute)
@@ -193,6 +235,12 @@ class Attributes(DialogUtils):
 
         if 'origin' not in new_data:
             new_data['origin'] = 'jansCustomPerson'
+
+        enable_custom_validation = new_data.pop('enableCustomValidation')
+        if enable_custom_validation:
+            new_data['attributeValidation'] = self.make_data_from_dialog({'attributeValidation': self.custom_validation_container})
+        else:
+            new_data.pop('attributeValidation', None)
 
         if self.check_required_fields(dialog.body, data=new_data):
             dialog.future.set_result(True)

--- a/jans-cli-tui/cli_tui/plugins/100_saml/main.py
+++ b/jans-cli-tui/cli_tui/plugins/100_saml/main.py
@@ -104,15 +104,6 @@ class Plugin(DialogUtils):
                             style=cli_style.titled_text
                         ),
 
-                    self.app.getTitledText(
-                        title=_("IDP Metadata File Pattern"),
-                        name='idpMetadataFilePattern',
-                        value=self.config.get('idpMetadataFilePattern', ''),
-                        style=cli_style.edit_text,
-                        jans_help=_("Pattern for saving metadata file"),
-                        widget_style=cli_style.black_bg_widget
-                    ),
-
                         self.app.getTitledCheckBox(_("Ignore Validation"), name='ignoreValidation', checked=self.config.get('ignoreValidation'), jans_help=self.app.get_help_from_schema(self.schema, 'ignoreValidation'), style=cli_style.check_box, widget_style=cli_style.black_bg_widget),
                         Window(height=1),
                         VSplit([Button(_("Save"), handler=self.save_config)], align=HorizontalAlign.CENTER),


### PR DESCRIPTION
closes #7590

![image](https://github.com/JanssenProject/jans/assets/6398752/9babaeb3-5108-4142-ab02-d1b8c99d8e85)

Also **idpMetadataFilePattern** is removed form SAML configuration (ref: https://github.com/JanssenProject/jans/pull/7569/files )