### PR TITLE
feat(jans-cli-tui): display agama project configuration

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/agama.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/agama.py
@@ -8,13 +8,14 @@ from typing import Any
 from types import SimpleNamespace
 from prompt_toolkit.application import Application
 from prompt_toolkit.eventloop import get_event_loop
+from prompt_toolkit.layout import ScrollablePane
 from prompt_toolkit.layout.dimension import D
 from prompt_toolkit.lexers import PygmentsLexer, DynamicLexer
 
 from prompt_toolkit.layout.containers import HSplit, VSplit, DynamicContainer, Window
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.formatted_text import HTML
-from prompt_toolkit.widgets import Button, Label, TextArea, Box
+from prompt_toolkit.widgets import Button, Label, TextArea, Box, Frame
 
 from utils.multi_lang import _
 from utils.utils import DialogUtils, fromisoformat, get_help_with
@@ -399,10 +400,20 @@ class Agama(DialogUtils):
         project_name = params['data']['details']['projectMetadata'].get('projectName')
 
         async def coroutine():
-            cli_args = {'operation_id': 'get-agama-prj-by-name', 'url_suffix': 'name:{}'.format(project_name)}
+            cli_args = {'operation_id': 'get-agama-prj-by-name', 'url_suffix': f'name:{project_name}'}
             self.app.start_progressing(_("Retrieving details for project {}".format(project_name)))
             response = await get_event_loop().run_in_executor(self.app.executor, self.app.cli_requests, cli_args)
             self.app.stop_progressing()
+
+            cli_args_config = {'operation_id': 'get-agama-prj-configs', 'url_suffix':f'name:{project_name}'}
+            self.app.start_progressing(_("Retrieving project configuration..."))
+            response_config = await get_event_loop().run_in_executor(self.app.executor, self.app.cli_requests, cli_args_config)
+            self.app.stop_progressing()
+
+            try:
+                result_config = response_config.json()
+            except Exception as e:
+                result_config = None
 
             if response.status_code == 200:
 
@@ -418,18 +429,43 @@ class Agama(DialogUtils):
                     ]
 
                 flow_errors = result['details'].get('flowsError', {})
-
+                buttons = [Button(_("Close"))]
 
                 if flow_errors:
                     jans_table = JansTableWidget(
                         app=self.app,
                         data=list(flow_errors.items()),
                         headers=["Flow", "Error"],
+                        max_height=D(),
                         )
                     body_widgets.append(jans_table)
 
-                buttons = [Button(_("Close"))]
-                dialog = JansGDialog(self.app, body=HSplit(body_widgets), title=_("Details of project {}").format(project_name), buttons=buttons)
+                if result_config:
+                    def show_config(dialog):
+                        config_text_area = TextArea(
+                            lexer=DynamicLexer(lambda: PygmentsLexer.from_filename('.json', sync_from_start=True)),
+                            scrollbar=True,
+                            line_numbers=True,
+                            multiline=True,
+                            read_only=True,
+                            text=str(json.dumps(result_config, indent=2)
+                            )
+                        )
+
+                        config_dialog = JansGDialog(self.app, body=HSplit([config_text_area]), title=_("Project Configuration"), buttons=[Button(_("Close"))])
+                        self.app.show_jans_dialog(config_dialog)
+
+                    config_button_label = _("View Configuration")
+                    config_button = Button(config_button_label, width=len(config_button_label)+4, handler=show_config)
+                    config_button.keep_dialog = True
+                    buttons.append(config_button)
+
+                dialog = JansGDialog(
+                        self.app, 
+                        body=ScrollablePane(content=HSplit(body_widgets), height=self.app.dialog_height, display_arrows=False, show_scrollbar=True),
+                        title=_("Details of project {}").format(project_name),
+                        buttons=buttons
+                        )
                 self.app.show_jans_dialog(dialog)
 
 


### PR DESCRIPTION
As explained in #7782 , if agama project has configuration, there will be **View Configuration** button in Details popup.

![project_configuration](https://github.com/JanssenProject/jans/assets/6398752/68f6e6d5-9472-49f0-b5b4-421a74c69389)

Closes #8352, 