### PR TITLE
fix(jans-linux-setup): set size of acr in jansToken is 1024

### DIFF
--- a/jans-linux-setup/jans_setup/static/rdbm/sql_data_types.json
+++ b/jans-linux-setup/jans_setup/static/rdbm/sql_data_types.json
@@ -444,6 +444,12 @@
       "type": "STRING"
     }
   },
+  "jansToken:acr": {
+    "mysql": {
+      "size": 1024,
+      "type": "VARCHAR"
+    }
+  },
   "jansJwks": {
     "mysql": {
       "type": "TEXT"


### PR DESCRIPTION
closes #9054

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
