### PR TITLE
fix(jans-linux-setup): suse mysql version 8.0.39

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/package_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/package_utils.py
@@ -64,7 +64,7 @@ class PackageUtils(SetupUtils):
                     self.run(['rpm', '-i', f'https://dev.mysql.com/get/mysql80-community-release-sl{base.os_version}-{base.os_subversion}.noarch.rpm'])
                     self.run(['rpm', '--import', '/etc/RPM-GPG-KEY-mysql'])
                     self.run(['zypper', '--no-gpg-checks', '--gpg-auto-import-keys', 'refresh'])
-                    package_list[os_type_version]['mandatory'] += ' mysql-community-server'
+                    package_list[os_type_version]['mandatory'] += ' mysql-community-server-8.0.39'
                 else:
                     package_list[os_type_version]['mandatory'] += ' mysql-server'
 


### PR DESCRIPTION
closes #9743

There is a recent MySQL built with `libc.so.6(GLIBC_2.38)(64bit)` and SUSE repositories does not provide GLIBC_2.38:

```
Problem: 1: nothing provides 'libc.so.6(GLIBC_2.38)(64bit)' needed by the to be installed mysql-community-server-8.0.40-1.sl15.x86_64
 Solution 1: do not install mysql-community-server-8.0.40-1.sl15.x86_64
 Solution 2: break mysql-community-server-8.0.40-1.sl15.x86_64 by ignoring some of its dependencies
```

To fix this issue, mysql version is restricted to `mysql-community-server-8.0.39`


- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
