### PR TITLE
human-readable test fixtures

### DIFF
--- a/jans-cedarling/cedarling/Cargo.toml
+++ b/jans-cedarling/cedarling/Cargo.toml
@@ -26,3 +26,4 @@ test_utils = { workspace = true }
 rand = "0.8.5"
 jsonwebkey = { version = "0.3.5", features = ["generate", "jwt-convert"] }
 mockito = "1.5.0"
+serde_yml = "0.0.12"

--- a/jans-cedarling/cedarling/src/common/cedar_schema.rs
+++ b/jans-cedarling/cedarling/src/common/cedar_schema.rs
@@ -151,6 +151,19 @@ mod deserialize {
         }
 
         #[test]
+        // In fact this fails because of limitations in cedar_policy::Policy::from_json
+        // see PolicyContentType
+        fn test_both_ok() {
+            static POLICY_STORE_RAW: &str =
+                include_str!("../../../test_files/policy-store_blobby.json");
+
+            let policy_result = serde_json::from_str::<PolicyStore>(POLICY_STORE_RAW);
+            let err = policy_result.unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("data did not match any variant of untagged enum MaybeEncoded"));
+        }
+
+        #[test]
         fn test_read_base64_error() {
             static POLICY_STORE_RAW: &str =
                 include_str!("../../../test_files/policy-store_schema_err_base64.json");

--- a/jans-cedarling/cedarling/src/common/cedar_schema.rs
+++ b/jans-cedarling/cedarling/src/common/cedar_schema.rs
@@ -45,33 +45,34 @@ impl PartialEq for CedarSchema {
         // Have to check principals, resources, action_groups, entity_types,
         // actions. Those can contain duplicates, and are not stored in comparison order.
         // So use HashSet to compare them.
+        use std::collections::HashSet;
 
-        let self_principals = self.schema.principals().collect::<std::collections::HashSet<_>>();
-        let other_principals = other.schema.principals().collect::<std::collections::HashSet<_>>();
+        let self_principals = self.schema.principals().collect::<HashSet<_>>();
+        let other_principals = other.schema.principals().collect::<HashSet<_>>();
         if self_principals != other_principals {
             return false
         }
 
-        let self_resources = self.schema.resources().collect::<std::collections::HashSet<_>>();
-        let other_resources = other.schema.resources().collect::<std::collections::HashSet<_>>();
+        let self_resources = self.schema.resources().collect::<HashSet<_>>();
+        let other_resources = other.schema.resources().collect::<HashSet<_>>();
         if self_resources != other_resources {
             return false
         }
 
-        let self_action_groups = self.schema.action_groups().collect::<std::collections::HashSet<_>>();
-        let other_action_groups = other.schema.action_groups().collect::<std::collections::HashSet<_>>();
+        let self_action_groups = self.schema.action_groups().collect::<HashSet<_>>();
+        let other_action_groups = other.schema.action_groups().collect::<HashSet<_>>();
         if self_action_groups != other_action_groups {
             return false
         }
 
-        let self_entity_types = self.schema.entity_types().collect::<std::collections::HashSet<_>>();
-        let other_entity_types = other.schema.entity_types().collect::<std::collections::HashSet<_>>();
+        let self_entity_types = self.schema.entity_types().collect::<HashSet<_>>();
+        let other_entity_types = other.schema.entity_types().collect::<HashSet<_>>();
         if self_entity_types != other_entity_types {
             return false
         }
 
-        let self_actions = self.schema.actions().collect::<std::collections::HashSet<_>>();
-        let other_actions = other.schema.actions().collect::<std::collections::HashSet<_>>();
+        let self_actions = self.schema.actions().collect::<HashSet<_>>();
+        let other_actions = other.schema.actions().collect::<HashSet<_>>();
         if self_actions != other_actions {
             return false
         }

--- a/jans-cedarling/cedarling/src/common/cedar_schema.rs
+++ b/jans-cedarling/cedarling/src/common/cedar_schema.rs
@@ -100,10 +100,10 @@ impl<'de> serde::Deserialize<'de> for CedarSchema {
             super::Encoding::Base64 => {
                 use base64::prelude::*;
                 let buf = BASE64_STANDARD.decode(encoded_schema.body).map_err(|err| {
-                    return serde::de::Error::custom(format!("{}: {}", deserialize::ParseCedarSchemaSetMessage::Base64, err))
+                    serde::de::Error::custom(format!("{}: {}", deserialize::ParseCedarSchemaSetMessage::Base64, err))
                 })?;
                 String::from_utf8(buf).map_err(|err| {
-                    return serde::de::Error::custom(format!("{}: {}", deserialize::ParseCedarSchemaSetMessage::Utf8, err))
+                    serde::de::Error::custom(format!("{}: {}", deserialize::ParseCedarSchemaSetMessage::Utf8, err))
                 })?
             }
         };

--- a/jans-cedarling/cedarling/src/common/mod.rs
+++ b/jans-cedarling/cedarling/src/common/mod.rs
@@ -12,3 +12,27 @@ pub(crate) mod app_types;
 pub(crate) mod cedar_schema;
 
 pub mod policy_store;
+
+/// Used for decoding the policy and schema metadata
+#[derive(Debug, Clone, serde::Deserialize)]
+enum Encoding {
+    /// indicates that the related value is base64 encoded
+    #[serde(rename = "base64")]
+    Base64,
+
+    /// indicates that the related value is not encoded, ie it's just a plain string
+    #[serde(rename = "none")]
+    None,
+}
+
+/// Used for decoding the policy and schema metadata
+#[derive(Debug, Clone, serde::Deserialize)]
+enum ContentType {
+    /// indicates that the related value is in the cedar policy / schema language
+    #[serde(rename = "cedar")]
+    Cedar,
+
+    /// indicates that the related value is in the json representation of the cedar policy / schema language
+    #[serde(rename = "cedar-json")]
+    CedarJson
+}

--- a/jans-cedarling/cedarling/src/common/policy_store.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store.rs
@@ -27,7 +27,7 @@ pub struct PolicyStore {
     pub cedar_version: Version,
 
     /// Cedar schema
-    pub cedar_schema: CedarSchema, // currently being loaded from a base64-encoded string
+    pub cedar_schema: CedarSchema,
 
     /// Cedar policy set
     #[serde(deserialize_with = "parse_cedar_policy")]

--- a/jans-cedarling/cedarling/src/common/policy_store.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, fmt};
 ///
 /// The `PolicyStore` contains the schema and a set of policies encoded in base64,
 /// which are parsed during deserialization.
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, PartialEq)]
 pub struct PolicyStore {
     /// The cedar version to use when parsing the schema and policies.
     #[serde(deserialize_with = "parse_cedar_version")]
@@ -44,7 +44,7 @@ pub struct PolicyStore {
 ///
 /// This struct includes the issuer's name, description, and the OpenID configuration endpoint
 /// for discovering issuer-related information.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize,PartialEq)]
 #[allow(dead_code)]
 pub struct TrustedIssuer {
     /// The name of the trusted issuer.
@@ -97,7 +97,7 @@ where
 ///
 /// This struct includes the type of token, the ID of the person associated with the token,
 /// and an optional role mapping for access control.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[allow(dead_code)]
 pub struct TokenMetadata {
     /// The type of token (e.g., Access, ID, Userinfo, Transaction).
@@ -111,7 +111,7 @@ pub struct TokenMetadata {
     pub role_mapping: Option<String>,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[allow(dead_code)]
 pub enum TokenKind {
     /// Access token used for granting access to resources.

--- a/jans-cedarling/cedarling/src/common/policy_store.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store.rs
@@ -324,10 +324,10 @@ where
         super::Encoding::Base64 => {
             use base64::prelude::*;
             let buf = BASE64_STANDARD.decode(policy_with_metadata.body).map_err(|err| {
-                return serde::de::Error::custom(format!("{}: {}", ParsePolicySetMessage::Base64, err))
+                serde::de::Error::custom(format!("{}: {}", ParsePolicySetMessage::Base64, err))
             })?;
             String::from_utf8(buf).map_err(|err| {
-                return serde::de::Error::custom(format!("{}: {}", ParsePolicySetMessage::String, err))
+                serde::de::Error::custom(format!("{}: {}", ParsePolicySetMessage::String, err))
             })?
         }
     };

--- a/jans-cedarling/test_files/policy-store_blobby.json
+++ b/jans-cedarling/test_files/policy-store_blobby.json
@@ -1,0 +1,28 @@
+{
+    "cedar_version": "v2.4.7",
+    "cedar_policies": {
+        "840da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
+            "description": "simple policy example for pricipal workload",
+            "creation_date": "2024-09-20T17:22:39.996050",
+            "policy_content": {
+                "encoding": "base64",
+                "content_type": "cedar-json",
+                "body":"ewogICAgInN0YXRpY1BvbGljaWVzIjogewogICAgICAgICJwb2xpY3kwIjogewogICAgICAgICAgICAiYWN0aW9uIjogewogICAgICAgICAgICAgICAgImVudGl0eSI6IHsKICAgICAgICAgICAgICAgICAgICAiaWQiOiAiVXBkYXRlIiwKICAgICAgICAgICAgICAgICAgICAidHlwZSI6ICJKYW5zOjpBY3Rpb24iCiAgICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICAgIm9wIjogImluIgogICAgICAgICAgICB9LAogICAgICAgICAgICAiY29uZGl0aW9ucyI6IFsKICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICAiYm9keSI6IHsKICAgICAgICAgICAgICAgICAgICAgICAgIj09IjogewogICAgICAgICAgICAgICAgICAgICAgICAgICAgImxlZnQiOiB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIi4iOiB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICJhdHRyIjogIm9yZ19pZCIsCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICJsZWZ0IjogewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIlZhciI6ICJwcmluY2lwYWwiCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICAgICAgICAgICAgICAgInJpZ2h0IjogewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICIuIjogewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAiYXR0ciI6ICJvcmdfaWQiLAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAibGVmdCI6IHsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICJWYXIiOiAicmVzb3VyY2UiCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICAgICAgICJraW5kIjogIndoZW4iCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIF0sCiAgICAgICAgICAgICJlZmZlY3QiOiAicGVybWl0IiwKICAgICAgICAgICAgInByaW5jaXBhbCI6IHsKICAgICAgICAgICAgICAgICJlbnRpdHlfdHlwZSI6ICJKYW5zOjpXb3JrbG9hZCIsCiAgICAgICAgICAgICAgICAib3AiOiAiaXMiCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJyZXNvdXJjZSI6IHsKICAgICAgICAgICAgICAgICJlbnRpdHlfdHlwZSI6ICJKYW5zOjpJc3N1ZSIsCiAgICAgICAgICAgICAgICAib3AiOiAiaXMiCiAgICAgICAgICAgIH0KICAgICAgICB9CiAgICB9LAogICAgInRlbXBsYXRlTGlua3MiOiBbXSwKICAgICJ0ZW1wbGF0ZXMiOiB7fQp9"
+            }
+        },
+        "444da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
+            "description": "simple policy example for pricipal user",
+            "creation_date": "2024-09-20T17:22:39.996050",
+            "policy_content": {
+                "encoding": "none",
+                "content_type": "cedar",
+                "body": "permit(\n    principal is Jans::User,\n    action in [Jans::Action::\"Update\"],\n    resource is Jans::Issue\n)when{\n    principal.country == resource.country\n};"
+            }
+        }
+    },
+    "cedar_schema": {
+      "encoding": "none",
+      "content_type": "cedar",
+      "body": "namespace Jans {\ntype Url = {\"host\": String, \"path\": String, \"protocol\": String};\nentity Access_token = {\"aud\": String, \"exp\": Long, \"iat\": Long, \"iss\": TrustedIssuer, \"jti\": String};\nentity Issue = {\"country\": String, \"org_id\": String};\nentity TrustedIssuer = {\"issuer_entity_id\": Url};\nentity User = {\"country\": String, \"email\": String, \"sub\": String, \"username\": String};\nentity Workload = {\"client_id\": String, \"iss\": TrustedIssuer, \"name\": String, \"org_id\": String};\nentity id_token = {\"acr\": String, \"amr\": String, \"aud\": String, \"exp\": Long, \"iat\": Long, \"iss\": TrustedIssuer, \"jti\": String, \"sub\": String};\naction \"Update\" appliesTo {\n  principal: [Workload, User],\n  resource: [Issue],\n  context: {}\n};\n}\n"
+    }
+}

--- a/jans-cedarling/test_files/policy-store_readable.json
+++ b/jans-cedarling/test_files/policy-store_readable.json
@@ -1,0 +1,20 @@
+{
+    "cedar_version": "v2.4.7",
+    "cedar_policies": {
+        "840da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
+            "description": "simple policy example for pricipal workload",
+            "creation_date": "2024-09-20T17:22:39.996050",
+            "policy_content": "cGVybWl0KAogICAgcHJpbmNpcGFsIGlzIEphbnM6Oldvcmtsb2FkLAogICAgYWN0aW9uIGluIFtKYW5zOjpBY3Rpb246OiJVcGRhdGUiXSwKICAgIHJlc291cmNlIGlzIEphbnM6Oklzc3VlCil3aGVuewogICAgcHJpbmNpcGFsLm9yZ19pZCA9PSByZXNvdXJjZS5vcmdfaWQKfTs="
+        },
+        "444da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
+            "description": "simple policy example for pricipal user",
+            "creation_date": "2024-09-20T17:22:39.996050",
+            "policy_content": "cGVybWl0KAogICAgcHJpbmNpcGFsIGlzIEphbnM6OlVzZXIsCiAgICBhY3Rpb24gaW4gW0phbnM6OkFjdGlvbjo6IlVwZGF0ZSJdLAogICAgcmVzb3VyY2UgaXMgSmFuczo6SXNzdWUKKXdoZW57CiAgICBwcmluY2lwYWwuY291bnRyeSA9PSByZXNvdXJjZS5jb3VudHJ5Cn07"
+        }
+    },
+    "cedar_schema": {
+      "encoding": "none",
+      "content_type": "cedar",
+      "body": "namespace Jans {\ntype Url = {\"host\": String, \"path\": String, \"protocol\": String};\nentity Access_token = {\"aud\": String, \"exp\": Long, \"iat\": Long, \"iss\": TrustedIssuer, \"jti\": String};\nentity Issue = {\"country\": String, \"org_id\": String};\nentity TrustedIssuer = {\"issuer_entity_id\": Url};\nentity User = {\"country\": String, \"email\": String, \"sub\": String, \"username\": String};\nentity Workload = {\"client_id\": String, \"iss\": TrustedIssuer, \"name\": String, \"org_id\": String};\nentity id_token = {\"acr\": String, \"amr\": String, \"aud\": String, \"exp\": Long, \"iat\": Long, \"iss\": TrustedIssuer, \"jti\": String, \"sub\": String};\naction \"Update\" appliesTo {\n  principal: [Workload, User],\n  resource: [Issue],\n  context: {}\n};\n}\n"
+    }
+}

--- a/jans-cedarling/test_files/policy-store_readable.json
+++ b/jans-cedarling/test_files/policy-store_readable.json
@@ -4,12 +4,20 @@
         "840da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
             "description": "simple policy example for pricipal workload",
             "creation_date": "2024-09-20T17:22:39.996050",
-            "policy_content": "cGVybWl0KAogICAgcHJpbmNpcGFsIGlzIEphbnM6Oldvcmtsb2FkLAogICAgYWN0aW9uIGluIFtKYW5zOjpBY3Rpb246OiJVcGRhdGUiXSwKICAgIHJlc291cmNlIGlzIEphbnM6Oklzc3VlCil3aGVuewogICAgcHJpbmNpcGFsLm9yZ19pZCA9PSByZXNvdXJjZS5vcmdfaWQKfTs="
+            "policy_content": {
+                "encoding": "none",
+                "content_type": "cedar",
+                "body":"permit(\n    principal is Jans::Workload,\n    action in [Jans::Action::\"Update\"],\n    resource is Jans::Issue\n)when{\n    principal.org_id == resource.org_id\n};"
+            }
         },
         "444da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
             "description": "simple policy example for pricipal user",
             "creation_date": "2024-09-20T17:22:39.996050",
