### PR TITLE
fix(jans-auth-server): introspection endpoint returns error for valid basic client authentication and invalid token #9093

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/introspection/ws/rs/IntrospectionWebService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/introspection/ws/rs/IntrospectionWebService.java
@@ -126,8 +126,18 @@ public class IntrospectionWebService {
             final Pair<AuthorizationGrant, Boolean> pair = getAuthorizationGrant(authorization, token);
             final AuthorizationGrant authorizationGrant = pair.getFirst();
             if (authorizationGrant == null) {
-                log.error("Authorization grant is null.");
-                throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).type(MediaType.APPLICATION_JSON_TYPE).entity(errorResponseFactory.errorAsJson(AuthorizeErrorResponseType.ACCESS_DENIED, "Authorization grant is null.")).build());
+                log.debug("Authorization grant is null.");
+                if (isTrue(pair.getSecond())) {
+                    log.debug("Returned {\"active\":false.");
+                    throw new WebApplicationException(Response.status(Response.Status.OK)
+                            .entity("{\"active\":false")
+                            .type(MediaType.APPLICATION_JSON_TYPE)
+                            .build());
+                }
+                throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED)
+                        .type(MediaType.APPLICATION_JSON_TYPE)
+                        .entity(errorResponseFactory.errorAsJson(AuthorizeErrorResponseType.ACCESS_DENIED, "Authorization grant is null."))
+                        .build());
             }
 
             final AbstractToken authorizationAccessToken = authorizationGrant.getAccessToken(tokenService.getToken(authorization));
@@ -334,8 +344,9 @@ public class IntrospectionWebService {
             }
             return new Pair<>(grant, true);
         } else {
-            if (log.isTraceEnabled())
+            if (log.isTraceEnabled()) {
                 log.trace("Failed to perform basic authentication for client: {}", clientId);
+            }
         }
         return EMPTY;
     }


### PR DESCRIPTION
### Description

fix(jans-auth-server): introspection endpoint returns error for valid basic client authentication and invalid token 



#### Target issue
  
closes #9093

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed


- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
