### PR TITLE
docs(lock): add missing files with placeholder content

### DIFF
--- a/docs/admin/lock/lock-auth-server-config.md
+++ b/docs/admin/lock/lock-auth-server-config.md
@@ -1,0 +1,13 @@
+# Configuring Janssen Server for Lock
+
+## This content is in progress
+
+The Janssen Project documentation is currently in development. Topic pages are being created in order of broadest relevance, and this page is coming in the near future.
+
+## Have questions in the meantime?
+
+While this documentation is in progress, you can ask questions through [GitHub Discussions](https://github.com/JanssenProject/jans/discussions) or the [community chat on Gitter](https://gitter.im/JanssenProject/Lobby). Any questions you have will help determine what information our documentation should cover.
+
+## Want to contribute?
+
+If you have content you'd like to contribute to this page in the meantime, you can get started with our [Contribution guide](https://docs.jans.io/head/CONTRIBUTING/).

--- a/docs/admin/lock/lock-client-config.md
+++ b/docs/admin/lock/lock-client-config.md
@@ -1,0 +1,13 @@
+# Lock Client Configuration
+
+## This content is in progress
+
+The Janssen Project documentation is currently in development. Topic pages are being created in order of broadest relevance, and this page is coming in the near future.
+
+## Have questions in the meantime?
+
+While this documentation is in progress, you can ask questions through [GitHub Discussions](https://github.com/JanssenProject/jans/discussions) or the [community chat on Gitter](https://gitter.im/JanssenProject/Lobby). Any questions you have will help determine what information our documentation should cover.
+
+## Want to contribute?
+
+If you have content you'd like to contribute to this page in the meantime, you can get started with our [Contribution guide](https://docs.jans.io/head/CONTRIBUTING/).

--- a/docs/admin/lock/lock-installation.md
+++ b/docs/admin/lock/lock-installation.md
@@ -1,0 +1,14 @@
+## Lock Installation
+
+
+## This content is in progress
+
+The Janssen Project documentation is currently in development. Topic pages are being created in order of broadest relevance, and this page is coming in the near future.
+
+## Have questions in the meantime?
+
+While this documentation is in progress, you can ask questions through [GitHub Discussions](https://github.com/JanssenProject/jans/discussions) or the [community chat on Gitter](https://gitter.im/JanssenProject/Lobby). Any questions you have will help determine what information our documentation should cover.
+
+## Want to contribute?
+
+If you have content you'd like to contribute to this page in the meantime, you can get started with our [Contribution guide](https://docs.jans.io/head/CONTRIBUTING/).

--- a/docs/admin/lock/lock-opa.md
+++ b/docs/admin/lock/lock-opa.md
@@ -1,0 +1,13 @@
+# Lock OPA
+
+## This content is in progress
+
+The Janssen Project documentation is currently in development. Topic pages are being created in order of broadest relevance, and this page is coming in the near future.
+
+## Have questions in the meantime?
+
+While this documentation is in progress, you can ask questions through [GitHub Discussions](https://github.com/JanssenProject/jans/discussions) or the [community chat on Gitter](https://gitter.im/JanssenProject/Lobby). Any questions you have will help determine what information our documentation should cover.
+
+## Want to contribute?
+
+If you have content you'd like to contribute to this page in the meantime, you can get started with our [Contribution guide](https://docs.jans.io/head/CONTRIBUTING/).

--- a/docs/admin/lock/lock-pdp-plugin.md
+++ b/docs/admin/lock/lock-pdp-plugin.md
@@ -1,0 +1,13 @@
+# Lock PDP Plugin
+
+## This content is in progress
+
+The Janssen Project documentation is currently in development. Topic pages are being created in order of broadest relevance, and this page is coming in the near future.
+
+## Have questions in the meantime?
+
+While this documentation is in progress, you can ask questions through [GitHub Discussions](https://github.com/JanssenProject/jans/discussions) or the [community chat on Gitter](https://gitter.im/JanssenProject/Lobby). Any questions you have will help determine what information our documentation should cover.
+
+## Want to contribute?
+
+If you have content you'd like to contribute to this page in the meantime, you can get started with our [Contribution guide](https://docs.jans.io/head/CONTRIBUTING/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -396,11 +396,11 @@ nav:
     - Jans Keycloak Link: admin/link/jans-keycloak-link.md
   - Lock Guide:
       - admin/lock/README.md
-      - Lock Installation: admin/lock/lock_installation.md
-      - Auth Server Configuration: admin/lock/lock_auth_server_config.md
-      - Lock Client Configuration: admin/lock/lock_client_config.md
-      - Implement Lock PDP Plugin: admin/lock/lock_pdp_plugin.md
-      - Policy Store Integration: admin/lock/lock_opa.md
+      - Lock Installation: admin/lock/lock-installation.md
+      - Auth Server Configuration: admin/lock/lock-auth-server-config.md
+      - Lock Client Configuration: admin/lock/lock-client-config.md
+      - Implement Lock PDP Plugin: admin/lock/lock-pdp-plugin.md
+      - Policy Store Integration: admin/lock/lock-opa.md
       - Lock Master: admin/lock/lock-master.md
       - Authorization Using Cedarling: admin/lock/cedarling.md
   - Janssen Recipes:


### PR DESCRIPTION
Add new lock documentation files with placeholder content.
Closes #9018, 