### PR TITLE
fix(jans-core): document store manager should have not null supported…

### DIFF
--- a/jans-core/document-store/src/main/java/io/jans/service/document/store/manager/DocumentStoreManager.java
+++ b/jans-core/document-store/src/main/java/io/jans/service/document/store/manager/DocumentStoreManager.java
@@ -73,7 +73,7 @@ public class DocumentStoreManager {
 	private long lastFinishedTime;
 	
     private boolean initialized = false;
-	private List<String> supportedServiceTypes;
+	private List<String> supportedServiceTypes = new ArrayList();
 	private DocumentStoreType previousServiceType;
 	
 	private Map<String, Object> loadedDocumentsStore = new TreeMap<String, Object>();
@@ -85,7 +85,7 @@ public class DocumentStoreManager {
 
 	@Asynchronous
 	public void initTimer(List<String> serviceTypes, int interval) {
-		this.supportedServiceTypes = serviceTypes;
+		this.supportedServiceTypes.addAll(serviceTypes);
 
 		configure();
 


### PR DESCRIPTION
closes #10001

- [X] **I confirm that there is no impact on the docs due to the code changes in this PR.**
