### PR TITLE
fix(docker-jans-certmanager): resolve key_ops_type created on key rotation

### DIFF
--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -280,11 +280,11 @@ class AuthHandler(BaseHandler):
                 continue
 
             # cannot have more than 2 connect keys for same algorithm in new JWKS
-            if ops_type == "connect" and cnt[jwk["alg"]] > 1:
+            if ops_type == "connect" and cnt[jwk["alg"]] >= 2:
                 continue
 
             # cannot have more than 1 connect keys for same algorithm in new JWKS
-            if ops_type == "ssa" and cnt_ssa[jwk["alg"]] > 0:
+            if ops_type == "ssa" and cnt_ssa[jwk["alg"]] >= 1:
                 continue
 
             # insert old key to new keys
@@ -369,6 +369,10 @@ class AuthHandler(BaseHandler):
             web_keys = json.loads(config["jansConfWebKeys"])
         except TypeError:
             web_keys = config["jansConfWebKeys"]
+        except json.decoder.JSONDecodeError as exc:
+            # probably corrupted JSON
+            logger.warning(f"Unable to load jansConfWebKeys; reason={exc}. New JWKS will be created and overwrite existing value.")
+            web_keys = {"keys": []}
 
         with open("/etc/certs/auth-keys.old.json", "w") as f:
             f.write(json.dumps(web_keys, indent=2))
@@ -520,6 +524,10 @@ class AuthHandler(BaseHandler):
             web_keys = json.loads(config["jansConfWebKeys"])
         except TypeError:
             web_keys = config["jansConfWebKeys"]
+        except json.decoder.JSONDecodeError as exc:
+            # probably corrupted JSON
+            logger.warning(f"Unable to load jansConfWebKeys; reason={exc}. Existing JWKS will be deleted.")
+            web_keys = {"keys": []}
 
         logger.info("Cleaning up keys (if any)")
 

--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -259,19 +259,21 @@ class AuthHandler(BaseHandler):
 
         # counter for `connect` keys
         cnt = Counter(
-            jwk["alg"] for jwk in new_jwks
+            jwk["alg"].upper() for jwk in new_jwks
             if key_ops_from_jwk(jwk) == "connect"
         )
 
         # counter for `ssa` keys
         cnt_ssa = Counter(
-            jwk["alg"] for jwk in new_jwks
+            jwk["alg"].upper() for jwk in new_jwks
             if key_ops_from_jwk(jwk) == "ssa"
         )
 
         for jwk in old_jwks:
+            alg = jwk.get("alg", "").upper()
+
             # exclude alg if it's not allowed
-            if jwk.get("alg") not in self.allowed_key_algs:
+            if alg not in self.allowed_key_algs:
                 continue
 
             ops_type = key_ops_from_jwk(jwk)
@@ -281,21 +283,21 @@ class AuthHandler(BaseHandler):
                 continue
 
             # cannot have more than 2 connect keys for same algorithm in new JWKS
-            if ops_type == "connect" and cnt[jwk["alg"]] >= 2:
+            if ops_type == "connect" and cnt[alg] >= 2:
                 continue
 
-            # cannot have more than 1 connect keys for same algorithm in new JWKS
-            if ops_type == "ssa" and cnt_ssa[jwk["alg"]] >= 1:
+            # cannot have more than 1 ssa keys for same algorithm in new JWKS
+            if ops_type == "ssa" and cnt_ssa[alg] >= 1:
                 continue
 
             # insert old key to new keys
             new_jwks.appendleft(jwk)
 
             if ops_type == "connect":
-                cnt[jwk["alg"]] += 1
+                cnt[alg] += 1
 
             if ops_type == "ssa":
-                cnt_ssa[jwk["alg"]] += 1
+                cnt_ssa[alg] += 1
 
             # import key to new JKS
             keytool_import_key(old_jks_fn, jks_fn, jwk["kid"], jks_pass)
@@ -544,30 +546,32 @@ class AuthHandler(BaseHandler):
         old_jwks = sorted(old_jwks, key=lambda k: k["exp"], reverse=True)
 
         cnt = Counter(
-            jwk["alg"] for jwk in new_jwks
+            jwk["alg"].upper() for jwk in new_jwks
             if key_ops_from_jwk(jwk) == "connect"
         )
 
         cnt_ssa = Counter(
-            jwk["alg"] for jwk in new_jwks
+            jwk["alg"].upper() for jwk in new_jwks
             if key_ops_from_jwk(jwk) == "ssa"
         )
 
         for jwk in old_jwks:
