### PR TITLE
fix(jans-linux-setup): client kc_saml_openid is trusted

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans_saml.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans_saml.py
@@ -147,8 +147,10 @@ class JansSamlInstaller(JettyInstaller):
                         grant_types=client_info['grant_types'],
                         authorization_methods=client_info['authorization_methods'],
                         application_type=client_info['application_type'],
-                        response_types=client_info['response_types']
+                        response_types=client_info['response_types'],
+                        trusted_client=client_info['trusted_client']
                         )
+
         self.dbUtils.import_ldif(client_ldif_fns)
 
     def install_keycloak(self):

--- a/jans-linux-setup/jans_setup/templates/jans-saml/clients.json
+++ b/jans-linux-setup/jans_setup/templates/jans-saml/clients.json
@@ -11,7 +11,8 @@
     "grant_types": ["client_credentials"],
     "authorization_methods": ["client_secret_basic", "client_secret_post"],
     "response_types": null,
-    "application_type": "web"
+    "application_type": "web",
+    "trusted_client": "false"
   },
   {
     "client_prefix": "2101.",
@@ -25,7 +26,8 @@
     "grant_types": ["authorization_code"],
     "authorization_methods": ["client_secret_basic"],
     "response_types": ["code", "token"],
-    "application_type": "native"
+    "application_type": "native",
+    "trusted_client": "true"
   },
   {
     "client_prefix": "2102.",
@@ -39,7 +41,8 @@
     "grant_types": ["client_credentials"],
     "authorization_methods": ["client_secret_basic"],
     "response_types": ["token"],
-    "application_type": "native"
+    "application_type": "native",
+    "trusted_client": "false"
   },
   {
     "client_prefix": "2103.",
@@ -53,6 +56,7 @@
     "grant_types": ["authorization_code"],
     "authorization_methods": ["client_secret_basic"],
     "response_types": ["code", "token"],
-    "application_type": "web"
+    "application_type": "web",
+    "trusted_client": "false"
   }
 ]


### PR DESCRIPTION
closes #8921

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
