### PR TITLE
fix(jans-cli-tui): focus to container after deleting asset

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/130_assets/main.py
+++ b/jans-cli-tui/cli_tui/plugins/130_assets/main.py
@@ -226,6 +226,7 @@ class Plugin(DialogUtils):
                     self.app.show_message(_("Error"), _("Deletion was not completed {}".format(response)))
                 else:
                     await self.get_assets()
+                self.app.layout.focus(self.main_container)
 
             asyncio.ensure_future(coroutine())
 
@@ -235,7 +236,7 @@ class Plugin(DialogUtils):
                 title=_("Confirm"),
                 message=HTML(_("Are you sure you want to delete asset <b>{}</b>?")).format(kwargs['selected'][1]),
                 buttons=buttons,
-                tobefocused=self.assets_container
+                tobefocused=self.main_container
                 )
 
 


### PR DESCRIPTION
closes #9158

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