+            alg = jwk.get("alg", "").upper()
+
             # exclude alg if it's not allowed
-            if jwk.get("alg") not in self.allowed_key_algs:
+            if alg not in self.allowed_key_algs:
                 keytool_delete_key(jks_fn, jwk["kid"], jks_pass)
                 continue
 
             ops_type = key_ops_from_jwk(jwk)
 
-            # cannot have more than 1 key for same algorithm in new JWKS
-            if ops_type == "connect" and cnt[jwk["alg"]]:
+            # cannot have more than 1 connect key for same algorithm in new JWKS
+            if ops_type == "connect" and cnt[alg] >= 1:
                 keytool_delete_key(jks_fn, jwk["kid"], jks_pass)
                 continue
 
-            # cannot have more than 1 key for same algorithm in new JWKS
-            if ops_type == "ssa" and cnt_ssa[jwk["alg"]]:
+            # cannot have more than 1 ssa key for same algorithm in new JWKS
+            if ops_type == "ssa" and cnt_ssa[alg] >= 1:
                 keytool_delete_key(jks_fn, jwk["kid"], jks_pass)
                 continue
 
@@ -575,10 +579,10 @@ class AuthHandler(BaseHandler):
             new_jwks.append(jwk)
 
             if ops_type == "connect":
-                cnt[jwk["alg"]] += 1
+                cnt[alg] += 1
 
             if ops_type == "ssa":
-                cnt_ssa[jwk["alg"]] += 1
+                cnt_ssa[alg] += 1
 
         web_keys["keys"] = new_jwks
 

--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -270,7 +270,7 @@ class AuthHandler(BaseHandler):
 
         for jwk in old_jwks:
             # exclude alg if it's not allowed
-            if jwk["alg"] not in self.allowed_key_algs:
+            if jwk.get("alg") not in self.allowed_key_algs:
                 continue
 
             ops_type = key_ops_from_jwk(jwk)

--- a/docker-jans-certmanager/scripts/auth_handler.py
+++ b/docker-jans-certmanager/scripts/auth_handler.py
@@ -230,6 +230,7 @@ class AuthHandler(BaseHandler):
 
         # a counter to determine value of `key_ops_type` to be passed to `KeyGenerator`
         ops_type_cnt = Counter(key_ops_from_jwk(jwk) for jwk in old_jwks)
+        logger.info(f"Detected key_ops_type={dict(ops_type_cnt)}")
 
         # if we have ssa key, use `connect` keys
         if ops_type_cnt["ssa"]:
@@ -371,7 +372,7 @@ class AuthHandler(BaseHandler):
             web_keys = config["jansConfWebKeys"]
         except json.decoder.JSONDecodeError as exc:
             # probably corrupted JSON
-            logger.warning(f"Unable to load jansConfWebKeys; reason={exc}. New JWKS will be created and overwrite existing value.")
+            logger.warning(f"Unable to load existing JWKS; reason={exc}. New JWKS will be created.")
             web_keys = {"keys": []}
 
         with open("/etc/certs/auth-keys.old.json", "w") as f:
@@ -526,7 +527,7 @@ class AuthHandler(BaseHandler):
             web_keys = config["jansConfWebKeys"]
         except json.decoder.JSONDecodeError as exc:
             # probably corrupted JSON
-            logger.warning(f"Unable to load jansConfWebKeys; reason={exc}. Existing JWKS will be deleted.")
+            logger.warning(f"Unable to load existing JWKS; reason={exc}. Existing JWKS will be deleted.")
             web_keys = {"keys": []}
 
         logger.info("Cleaning up keys (if any)")
@@ -712,7 +713,7 @@ def key_ops_from_jwk(jwk):
             type_ = "ssa"
         else:
             type_ = ""
-    return type_
+    return type_.lower()
 
 
 def has_ext_jwks_uri(conf_dynamic, manager) -> bool:


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #7711 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

- Ensure checking lowercased `key_ops_type`
- Ensure checking uppercased JWK algorithm
- Delete and/or recreate corrupted JWKS

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

