### PR TITLE
fix(config-api): user mgt error for duplicate jansStatus issue

### DIFF
--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -8219,19 +8219,19 @@ components:
           type: string
         selected:
           type: boolean
-        whitePagesCanView:
+        adminCanView:
           type: boolean
         adminCanEdit:
-          type: boolean
-        adminCanView:
           type: boolean
         userCanView:
           type: boolean
         userCanEdit:
           type: boolean
+        userCanAccess:
+          type: boolean
         adminCanAccess:
           type: boolean
-        userCanAccess:
+        whitePagesCanView:
           type: boolean
         baseDn:
           type: string
@@ -10519,10 +10519,10 @@ components:
         ttl:
           type: integer
           format: int32
-        persisted:
-          type: boolean
         opbrowserState:
           type: string
+        persisted:
+          type: boolean
     SessionIdAccessMap:
       type: object
       properties:

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -8219,19 +8219,19 @@ components:
           type: string
         selected:
           type: boolean
-        userCanView:
+        whitePagesCanView:
           type: boolean
         adminCanEdit:
           type: boolean
-        userCanEdit:
-          type: boolean
         adminCanView:
           type: boolean
-        userCanAccess:
+        userCanView:
+          type: boolean
+        userCanEdit:
           type: boolean
         adminCanAccess:
           type: boolean
-        whitePagesCanView:
+        userCanAccess:
           type: boolean
         baseDn:
           type: string
@@ -9053,8 +9053,6 @@ components:
           type: boolean
         lockMessageConfig:
           $ref: '#/components/schemas/LockMessageConfig'
-        fapi:
-          type: boolean
         allResponseTypesSupported:
           uniqueItems: true
           type: array
@@ -9064,6 +9062,8 @@ components:
             - code
             - token
             - id_token
+        fapi:
+          type: boolean
     AuthenticationFilter:
       required:
       - baseDn
@@ -9830,10 +9830,10 @@ components:
           type: array
           items:
             type: object
-        displayValue:
-          type: string
         value:
           type: object
+        displayValue:
+          type: string
     LocalizedString:
       type: object
       properties:
@@ -10519,10 +10519,10 @@ components:
         ttl:
           type: integer
           format: int32
-        opbrowserState:
-          type: string
         persisted:
           type: boolean
+        opbrowserState:
+          type: string
     SessionIdAccessMap:
       type: object
       properties:

--- a/jans-config-api/plugins/docs/user-mgt-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/user-mgt-plugin-swagger.yaml
@@ -863,10 +863,10 @@ components:
           type: array
           items:
             type: object
-        displayValue:
-          type: string
         value:
           type: object
+        displayValue:
+          type: string
     CustomUser:
       type: object
       properties:
@@ -913,6 +913,11 @@ components:
           type: string
         jansStatus:
           type: string
+          enum:
+          - active
+          - inactive
+          - expired
+          - register
         givenName:
           type: string
         userPassword:

--- a/jans-config-api/plugins/docs/user-mgt-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/user-mgt-plugin-swagger.yaml
@@ -911,13 +911,6 @@ components:
           type: string
         displayName:
           type: string
