### PR TITLE
fix(docs): changes to add content in script block instead of overwriting

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block scripts %}
-
+{{ super() }}
 <!--Release automation scripts should replace the placeholder with actual URL-->
 <!--for Scarf pixel. This will be done when docs are released into PROD. Not-->
 <!--when releasing for HEAD or nightly builds. This is to ensure that Scarf -->


### PR DESCRIPTION
Adding `super()` will first add the content in the script block as usual plus add the content `img`. More details [here](https://squidfunk.github.io/mkdocs-material/customization/#overriding-blocks)

Breakage was introduced by #7765 

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #7838 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

