### PR TITLE
fix(jans-cli-tui): authn page for non-ldap backend

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/authn.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/authn.py
@@ -154,7 +154,7 @@ class Authn(DialogUtils):
 
     def on_page_enter(self) -> None:
 
-        if common_data.server_persistence_type != 'ldap':
+        if common_data.server_persistence_type != 'ldap' and 'LDAP Servers' in self.side_nav_bar.navbar_entries:
             self.side_nav_bar.navbar_entries.remove('LDAP Servers')
 
         def populate_acr_list():


### PR DESCRIPTION
closes #9330

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
