### PR TITLE
feat(jans-auth): removed extra info from `acr` claim in `id_token` when it's an agama flow

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/AcrService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/AcrService.java
@@ -52,12 +52,32 @@ public class AcrService {
     }
 
     public void validateAcrs(AuthzRequest authzRequest, Client client) throws AcrChangedException {
+        removeParametersForAgamaAcr(authzRequest);
+
         applyAcrMappings(authzRequest);
 
         checkClientAuthorizedAcrs(authzRequest, client);
 
         checkAcrScriptIsAvailable(authzRequest);
         checkAcrChanged(authzRequest, identity.getSessionId()); // check after redirect uri is validated
+    }
+
+    public static void removeParametersForAgamaAcr(AuthzRequest authzRequest) {
+        final List<String> acrValues = authzRequest.getAcrValuesList();
+        for (int i = 0; i < acrValues.size(); i++) {
+            final String acr = acrValues.get(i);
+            acrValues.set(i, removeParametersFromAgamaAcr(acr));
+        }
+
+        final String result = implode(acrValues, " ");
+        authzRequest.setAcrValues(result);
+    }
+
+    public static String removeParametersFromAgamaAcr(String acr) {
+        if (isAgama(acr)) {
+            return StringUtils.substringBefore(acr, "-");
+        }
+        return acr;
     }
 
     public void checkClientAuthorizedAcrs(AuthzRequest authzRequest, Client client) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/AcrServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/AcrServiceTest.java
@@ -53,6 +53,23 @@ public class AcrServiceTest {
     private AppConfiguration appConfiguration;
 
     @Test
+    public void removeParametersFromAgamaAcr_whenAcrHasParameters_shouldRemoveParameters() {
+        assertEquals(AcrService.removeParametersFromAgamaAcr("agama_flow-parameter1"), "agama_flow");
+        assertEquals(AcrService.removeParametersFromAgamaAcr("agama_io.jans.flow-parameter1"), "agama_io.jans.flow");
+        assertEquals(AcrService.removeParametersFromAgamaAcr("agama_io.jans.flow"), "agama_io.jans.flow");
+    }
+
+    @Test
+    public void removeParametersFromAgamaAcr_whenAuthzRequestIsWithAcrWithParameters_shouldRemoveParameters() {
+        AuthzRequest authzRequest = new AuthzRequest();
+        authzRequest.setAcrValues("agama_io.jans.flow-parameter1 acr2");
+
+        AcrService.removeParametersForAgamaAcr(authzRequest);
+
+        assertEquals(authzRequest.getAcrValues(), "agama_io.jans.flow acr2");
+    }
+
+    @Test
     public void isAgama_whenAcrIsNullOrNonAgama_shouldReturnFalse() {
         assertFalse(AcrService.isAgama(null));
         assertFalse(AcrService.isAgama(""));


### PR DESCRIPTION
### Description

feat(jans-auth): removed extra info from `acr` claim in `id_token` when it's an agama flow

#### Target issue

closes #8348

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

