### PR TITLE
fix(jans-linux-setup): increase setup time-out

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/progress.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/progress.py
@@ -22,7 +22,7 @@ except:
 
 
 class ShowProgress(Thread):
-    def __init__(self, services, queue, timeout=15):
+    def __init__(self, services, queue, timeout=30):
         Thread.__init__(self)
         self.services = services
         self.service_names = [s['name'] for s in services]


### PR DESCRIPTION
closes #10019

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
