### PR TITLE
fix(jans-cli-tui): re-order feed and background task messages

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/140_config_api/main.py
+++ b/jans-cli-tui/cli_tui/plugins/140_config_api/main.py
@@ -41,12 +41,14 @@ class Plugin(DialogUtils):
             app (Generic): The main Application class
         """
         self.app = app
-        common_data.background_tasks_feeds['attributes'].append(self.feed_attribute_widgets)
+        
         self.pid = 'config-api'
         self.name = 'Config API'
         self.server_side_plugin = False
         self.page_entered = False
         self.data = {}
+
+        common_data.background_tasks_feeds['attributes'].append(self.feed_attribute_widgets)
         self.prepare_navbar()
         self.prepare_containers()
 
@@ -54,6 +56,22 @@ class Plugin(DialogUtils):
     def init_plugin(self) -> None:
         """The initialization for this plugin
         """
+
+        self.label_widget_width = common_data.app.output.get_size().columns - 3
+
+        self.user_exclusion_attributes_widget = JansLabelWidget(
+                        title = _("User Exclusion Attributes"),
+                        values = ['test'],
+                        data = [],
+                        label_width=self.label_widget_width
+                        )
+
+        self.user_mandatory_attributes_widget = JansLabelWidget(
+                        title = _("User Mandatory Attributes"),
+                        values = ['test'],
+                        data = [],
+                        label_width=self.label_widget_width
+                        )
 
         self.app.create_background_task(self.get_configuration())
 
@@ -65,21 +83,6 @@ class Plugin(DialogUtils):
 
     def create_widgets(self):
         self.schema = self.app.cli_object.get_schema_from_reference('', '#/components/schemas/ApiAppConfiguration')
-        label_widget_width = common_data.app.output.get_size().columns - 3
-
-        self.user_exclusion_attributes_widget = JansLabelWidget(
-                        title = _("User Exclusion Attributes"),
-                        values = ['test'],
-                        data = [],
-                        label_width=label_widget_width
-                        )
-
-        self.user_mandatory_attributes_widget = JansLabelWidget(
-                        title = _("User Mandatory Attributes"),
-                        values = ['test'],
-                        data = [],
-                        label_width=label_widget_width
-                        )
 
         self.tabs['main_'] = HSplit([
                         self.app.getTitledCheckBox(
@@ -162,14 +165,14 @@ class Plugin(DialogUtils):
                         title = _("Mandatory Attributes"),
                         values = copy.deepcopy(self.data.get('agamaConfiguration', {}).get('mandatoryAttributes', [])),
                         data = [('qname', 'qname'),('source', 'source')],
-                        label_width=label_widget_width
+                        label_width=self.label_widget_width
                         )
 
         self.agama_configuration_optional_attributes_widget = JansLabelWidget(
                         title = _("Optioanl Attributes"),
                         values = copy.deepcopy(self.data.get('agamaConfiguration', {}).get('optionalAttributes', [])),
                         data = [('serialVersionUID', 'serialVersionUID'), ('enabled', 'enabled')],
-                        label_width=label_widget_width
+                        label_width=self.label_widget_width
                         )
 
         self.tabs['agamaConfiguration'] = HSplit([
@@ -207,7 +210,7 @@ class Plugin(DialogUtils):
                         title = _("Header Attributes"),
                         values = copy.deepcopy(self.data.get('auditLogConf', {}).get('headerAttributes', [])),
                         data = [('User-inum', 'User-inum')],
-                        label_width=label_widget_width
+                        label_width=self.label_widget_width
                         )
 
         self.tabs['auditLogConf'] = HSplit([

--- a/jans-cli-tui/cli_tui/utils/background_tasks.py
+++ b/jans-cli-tui/cli_tui/utils/background_tasks.py
@@ -38,6 +38,7 @@ async def get_attributes_coroutine(app) -> None:
             break
 
     for feed in common_data.background_tasks_feeds['attributes']:
+        app.logger.info(f"Executing feed {feed.__name__}")
         feed()
 
 async def retrieve_enabled_scripts() -> None:
@@ -65,6 +66,14 @@ async def get_admin_ui_roles() -> None:
     common_data.app.start_progressing(_("Retreiving admin UI roles from server..."))
     response = await get_event_loop().run_in_executor(common_data.app.executor, common_data.app.cli_requests, cli_args)
     common_data.app.stop_progressing()
+    if response.status_code not in (200, 201):
+        common_data.app.show_message(
+            title=_("Error getting Admin-UI Roles"),
+            message=_("Error while retreiving admin UI roles:\n") + str(response.text),
+            tobefocused=common_data.app.center_frame
+        )
+        return
+
     common_data.admin_ui_roles = response.json()
 
 
@@ -76,5 +85,12 @@ async def get_persistence_type() -> None:
     common_data.app.start_progressing(_("Retreiving persistence type from server..."))
     response = await get_event_loop().run_in_executor(common_data.app.executor, common_data.app.cli_requests, cli_args)
     common_data.app.stop_progressing()
+    if response.status_code not in (200, 201):
+        common_data.app.show_message(
+            title=_("Error getting persistence type"),
+            message=_("Error while getting persistence type configured for Jans authorization server:\n") + str(response.text),
+            tobefocused=common_data.app.center_frame
+        )
+        return
     result = response.json()
     common_data.server_persistence_type = result['persistenceType']


### PR DESCRIPTION
closes #9414

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
