### PR TITLE
fix(jans-casa): wrong endpoint to retrieve userinfo in accts linking plugin

### DIFF
--- a/docs/casa/plugins/accts-linking/account-linking-index.md
+++ b/docs/casa/plugins/accts-linking/account-linking-index.md
@@ -19,6 +19,9 @@ From the perspective of a user already logged into Casa, the experience is as fo
 
 ## Components deployment
 
+!!! Note
+    Ensure you are running at least version 1.1.1 of Jans Authentication Server and Casa
+
 The pieces that allow materialization of the experience summarized above are the following:
 
 a) The Casa plugin jar file

--- a/jans-auth-server/agama/inboundID/pom.xml
+++ b/jans-auth-server/agama/inboundID/pom.xml
@@ -65,22 +65,6 @@
         <!-- JANSSEN -->
         <dependency>
             <groupId>io.jans</groupId>
-            <artifactId>jans-core-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jans</groupId>
-            <artifactId>jans-core-service</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jans</groupId>
-            <artifactId>jans-orm-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jans</groupId>
-            <artifactId>jans-orm-model</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jans</groupId>
             <artifactId>jans-auth-common</artifactId>
         </dependency>
 

--- a/jans-auth-server/agama/inboundID/src/main/java/io/jans/inbound/ConfigProcessor.java
+++ b/jans-auth-server/agama/inboundID/src/main/java/io/jans/inbound/ConfigProcessor.java
@@ -100,7 +100,7 @@ public class ConfigProcessor {
         s = oap.getUserInfoEndpoint();
         if (s == null) {
             logger.info("Grabbing userInfo endpoint from OP configuration document");
-            oap.setUserInfoEndpoint(opMetadata.getAuthorizationEndpointURI().toString());
+            oap.setUserInfoEndpoint(opMetadata.getUserInfoEndpointURI().toString());
         }
         
         s = oap.getRedirectUri();

--- a/jans-casa/plugins/acct-linking/extras/agama/lib/io/jans/casa/acctlinking/UidUtils.java
+++ b/jans-casa/plugins/acct-linking/extras/agama/lib/io/jans/casa/acctlinking/UidUtils.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 
 public class UidUtils {
     
-    private static final Logger logger = LoggerFactory.getLogger(Utils.class);
+    private static final Logger logger = LoggerFactory.getLogger(UidUtils.class);
     
     public static String lookupUid(String uidRef, String uid, String extUid, String jansExtAttrName,
             String jansExtUid) throws IOException {


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #8184

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

