### PR TITLE
fix(jans-cli-tui): file browser not re-open in asset mgt

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/130_assets/main.py
+++ b/jans-cli-tui/cli_tui/plugins/130_assets/main.py
@@ -144,6 +144,7 @@ class Plugin(DialogUtils):
 
 
         def display_file_browser_dialog():
+            file_browser_dialog.future = asyncio.futures.Future()
             common_data.app.show_jans_dialog(file_browser_dialog)
 
 


### PR DESCRIPTION
closes #8645