### PR TITLE
feat(jans-auth-server): used single-valued attribute for client id instead of multi-valued where it is needed (e.g. jansClntAuthz ) #10033

### DIFF
--- a/jans-auth-server/persistence-model/src/main/java/io/jans/as/persistence/model/ClientAuthorization.java
+++ b/jans-auth-server/persistence-model/src/main/java/io/jans/as/persistence/model/ClientAuthorization.java
@@ -26,7 +26,7 @@ public class ClientAuthorization implements Serializable {
     @AttributeName(name = "jansId")
     private String id;
 
-    @AttributeName(name = "jansClntId", consistency = true)
+    @AttributeName(name = "clnId", consistency = true)
     private String clientId;
 
     @AttributeName(name = "jansUsrId", consistency = true)

--- a/jans-auth-server/persistence-model/src/main/java/io/jans/as/persistence/model/PairwiseIdentifier.java
+++ b/jans-auth-server/persistence-model/src/main/java/io/jans/as/persistence/model/PairwiseIdentifier.java
@@ -25,7 +25,7 @@ public class PairwiseIdentifier extends BaseEntry {
     @AttributeName(name = "jansSectorIdentifier")
     private String sectorIdentifier;
 
-    @AttributeName(name = "jansClntId")
+    @AttributeName(name = "clnId")
     private String clientId;
 
     @AttributeName(name = "jansUsrId")

--- a/jans-casa/plugins/client-authorizations/src/main/java/io/jans/casa/plugins/consent/model/ClientAuthorization.java
+++ b/jans-casa/plugins/client-authorizations/src/main/java/io/jans/casa/plugins/consent/model/ClientAuthorization.java
@@ -14,7 +14,7 @@ import io.jans.casa.misc.Utils;
 public class ClientAuthorization extends Entry {
 
     @AttributeName
-    private String jansClntId;
+    private String clnId;
 
     @AttributeName(name = "jansScope")
     private List<String> scopes;

--- a/jans-casa/plugins/client-authorizations/src/main/java/io/jans/casa/plugins/consent/model/ClientAuthorization.java
+++ b/jans-casa/plugins/client-authorizations/src/main/java/io/jans/casa/plugins/consent/model/ClientAuthorization.java
@@ -13,8 +13,8 @@ import io.jans.casa.misc.Utils;
 @ObjectClass("jansClntAuthz")
 public class ClientAuthorization extends Entry {
 
-    @AttributeName
-    private String clnId;
+    @AttributeName(name = "clnId")
+    private String jansClntId;
 
     @AttributeName(name = "jansScope")
     private List<String> scopes;

--- a/jans-linux-setup/jans_setup/schema/jans_schema.json
+++ b/jans-linux-setup/jans_setup/schema/jans_schema.json
@@ -4139,7 +4139,7 @@
       "may": [
         "jansId",
         "jansSectorIdentifier",
-        "jansClntId",
+        "clnId",
         "jansUsrId"
       ],
       "must": [
@@ -5005,7 +5005,7 @@
       "kind": "STRUCTURAL",
       "may": [
         "jansId",
-        "jansClntId",
+        "clnId",
         "jansUsrId",
         "exp",
         "del",


### PR DESCRIPTION
### Description

feat(jans-auth-server): used single-valued attribute for client id instead of multi-valued where it is needed (e.g. jansClntAuthz ) 

#### Target issue
  
closes #10033

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
