### PR TITLE
docs: correct spelling of properties

### DIFF
--- a/docs/admin/planning/security-best-practices.md
+++ b/docs/admin/planning/security-best-practices.md
@@ -55,7 +55,7 @@ flow, Review the CORS filter configuration for Jans Auth Server. CORS restricts
 access to trusted domains to execute browser application requests to Auth Server
 endpoints. By default, the filter allows any RP to call OpenID endpoints.
 
-Review Auth Server propoerties chosen for `sessionIdUnusedLifetime` and
+Review Auth Server properties chosen for `sessionIdUnusedLifetime` and
 `sessionIdLifetime`. Long sessions present higher risks of session hijacking and
 unauthorized access from shared devices.
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

There is a typo in the [documentation](https://github.com/JanssenProject/jans/blob/main/docs/admin/planning/security-best-practices.md) 

#### Target issue
https://github.com/JanssenProject/jans/issues/8708
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes 8708

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->
This is an change to the documentation.

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed - NA
- [ ] Relevant unit and integration tests have been added/updated - NA
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

