### PR TITLE
chore(jans-cedarling): add missing license headers

### DIFF
--- a/jans-cedarling/bindings/cedarling_python/cedarling_python.pyi
+++ b/jans-cedarling/bindings/cedarling_python/cedarling_python.pyi
@@ -1,3 +1,8 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
+
 from typing import Optional, List, final, Dict, Any
 
 @final

--- a/jans-cedarling/bindings/cedarling_python/example.py
+++ b/jans-cedarling/bindings/cedarling_python/example.py
@@ -1,3 +1,8 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
+
 from cedarling_python import BootstrapConfig
 from cedarling_python import Cedarling
 from cedarling_python import ResourceData, Request

--- a/jans-cedarling/bindings/cedarling_python/print_documentation.py
+++ b/jans-cedarling/bindings/cedarling_python/print_documentation.py
@@ -1,3 +1,8 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
+
 import inspect
 from types import ModuleType
 from cedarling_python import BootstrapConfig

--- a/jans-cedarling/bindings/cedarling_python/tests/test_authorize.py
+++ b/jans-cedarling/bindings/cedarling_python/tests/test_authorize.py
@@ -1,3 +1,8 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
+
 from cedarling_python import Cedarling
 from config import sample_bootstrap_config
 from cedarling_python import ResourceData, Request, authorize_errors

--- a/jans-cedarling/bindings/cedarling_python/tests/test_logger.py
+++ b/jans-cedarling/bindings/cedarling_python/tests/test_logger.py
@@ -1,3 +1,8 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
+
 from cedarling_python import Cedarling
 from config import sample_bootstrap_config
 

--- a/jans-cedarling/bindings/cedarling_python/tests/test_policy_store.py
+++ b/jans-cedarling/bindings/cedarling_python/tests/test_policy_store.py
@@ -1,3 +1,8 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
+
 from cedarling_python import BootstrapConfig
 from cedarling_python import Cedarling
 from config import TEST_FILES_PATH, sample_bootstrap_config

--- a/jans-cedarling/bindings/cedarling_python/tests/test_policy_store.py
+++ b/jans-cedarling/bindings/cedarling_python/tests/test_policy_store.py
@@ -29,9 +29,9 @@ test_cases_err = [
     ("policy-store_schema_err_base64.json",
      "unable to decode cedar policy schema base64"),
     ("policy-store_schema_err.yaml",
-     "Could not load policy: failed to parse the policy store from policy_store yaml: policy_stores.e8c39ee71792766d3b9b12846f0479419051bb5fafff: unable to parse cedar policy schema: error parsing schema: unexpected end of input at line 4 column 5"),
+     "Could not load policy: failed to parse the policy store from policy_store yaml: policy_stores.e8c39ee71792766d3b9b12846f0479419051bb5fafff: unable to parse cedar policy schema: error parsing schema: unexpected end of input at line 8 column 5"),
     ("policy-store_schema_err_cedar_mistake.yaml",
-     "Could not load policy: failed to parse the policy store from policy_store yaml: policy_stores.a1bf93115de86de760ee0bea1d529b521489e5a11747: unable to parse cedar policy schema: failed to resolve type: User_TypeNotExist at line 4 column 5"),
+     "Could not load policy: failed to parse the policy store from policy_store yaml: policy_stores.a1bf93115de86de760ee0bea1d529b521489e5a11747: unable to parse cedar policy schema: failed to resolve type: User_TypeNotExist at line 8 column 5"),
 ]
 
 

--- a/jans-cedarling/cedarling/src/common/cedar_schema/mod.rs
+++ b/jans-cedarling/cedarling/src/common/cedar_schema/mod.rs
@@ -306,7 +306,7 @@ mod deserialize {
             let err_msg = policy_result.unwrap_err().to_string();
             assert_eq!(
                 err_msg,
-                "policy_stores.a1bf93115de86de760ee0bea1d529b521489e5a11747: unable to parse cedar policy schema: failed to resolve type: User_TypeNotExist at line 4 column 5"
+                "policy_stores.a1bf93115de86de760ee0bea1d529b521489e5a11747: unable to parse cedar policy schema: failed to resolve type: User_TypeNotExist at line 8 column 5"
             );
         }
     }

--- a/jans-cedarling/cedarling/src/common/policy_store/test.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/test.rs
@@ -157,7 +157,7 @@ fn test_broken_policy_parsing_error_in_policy_store() {
     // TODO: this isn't really a human readable format but the current plan is to fetch it from
     // a which will respond with the policy encoded in base64. This could probably be improved
     // in the future once the structure of the project is clearer.
-    assert_eq!(err_msg, "policy_stores.ba1f39115ed86ed760ee0bea1d529b52189e5a117474: Errors encountered while parsing policies: [Error(\"unable to decode policy with id: 840da5d85403f35ea76519ed1a18a33989f855bf1cf8, error: unable to decode policy_content from human readable format: unexpected token `)`\")] at line 4 column 5")
+    assert_eq!(err_msg, "policy_stores.ba1f39115ed86ed760ee0bea1d529b52189e5a117474: Errors encountered while parsing policies: [Error(\"unable to decode policy with id: 840da5d85403f35ea76519ed1a18a33989f855bf1cf8, error: unable to decode policy_content from human readable format: unexpected token `)`\")] at line 8 column 5")
 }
 
 /// Tests that a valid version string is accepted.

