### PR TITLE
fix(jans-linux-setup): use sqlconnection instead of mysqlconnection

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/rdbm.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/rdbm.py
@@ -124,7 +124,7 @@ class RDBMInstaller(BaseInstaller, SetupUtils):
                 else:
                     Config.backend_service = 'mysql.service'
 
-                result, conn = self.dbUtils.mysqlconnection(log=False)
+                result, conn = self.dbUtils.sqlconnection(log=False)
                 user_passwd_str = f"-u root -p'{Config.mysql_root_password}' " if base.os_type == 'suse' else ''
                 if not result:
                     sql_cmd_list = [


### PR DESCRIPTION
Closes #10160

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
