### PR TITLE
chore(jans-auth-server): fix typo build-oxauth-fips-war #8036

### DIFF
--- a/jans-auth-server/server-fips/pom.xml
+++ b/jans-auth-server/server-fips/pom.xml
@@ -52,7 +52,7 @@
 				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>build-oxauth-fips-war</id>
+						<id>build-auth-server-fips-war</id>
 						<phase>prepare-package</phase>
 						<configuration>
 							<target>

--- a/jans-config-api/server-fips/pom.xml
+++ b/jans-config-api/server-fips/pom.xml
@@ -52,7 +52,7 @@
 				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>build-oxauth-fips-war</id>
+						<id>build-configapi-fips-war</id>
 						<phase>process-sources</phase>
 						<configuration>
 							<target>


### PR DESCRIPTION
### Description

chore(jans-auth-server): fix typo build-oxauth-fips-war 

#### Target issue
  
closes #8036

