### PR TITLE
fix(docs): install `mkdocs-include-markdown-plugin` along with dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,8 +8,6 @@ mike==1.1.2 --hash=sha256:4c307c28769834d78df10f834f57f810f04ca27d248f80a75f49c6
 mkdocs-git-revision-date-localized-plugin==1.1.0 --hash=sha256:4ba0e49abea3e9f6ee26e2623ff7283873da657471c61f1d0cfbb986f403316d
 mkdocs-git-committers-plugin-2==1.1.1 --hash=sha256:14d4a89bf8965ab62ca9b8b0cd90f6c9b421bb89bfedca0d91c5119f18791360
 mkdocs-exclude-search==0.6.6 --hash=sha256:2b4b941d1689808db533fe4a6afba75ce76c9bab8b21d4e31efc05fd8c4e0a4f
-bracex==2.4 --hash=sha256:efdc71eff95eaff5e0f8cfebe7d01adf2c8637c8c92edaf63ef348c241a82418
-wcmatch==8.5.2 --hash=sha256:17d3ad3758f9d0b5b4dedc770b65420d4dac62e680229c287bf24c9db856a478
 mkdocs-include-markdown-plugin==6.0.5 --hash=sha256:db41aa1937a618afa3497616f457d4e51d9123b13b2034bb15505ff9ce061f86
 
 # Transitive dependencies
@@ -45,3 +43,5 @@ soupsieve==2.3.2.post1 --hash=sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863
 smmap==5.0.0 --hash=sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94
 lxml==4.9.1 --hash=sha256:e5f66bdf0976ec667fc4594d2812a00b07ed14d1b44259d19a41ae3fff99f2b8
 setuptools==65.6.3 --hash=sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54 # not directly required, pinned by Snyk to avoid a vulnerability
+bracex==2.4 --hash=sha256:efdc71eff95eaff5e0f8cfebe7d01adf2c8637c8c92edaf63ef348c241a82418
+wcmatch==8.5.2 --hash=sha256:17d3ad3758f9d0b5b4dedc770b65420d4dac62e680229c287bf24c9db856a478

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,9 @@ mike==1.1.2 --hash=sha256:4c307c28769834d78df10f834f57f810f04ca27d248f80a75f49c6
 mkdocs-git-revision-date-localized-plugin==1.1.0 --hash=sha256:4ba0e49abea3e9f6ee26e2623ff7283873da657471c61f1d0cfbb986f403316d
 mkdocs-git-committers-plugin-2==1.1.1 --hash=sha256:14d4a89bf8965ab62ca9b8b0cd90f6c9b421bb89bfedca0d91c5119f18791360
 mkdocs-exclude-search==0.6.6 --hash=sha256:2b4b941d1689808db533fe4a6afba75ce76c9bab8b21d4e31efc05fd8c4e0a4f
+bracex==2.4 --hash=sha256:efdc71eff95eaff5e0f8cfebe7d01adf2c8637c8c92edaf63ef348c241a82418
+wcmatch==8.5.2 --hash=sha256:17d3ad3758f9d0b5b4dedc770b65420d4dac62e680229c287bf24c9db856a478
+mkdocs-include-markdown-plugin==6.0.5 --hash=sha256:db41aa1937a618afa3497616f457d4e51d9123b13b2034bb15505ff9ce061f86
 
 # Transitive dependencies
 click==8.1.3 --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -462,6 +462,7 @@ nav:
         - 'Adding authentication methods': 'casa/developer/add-authn-methods.md'
     - User Guide: 'casa/user-guide.md'
 plugins:
+- include-markdown
 - tags
 - search
 - exclude-search:


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description


#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #8543 

#### Implementation Details
Since the transitive dependencies were having trouble with hash verification, I have added them separately with a corresponding hash that can be verified.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

