### PR TITLE
fix(jans-auth-server): missed chain call in header filter

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/filter/HeadersFilter.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/filter/HeadersFilter.java
@@ -32,6 +32,8 @@ public class HeadersFilter implements Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
         addXFrameOptionsResponseHeader(httpRequest, httpResponse, configurationFactory.getAppConfiguration());
+
+        chain.doFilter(request, response);
     }
 
     public static void addXFrameOptionsResponseHeader(HttpServletRequest httpRequest, HttpServletResponse httpResponse, AppConfiguration appConfiguration) {


### PR DESCRIPTION
### Description

fix(jans-auth-server): missed chain call in header filter