-            "policy_content": "cGVybWl0KAogICAgcHJpbmNpcGFsIGlzIEphbnM6OlVzZXIsCiAgICBhY3Rpb24gaW4gW0phbnM6OkFjdGlvbjo6IlVwZGF0ZSJdLAogICAgcmVzb3VyY2UgaXMgSmFuczo6SXNzdWUKKXdoZW57CiAgICBwcmluY2lwYWwuY291bnRyeSA9PSByZXNvdXJjZS5jb3VudHJ5Cn07"
+            "policy_content": {
+                "encoding": "none",
+                "content_type": "cedar",
+                "body": "permit(\n    principal is Jans::User,\n    action in [Jans::Action::\"Update\"],\n    resource is Jans::Issue\n)when{\n    principal.country == resource.country\n};"
+            }
         }
     },
     "cedar_schema": {

--- a/jans-cedarling/test_files/policy-store_readable.yaml
+++ b/jans-cedarling/test_files/policy-store_readable.yaml
@@ -1,0 +1,48 @@
+cedar_version: v2.4.7
+cedar_policies:
+  840da5d85403f35ea76519ed1a18a33989f855bf1cf8:
+    description: simple policy example for pricipal workload
+    creation_date: '2024-09-20T17:22:39.996050'
+    policy_content:
+      encoding: none
+      content_type: cedar
+      body: |-
+        permit(
+            principal is Jans::Workload,
+            action in [Jans::Action::"Update"],
+            resource is Jans::Issue
+        )when{
+            principal.org_id == resource.org_id
+        };
+  444da5d85403f35ea76519ed1a18a33989f855bf1cf8:
+    description: simple policy example for pricipal user
+    creation_date: '2024-09-20T17:22:39.996050'
+    policy_content:
+      encoding: none
+      content_type: cedar
+      body: |-
+        permit(
+            principal is Jans::User,
+            action in [Jans::Action::"Update"],
+            resource is Jans::Issue
+        )when{
+            principal.country == resource.country
+        };
+cedar_schema:
+  encoding: none
+  content_type: cedar
+  body: |
+    namespace Jans {
+    type Url = {"host": String, "path": String, "protocol": String};
+    entity Access_token = {"aud": String, "exp": Long, "iat": Long, "iss": TrustedIssuer, "jti": String};
+    entity Issue = {"country": String, "org_id": String};
+    entity TrustedIssuer = {"issuer_entity_id": Url};
+    entity User = {"country": String, "email": String, "sub": String, "username": String};
+    entity Workload = {"client_id": String, "iss": TrustedIssuer, "name": String, "org_id": String};
+    entity id_token = {"acr": String, "amr": String, "aud": String, "exp": Long, "iat": Long, "iss": TrustedIssuer, "jti": String, "sub": String};
+    action "Update" appliesTo {
+      principal: [Workload, User],
+      resource: [Issue],
+      context: {}
+    };
+    }


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

There are two main goals this PR aims to achieve:

1) Extend the `policy-store_xxx.json` to allow for metadata for `cedar_schema` and `policy_content` fields.

