### PR TITLE
fix(jans-linux-setup): install with setup.properties

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -194,13 +194,21 @@ class PropertiesUtils(SetupUtils):
         if p.get('cb_install') == '0':
            p['cb_install'] = InstallTypes.NONE
 
+        if p.get('cb_install'):
+            p['opendj_install'] = InstallTypes.NONE
+            p['rdbm_install'] = InstallTypes.NONE
+
         if p.get('opendj_install') == '0':
             p['opendj_install'] = InstallTypes.NONE
+
+        if base.as_bool(p.get('installLdap', False)):
+            p['opendj_install'] = InstallTypes.LOCAL
+            p['rdbm_install'] = InstallTypes.NONE
 
         if p.get('enable-script'):
             base.argsp.enable_script = p['enable-script'].split()
 
-        if p.get('loadTestData'):
+        if base.as_bool(p.get('loadTestData', False)):
             base.argsp.t = True
 
         if p.get('rdbm_type') == 'pgsql' and not p.get('rdbm_port'):
@@ -634,8 +642,6 @@ class PropertiesUtils(SetupUtils):
         prompt = self.getPrompt("Install Jans Lock?",
                                             self.getDefaultOption(Config.install_jans_lock)
                                             )[0].lower()
-
-        
 
         if prompt == 'y':
             prompt = self.getPrompt("  Install Jans Lock as Server?",


### PR DESCRIPTION
closes #8985
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

@moabu setup can't install spanner emulator. It is not possible to automate spanner emulator installetion. So you should install spanner emulator manually and add these to your `setup.properties` file:

```
rdbm_type=spanner
rdbm_install_type=2
spanner_emulator_host=myhost
spanner_project=jans-project
spanner_instance=jans-instance
spanner_database=jansdb
```
If you use defaults for the last three items, you don't need to add them.