--- a/jans-cedarling/test_files/agama-store.yaml
+++ b/jans-cedarling/test_files/agama-store.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 cedar_version: "4.0.0"
 policy_stores:
   873e650f3739e4800b48d7d6752f93619eee2bc7dad6:

--- a/jans-cedarling/test_files/agama-store_2.yaml
+++ b/jans-cedarling/test_files/agama-store_2.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 ---
 cedar_version: 4.2.2
 policy_stores:

--- a/jans-cedarling/test_files/bootstrap_props.yaml
+++ b/jans-cedarling/test_files/bootstrap_props.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 CEDARLING_APPLICATION_NAME: My App
 CEDARLING_POLICY_STORE_URI: ''
 CEDARLING_POLICY_STORE_ID: '840da5d85403f35ea76519ed1a18a33989f855bf1cf8'

--- a/jans-cedarling/test_files/policy-store_ok.yaml
+++ b/jans-cedarling/test_files/policy-store_ok.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 cedar_version: v4.0.0
 policy_stores:
   a1bf93115de86de760ee0bea1d529b521489e5a11747:

--- a/jans-cedarling/test_files/policy-store_ok_2.yaml
+++ b/jans-cedarling/test_files/policy-store_ok_2.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 cedar_version: v4.0.0
 policy_stores:
   a1bf93115de86de760ee0bea1d529b521489e5a11747:

--- a/jans-cedarling/test_files/policy-store_ok_namespace_Jans2.yaml
+++ b/jans-cedarling/test_files/policy-store_ok_namespace_Jans2.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 cedar_version: v4.0.0
 policy_stores:
   a1bf93115de86de760ee0bea1d529b521489e5a11747:

--- a/jans-cedarling/test_files/policy-store_policy_err_broken_policy.yaml
+++ b/jans-cedarling/test_files/policy-store_policy_err_broken_policy.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 cedar_version: v4.0.0
 policy_stores:
   ba1f39115ed86ed760ee0bea1d529b52189e5a117474:

--- a/jans-cedarling/test_files/policy-store_readable.yaml
+++ b/jans-cedarling/test_files/policy-store_readable.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 cedar_version: v4.0.0
 policy_stores:
   8ec39ee717927663db9b18246f0479419051bb5af15a:

--- a/jans-cedarling/test_files/policy-store_schema_err.yaml
+++ b/jans-cedarling/test_files/policy-store_schema_err.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 cedar_version: v4.0.0
 policy_stores:
   e8c39ee71792766d3b9b12846f0479419051bb5fafff:

--- a/jans-cedarling/test_files/policy-store_schema_err_cedar_mistake.yaml
+++ b/jans-cedarling/test_files/policy-store_schema_err_cedar_mistake.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 cedar_version: v4.0.0
 policy_stores:
   a1bf93115de86de760ee0bea1d529b521489e5a11747:

--- a/jans-cedarling/test_files/policy-store_with_multiple_role_mappings_err.yaml
+++ b/jans-cedarling/test_files/policy-store_with_multiple_role_mappings_err.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 ---
 cedar_version: v4.0.0
 cedar_policies:

--- a/jans-cedarling/test_files/policy-store_with_trusted_issuers_ok.yaml
+++ b/jans-cedarling/test_files/policy-store_with_trusted_issuers_ok.yaml
@@ -1,3 +1,7 @@
+# This software is available under the Apache-2.0 license.
+# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+#
+# Copyright (c) 2024, Gluu, Inc.
 ---
 cedar_version: v4.0.0
 cedar_policies:

--- a/jans-cedarling/test_utils/src/lib.rs
+++ b/jans-cedarling/test_utils/src/lib.rs
@@ -1,3 +1,10 @@
+/*
+ * This software is available under the Apache-2.0 license.
+ * See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+ *
+ * Copyright (c) 2024, Gluu, Inc.
+ */
+
 mod sort_json;
 
 pub use pretty_assertions::*;

--- a/jans-cedarling/test_utils/src/sort_json.rs
+++ b/jans-cedarling/test_utils/src/sort_json.rs
@@ -1,3 +1,10 @@
+/*
+ * This software is available under the Apache-2.0 license.
+ * See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+ *
+ * Copyright (c) 2024, Gluu, Inc.
+ */
+
 use serde_json::{Map, Value};
 
 // Recursively sort the fields of JSON objects


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

This PR adds the missing license headers in the Cedarling files.

#### Target issue

target issue: #10323
  
closes: #10323

#### Implementation Details

License headers were just added to the files. Most of the files are python files.

```py
# This software is available under the Apache-2.0 license.
# See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
#
# Copyright (c) 2024, Gluu, Inc.
```

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
