### PR TITLE
doc(jans-auth-server): client authn script is missed in navigation #9140

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -309,6 +309,7 @@ nav:
       - Authorization Challenge: admin/developer/scripts/authorization-challenge.md
       - CIBA End User Notification: admin/developer/scripts/ciba.md
       - Client Registration: admin/developer/scripts/client-registration.md
+      - Client Authentication: admin/developer/scripts/client-authn.md
       - Config API: admin/developer/scripts/config-api.md
       - Consent Gathering: admin/developer/scripts/consent-gathering.md
       - Dynamic Scope: admin/developer/scripts/dynamic-scope.md


### PR DESCRIPTION
### Description

doc(jans-auth-server): client authn script is missed in navigation 

#### Target issue
  
closes #9140

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
