### PR TITLE
fix(jans-lock): fix broken link in lock docs

### DIFF
--- a/docs/janssen-server/lock/lock-server.md
+++ b/docs/janssen-server/lock/lock-server.md
@@ -11,7 +11,7 @@ tags:
 # Jans Lock Overview
 
 Lock Server is a Java Weld application that connects ephemeral Cedarlings to the enterprise by 
-providing a number of [endpoints](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/main/jans-lock/lock-server.yaml)
+providing a number of [endpoints](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/refs/heads/main/jans-lock/lock-server.yaml)
 
 ## Installation 
 


### PR DESCRIPTION

closes #9572


- [X] **I confirm that there is no impact on the docs due to the code changes in this PR.**
