### PR TITLE
fix(config-api): asset service param decleration

### DIFF
--- a/jans-config-api/common/src/main/java/io/jans/configapi/util/ApiConstants.java
+++ b/jans-config-api/common/src/main/java/io/jans/configapi/util/ApiConstants.java
@@ -84,7 +84,7 @@ public class ApiConstants {
     public static final String SERVICES = "/services";
     public static final String ASSET_TYPE = "/asset-type";
     public static final String SERVICE = "/service";
-    
+        
     public static final String APP_VERSION = "/app-version";
     public static final String SERVER_STAT = "/server-stat";
     public static final String USERNAME_PATH = "/{username}";
@@ -127,6 +127,7 @@ public class ApiConstants {
     public static final String SESSIONID = "sessionId";
     public static final String USERDN = "userDn";
     public static final String PLUGIN_NAME = "pluginName";
+    public static final String SERVICE_NAME = "service-name";
     
 
     public static final String ALL = "all";

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -805,6 +805,13 @@ paths:
       summary: Load assets on server for a service
       description: Load assets on server for a service
       operationId: load-service-asset
+      parameters:
+      - name: service-name
+        in: path
+        description: Service Name
+        required: true
+        schema:
+          type: string
       requestBody:
         description: String multipart form.
         content:
@@ -8359,21 +8366,21 @@ components:
           $ref: '#/components/schemas/AttributeValidation'
         tooltip:
           type: string
-        selected:
+        userCanView:
           type: boolean
-        whitePagesCanView:
+        userCanEdit:
           type: boolean
         adminCanView:
           type: boolean
         adminCanEdit:
           type: boolean
-        userCanView:
-          type: boolean
-        userCanEdit:
+        adminCanAccess:
           type: boolean
         userCanAccess:
           type: boolean
-        adminCanAccess:
+        selected:
+          type: boolean
+        whitePagesCanView:
           type: boolean
         baseDn:
           type: string
@@ -9210,6 +9217,8 @@ components:
           type: boolean
         lockMessageConfig:
           $ref: '#/components/schemas/LockMessageConfig'
+        fapi:
+          type: boolean
         allResponseTypesSupported:
           uniqueItems: true
           type: array
@@ -9219,8 +9228,6 @@ components:
             - code
             - token
             - id_token
-        fapi:
-          type: boolean
     AuthenticationFilter:
       required:
       - baseDn
@@ -9987,10 +9994,10 @@ components:
           type: array
           items:
             type: object
-        value:
-          type: object
         displayValue:
           type: string
+        value:
+          type: object
     LocalizedString:
       type: object
       properties:
@@ -10345,14 +10352,14 @@ components:
           type: boolean
         internal:
           type: boolean
-        locationPath:
-          type: string
         locationType:
           type: string
           enum:
           - ldap
           - db
           - file
+        locationPath:
+          type: string
         baseDn:
           type: string
     ScriptError:

--- a/jans-config-api/plugins/docs/user-mgt-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/user-mgt-plugin-swagger.yaml
@@ -863,10 +863,10 @@ components:
           type: array
           items:
             type: object
-        value:
-          type: object
         displayValue:
           type: string
+        value:
+          type: object
     CustomUser:
       type: object
       properties:

--- a/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/AssetResource.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/rest/resource/auth/AssetResource.java
@@ -339,15 +339,17 @@ public class AssetResource extends ConfigBaseResource {
     @POST
     @Path(ApiConstants.SERVICE + ApiConstants.SERVICE_NAME_PARAM_PATH)
     @ProtectedApi(scopes = { ApiAccessConstants.JANS_ASSET_WRITE_ACCESS })
-    public Response loadServiceAsset(String serviceName) throws Exception {
+    public Response loadServiceAsset(
+            @Parameter(description = "Service Name") @PathParam(ApiConstants.SERVICE_NAME) @NotNull String serviceName)
+            throws Exception {
         if (log.isInfoEnabled()) {
             log.info("Create Asset details serviceName:{}", serviceName);
         }
 
-// validation
+        // validation
         checkResourceNotNull(serviceName, "Service Name");
         String result = null;
-// save asset
+        // save asset
         try {
             result = assetService.loadServiceAsset(serviceName);
 


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Build is failing due to incorrect param decleration

Errors:
	-paths.'/api/v1/jans-assets/service/{service-name}'. Declared path parameter service-name needs to be defined as a path parameter in path or operation level

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #9189

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
