### PR TITLE
fix(jans-auth): plaintext passwords logged from TokenRestWebServiceImpl with DEBUG log level #8959

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/util/ServerUtil.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/util/ServerUtil.java
@@ -75,6 +75,9 @@ public class ServerUtil {
         if (result.containsKey("client_secret")) {
             result.put("client_secret", new String[] {"*****"});
         }
+        if (result.containsKey("password")) {
+            result.put("password", new String[] {"*****"});
+        }
         return result;
     }
 

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/util/ServerUtilTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/util/ServerUtilTest.java
@@ -21,4 +21,14 @@ public class ServerUtilTest {
 
         assertEquals("*****", result.get("client_secret")[0]);
     }
+
+    @Test
+    public void prepareForLogs_whenCalled_shouldNotHaveClearTextPassword() {
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("password", new String[] {"124"});
+
+        final Map<String, String[]> result = ServerUtil.prepareForLogs(parameters);
+
+        assertEquals("*****", result.get("password")[0]);
+    }
 }


### PR DESCRIPTION
### Description

fix(jans-auth): plaintext passwords logged from TokenRestWebServiceImpl with DEBUG log level 

#### Target issue
  
closes #8959

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
