### PR TITLE
docs: fix wrong Agama engine paths

### DIFF
--- a/docs/janssen-server/developer/agama/engine-bridge-config.md
+++ b/docs/janssen-server/developer/agama/engine-bridge-config.md
@@ -24,21 +24,21 @@ The properties of Agama engine configuration are described in the following:
 
 - `enabled`: A boolean value that specifies if the engine is enabled. To disable the engine, open [TUI](../../config-guide/config-tools/jans-tui/README.md) and navigate to `Auth Server` > `properties` > `agamaConfiguration`. Then uncheck `enabled` and hit `save`
 
-- `templatesPath`: A path relative to `/opt/jans/jetty/jans-auth/server/agama` that serves as the root of Agama flow pages. Default value is `/ftl`
+- `templatesPath`: A path relative to `/opt/jans/jetty/jans-auth/agama` that serves as the root of Agama flow pages. Default value is `/ftl`
 
-- `scriptsPath`: A path relative to `/opt/jans/jetty/jans-auth/server/agama` that serves as the root of the hierarchy of (Java/Groovy) classes added on the fly. Default value is `/scripts`
+- `scriptsPath`: A path relative to `/opt/jans/jetty/jans-auth/agama` that serves as the root of the hierarchy of (Java/Groovy) classes added on the fly. Default value is `/scripts`
 
 - `maxItemsLoggedInCollections`: When a list or map is [logged](../../../agama/language-reference.md#logging)
   in 
   a flow, only the first few items are included in the output. You can use this property to increase that limit. Default value is `9`
 
-- `pageMismatchErrorPage`: A path relative to `/opt/jans/jetty/jans-auth/server/agama` containing the location of the page shown when an unexpected URL is requested while a flow is in course. Default value is `mismatch.ftlh`
+- `pageMismatchErrorPage`: A path relative to `/opt/jans/jetty/jans-auth/agama` containing the location of the page shown when an unexpected URL is requested while a flow is in course. Default value is `mismatch.ftlh`
 
-- `interruptionErrorPage`: A path relative to `/opt/jans/jetty/jans-auth/server/agama` containing the location of the page shown when a user exceeds the amount of time allowed to take a flow to completion. Note that in order to preserve resources, the engine holds references to unfinished flows only for a small period of time (usually less than two minutes). Once the reference is lost, the error page regarded here won't be shown but `pageMismatchErrorPage`. Default value is `timeout.ftlh`
+- `interruptionErrorPage`: A path relative to `/opt/jans/jetty/jans-auth/agama` containing the location of the page shown when a user exceeds the amount of time allowed to take a flow to completion. Note that in order to preserve resources, the engine holds references to unfinished flows only for a small period of time (usually less than two minutes). Once the reference is lost, the error page regarded here won't be shown but `pageMismatchErrorPage`. Default value is `timeout.ftlh`
 
-- `crashErrorPage`: A path relative to `/opt/jans/jetty/jans-auth/server/agama` containing the location of the page shown when an error has occured while running the flow. It contains a brief description of the problem for troubleshooting. Default value is `crash.ftlh`
+- `crashErrorPage`: A path relative to `/opt/jans/jetty/jans-auth/agama` containing the location of the page shown when an error has occured while running the flow. It contains a brief description of the problem for troubleshooting. Default value is `crash.ftlh`
 
-- `finishedFlowPage`:  A path relative to `/opt/jans/jetty/jans-auth/server/agama` containing the location of the page shown when a flow has finished (whether successfully or not) in the phase handled exclusively by the engine. This page features an auto-submitting form that users won't notice in practice. This page will rarely need modifications. Default value is `finished.ftlh`
+- `finishedFlowPage`:  A path relative to `/opt/jans/jetty/jans-auth/agama` containing the location of the page shown when a flow has finished (whether successfully or not) in the phase handled exclusively by the engine. This page features an auto-submitting form that users won't notice in practice. This page will rarely need modifications. Default value is `finished.ftlh`
 
 - `bridgeScriptPage`: This is a facelets (JSF) page the bridge needs for proper operation. This page resides in the authentication server WAR file and will rarely need modifications. Default value is `agama.xhtml`
 


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes  #9661

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [X] **I confirm that there is no impact on the docs due to the code changes in this PR.**
