### PR TITLE
fix(jans-auth-server): tx token replace failing with 500 #8623

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TxTokenService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TxTokenService.java
@@ -44,6 +44,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 
@@ -161,23 +162,34 @@ public class TxTokenService {
             jwr.getClaims().addAudience(audience);
         }
 
-        if (StringUtils.isNotBlank(requestContext)) {
-            requestContext = Base64Util.base64urldecodeToString(requestContext);
-            jwr.getClaims().setClaim("rctx", new JSONObject(requestContext));
+        JSONObject requestContextObj = decodeJson(requestContext);
+        if (requestContextObj != null) {
+            jwr.getClaims().setClaim("rctx", requestContextObj);
         }
 
         if (authorizationGrant != null) {
             jwr.setClaim("sub", authorizationGrant.getSub());
         }
 
-        JSONObject azd = new JSONObject();
-        if (StringUtils.isNotBlank(requestDetails)) {
-            requestDetails = Base64Util.base64urldecodeToString(requestDetails);
-            azd = new JSONObject(requestDetails);
+        JSONObject azd = decodeJson(requestDetails);
+        if (azd == null) {
+            azd = new JSONObject();
         }
         azd.put("client_id", client.getClientId());
 
         jwr.getClaims().setClaim("azd", azd);
+    }
+
+    private static JSONObject decodeJson(String jsonString) {
+        if (StringUtils.isBlank(jsonString)) {
+            return null;
+        }
+        try {
+           return new JSONObject(jsonString);
+        } catch (JSONException e) {
+            String decoded = Base64Util.base64urldecodeToString(jsonString);
+            return new JSONObject(decoded);
+        }
     }
 
     private int getTxTokenLifetime(Client client) {


### PR DESCRIPTION
### Description

fix(jans-auth-server): tx token replace failing with 500 

```
POST /jans-auth/restv1/token HTTP/1.1
Content-Type: application/x-www-form-urlencoded

grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&audience=http%3A%2F%2Ftrusted2.com&subject_token=eyJraWQiOiJjb25uZWN0XzViODA2OWM3LWM5MDQtNDM4Mi1iNDNkLWVlNWJmMzBhNjQwYV9zaWdfcnMyNTYiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJyY3R4Ijp7InJlcV9pcCI6IjY5LjE1MS43Mi4xMjMifSwiYXVkIjpbIjgzYmM2NWYyLWIxNTUtNGQxNS1iODBkLWFiMWY0ZDlhMjQwZCIsImh0dHA6Ly90cnVzdGVkLmNvbSJdLCJzdWIiOiIiLCJwdXJwIjoidHhuX3Rva2VuIiwiaXNzIjoiaHR0cHM6Ly9qZW5raW5zLWJ1aWxkLmphbnMuaW8iLCJhemQiOnsiY2xpZW50X2lkIjoiODNiYzY1ZjItYjE1NS00ZDE1LWI4MGQtYWIxZjRkOWEyNDBkIn0sInR4biI6ImZiNzg2OWY5LTE1ZjgtNDhjNS05OWE0LWI3ZjQzOGUxYjJjNCIsImV4cCI6MTcxNzE0NjE0NiwiaWF0IjoxNzE3MTQ1OTY2fQ.he89X74L_STMxA34FCA3Kms9t1VVeleemHIMZFmYOmvti75b0h13nNM6AafKhfp1mFL4sK6ZvxgfZlRwCSmQTe0TTS1y-zyOZbSlcFpynzNakCn2a0avItjlInuQ09fiRq4nHK3B4SjHA_DHY2xiJT3QAiuSO-dbyFBhCudf0mp2ZB2fADyYscLBtu8lD4kiMlm1puh9lbyUlUCFdGcGeRyvq_iXBS3YyRuDPVIm6eQxdEVrKEP6qJEY1tai7k5GvliLdogks3ZJ2CvB8yYzMaGvnipfjhyHtRoSIlrNhmNZhU3vZ2VBH2aS4fUzxSEGe7VJkgzKh6Honvdt5X1SBg&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Atxn-token&request_context=%7B%22req_ip%22%3A%2269.151.72.100%22%7D

-------------------------------------------------------
RESPONSE:
-------------------------------------------------------
HTTP/1.1 500
Cache-Control: no-store
Connection: close
Content-Length: 0
```


#### Target issue
  
closes #8623

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed

