### PR TITLE
feat(jans-auth-server): added exp,nbf, and iat to UserInfo JWT

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -43,6 +43,7 @@ public class AppConfiguration implements Configuration {
     public static final int DEFAULT_STATUS_LIST_BIT_SIZE = 2;
     public static final int DEFAULT_STATUS_LIST_INDEX_ALLOCATION_BLOCK_SIZE = 100;
     public static final XFrameOptions DEFAULT_X_FRAME_ORIGINS_VALUE = XFrameOptions.SAMEORIGIN;
+    public static final int DEFAULT_USER_INFO_LIFETIME = 3600;
 
     @DocProperty(description = "URL using the https scheme that OP asserts as Issuer identifier")
     private String issuer;
@@ -403,6 +404,9 @@ public class AppConfiguration implements Configuration {
 
     @DocProperty(description = "The lifetime of the short lived Access Token")
     private int accessTokenLifetime;
+
+    @DocProperty(description = "The lifetime of the User Info", defaultValue = "3600")
+    private int userInfoLifetime;
 
     @DocProperty(description = "Time interval for the Clean Service in seconds")
     private int cleanServiceInterval;
@@ -2410,6 +2414,16 @@ public class AppConfiguration implements Configuration {
 
     public void setAccessTokenLifetime(int accessTokenLifetime) {
         this.accessTokenLifetime = accessTokenLifetime;
+    }
+
+    public int getUserInfoLifetime() {
+        if (userInfoLifetime <= 0) userInfoLifetime = DEFAULT_USER_INFO_LIFETIME;
+        return userInfoLifetime;
+    }
+
+    public AppConfiguration setUserInfoLifetime(int userInfoLifetime) {
+        this.userInfoLifetime = userInfoLifetime;
+        return this;
     }
 
     public Boolean getSaveTokensInCache() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/userinfo/ws/rs/UserInfoService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/userinfo/ws/rs/UserInfoService.java
@@ -1,5 +1,6 @@
 package io.jans.as.server.userinfo.ws.rs;
 
+import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.token.JsonWebResponse;
 import io.jans.as.server.model.common.AuthorizationGrant;
 import io.jans.util.IdUtil;
@@ -7,6 +8,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
+
+import java.util.Calendar;
+import java.util.Date;
 
 /**
  * @author Yuriy Z
@@ -17,10 +21,23 @@ public class UserInfoService {
     @Inject
     private Logger log;
 
+    @Inject
+    private AppConfiguration appConfiguration;
+
     public void fillJwr(JsonWebResponse jwr, AuthorizationGrant authorizationGrant) {
         final String clientId = authorizationGrant.getClientId();
 
+        final int lifetime = appConfiguration.getUserInfoLifetime();
+
+        final Calendar calendar = Calendar.getInstance();
+        final Date issuedAt = calendar.getTime();
+        calendar.add(Calendar.SECOND, lifetime);
+        final Date expiration = calendar.getTime();
+
         jwr.getClaims().setClaim("jti", IdUtil.randomShortUUID());
+        jwr.getClaims().setExpirationTime(expiration);
+        jwr.getClaims().setIat(issuedAt);
+        jwr.getClaims().setNbf(issuedAt);
 
         if (StringUtils.isNotBlank(clientId)) {
             jwr.getClaims().setClaim("client_id", clientId);

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/userinfo/ws/rs/UserInfoServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/userinfo/ws/rs/UserInfoServiceTest.java
@@ -3,6 +3,7 @@ package io.jans.as.server.userinfo.ws.rs;
 import io.jans.as.common.model.common.User;
 import io.jans.as.common.model.registration.Client;
 import io.jans.as.model.common.GrantType;
+import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.token.JsonWebResponse;
 import io.jans.as.server.model.common.AuthorizationGrant;
 import io.jans.as.server.model.common.AuthorizationGrantType;
@@ -15,6 +16,7 @@ import org.testng.annotations.Test;
 
 import java.util.Date;
 
+import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
@@ -30,8 +32,13 @@ public class UserInfoServiceTest {
     @Mock
     private Logger log;
 
+    @Mock
+    private AppConfiguration appConfiguration;
+
     @Test
     public void fillJwr_whenCalled_shouldFillRequiredClaims() {
+        when(appConfiguration.getUserInfoLifetime()).thenReturn(3600);
+
         Client client = new Client();
         client.setClientId("1234");
         AuthorizationGrant grant = getTestGrant(client);
@@ -42,6 +49,9 @@ public class UserInfoServiceTest {
 
         assertEquals("1234", jwr.getClaims().getClaimAsString("client_id"));
         assertNotNull(jwr.getClaims().getClaimAsString("jti"));
+        assertNotNull(jwr.getClaims().getClaimAsDate("exp"));
+        assertNotNull(jwr.getClaims().getClaimAsDate("iat"));
+        assertNotNull(jwr.getClaims().getClaimAsDate("nbf"));
     }
 
     private static AuthorizationGrant getTestGrant(final Client client) {


### PR DESCRIPTION
### Description

feat(jans-auth-server): added exp,nbf, and iat to UserInfo JWT

#### Target issue
  
closes #10384

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
