### PR TITLE
feat(jans-orm): use protobuf-java defined in upstream dependecies

### DIFF
--- a/jans-orm/sql/pom.xml
+++ b/jans-orm/sql/pom.xml
@@ -45,11 +45,6 @@
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 		</dependency>
-		<!-- remove after nupdate mysql-libs -->
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java</artifactId>
-		</dependency>
 		<dependency>
 		    <groupId>org.postgresql</groupId>
 		    <artifactId>postgresql</artifactId>


### PR DESCRIPTION
closes #9618

- [X] **I confirm that there is no impact on the docs due to the code changes in this PR.**
