### PR TITLE
feat(config-api)-Blacklist-some-urls-from-webhook-for-security-reason added check for perform URL

### DIFF
--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/webhook/WebhookService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/webhook/WebhookService.java
@@ -342,6 +342,10 @@ public class WebhookService {
             log.error(ErrorResponse.WEBHOOK_URL_BLOCKED.getDescription());
             throw new ApplicationException(Response.Status.BAD_REQUEST.getStatusCode(), ErrorResponse.WEBHOOK_URL_BLOCKED.getDescription());
         }
+        if (!webhookEntry.getUrl().startsWith("https://")) {
+            log.error(ErrorResponse.WEBHOOK_URL_PREFIX.getDescription());
+            throw new ApplicationException(Response.Status.BAD_REQUEST.getStatusCode(), ErrorResponse.WEBHOOK_URL_PREFIX.getDescription());
+        }
     }
 
     /**

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/webhook/WebhookService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/webhook/WebhookService.java
@@ -1,7 +1,29 @@
 package io.jans.ca.plugin.adminui.service.webhook;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import javax.validation.Valid;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.python.google.common.collect.Sets;
+import org.slf4j.Logger;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+
 import io.jans.as.common.util.AttributeConstants;
 import io.jans.ca.plugin.adminui.model.auth.GenericResponse;
 import io.jans.ca.plugin.adminui.model.exception.ApplicationException;
@@ -21,16 +43,6 @@ import io.jans.orm.search.filter.Filter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.Response;
-import org.python.google.common.collect.Sets;
-import org.slf4j.Logger;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
-import javax.validation.Valid;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.stream.Collectors;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Singleton
 public class WebhookService {
@@ -325,6 +337,10 @@ public class WebhookService {
                 log.error(ErrorResponse.WEBHOOK_CONTENT_TYPE_REQUIRED.getDescription());
                 throw new ApplicationException(Response.Status.BAD_REQUEST.getStatusCode(), ErrorResponse.WEBHOOK_CONTENT_TYPE_REQUIRED.getDescription());
             }
+        }
+        if (Lists.newArrayList("http://", "file://", "localhost", "127.0.", "192.168.", "172.").contains(webhookEntry.getUrl())) {
+            log.error(ErrorResponse.WEBHOOK_URL_BLOCKED.getDescription());
+            throw new ApplicationException(Response.Status.BAD_REQUEST.getStatusCode(), ErrorResponse.WEBHOOK_URL_BLOCKED.getDescription());
         }
     }
 

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/utils/ErrorResponse.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/utils/ErrorResponse.java
@@ -46,6 +46,7 @@ public enum ErrorResponse {
     WEBHOOK_ENTRY_EMPTY("Webhook entry is empty."),
     WEBHOOK_NAME_EMPTY("Webhook name is required."),
     WEBHOOK_URL_EMPTY("Webhook URL is required."),
+    WEBHOOK_URL_BLOCKED("Webhook URL is disallowed."),
     WEBHOOK_HTTP_METHOD_EMPTY("HTTP method for webhook is required."),
     WEBHOOK_REQUEST_BODY_EMPTY("HTTP request-body for webhook is required for POST/PUT/PATCH request."),
     WEBHOOK_REQUEST_BODY_PARSING_ERROR("Error in parsing request body."),

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/utils/ErrorResponse.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/utils/ErrorResponse.java
@@ -47,6 +47,7 @@ public enum ErrorResponse {
     WEBHOOK_NAME_EMPTY("Webhook name is required."),
     WEBHOOK_URL_EMPTY("Webhook URL is required."),
     WEBHOOK_URL_BLOCKED("Webhook URL is disallowed."),
+    WEBHOOK_URL_PREFIX("Webhook URL must start with 'https://."),
     WEBHOOK_HTTP_METHOD_EMPTY("HTTP method for webhook is required."),
     WEBHOOK_REQUEST_BODY_EMPTY("HTTP request-body for webhook is required for POST/PUT/PATCH request."),
     WEBHOOK_REQUEST_BODY_PARSING_ERROR("Error in parsing request body."),


### PR DESCRIPTION
feat(config-api)-Blacklist-some-urls-from-webhook-for-security-reason: added check for perform URL

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

1. Perform URL validation(url should be valid url and resolvable).
2. Ensure URL starts with "https://", disallow "file://" and other non-HTTPS schemes.
3. Block typical local IPs: 127.0.x, 192.168.x, 172.x.
4. Prohibit "localhost" and "http://"
5. Require a specific response header for POST requests, unique to the customer.

#### Target issue
  https://github.com/JanssenProject/jans/issues/8574
  
closes #8574

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
