### PR TITLE
feat(config-api): Blacklist some urls from webhook for security reason

### DIFF
--- a/docs/janssen-server/config-guide/auth-server-config/jans-authorization-server-config.md
+++ b/docs/janssen-server/config-guide/auth-server-config/jans-authorization-server-config.md
@@ -60,6 +60,14 @@ It returns all the information of the Jans Authorization server.
   "checkSessionIFrame": "https://example.jans.io/jans-auth/opiframe.htm",
   "endSessionEndpoint": "https://example.jans.io/jans-auth/restv1/end_session",
   "jwksUri": "https://example.jans.io/jans-auth/restv1/jwks",
+  "blockedUrls": [
+    "http://",
+    "file://",
+    "localhost",
+    "127.0.",
+    "192.168.",
+    "172."
+  ],
   "registrationEndpoint": "https://example.jans.io/jans-auth/restv1/register",
   "openIdDiscoveryEndpoint": "https://example.jans.io/.well-known/webfinger",
   "openIdConfigurationEndpoint": "https://example.jans.io/.well-known/openid-configuration",

--- a/docs/janssen-server/reference/json/properties/janssenauthserver-properties.md
+++ b/docs/janssen-server/reference/json/properties/janssenauthserver-properties.md
@@ -1588,6 +1588,14 @@ tags:
 
 - Default value: None
 
+###  blockedUrls
+
+- Description: A list of URLs that should be blocked from access. This parameter is used to prevent access to unwanted resources or domains, which may include unsafe protocols
+
+- Required: No
+
+- Default value: ["http://", "file://", "localhost", "127.0.", "192.168.", "172."]
+
 
 ### keepAuthenticatorAttributesOnAcrChange
 

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -179,6 +179,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "UMA PCT lifetime")
     private int umaPctLifetime;
 
+    @DocProperty(description = "Provide a list of the urls we want to block")
+    private List<String> blockedUrls;
+
     @DocProperty(description = "UMA Resource lifetime")
     private int umaResourceLifetime;
 
