### PR TITLE
feat(jans-auth): removed extra info from `acr` claim in `id_token` when it's an agama flow

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
@@ -23,6 +23,7 @@ import io.jans.as.persistence.model.Scope;
 import io.jans.as.server.model.authorize.Claim;
 import io.jans.as.server.model.authorize.JwtAuthorizationRequest;
 import io.jans.as.server.model.common.*;
+import io.jans.as.server.service.AcrService;
 import io.jans.as.server.service.ScopeService;
 import io.jans.as.server.service.SessionIdService;
 import io.jans.as.server.service.date.DateFormatterService;
@@ -159,9 +160,11 @@ public class IdTokenFactory {
 
         addTokenExchangeClaims(jwr, executionContext, session);
 
-        if (authorizationGrant.getAcrValues() != null) {
-            jwr.setClaim(JwtClaimName.AUTHENTICATION_CONTEXT_CLASS_REFERENCE, authorizationGrant.getAcrValues());
-            setAmrClaim(jwr, authorizationGrant.getAcrValues());
+        String acrValues = authorizationGrant.getAcrValues();
+        acrValues = AcrService.removeParametersFromAgamaAcr(acrValues);
+        if (acrValues != null) {
+            jwr.setClaim(JwtClaimName.AUTHENTICATION_CONTEXT_CLASS_REFERENCE, acrValues);
+            setAmrClaim(jwr, acrValues);
         }
         String nonce = executionContext.getNonce();
         if (StringUtils.isNotBlank(nonce)) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/AcrService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/AcrService.java
@@ -52,8 +52,6 @@ public class AcrService {
     }
 
     public void validateAcrs(AuthzRequest authzRequest, Client client) throws AcrChangedException {
-        removeParametersForAgamaAcr(authzRequest);
-
         applyAcrMappings(authzRequest);
 
         checkClientAuthorizedAcrs(authzRequest, client);


### PR DESCRIPTION
### Description

feat(jans-auth): removed extra info from `acr` claim in `id_token` when it's an agama flow

#### Target issue
  
closes #8348

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

