### PR TITLE
fix(jans-linux-setup): apache config for jans-lock wellknown endpoint

### DIFF
--- a/jans-linux-setup/jans_setup/templates/apache/https_jans.conf
+++ b/jans-linux-setup/jans_setup/templates/apache/https_jans.conf
@@ -118,7 +118,6 @@
     ProxyPass   /.well-known/scim-configuration http://localhost:8087/jans-scim/restv1/scim-configuration
     ProxyPass   /firebase-messaging-sw.js http://localhost:%(jans_auth_port)s/jans-auth/firebase-messaging-sw.js
     ProxyPass   /device-code http://localhost:%(jans_auth_port)s/jans-auth/device_authorization.htm
-    ProxyPass   /.well-known/lock-master-configuration http://localhost:%(jans_lock_port)s/jans-lock/.well-known/lock-master-configuration
 
     ProxyErrorOverride On
 


### PR DESCRIPTION
closes  #9069

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
