### PR TITLE
fix(jans-auth-server): typo in forceIdTokenHintPrecense, precense -> presence #9559

### DIFF
--- a/docs/admin/auth-server/endpoints/end-session.md
+++ b/docs/admin/auth-server/endpoints/end-session.md
@@ -57,7 +57,7 @@ navigate via `Auth Server`->`Properties`.
 - [mtlsEndSessionEndpoint](../../reference/json/properties/janssenauthserver-properties.md#mtlsendsessionendpoint)
 - [rejectEndSessionIfIdTokenExpired](../../reference/json/properties/janssenauthserver-properties.md#rejectendsessionifidtokenexpired)
 - [allowPostLogoutRedirectWithoutValidation](../../reference/json/properties/janssenauthserver-properties.md#allowpostlogoutredirectwithoutvalidation)
-- [forceIdTokenHintPrecense](../../reference/json/properties/janssenauthserver-properties.md#forceidtokenhintprecense)
+- [forceIdTokenHintPresence](../../reference/json/properties/janssenauthserver-properties.md#forceidtokenhintprecense)
 
 Apart from the above-mentioned server properties, the properties relevant to individual clients can be configured
 during client registration or can be edited later. When using 

--- a/docs/admin/config-guide/auth-server-config/jans-authorization-server-config.md
+++ b/docs/admin/config-guide/auth-server-config/jans-authorization-server-config.md
@@ -501,7 +501,7 @@ It returns all the information of the Jans Authorization server.
   "dcrAuthorizationWithMTLS": false,
   "useLocalCache": true,
   "fapiCompatibility": false,
-  "forceIdTokenHintPrecense": false,
+  "forceIdTokenHintPresence": false,
   "rejectEndSessionIfIdTokenExpired": false,
   "allowEndSessionWithUnmatchedSid": false,
   "forceOfflineAccessScopeToEnableRefreshToken": true,

--- a/docs/admin/reference/json/properties/janssenauthserver-properties.md
+++ b/docs/admin/reference/json/properties/janssenauthserver-properties.md
@@ -122,7 +122,7 @@ tags:
 | externalUriWhiteList | This list specifies which external URIs can be called by AS (if empty any URI can be called) | [Details](#externaluriwhitelist) |
 | fapiCompatibility | Boolean value specifying whether to turn on FAPI compatibility mode. If true AS behaves in more strict mode | [Details](#fapicompatibility) |
 | featureFlags | List of enabled feature flags | [Details](#featureflags) |
-| forceIdTokenHintPrecense | Boolean value specifying whether force id_token_hint parameter presence | [Details](#forceidtokenhintprecense) |
+| forceIdTokenHintPresence | Boolean value specifying whether force id_token_hint parameter presence | [Details](#forceidtokenhintprecense) |
 | forceOfflineAccessScopeToEnableRefreshToken | Boolean value specifying whether force offline_access scope to enable refresh_token grant type. Default value is true | [Details](#forceofflineaccessscopetoenablerefreshtoken) |
 | forceSignedRequestObject | Boolean value true indicates that signed request object is mandatory | [Details](#forcesignedrequestobject) |
 | frontChannelLogoutSessionSupported | Choose whether to support front channel session logout | [Details](#frontchannellogoutsessionsupported) |
@@ -1283,7 +1283,7 @@ tags:
 - Default value: None
 
 
-### forceIdTokenHintPrecense
+### forceIdTokenHintPresence
 
 - Description: Boolean value specifying whether force id_token_hint parameter presence
 

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -744,7 +744,7 @@ public class AppConfiguration implements Configuration {
     private Boolean fapiCompatibility = false;
 
     @DocProperty(description = "Boolean value specifying whether force id_token_hint parameter presence", defaultValue = "false")
-    private Boolean forceIdTokenHintPrecense = false;
+    private Boolean forceIdTokenHintPresence = false;
 
     @DocProperty(description = "default value false. If true and id_token is not found in db, request is rejected", defaultValue = "false")
     private Boolean rejectEndSessionIfIdTokenExpired = false;
@@ -1476,13 +1476,13 @@ public class AppConfiguration implements Configuration {
         this.trustedSsaIssuers = trustedSsaIssuers;
     }
 
-    public Boolean getForceIdTokenHintPrecense() {
-        if (forceIdTokenHintPrecense == null) forceIdTokenHintPrecense = false;
-        return forceIdTokenHintPrecense;
+    public Boolean getForceIdTokenHintPresence() {
+        if (forceIdTokenHintPresence == null) forceIdTokenHintPresence = false;
+        return forceIdTokenHintPresence;
     }
 
-    public void setForceIdTokenHintPrecense(Boolean forceIdTokenHintPrecense) {
-        this.forceIdTokenHintPrecense = forceIdTokenHintPrecense;
+    public void setForceIdTokenHintPresence(Boolean forceIdTokenHintPresence) {
+        this.forceIdTokenHintPresence = forceIdTokenHintPresence;
     }
 
     public Boolean getRejectEndSessionIfIdTokenExpired() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/session/ws/rs/EndSessionRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/session/ws/rs/EndSessionRestWebServiceImpl.java
@@ -332,7 +332,7 @@ public class EndSessionRestWebServiceImpl implements EndSessionRestWebService {
     }
 
     public Jwt validateIdTokenHint(String idTokenHint, SessionId sidSession, String postLogoutRedirectUri, String state, String clientId) {
-        final boolean isIdTokenHintRequired = isTrue(appConfiguration.getForceIdTokenHintPrecense());
+        final boolean isIdTokenHintRequired = isTrue(appConfiguration.getForceIdTokenHintPresence());
 
         if (isIdTokenHintRequired && StringUtils.isBlank(idTokenHint)) { // must be present for logout tests #1279
             final String reason = "id_token_hint is not set";

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/session/ws/rs/EndSessionRestWebServiceImplTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/session/ws/rs/EndSessionRestWebServiceImplTest.java
@@ -116,7 +116,7 @@ public class EndSessionRestWebServiceImplTest {
 
     @Test(expectedExceptions = WebApplicationException.class)
     public void validateIdTokenHint_whenIdTokenHintIsBlankButRequired_shouldGetError() {
-        when(appConfiguration.getForceIdTokenHintPrecense()).thenReturn(true);
+        when(appConfiguration.getForceIdTokenHintPresence()).thenReturn(true);
 
         endSessionRestWebService.validateIdTokenHint("", null, "", "http://postlogout.com", "");
     }

--- a/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
+++ b/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
@@ -291,7 +291,7 @@ class TestDataLoader(BaseInstaller, SetupUtils):
                                     'rejectJwtWithNoneAlg': False,
                                     'removeRefreshTokensForClientOnLogout': True,
                                     'fapiCompatibility': False,
-                                    'forceIdTokenHintPrecense': False,
+                                    'forceIdTokenHintPresence': False,
                                     'introspectionScriptBackwardCompatibility': False,
                                     'allowSpontaneousScopes': True,
                                     'spontaneousScopeLifetime': 0,


### PR DESCRIPTION
### Description

fix(jans-auth-server): typo in forceIdTokenHintPrecense, precense -> presence 

#### Target issue
  
closes #9559

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