-        jansStatus:
-          type: string
-          enum:
-          - active
-          - inactive
-          - expired
-          - register
         givenName:
           type: string
         userPassword:

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/model/user/CustomUser.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/model/user/CustomUser.java
@@ -3,6 +3,7 @@ package io.jans.configapi.plugin.mgt.model.user;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.jans.as.common.model.common.User;
+import io.jans.model.GluuStatus;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CustomUser extends User {
@@ -12,7 +13,7 @@ public class CustomUser extends User {
     private String inum;
     private String mail;
     private String displayName;
-    private String jansStatus;
+    private GluuStatus jansStatus;
     private String givenName;
     private String userPassword;
     
@@ -41,11 +42,11 @@ public class CustomUser extends User {
         this.displayName = displayName;
     }
     
-    public String getJansStatus() {
+    public GluuStatus getJansStatus() {
         return jansStatus;
     }
     
-    public void setJansStatus(String jansStatus) {
+    public void setJansStatus(GluuStatus jansStatus) {
         this.jansStatus = jansStatus;
     }
     

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/model/user/CustomUser.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/model/user/CustomUser.java
@@ -13,7 +13,6 @@ public class CustomUser extends User {
     private String inum;
     private String mail;
     private String displayName;
-    private GluuStatus jansStatus;
     private String givenName;
     private String userPassword;
     
@@ -41,15 +40,7 @@ public class CustomUser extends User {
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
     }
-    
-    public GluuStatus getJansStatus() {
-        return jansStatus;
-    }
-    
-    public void setJansStatus(GluuStatus jansStatus) {
-        this.jansStatus = jansStatus;
-    }
-    
+       
     public String getGivenName() {
         return givenName;
     }
@@ -68,8 +59,8 @@ public class CustomUser extends User {
     
     @Override
     public String toString() {
-        return "CustomUser [inum=" + inum + ", mail=" + mail + ", displayName=" + displayName + ", jansStatus="
-                + jansStatus + ", givenName=" + givenName + ", userPassword=" + userPassword + "]";
+        return "CustomUser [inum=" + inum + ", mail=" + mail + ", displayName=" + displayName 
+                + ", givenName=" + givenName + ", userPassword=" + userPassword + "]";
     }
     
     

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/model/user/CustomUser.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/model/user/CustomUser.java
@@ -3,7 +3,6 @@ package io.jans.configapi.plugin.mgt.model.user;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.jans.as.common.model.common.User;
-import io.jans.model.GluuStatus;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CustomUser extends User {

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/rest/UserResource.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/rest/UserResource.java
@@ -53,7 +53,6 @@ public class UserResource extends BaseResource {
     private static final String USER = "user";
     private static final String MAIL = "mail";
     private static final String DISPLAY_NAME = "displayName";
-    private static final String JANS_STATUS = "jansStatus";
     private static final String GIVEN_NAME = "givenName";
     private static final String USER_PWD = "userPassword";
     private static final String INUM = "inum";

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/rest/UserResource.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/rest/UserResource.java
@@ -177,7 +177,7 @@ public class UserResource extends BaseResource {
         logger.info("newly created customUser:{}", customUser);
         }catch(WebApplicationException wex) {
             logger.error("ApplicationException while creating user is:{}, cause:{}", wex, wex.getCause());
-            throwInternalServerException("USER_CREATION_ERROR", wex.getMessage());
+            throwInternalServerException("USER_CREATION_ERROR", wex);
         }catch(Exception ex) {
             logger.error("Exception while creating user is:{}, cause:{}", ex, ex.getCause());
             throwInternalServerException(ex);
@@ -400,7 +400,7 @@ public class UserResource extends BaseResource {
         customUser.setOxAuthPersistentJwt(user.getOxAuthPersistentJwt());
         customUser.setUpdatedAt(user.getUpdatedAt());
         customUser.setUserId(user.getUserId());
-
+        customUser.setStatus(user.getStatus());
         ignoreCustomAttributes(customUser, removeNonLDAPAttributes);
         return setCustomUserAttributes(customUser, user);
     }
@@ -408,14 +408,12 @@ public class UserResource extends BaseResource {
     public CustomUser setCustomUserAttributes(CustomUser customUser, User user) {
         customUser.setMail(user.getAttribute(MAIL));
         customUser.setDisplayName(user.getAttribute(DISPLAY_NAME));
-        customUser.setJansStatus(user.getAttribute(JANS_STATUS));
         customUser.setGivenName(user.getAttribute(GIVEN_NAME));
         customUser.setUserPassword(user.getAttribute(USER_PWD));
         customUser.setInum(user.getAttribute(INUM));
 
         customUser.removeAttribute(MAIL);
         customUser.removeAttribute(DISPLAY_NAME);
-        customUser.removeAttribute(JANS_STATUS);
         customUser.removeAttribute(GIVEN_NAME);
         customUser.removeAttribute(USER_PWD);
         customUser.removeAttribute(INUM);
@@ -433,6 +431,8 @@ public class UserResource extends BaseResource {
         user.setOxAuthPersistentJwt(customUser.getOxAuthPersistentJwt());
         user.setUpdatedAt(customUser.getUpdatedAt());
         user.setUserId(customUser.getUserId());
+        user.setStatus(customUser.getJansStatus());
+               
         return setUserCustomAttributes(customUser, user);
     }
 
@@ -442,20 +442,19 @@ public class UserResource extends BaseResource {
         }
         
         user.setAttribute(DISPLAY_NAME, customUser.getDisplayName(), false);
-        user.setAttribute(JANS_STATUS, customUser.getJansStatus(), false);
         user.setAttribute(GIVEN_NAME, customUser.getGivenName(), false);
-        
         if(StringUtils.isNotBlank(customUser.getUserPassword())) {  
             user.setAttribute(USER_PWD, customUser.getUserPassword(), false);
         }
-        user.setAttribute(INUM, customUser.getInum(), false);
-
-        logger.debug("Custom User - user:{}", user);
+        if(StringUtils.isNotBlank(customUser.getInum())) {    
+            user.setAttribute(INUM, customUser.getInum(), false);
+        }
+        
         return user;
     }
 
     private User ignoreCustomAttributes(User user, boolean removeNonLDAPAttributes) {
-        logger.debug(
+        logger.info(
                 "** validate User CustomObjectClasses - User user:{}, removeNonLDAPAttributes:{}, user.getCustomObjectClasses():{}, userMgmtSrv.getPersistenceType():{}, userMgmtSrv.isLDAP():?{}",
                 user, removeNonLDAPAttributes, user.getCustomObjectClasses(), userMgmtSrv.getPersistenceType(),
                 userMgmtSrv.isLDAP());

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/rest/UserResource.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/rest/UserResource.java
@@ -152,7 +152,6 @@ public class UserResource extends BaseResource {
                     removeNonLDAPAttributes);
         }
 
-        try {
         // get User object
         User user = setUserAttributes(customUser);
 
@@ -166,15 +165,17 @@ public class UserResource extends BaseResource {
         validateAttributes(user);
 
         logger.info("Service call to create user:{}", user);
-        user = userMgmtSrv.addUser(user, true);
-        logger.info("User created {}", user);
 
-        // excludedAttributes
-        user = excludeUserAttributes(user);
+        try {
+            user = userMgmtSrv.addUser(user, true);
+            logger.info("User created {}", user);
 
-        // get custom user
-        customUser = getCustomUser(user, removeNonLDAPAttributes);
-        logger.info("newly created customUser:{}", customUser);
+            // excludedAttributes
+            user = excludeUserAttributes(user);
+
+            // get custom user
+            customUser = getCustomUser(user, removeNonLDAPAttributes);
+            logger.info("newly created customUser:{}", customUser);
         }catch(WebApplicationException wex) {
             logger.error("ApplicationException while creating user is:{}, cause:{}", wex, wex.getCause());
             throwInternalServerException("USER_CREATION_ERROR", wex);
@@ -207,21 +208,22 @@ public class UserResource extends BaseResource {
                     removeNonLDAPAttributes);
         }
 
+      
+        // get User object
+        User user = setUserAttributes(customUser);
+
+        // parse birthdate if present
+        userMgmtSrv.parseBirthDateAttribute(user);
+        logger.debug("Create  user:{}", user);
+
+        // checking mandatory attributes
+        List<String> excludeAttributes = List.of(USER_PWD);
+        checkMissingAttributes(user, excludeAttributes);
+        ignoreCustomAttributes(user, removeNonLDAPAttributes);
+        validateAttributes(user);
+
+        logger.info("Call update user:{}", user);
         try {
-            // get User object
-            User user = setUserAttributes(customUser);
-
-            // parse birthdate if present
-            userMgmtSrv.parseBirthDateAttribute(user);
-            logger.debug("Create  user:{}", user);
-
-            // checking mandatory attributes
-            List<String> excludeAttributes = List.of(USER_PWD);
-            checkMissingAttributes(user, excludeAttributes);
-            ignoreCustomAttributes(user, removeNonLDAPAttributes);
-            validateAttributes(user);
-
-            logger.info("Call update user:{}", user);
             user = userMgmtSrv.updateUser(user);
             logger.info("Updated user:{}", user);
 
@@ -411,6 +413,7 @@ public class UserResource extends BaseResource {
         customUser.setGivenName(user.getAttribute(GIVEN_NAME));
         customUser.setUserPassword(user.getAttribute(USER_PWD));
         customUser.setInum(user.getAttribute(INUM));
+        customUser.setStatus(user.getStatus());
 
         customUser.removeAttribute(MAIL);
         customUser.removeAttribute(DISPLAY_NAME);
@@ -431,8 +434,8 @@ public class UserResource extends BaseResource {
         user.setOxAuthPersistentJwt(customUser.getOxAuthPersistentJwt());
         user.setUpdatedAt(customUser.getUpdatedAt());
         user.setUserId(customUser.getUserId());
-        user.setStatus(customUser.getJansStatus());
-               
+        user.setStatus(customUser.getStatus());     
+        
         return setUserCustomAttributes(customUser, user);
     }
 

--- a/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/service/UserMgmtService.java
+++ b/jans-config-api/plugins/user-mgt-plugin/src/main/java/io/jans/configapi/plugin/mgt/service/UserMgmtService.java
@@ -504,15 +504,18 @@ public class UserMgmtService {
             logger.info("customObjectAttribute:{}, customObjectAttribute.getName():{}", customObjectAttribute, customObjectAttribute.getName());
             JansAttribute attribute = attributeService.getAttributeByName(customObjectAttribute.getName());
             AttributeValidation validation = null;
-            if(attribute!=null) {
+            if (attribute != null) {
                 validation = attribute.getAttributeValidation();
             }
-            logger.info("customObjectAttribute.getName():{}, validation:{}", customObjectAttribute.getName(), validation);
-
-            String errorMsg = validateCustomAttributes(customObjectAttribute, validation);
-            logger.info("customObjectAttribute.getName():{}, errorMsg:{}", customObjectAttribute.getName(), errorMsg);
-            if (StringUtils.isNotBlank(errorMsg)) {
-                sb.append(errorMsg);
+            logger.info("customObjectAttribute.getName():{}, validation:{}", customObjectAttribute.getName(),
+                    validation);
+            if (validation != null) {
+                String errorMsg = validateCustomAttributes(customObjectAttribute, validation);
+                logger.info("customObjectAttribute.getName():{}, errorMsg:{}", customObjectAttribute.getName(),
+                        errorMsg);
+                if (StringUtils.isNotBlank(errorMsg)) {
+                    sb.append(errorMsg);
+                }
             }
         }
 

--- a/jans-config-api/pom.xml
+++ b/jans-config-api/pom.xml
@@ -245,10 +245,6 @@
 
 			<!-- Security -->
 			<dependency>
-				<groupId>com.nimbusds</groupId>
-				<artifactId>nimbus-jose-jwt</artifactId>
-			</dependency>
-			<dependency>
 				<groupId>org.bitbucket.b_c</groupId>
 				<artifactId>jose4j</artifactId>
 				<version>0.9.3</version>

--- a/jans-config-api/server/pom.xml
+++ b/jans-config-api/server/pom.xml
@@ -566,10 +566,6 @@
 					<scope>test</scope>
 				</dependency>
 				<dependency>
-					<groupId>com.nimbusds</groupId>
-					<artifactId>nimbus-jose-jwt</artifactId>
-				</dependency>
-				<dependency>
 					<groupId>org.bitbucket.b_c</groupId>
 					<artifactId>jose4j</artifactId>
 				</dependency>

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/AssetResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/AssetResource.java
@@ -177,7 +177,7 @@ public class AssetResource extends ConfigBaseResource {
             log.debug(" Fetched  assetStream:{} ", assetStream);
         } catch (Exception ex) {
             log.error("Application Error while reading asset stream is - status:{}", ex.getMessage());
-            throwInternalServerException(APPLICATION_ERROR, ex.getMessage());
+            throwInternalServerException(APPLICATION_ERROR, ex);
         }
         return Response.status(Response.Status.OK).entity(assetStream).build();
     }
@@ -229,7 +229,7 @@ public class AssetResource extends ConfigBaseResource {
             log.debug("Saved asset:{} ", asset);
         } catch (Exception ex) {
             log.error("Application Error while creating asset is - status:{}", ex.getMessage());
-            throwInternalServerException(APPLICATION_ERROR, ex.getMessage());
+            throwInternalServerException(APPLICATION_ERROR, ex);
         }
 
         log.info("Create IdentityProvider - asset:{}", asset);
@@ -289,7 +289,7 @@ public class AssetResource extends ConfigBaseResource {
             log.debug(" Updated asset:{} ", asset);
         } catch (Exception ex) {
             log.error("Application Error while updated asset is:{}", ex.getMessage());
-            throwInternalServerException(APPLICATION_ERROR, ex.getMessage());
+            throwInternalServerException(APPLICATION_ERROR, ex);
         }
 
         log.info("Updated asset:{}", asset);
@@ -320,7 +320,7 @@ public class AssetResource extends ConfigBaseResource {
             if (ex instanceof NotFoundException) {
                 throwNotFoundException(NOT_FOUND_ERROR, ex.getMessage());
             }
-            throwInternalServerException(APPLICATION_ERROR, ex.getMessage());
+            throwInternalServerException(APPLICATION_ERROR, ex);
         }
         return Response.noContent().build();
 

--- a/jans-config-api/server/src/main/java/io/jans/configapi/service/auth/AssetService.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/service/auth/AssetService.java
@@ -172,7 +172,7 @@ public class AssetService {
         // Get final asset
         List<Document >assets = this.getAssetByName(asset.getDisplayName());
         if(assets==null) {
-            throw new WebApplicationException(" Error while saving asset");
+            throw new WebApplicationException(" Could not  save asset");
         }
         asset = assets.get(0);
         log.info("\n * Asset saved :{}", asset);
@@ -233,7 +233,7 @@ public class AssetService {
     }
 
     private Document updateAsset(Document asset, InputStream documentStream) throws Exception {
-        log.info("Update new asset - asset:{}, documentStream:{}", asset, documentStream);
+        log.info("Update an asset - asset:{}, documentStream:{}", asset, documentStream);
         if (asset == null) {
             throw new InvalidAttributeException(" Asset object is null!!!");
         }

--- a/jans-config-api/shared/src/main/java/io/jans/configapi/core/rest/BaseResource.java
+++ b/jans-config-api/shared/src/main/java/io/jans/configapi/core/rest/BaseResource.java
@@ -139,6 +139,13 @@ public class BaseResource {
     public static void throwInternalServerException(String msg, String description) {
         throw new InternalServerErrorException(getInternalServerException(msg, description));
     }
+    
+    public static void throwInternalServerException(String msg, Throwable throwable) {
+        throwable = findRootError(throwable);
+        if (throwable != null) {
+            throw new InternalServerErrorException(getInternalServerException(msg, throwable.getMessage()));
+        }
+    }
 
     public static void throwInternalServerException(Throwable throwable) {
         throwable = findRootError(throwable);


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
User creation was failing with error as duplicate `jansStatus` column.  It seems that a `status` attribute was added at base level which was earlier at customAttribute level causing the error. 

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #8258

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

