### PR TITLE
fix(jans-auth-server): client secret printed on logs

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
@@ -62,6 +62,7 @@ import java.util.HashSet;
 import java.util.function.Function;
 
 import static io.jans.as.model.config.Constants.*;
+import static io.jans.as.server.util.ServerUtil.prepareForLogs;
 import static org.apache.commons.lang.BooleanUtils.isFalse;
 import static org.apache.commons.lang.BooleanUtils.isTrue;
 
@@ -152,7 +153,7 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
         log.debug(
                 "Attempting to request access token: grantType = {}, code = {}, redirectUri = {}, username = {}, refreshToken = {}, " +
                         "clientId = {}, ExtraParams = {}, isSecure = {}, codeVerifier = {}, ticket = {}",
-                grantType, code, redirectUri, username, refreshToken, clientId, request.getParameterMap(),
+                grantType, code, redirectUri, username, refreshToken, clientId, prepareForLogs(request.getParameterMap()),
                 sec.isSecure(), codeVerifier, ticket);
 
         boolean isUma = StringUtils.isNotBlank(ticket);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/util/ServerUtil.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/util/ServerUtil.java
@@ -6,25 +6,6 @@
 
 package io.jans.as.server.util;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
-
-import org.apache.commons.lang.StringUtils;
-import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -32,7 +13,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
-
 import io.jans.as.common.service.common.ApplicationFactory;
 import io.jans.as.model.uma.persistence.UmaPermission;
 import io.jans.as.server.uma.service.UmaScopeService;
@@ -45,6 +25,20 @@ import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.CacheControl;
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * @author Yuriy Zabrovarnyy
@@ -70,6 +64,18 @@ public class ServerUtil {
     };
 
     private ServerUtil() {
+    }
+
+    public static Map<String, String[]> prepareForLogs(Map<String, String[]> parameters) {
+        if (parameters == null || parameters.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        Map<String, String[]> result = new HashMap<>(parameters);
+        if (result.containsKey("client_secret")) {
+            result.put("client_secret", new String[] {"*****"});
+        }
+        return result;
     }
 
     public static GregorianCalendar now() {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/util/ServerUtilTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/util/ServerUtilTest.java
@@ -1,0 +1,24 @@
+package io.jans.as.server.util;
+
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Yuriy Z
+ */
+public class ServerUtilTest {
+
+    @Test
+    public void prepareForLogs_whenCalled_shouldNotHaveClearTextClientPassword() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("client_secret", new String[] {"124"});
+
+        final Map<String, String[]> result = ServerUtil.prepareForLogs(parameters);
+
+        assertEquals("*****", result.get("client_secret")[0]);
+    }
+}

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -49,6 +49,9 @@
             <!-- SESSION -->
             <class name="io.jans.as.server.session.ws.rs.EndSessionRestWebServiceImplTest" />
             <class name="io.jans.as.server.session.ws.rs.EndSessionServiceTest" />
+
+            <!-- UTIL -->
+            <class name="io.jans.as.server.util.ServerUtilTest" />
         </classes>
     </test>
 


### PR DESCRIPTION
https://github.com/JanssenProject/jans/issues/4323

### Description

fix(jans-auth-server): client secret printed on logs

#### Target issue
  
closes #4323

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