2) Provide a proof of concept for a 100% human-readable test fixture, in yaml.

#### Target issue
  https://github.com/JanssenProject/jans/issues/9961
  
#### Implementation Details

1) In `policy-store_xxx.json` files, allow for `cedar_schema` and `policy_content` fields to store human-readable values, rather than only the base64-encoded values that agama lab produces. To achieve this, the `policy-store_xxx.json` json for `cedar_schema` and `policy_content` is extended slightly with the following:

```
"policy_content": {
    "encoding": "none",
    "content_type": "cedar",
    "body": "permit(...) when { ... };"
}
```

- `encoding` can be one of `none` or `base64`

- `content_type` can be one of `cedar` or `cedar-json` for `cedar_schema`, but only `cedar` for `policy_content`

- `body` must contain a value that conforms with the above two.

Where the value for `cedar_schema` and `policy_content` is a plain string, it is assumed that the current convention is used:

- for `cedar_schema`, the value is base64 encoded, and contains the cedar-json representation of a schema

- for `policy_content`, the value is base64 encoded, and contains the cedar representation of a policy

2) This is a proof-of-concept, and intended for test fixtures only. Since serde is deisnged to deserialize from several formats, and since `serde_yml` exists, and since json is a proper subset of yaml, the last commit contains a 100% human readable test fixture containing cedar embedded in yaml.


-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

NOTE that docs will be updated once it's been agreed that the above code changes make sense.

- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #10007, 