### PR TITLE
feat(jans-linux-setup): top level wrapper command jans

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/config.py
+++ b/jans-linux-setup/jans_setup/setup_app/config.py
@@ -280,7 +280,8 @@ class Config:
 
         self.jansScriptFiles = [
                             os.path.join(self.install_dir, 'static/scripts/logmanager.sh'),
-                            os.path.join(self.install_dir, 'static/scripts/testBind.py')
+                            os.path.join(self.install_dir, 'static/scripts/testBind.py'),
+                            os.path.join(self.install_dir, 'static/scripts/jans'),
                             ]
 
         self.redhat_services = ['httpd', 'rsyslog']

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -315,6 +315,7 @@ class JansInstaller(BaseInstaller, SetupUtils):
 
         for script in Config.jansScriptFiles:
             self.copyFile(script, Config.jansOptBinFolder)
+            self.run([paths.cmd_chmod, '+x', script])
 
         self.logIt("Rendering encode.py")
         encode_script = self.readFile(os.path.join(Config.templateFolder, 'encode.py'))

--- a/jans-linux-setup/jans_setup/static/scripts/jans
+++ b/jans-linux-setup/jans_setup/static/scripts/jans
@@ -1,0 +1,137 @@
+#! /usr/bin/env python3
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+from collections import OrderedDict
+
+JANS_JETTY_DIR = '/opt/jans/jetty'
+JANS_SERVICES_ = os.listdir(JANS_JETTY_DIR)
+HEALTH_ENDPOINTS = OrderedDict((
+            ('jans-auth', 'http://localhost:8081/jans-auth/sys/health-check'),
+            ('jans-config-api', 'http://localhost:8074/jans-config-api/api/v1/health/live'),
+            ('jans-casa', 'http://localhost:8080/jans-casa/health-check'),
+            ('jans-fido2', 'http://localhost:8073/jans-fido2/sys/health-check'),
+            ('jans-scim', 'http://localhost:8087/jans-scim/sys/health-check'),
+            ('jans-link', 'http://localhost:9091/jans-link/sys/health-check'),
+            ('jans-lock', 'http://localhost:8076/jans-lock/sys/health-check')
+        ))
+
+JANS_SERVICES = []
+for k in HEALTH_ENDPOINTS:
+    if k in JANS_SERVICES_:
+        JANS_SERVICES.append(k)
+
+for i in JANS_SERVICES_:
+    if not i in JANS_SERVICES:
+        JANS_SERVICES.append(i)
+
+parser = argparse.ArgumentParser(description="A top-level wrapper script for Janssen")
+subparsers = parser.add_subparsers(dest='command')
+subparsers.add_parser('version', help="shows version of currently installed Janssen Server")
+subparsers.add_parser('cli', help="invokes jans-cli")
+subparsers.add_parser('tui', help="invokes jans text based user interface")
+subparsers.add_parser('logs', help="Shows the log file paths for various Janssen Server modules")
+subparsers.add_parser('status', help="Show status of Janssen Server module services")
+start_service_parser = subparsers.add_parser('start', help="Starts services for Janssen Server ( -service=<service-name> if you want to start just one specific service)")
+start_service_parser.add_argument('-service', choices=JANS_SERVICES)
+stop_service_parser = subparsers.add_parser('stop', help="Stops services for Janssen Server ( -service=<service-name> if you want to stop just one specific service)")
+stop_service_parser.add_argument('-service', choices=JANS_SERVICES)
+restart_service_parser = subparsers.add_parser('restart', help="restarts services for Janssen Server ( -service=<service-name> if you want to restart just one specific service)")
+restart_service_parser.add_argument('-service', choices=JANS_SERVICES)
+health_parser = subparsers.add_parser('health', help="gets output from Janssen services `health-check` endpoint ( -service=<service-name> if you want to get health status of just one specific service)")
+health_parser.add_argument('-service', choices=JANS_SERVICES)
+subparsers.add_parser('info', help="lists important URLs (like .well-known, Casa etc)")
+argsp = parser.parse_args()
+
+
+
+def status():
+    subprocess.run('sudo systemctl list-units --all "jans*"', shell=True)
+
+def tui():
+    subprocess.run('/opt/jans/jans-cli/jans_cli_tui.py', shell=True)
+
+def version():
+    subprocess.run('/opt/jans/bin/show_version.py', shell=True)
+
+def logs():
+    jetty_path = Path(JANS_JETTY_DIR).glob('*')
+    for p in jetty_path:
+        if p.is_dir():
+            print(f"Log files for {p.stem}:")
+            for l in p.glob('logs/*.log'):
+                print(f"  {l}")
+            print()
+
+def service_command(todo):
+    services = [argsp.service] if argsp.service else JANS_SERVICES
+    if todo == 'stop':
+        services = reversed(services)
+    for jservice in services:
+        cmd = f'sudo systemctl {todo} {jservice}'
+        print(f"Executing {cmd}")
+        out = subprocess.getoutput(cmd).strip()
+        if out:
+            print(f"Command output: {out}")
+
+
+def start():
+    service_command('start')
+
+def stop():
+    service_command('stop')
+
+def restart():
+    service_command('restart')
+
+def health():
+
+
+    services = [argsp.service] if argsp.service else JANS_SERVICES
+
+    for jservice in HEALTH_ENDPOINTS:
+        if jservice in services:
+            print(f"Checking health status for {jservice}")
+            cmd = f'curl -s {HEALTH_ENDPOINTS[jservice]}'
+            print(f"  Executing {cmd}")
+            out = subprocess.getoutput(cmd).strip()
+            if out:
+                print(f"  Command output: {out}")
+
+    print()
+
+def get_hostname():
+    for http_conf_path in (
+                '/etc/apache2/vhosts.d/_https_jans.conf',
+                '/etc/httpd/conf.d/https_jans.conf',
+                '/etc/apache2/sites-available/https_jans.conf'
+                ):
+        if os.path.isfile(http_conf_path):
+            with open(http_conf_path) as f:
+                for l in f:
+                    ls = l.strip()
+                    if ls.startswith('ServerName'):
+                        server_name = ls[10:].strip()
+                        return server_name
+
+    print("Can't determine server name")
+    sys.exit()
+
+def info():
+    hostname = get_hostname()
+    print("Important URLs")
+    for url in (
+            'jans-auth/.well-known/openid-configuration',
+            'jans-scim/restv1/scim-configuration',
+            'jans-fido2/restv1/configuration'
+            ):
+        jservice = url.split('/')[0]
+        if jservice in JANS_SERVICES:
+            print(f'https://{hostname}/{url}')
+
+if argsp.command:
+    locals()[argsp.command]()
+else:
+    print(parser.print_help())