@@ -2436,6 +2439,14 @@ public class AppConfiguration implements Configuration {
 
     public void setUmaPctLifetime(int umaPctLifetime) {
         this.umaPctLifetime = umaPctLifetime;
+    }
+
+    public List<String> getBlockedUrls() {
+        return blockedUrls;
+    }
+
+    public void setBlockedUrls(List<String> blockedUrls) {
+        this.blockedUrls = blockedUrls;
     }
 
     public Boolean getAllowSpontaneousScopes() {

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/ConfigurationResponseClaim.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/ConfigurationResponseClaim.java
@@ -28,6 +28,7 @@ public final class ConfigurationResponseClaim {
     public static final String CHECK_SESSION_IFRAME = "check_session_iframe";
     public static final String END_SESSION_ENDPOINT = "end_session_endpoint";
     public static final String JWKS_URI = "jwks_uri";
+    public static final String BLOCKED_URL = "blocked_url";
     public static final String ARCHIVED_JWKS_URI = "archived_jwks_uri";
     public static final String REGISTRATION_ENDPOINT = "registration_endpoint";
     public static final String ID_GENERATION_ENDPOINT = "id_generation_endpoint";

--- a/jans-auth-server/server/conf/jans-config.json
+++ b/jans-auth-server/server/conf/jans-config.json
@@ -35,6 +35,14 @@
     "checkSessionIFrame":"${config.oxauth.contextPath}/opiframe.htm",
     "endSessionEndpoint":"${config.oxauth.contextPath}/restv1/end_session",
     "jwksUri":"${config.oxauth.contextPath}/restv1/jwks",
+    "blockedUrls": [
+        "http://",
+        "file://",
+        "localhost",
+        "127.0.",
+        "192.168.",
+        "172."
+    ],
     "archivedJwksUri":"${config.oxauth.contextPath}/restv1/jwks/archived",
     "registrationEndpoint":"${config.oxauth.contextPath}/restv1/register",
     "openIdDiscoveryEndpoint":"${config.oxauth.issuer}/.well-known/webfinger",

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/DiscoveryService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/DiscoveryService.java
@@ -71,6 +71,7 @@ public class DiscoveryService {
         jsonObj.put(AUTHORIZATION_CHALLENGE_ENDPOINT, appConfiguration.getAuthorizationChallengeEndpoint());
         jsonObj.put(TOKEN_ENDPOINT, appConfiguration.getTokenEndpoint());
         jsonObj.put(JWKS_URI, appConfiguration.getJwksUri());
+        jsonObj.put(BLOCKED_URL, appConfiguration.getBlockedUrls());
         jsonObj.put(ARCHIVED_JWKS_URI, appConfiguration.getArchivedJwksUri());
         jsonObj.put(CHECK_SESSION_IFRAME, appConfiguration.getCheckSessionIFrame());
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/FapiOpenIdConfiguration.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/servlet/FapiOpenIdConfiguration.java
@@ -212,6 +212,7 @@ public class FapiOpenIdConfiguration extends HttpServlet {
             jsonObj.put(CHECK_SESSION_IFRAME, appConfiguration.getCheckSessionIFrame());
             jsonObj.put(END_SESSION_ENDPOINT, appConfiguration.getEndSessionEndpoint());
             jsonObj.put(JWKS_URI, appConfiguration.getJwksUri());
+            jsonObj.put(BLOCKED_URL, appConfiguration.getBlockedUrls());
             jsonObj.put(ARCHIVED_JWKS_URI, appConfiguration.getArchivedJwksUri());
             jsonObj.put(REGISTRATION_ENDPOINT, appConfiguration.getRegistrationEndpoint());
             jsonObj.put(ID_GENERATION_ENDPOINT, appConfiguration.getIdGenerationEndpoint());

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterValidateRequestObjectTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/register/ws/rs/RegisterValidateRequestObjectTest.java
@@ -1,0 +1,151 @@
+package io.jans.as.server.register.ws.rs;
+
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.crypto.AbstractCryptoProvider;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.exception.InvalidJwtException;
+import io.jans.as.model.jwt.Jwt;
+import io.jans.as.model.jwt.JwtHeader;
+import io.jans.as.server.service.external.ExternalDynamicClientRegistrationService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+
+import java.util.List;
+
+import static io.jans.as.model.crypto.signature.SignatureAlgorithm.HS256;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+@Listeners(MockitoTestNGListener.class)
+public class RegisterValidateRequestObjectTest {
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private AbstractCryptoProvider cryptoProvider;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private SsaValidationConfigService ssaValidationConfigService;
+
+    @Mock
+    private ExternalDynamicClientRegistrationService externalDynamicClientRegistrationService;
+
+    @Mock
+    private HttpServletRequest httpRequest;
+
+    @Mock
+    private SsaValidationConfigContext ssaContext;
+
+    @Mock
+    private Logger log;
+
+    @InjectMocks
+    private RegisterValidator registerValidator;
+
+    private Jwt jwt;
+
+    @Test
+    public void validateRequestObjectHmac_noBlockedUrlsCheck() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        jwt = mock(Jwt.class);
+        when(ssaContext.getJwt()).thenReturn(jwt);
+        when(jwt.getSigningInput()).thenReturn("signingInput");
+        when(jwt.getEncodedSignature()).thenReturn("encodedSignature");
+
+        JwtHeader jwtHeader = new JwtHeader();
+        when(jwt.getHeader()).thenReturn(jwtHeader);
+        when(cryptoProvider.verifySignature(
+                eq("signingInput"),
+                eq("encodedSignature"),
+                isNull(),
+                isNull(),
+                eq("secret"),
+                eq(HS256)
+        )).thenReturn(false);
+
+        when(ssaValidationConfigService.isHmacValid(ssaContext)).thenReturn(false);
+        when(appConfiguration.getDcrSignatureValidationSharedSecret()).thenReturn("secret");
+        when(appConfiguration.getBlockedUrls()).thenReturn(List.of(
+                "http://",
+                "file://",
+                "localhost",
+                "127.0.",
+                "192.168.",
+                "172."
+        ));
+
+        String allowedUrl = "https://example.com/test";
+        when(httpRequest.getRequestURL()).thenReturn(new StringBuffer(allowedUrl));
+
+        InvalidJwtException exception = assertThrows(InvalidJwtException.class, () ->
+                registerValidator.validateRequestObjectHmac(httpRequest, ssaContext)
+        );
+
+        assertEquals("Invalid cryptographic segment in the request object.", exception.getMessage());
+
+        verify(log, never()).error(eq("URL '{}' is disallowed."), anyString());
+    }
+
+    @Test
+    public void validateRequestObjectHmac_blockedUrlsCheck() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        jwt = mock(Jwt.class);
+        when(ssaContext.getJwt()).thenReturn(jwt);
+        when(jwt.getSigningInput()).thenReturn("signingInput");
+        when(jwt.getEncodedSignature()).thenReturn("encodedSignature");
+
+        JwtHeader jwtHeader = new JwtHeader();
+        when(jwt.getHeader()).thenReturn(jwtHeader);
+
+        when(cryptoProvider.verifySignature(
+                eq("signingInput"),
+                eq("encodedSignature"),
+                isNull(),
+                isNull(),
+                eq("secret"),
+                eq(HS256)
+        )).thenReturn(false);
+
+        when(ssaValidationConfigService.isHmacValid(ssaContext)).thenReturn(false);
+        when(appConfiguration.getDcrSignatureValidationSharedSecret()).thenReturn("secret");
+
+        when(appConfiguration.getBlockedUrls()).thenReturn(List.of(
+                "http://",
+                "file://",
+                "localhost",
+                "127.0.",
+                "192.168.",
+                "172."
+        ));
+
+        String blockedUrl = "http://localhost/test";
+        when(httpRequest.getRequestURL()).thenReturn(new StringBuffer(blockedUrl));
+
+        InvalidJwtException exception = assertThrows(InvalidJwtException.class, () ->
+                registerValidator.validateRequestObjectHmac(httpRequest, ssaContext)
+        );
+
+        assertEquals("The request object contains a disallowed URL: " + blockedUrl, exception.getMessage());
+
+        ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
+        verify(log).error(logCaptor.capture(), eq(blockedUrl));
+
+        assertTrue(logCaptor.getValue().contains("URL '{}' is disallowed."));
+    }
+
+}

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -9317,6 +9317,8 @@ components:
           type: string
         jwksUri:
           type: string
+        blockedUrls:
+          type: string
         archivedJwksUri:
           type: string
         registrationEndpoint:

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -33,6 +33,14 @@
     "checkSessionIFrame":"https://%(hostname)s/jans-auth/opiframe.htm",
     "endSessionEndpoint":"https://%(hostname)s/jans-auth/restv1/end_session",
     "jwksUri":"https://%(hostname)s/jans-auth/restv1/jwks",
+    "blockedUrls": [
+        "http://",
+        "file://",
+        "localhost",
+        "127.0.",
+        "192.168.",
+        "172."
+    ],
     "archivedJwksUri":"https://%(hostname)s/jans-auth/restv1/jwks/archived",
     "registrationEndpoint":"https://%(hostname)s/jans-auth/restv1/register",
     "openIdDiscoveryEndpoint":"https://%(hostname)s/.well-known/webfinger",

--- a/terraform-provider-jans/jans/app_configuration.go
+++ b/terraform-provider-jans/jans/app_configuration.go
@@ -121,6 +121,7 @@ type AppConfiguration struct {
 	EndSessionEndpoint                                        string                                `schema:"end_session_endpoint" json:"endSessionEndpoint"`
 	RegistrationEndpoint                                      string                                `schema:"registration_endpoint" json:"registrationEndpoint"`
 	JwksUri                                                   string                                `schema:"jwks_uri" json:"jwksUri"`
+	BlockedUrls                                               string                                `schema:"blockedUrls" json:"blockedUrls"`
 	ArchivedJwksUri                                           string                                `schema:"archived_jwks_uri" json:"archivedJwksUri"`
 	OpenIDDiscoveryEndpoint                                   string                                `schema:"openid_discovery_endpoint" json:"openIdDiscoveryEndpoint"`
 	OpenIDConfigurationEndpoint                               string                                `schema:"openid_configuration_endpoint" json:"openIdConfigurationEndpoint"`


### PR DESCRIPTION
feat(config-api): implemented logic to add and verify URLs against a blacklist, blocked insecure protocols and private IP addresses, added mock tests

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

1. Perform URL validation(url should be valid url and resolvable).
2. Ensure URL starts with "https://", disallow "file://" and other non-HTTPS schemes.
3. Block typical local IPs: 127.0.x, 192.168.x, 172.x.
4. Prohibit "localhost" and "http://"
5. Require a specific response header for POST requests, unique to the customer.

#### Target issue
 https://github.com/JanssenProject/jans/issues/8574
 
closes #8574

#### Implementation Details
-------------------
### Test and Document the changes
- [] Relevant unit and integration tests have been added/updated
- [] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

