### PR TITLE
fix(jans-auth-server): clean up jansDeviceSess entries after expiration #8704

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/CleanerTimer.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/CleanerTimer.java
@@ -10,6 +10,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Maps;
 import io.jans.as.common.model.common.ArchivedJwk;
 import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.model.session.DeviceSession;
 import io.jans.as.common.model.session.SessionId;
 import io.jans.as.model.config.StaticConfiguration;
 import io.jans.as.model.configuration.AppConfiguration;
@@ -36,7 +37,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 import org.apache.tika.utils.StringUtils;
 import org.slf4j.Logger;
 
@@ -217,6 +217,7 @@ public class CleanerTimer {
         cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getAuthorizations(), ClientAuthorization.class);
         cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getScopes(), Scope.class);
         cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getSessions(), SessionId.class);
+        cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getSessions(), DeviceSession.class);
         cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getPar(), Par.class);
         cleanServiceBaseDns.put(staticConfiguration.getBaseDn().getArchivedJwks(), ArchivedJwk.class);
 


### PR DESCRIPTION
### Description

fix(jans-auth-server): clean up jansDeviceSess entries after expiration 

#### Target issue
  
closes #8704



- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
