### PR TITLE
fix(docker-jans-persistence-loader): handle missing data type for overriden column

### DIFF
--- a/docker-jans-persistence-loader/scripts/spanner_setup.py
+++ b/docker-jans-persistence-loader/scripts/spanner_setup.py
@@ -46,6 +46,9 @@ class SpannerBackend:
 
             type_ = type_def.get(self.client.dialect)
 
+            if not type_:
+                continue
+
             if table in type_.get("tables", {}):
                 type_ = type_["tables"][table]
 

--- a/docker-jans-persistence-loader/scripts/sql_setup.py
+++ b/docker-jans-persistence-loader/scripts/sql_setup.py
@@ -54,6 +54,9 @@ class SQLBackend:
 
             type_ = type_def.get(self.client.dialect) or type_def["mysql"]
 
+            if not type_:
+                continue
+
             if table in type_.get("tables", {}):
                 type_ = type_["tables"][table]
 

--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -369,9 +369,7 @@ class Upgrade:
             else:
                 props = agama_entry.attrs["jansConfProperty"]
 
-            if self.backend.type != "couchbase":
-                # try converting to mapping
-                props = [json.loads(prop) for prop in props]
+            props = [json.loads(prop) for prop in props]
 
             # filter out unwanted properties
             new_props = [
@@ -380,8 +378,7 @@ class Upgrade:
             ]
 
             if new_props != props:
-                if self.backend.type != "couchbase":
-                    new_props = [json.dumps(prop) for prop in new_props]
+                new_props = [json.dumps(prop) for prop in new_props]
 
                 if self.backend.type == "sql" and self.backend.client.dialect == "mysql":
                     agama_entry.attrs["jansConfProperty"]["v"] = new_props

--- a/docker-jans-persistence-loader/scripts/upgrade.py
+++ b/docker-jans-persistence-loader/scripts/upgrade.py
@@ -369,6 +369,9 @@ class Upgrade:
             else:
                 props = agama_entry.attrs["jansConfProperty"]
 
+            if not isinstance(props, list):
+                props = [props]
+
             props = [json.loads(prop) for prop in props]
 
             # filter out unwanted properties


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #8391 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

