### PR TITLE
chore(jans-bom): upgrade org.postgresql:postgresql from 42.6.0 to 42.6.1 #7924

### DIFF
--- a/jans-bom/pom.xml
+++ b/jans-bom/pom.xml
@@ -784,7 +784,7 @@
 			<dependency>
 			    <groupId>org.postgresql</groupId>
 			    <artifactId>postgresql</artifactId>
-			    <version>42.6.0</version>
+			    <version>42.6.1</version>
 			</dependency>
 
 			<!-- SQL Query -->


### PR DESCRIPTION
### Description

upgrade org.postgresql:postgresql from 42.6.0 to 42.6.1 

#### Target issue
  
closes #7924

