### PR TITLE
feat(jans-auth-server): added ability to propagate session from authz challenge script to grant object #6864

### DIFF
--- a/docs/admin/auth-server/endpoints/authorization-challenge.md
+++ b/docs/admin/auth-server/endpoints/authorization-challenge.md
@@ -152,6 +152,29 @@ deviceSessionObject.getAttributes().getAttributes().put("client_id", clientId);
 
 Full sample script can be found [here](../../../script-catalog/authorization_challenge/AuthorizationChallenge.java)
 
+## Web session
+
+Authorization challenge script is first-party flow and thus web session is not created by default. 
+However there can be cases when such session has to be created. Please set **authorizationChallengeShouldGenerateSession** configuration property to **true**
+to force session creation. 
+
+In case it is needed to prepare session with specific data, it is possible to create session
+in script and set it into context. Example:
+
+```java
+SessionIdService sessionIdService = CdiUtil.bean(SessionIdService.class);
+Identity identityService = CdiUtil.bean(Identity.class);
+
+Map<String, String> sessionStore = new HashMap<String, String>();
+sessionStore.put("login_id_token",login_id_token);
+sessionStore.put("login_access_token",login_access_token);
+sessionStore.put("transaction_status","PENDING");
+SessionId sessionId = sessionIdService.generateAuthenticatedSessionId(context.getHttpRequest(), user.getDn(), sessionStore);
+
+context.getExecutionContext().setAuthorizationChallengeSessionId(sessionId);
+scriptLogger.trace("Created Authorization challenge session successfully");
+``` 
+
 ## Multi-step example
 
 Sometimes it's required to send data sequentially. Step by step. Calls to Authorization Challenge Endpoint must have 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/ExecutionContext.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/ExecutionContext.java
@@ -44,6 +44,7 @@ public class ExecutionContext {
 
     private SessionId sessionId;
     private List<SessionId> currentSessions;
+    private SessionId authorizationChallengeSessionId;
 
     private AuthzRequest authzRequest;
     private AuthzDetails authzDetails;
@@ -127,6 +128,7 @@ public class ExecutionContext {
         executionContext.user = context.user;
         executionContext.sessionId = context.sessionId;
         executionContext.currentSessions = context.currentSessions;
+        executionContext.authorizationChallengeSessionId = context.authorizationChallengeSessionId;
         executionContext.authzRequest = context.authzRequest;
         executionContext.authzDetails = context.authzDetails;
         executionContext.authzDetail = context.authzDetail;
@@ -190,6 +192,14 @@ public class ExecutionContext {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public SessionId getAuthorizationChallengeSessionId() {
+        return authorizationChallengeSessionId;
+    }
+
+    public void setAuthorizationChallengeSessionId(SessionId authorizationChallengeSessionId) {
+        this.authorizationChallengeSessionId = authorizationChallengeSessionId;
     }
 
     public List<SessionId> getCurrentSessions() {


### PR DESCRIPTION
### Description

feat(jans-auth-server): added ability to propagate session from authz challenge script to grant object 

#### Target issue
  
closes #6864

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