--- a/jans-linux-setup/jans_setup/templates/system_profile_systemd
+++ b/jans-linux-setup/jans_setup/templates/system_profile_systemd
@@ -5,7 +5,7 @@
 export JAVA_HOME=%(jre_home)s
 export OPENDJ_JAVA_HOME=%(jre_home)s
 
-export PATH=$PATH:$JAVA_HOME/bin:$NODE_HOME/bin:%(ldap_base_dir)s/bin
+export PATH=$PATH:$JAVA_HOME/bin:$NODE_HOME/bin:%(ldap_base_dir)s/bin:%(jansOptBinFolder)s
 ########################################################################
 # End Jans Block                                                       #
 ########################################################################


### PR DESCRIPTION
closes #8697

In this PR a command `jans` is located under directory `/opt/jans/bin` and this directory is added to `$PATH` so that command is available without full path. To see help,

```
# jans -h
usage: jans [-h] {version,cli,tui,logs,status,start,stop,restart,health,info} ...

A top-level wrapper script for Janssen

positional arguments:
  {version,cli,tui,logs,status,start,stop,restart,health,info}
    version             shows version of currently installed Janssen Server
    cli                 invokes jans-cli
    tui                 invokes jans text based user interface
    logs                Shows the log file paths for various Janssen Server modules
    status              Show status of Janssen Server module services
    start               Starts services for Janssen Server ( -service=<service-name> if you want to start just one specific
                        service)
    stop                Stops services for Janssen Server ( -service=<service-name> if you want to stop just one specific
                        service)
    restart             restarts services for Janssen Server ( -service=<service-name> if you want to restart just one
                        specific service)
    health              gets output from Janssen services `health-check` endpoint ( -service=<service-name> if you want to
                        get health status of just one specific service)
    info                lists important URLs (like .well-known, Casa etc)

options:
  -h, --help            show this help message and exit
```
