### PR TITLE
test(jans-auth-server): ExternalAuthenticationServiceTest test failure #8655

### DIFF
--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/external/ExternalAuthenticationServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/external/ExternalAuthenticationServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -34,6 +35,9 @@ public class ExternalAuthenticationServiceTest {
 
     @Mock
     private AppConfiguration appConfiguration;
+
+    @Mock
+    private Logger log;
 
     @Mock
     private InternalDefaultPersonAuthenticationType authenticationType;


### PR DESCRIPTION
### Description

test(jans-auth-server): ExternalAuthenticationServiceTest test failure 

#### Target issue
  
closes #8655

