### PR TITLE
fix(jans-linux-setup): jans ldap link server

### DIFF
--- a/docs/admin/install/setup.md
+++ b/docs/admin/install/setup.md
@@ -43,7 +43,7 @@ tags:
 Install Jans Config API? [Yes] : 
 Install Scim Server? [Yes] : 
 Install Fido2 Server? [Yes] : 
-Install Jans Link Server? [Yes] : 
+Install Jans LDAP Link Server? [Yes] : 
 Install Gluu Casa? [No] :
   ```
    
@@ -86,7 +86,7 @@ To check usage of this script run help command
                      [-couchbase-admin-user COUCHBASE_ADMIN_USER] [-couchbase-admin-password COUCHBASE_ADMIN_PASSWORD]
                      [-couchbase-bucket-prefix COUCHBASE_BUCKET_PREFIX] [-couchbase-hostname COUCHBASE_HOSTNAME] [--no-data]
                      [--no-jsauth] [-ldap-admin-password LDAP_ADMIN_PASSWORD] [--no-config-api] [--no-scim] [--no-fido2]
-                     [--install-jans-link] [--with-casa] [--load-config-api-test]
+                     [--install-jans-ldap-link] [--with-casa] [--load-config-api-test]
                      [-config-patch-creds CONFIG_PATCH_CREDS] [-spanner-project SPANNER_PROJECT] [-spanner-instance SPANNER_INSTANCE]
                      [-spanner-database SPANNER_DATABASE]
                      [-spanner-emulator-host SPANNER_EMULATOR_HOST | -google-application-credentials GOOGLE_APPLICATION_CREDENTIALS]
@@ -162,7 +162,7 @@ Below are the optional arguments:
 | --no-config-api | Do not install Jans Auth Config Api |
 | --no-scim | Do not install Scim Server |
 | --no-fido2 | Do not install Fido2 Server |
-| --install-jans-link | Install Link Server |
+| --install-jans-ldap-link | Install LDAP Link Server |
 | --with-casa | Install Gluu/Flex Casa Server |
 | --load-config-api-test | Load Config Api Test Data |
 | --install-cache-refresh | Install Cache Refresh Server |

--- a/jans-linux-setup/jans_setup/setup_app/config.py
+++ b/jans-linux-setup/jans_setup/setup_app/config.py
@@ -200,7 +200,7 @@ class Config:
         self.install_config_api = True
         self.install_casa = False
         self.install_jans_cli = True
-        self.install_jans_link = False
+        self.install_jans_ldap_link = False
         self.loadTestData = False
         self.allowPreReleasedFeatures = False
         self.install_jans_saml = False

--- a/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/config_api.py
@@ -67,7 +67,7 @@ class ConfigApiInstaller(JettyInstaller):
         if Config.install_fido2:
             self.install_plugin('fido2-plugin')
 
-        if Config.install_jans_link:
+        if Config.install_jans_ldap_link:
             self.install_plugin('jans-link-plugin')
 
         self.enable()

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -80,7 +80,7 @@ class JansInstaller(BaseInstaller, SetupUtils):
                 for prompt_str, install_var in (
                         ('Install Fido2 Server', 'install_fido2'),
                         ('Install Scim Server', 'install_scim_server'),
-                        ('Install Jans Link Server', 'install_jans_link'),
+                        ('Install Jans LDAP Link Server', 'install_jans_ldap_link'),
                         ('Install Jans KC Link Server', 'install_jans_keycloak_link'),
                         ('Install Jans Casa', 'install_casa'),
                         ('Install Jans Lock', 'install_jans_lock'),
@@ -657,7 +657,7 @@ class JansInstaller(BaseInstaller, SetupUtils):
                         ('jans-config-api', 'install_config_api'),
                         ('jans-casa', 'install_casa'),
                         ('jans-fido2', 'install_fido2'),
-                        ('jans-link', 'install_jans_link'),
+                        ('jans-link', 'install_jans_ldap_link'),
                         ('jans-scim', 'install_scim_server'),
                         ('jans-lock', 'install_jans_lock_as_server'),
                         ('opa', 'install_opa'),

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans_link.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans_link.py
@@ -22,7 +22,7 @@ class JansLinkInstaller(JettyInstaller):
         self.needdb = True
         self.app_type = AppType.SERVICE
         self.install_type = InstallOption.OPTONAL
-        self.install_var = 'install_jans_link'
+        self.install_var = 'install_jans_ldap_link'
         self.register_progess()
 
         self.output_folder = os.path.join(Config.output_dir, self.service_name)

--- a/jans-linux-setup/jans_setup/setup_app/setup_options.py
+++ b/jans-linux-setup/jans_setup/setup_app/setup_options.py
@@ -16,7 +16,7 @@ def get_setup_options():
         'install_httpd': True,
         'install_scim_server': True if base.current_app.profile == 'jans' else False,
         'install_fido2': True,
-        'install_jans_link': False,
+        'install_jans_ldap_link': False,
         'install_jans_keycloak_link': False,
         'install_casa': False,
         'install_jans_saml': False,
@@ -103,8 +103,8 @@ def get_setup_options():
         if base.argsp.no_fido2:
             setupOptions['install_fido2'] = False
 
-        if base.argsp.install_jans_link:
-            setupOptions['install_jans_link'] = True
+        if base.argsp.install_jans_ldap_link:
+            setupOptions['install_jans_ldap_link'] = True
 
         if base.argsp.install_jans_keycloak_link:
             setupOptions['install_jans_keycloak_link'] = True

--- a/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/arg_parser.py
@@ -101,7 +101,7 @@ if PROFILE != OPENBANKING_PROFILE:
 
     parser.add_argument('--no-scim', help="Do not install Scim Server", action='store_true')
     parser.add_argument('--no-fido2', help="Do not install Fido2 Server", action='store_true')
-    parser.add_argument('--install-jans-link', help="Install Jans Link Server", action='store_true')
+    parser.add_argument('--install-jans-ldap-link', help="Install Jans LDAP Link Server", action='store_true')
     parser.add_argument('--install-jans-keycloak-link', help="Install Keycloak Link Server", action='store_true')
 
     parser.add_argument('--with-casa', help="Install Jans Casa", action='store_true')

--- a/jans-linux-setup/jans_setup/setup_app/utils/collect_properties.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/collect_properties.py
@@ -218,7 +218,7 @@ class CollectProperties(SetupUtils, BaseInstaller):
         Config.install_scim_server = os.path.exists(os.path.join(Config.jetty_base, 'jans-scim/start.d'))
         Config.install_fido2 = os.path.exists(os.path.join(Config.jetty_base, 'jans-fido2/start.d'))
         Config.install_config_api = os.path.exists(os.path.join(Config.jansOptFolder, 'jans-config-api'))
-        Config.install_jans_link = os.path.exists(os.path.join(Config.jansOptFolder, 'jans-link'))
+        Config.install_jans_ldap_link = os.path.exists(os.path.join(Config.jansOptFolder, 'jans-link'))
         Config.install_casa = os.path.exists(os.path.join(Config.jetty_base, 'casa/start.d'))
         Config.install_jans_keycloak_link = os.path.exists(os.path.join(Config.jetty_base, 'jans-keycloak-link/start.d'))
 

--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -517,17 +517,17 @@ class PropertiesUtils(SetupUtils):
 
 
     def prompt_for_jans_link(self):
-        if Config.installed_instance and Config.install_jans_link:
+        if Config.installed_instance and Config.install_jans_ldap_link:
             return
 
         prompt_jans_link = self.getPrompt("Install Jans LDAP Link Server?",
-                                            self.getDefaultOption(Config.install_jans_link)
+                                            self.getDefaultOption(Config.install_jans_ldap_link)
                                             )[0].lower()
 
-        Config.install_jans_link = prompt_jans_link == 'y'
+        Config.install_jans_ldap_link = prompt_jans_link == 'y'
 
-        if Config.installed_instance and Config.install_jans_link:
-            Config.addPostSetupService.append('install_jans_link')
+        if Config.installed_instance and Config.install_jans_ldap_link:
+            Config.addPostSetupService.append('install_jans_ldap_link')
 
 
     def prompt_for_jans_keycloak_link(self):

--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -520,7 +520,7 @@ class PropertiesUtils(SetupUtils):
         if Config.installed_instance and Config.install_jans_link:
             return
 
-        prompt_jans_link = self.getPrompt("Install Jans Link Server?",
+        prompt_jans_link = self.getPrompt("Install Jans LDAP Link Server?",
                                             self.getDefaultOption(Config.install_jans_link)
                                             )[0].lower()
 


### PR DESCRIPTION
closes #9456

- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)
