### PR TITLE
fix(jans-linux-setup): import ruamel in fucntion read_yaml_file()

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -17,8 +17,6 @@ import multiprocessing
 import ssl
 import tempfile
 import urllib.request
-import ruamel.yaml
-
 
 from pathlib import Path
 from collections import OrderedDict
@@ -323,6 +321,7 @@ def readJsonFile(jsonFile, ordered=False):
             return json.load(f, object_pairs_hook=object_pairs_hook)
 
 def read_yaml_file(yaml_fn):
+    import ruamel.yaml
     yaml_obj = ruamel.yaml.YAML()
     with open(yaml_fn) as f:
         data = yaml_obj.load(f)


### PR DESCRIPTION
Closes #9634

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
