### PR TITLE
fix(jans-cli-tui): remove filePath when putting asset

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/130_assets/main.py
+++ b/jans-cli-tui/cli_tui/plugins/130_assets/main.py
@@ -131,6 +131,7 @@ class Plugin(DialogUtils):
                 return
 
             data.pop('document', None)
+            data.pop('filePath', None)
             form_data = {'document': data}
 
             if self.asset_file_path:


### PR DESCRIPTION
Closes #10074

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
