### PR TITLE
fix(jans-linux-setup): dummy values for KC db options

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans_saml.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans_saml.py
@@ -26,6 +26,10 @@ Config.jans_idp_user_password = os.urandom(10).hex()
 Config.jans_idp_idp_root_dir = os.path.join(Config.jansOptFolder, 'idp')
 Config.jans_idp_ignore_validation = 'true'
 Config.jans_idp_idp_metadata_file = 'idp-metadata.xml'
+Config.kc_db_provider = 'postgresql'
+Config.kc_db_username = 'kcdbuser'
+Config.kc_db_password = 'kcdbuserpassword'
+Config.kc_jdbc_url = 'jdbc:postgresql:kcdbuser:kcdbuserpassword@//localhost:1122/kc_service'
 
 class JansSamlInstaller(JettyInstaller):
 

--- a/jans-linux-setup/jans_setup/templates/jans-saml/keycloak.conf
+++ b/jans-linux-setup/jans_setup/templates/jans-saml/keycloak.conf
@@ -1,7 +1,7 @@
 # Basic settings for running in production. Change accordingly before deploying the server.
 
 # Database 
-#db=%{kc_db_provider}
+#db=%(kc_db_provider)s
 
 # The username of the database user
 #db-username=%(kc_db_username)s
@@ -26,7 +26,7 @@ http-max-queued-requests=1000
 # Enable the http listener
 http-enabled=true
 # set application hostname 
-hostname=https://%(kc_hostname)s/kc
+hostname=https://%(keycloack_hostname)s/kc
 
 # http listen address 
 http-host=127.0.0.1


### PR DESCRIPTION
closes #8805