### PR TITLE
fix(jans-cli-tui): do not hide ldap servers in authn when database is not ldap

### DIFF
--- a/docs/janssen-server/config-guide/auth-server-config/authentication-method-config.md
+++ b/docs/janssen-server/config-guide/auth-server-config/authentication-method-config.md
@@ -168,9 +168,6 @@ and navigate to the new default method with **Up** and **Down** keys.
 To choose hit **Space** key.
 Navigate to **Save** button and hit **Enter** key
 
-!!! Note 
-    If your backend database is not LDAP, you won't see any LDAP servers 
-    related tab/items.
 
 ### Basic Authentication Method
 
@@ -184,9 +181,8 @@ navigate to **Save** button and hit **Enter** key
 
 ### LDAP Servers As Authentication Method
 
-If your backend database is LDAP, you will have this tab where you can add and 
-modify LDAP Servers are to be used as the default authentication method. 
-See below image
+In this tab you can add and modify LDAP Servers are to be used as the
+default authentication method. See below image
 
 ![image](../../../assets/tui-authn-ldap-servers.png)
 

--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/authn.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/authn.py
@@ -154,9 +154,6 @@ class Authn(DialogUtils):
 
     def on_page_enter(self) -> None:
 
-        if common_data.server_persistence_type != 'ldap' and 'LDAP Servers' in self.side_nav_bar.navbar_entries:
-            self.side_nav_bar.navbar_entries.remove('LDAP Servers')
-
         def populate_acr_list():
 
             acr_values = [(BUILTIN_AUTHN, BUILTIN_AUTHN + ' [builtin]')]


### PR DESCRIPTION
closes #9872

- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)
