### PR TITLE
fix(jans-linux-setup): mysql backend with setup.properties

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -206,6 +206,8 @@ class PropertiesUtils(SetupUtils):
 
         if p.get('rdbm_type') == 'pgsql' and not p.get('rdbm_port'):
             p['rdbm_port'] = '5432'
+        elif p.get('rdbm_type') == 'mysql' and not p.get('rdbm_port'):
+            p['rdbm_port'] = '3306'
 
         properties_list = list(p.keys())
 


### PR DESCRIPTION
closes #8113

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
