### PR TITLE
feat(jans-cli-tui): log command for delete operation

### DIFF
--- a/jans-cli-tui/cli_tui/cli/config_cli.py
+++ b/jans-cli-tui/cli_tui/cli/config_cli.py
@@ -1315,7 +1315,7 @@ class JCA_CLI:
             else:
                 cmd_data = self.get_json_from_file(data_fn)
 
-        if call_method in ('post', 'put', 'patch'):
+        if call_method in ('post', 'put', 'patch', 'delete'):
             self.log_cmd(operation_id, url_suffix, endpoint_args, cmd_data)
 
         if path['__path__'] == '/admin-ui/adminUIPermissions' and data and 'permission' in data:


### PR DESCRIPTION
closes #7716
Write operations **post**, **put**, **patch** were written to file `cli_cmd.log` in logging directory. Only **delete** operation was added in this PR.