### PR TITLE
feat(jans-auth-server): updated first party native authn implementation ( in backwards compatibility way) #10380

### DIFF
--- a/docs/janssen-server/auth-server/endpoints/authorization-challenge.md
+++ b/docs/janssen-server/auth-server/endpoints/authorization-challenge.md
@@ -11,7 +11,7 @@ tags:
 Authorization Challenge Endpoint allows first-party native client obtain authorization code which later can be exchanged on access token.
 This can provide an entirely browserless OAuth 2.0 experience suited for native applications.
 
-This endpoint conforms to [OAuth 2.0 for First-Party Native Applications](https://www.ietf.org/archive/id/draft-parecki-oauth-first-party-native-apps-02.html) specifications.
+This endpoint conforms to [OAuth 2.0 for First-Party Applications](https://www.ietf.org/archive/id/draft-parecki-oauth-first-party-apps-02.html) specifications.
 
 URL to access authorization challenge endpoint on Janssen Server is listed in the response of Janssen Server's well-known
 [configuration endpoint](./configuration.md) given below.
@@ -151,6 +151,15 @@ Example
 String clientId = context.getHttpRequest().getParameter("client_id");
 authorizationChallengeSessionObject.getAttributes().getAttributes().put("client_id", clientId);
 ``` 
+
+AS automatically validates DPoP if it is set during auth session creation.
+Thus it's recommended to set `jkt` of the auth session if DPoP is used.
+```java
+final String dpop = context.getHttpRequest().getHeader(DpopService.DPOP);
+if (StringUtils.isNotBlank(dpop)) {
+    authorizationChallengeSessionObject.getAttributes().setJkt(getDpopJkt(dpop));
+}
+```
 
 Full sample script can be found [here](../../../script-catalog/authorization_challenge/AuthorizationChallenge.java)
 

--- a/docs/janssen-server/auth-server/oauth-features/README.md
+++ b/docs/janssen-server/auth-server/oauth-features/README.md
@@ -26,7 +26,7 @@ The [Janssen Authentication Server](https://github.com/JanssenProject/jans/tree/
 - OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens [(spec)](https://datatracker.ietf.org/doc/html/rfc8705)
 - Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants [(spec)](https://www.rfc-editor.org/rfc/rfc7521.html)
 - JWT Secured Authorization Response Mode for OAuth 2.0 (JARM) [(spec)](https://openid.net/specs/oauth-v2-jarm.html)
-- OAuth 2.0 for First-Party Native Applications [(spec draft)](https://www.ietf.org/archive/id/draft-parecki-oauth-first-party-native-apps-02.html)
+- OAuth 2.0 for First-Party Applications [(spec draft)](https://www.ietf.org/archive/id/draft-parecki-oauth-first-party-apps-02.html)
 - The Use of Attestation in OAuth 2.0 Dynamic Client Registration [(spec draft)](https://www.ietf.org/id/draft-tschofenig-oauth-attested-dclient-reg-00.html)
 - OpenID Connect Core Error Code unmet_authentication_requirements [(spec)](https://openid.net/specs/openid-connect-unmet-authentication-requirements-1_0.html)
 - Transaction Tokens [(spec)](https://drafts.oauth.net/oauth-transaction-tokens/draft-ietf-oauth-transaction-tokens.html)

--- a/docs/script-catalog/authorization_challenge/authorization-challenge.md
+++ b/docs/script-catalog/authorization_challenge/authorization-challenge.md
@@ -9,7 +9,7 @@ tags:
 
 ## Overview
 
-The Jans-Auth server implements [OAuth 2.0 for First-Party Native Applications](https://www.ietf.org/archive/id/draft-parecki-oauth-first-party-native-apps-02.html).
+The Jans-Auth server implements [OAuth 2.0 for First-Party Applications](https://www.ietf.org/archive/id/draft-parecki-oauth-first-party-apps-02.html).
 This script is used to control/customize Authorization Challenge Endpoint.
 
 ## Behavior

--- a/jans-auth-server/common/src/main/java/io/jans/as/common/model/session/AuthorizationChallengeSessionAttributes.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/model/session/AuthorizationChallengeSessionAttributes.java
@@ -18,6 +18,12 @@ public class AuthorizationChallengeSessionAttributes implements Serializable {
     @JsonProperty("acr_values")
     private String acrValues;
 
+    // jkt - JWK SHA-256 Thumbprint confirmation method.
+    // The value of the jkt member MUST be the base64url encoding (as defined in [RFC7515]) of the JWK SHA-256 Thumbprint
+    // (according to [RFC7638]) of the DPoP public key (in JWK format) to which the access token is bound.
+    @JsonProperty("jkt")
+    private String jkt;
+
     @JsonProperty("attributes")
     private Map<String, String> attributes;
 
@@ -38,11 +44,21 @@ public class AuthorizationChallengeSessionAttributes implements Serializable {
         this.acrValues = acrValues;
     }
 
+    public String getJkt() {
+        return jkt;
+    }
+
+    public AuthorizationChallengeSessionAttributes setJkt(String jkt) {
+        this.jkt = jkt;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "DeviceSessionAttributes{" +
                 "acrValues='" + acrValues + '\'' +
                 "attributes='" + attributes + '\'' +
+                "jkt='" + jkt + '\'' +
                 '}';
     }
 }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/auth/DpopService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/auth/DpopService.java
@@ -221,7 +221,7 @@ public class DpopService {
         return Response.status(status).type(MediaType.APPLICATION_JSON_TYPE).entity(errorResponseFactory.errorAsJson(type, reason));
     }
 
-    public String getDpopJwkThumbprint(String dpopStr) throws InvalidJwtException, NoSuchAlgorithmException, JWKException, NoSuchProviderException {
+    public static String getDpopJwkThumbprint(String dpopStr) throws InvalidJwtException, NoSuchAlgorithmException, JWKException, NoSuchProviderException {
         final Jwt dpop = Jwt.parseOrThrow(dpopStr);
         JSONWebKey jwk = JSONWebKey.fromJSONObject(dpop.getHeader().getJwk());
         return jwk.getJwkThumbprint();

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeEndpoint.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeEndpoint.java
@@ -1,6 +1,7 @@
 package io.jans.as.server.authorize.ws.rs;
 
 import io.jans.as.model.util.QueryStringDecoder;
+import io.jans.as.server.auth.DpopService;
 import io.jans.as.server.service.RequestParameterService;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,6 +39,8 @@ public class AuthorizationChallengeEndpoint {
             @FormParam("acr_values") String acrValues,
             @FormParam("auth_session") String authorizationChallengeSession,
             @FormParam("use_auth_session") String useAuthorizationChallengeSession,
+            @FormParam("device_session") String deviceSession, // old name in draft 00
+            @FormParam("use_device_session") String useDeviceSession, // old name in draft 00
             @FormParam("prompt") String prompt,
             @FormParam("state") String state,
             @FormParam("nonce") String nonce,
@@ -63,6 +66,15 @@ public class AuthorizationChallengeEndpoint {
         authzRequest.setCodeChallenge(codeChallenge);
         authzRequest.setCodeChallengeMethod(codeChallengeMethod);
         authzRequest.setAuthzDetailsString(authorizationDetails);
+        authzRequest.setDpop(httpRequest.getHeader(DpopService.DPOP));
+
+        // backwards compatibilty: device_session (up to draft 02) vs auth_session (draft 02 and later)
+        if (authorizationChallengeSession == null && deviceSession != null) {
+            authzRequest.setAuthorizationChallengeSession(deviceSession);
+        }
+        if (useAuthorizationChallengeSession == null && useDeviceSession != null) {
+            authzRequest.setUseAuthorizationChallengeSession(Boolean.parseBoolean(useDeviceSession));
+        }
 
         return authorizationChallengeService.requestAuthorization(authzRequest);
     }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeService.java
@@ -117,6 +117,8 @@ public class AuthorizationChallengeService {
         if (StringUtils.isNotBlank(authzRequest.getAuthorizationChallengeSession())) {
             final AuthorizationChallengeSession session = authorizationChallengeSessionService.getAuthorizationChallengeSession(authzRequest.getAuthorizationChallengeSession());
 
+            authorizationChallengeValidator.validateDpopJkt(session, authzRequest.getDpop());
+
             authzRequest.setAuthorizationChallengeSessionObject(session);
             if (session != null) {
                 final Map<String, String> attributes = session.getAttributes().getAttributes();
@@ -188,6 +190,7 @@ public class AuthorizationChallengeService {
         authorizationGrant.setClaims(authzRequest.getClaims());
         authorizationGrant.setSessionDn(sessionUser != null ? sessionUser.getDn() : "no_session_for_authorization_challenge"); // no need for session as at Authorization Endpoint
         authorizationGrant.setAcrValues(grantAcr);
+        authorizationGrant.setAuthorizationChallenge(true);
         authorizationGrant.save();
 
         String authorizationCode = authorizationGrant.getAuthorizationCode().getCode();

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeSessionService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeSessionService.java
@@ -10,7 +10,10 @@ import jakarta.inject.Named;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.UUID;
 
 /**
  * @author Yuriy Z

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizationChallengeValidator.java
@@ -1,10 +1,13 @@
 package io.jans.as.server.authorize.ws.rs;
 
 import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.model.session.AuthorizationChallengeSession;
 import io.jans.as.model.authorize.AuthorizeErrorResponseType;
 import io.jans.as.model.common.GrantType;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.token.TokenErrorResponseType;
+import io.jans.as.server.auth.DpopService;
 import io.jans.as.server.model.config.Constants;
 import io.jans.as.server.service.ScopeService;
 import jakarta.enterprise.context.RequestScoped;
@@ -12,6 +15,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import java.util.Arrays;
@@ -34,6 +38,30 @@ public class AuthorizationChallengeValidator {
 
     @Inject
     private ScopeService scopeService;
+
+    public void validateDpopJkt(AuthorizationChallengeSession session, String dpop) {
+        final String jkt = session.getAttributes().getJkt();
+        if (StringUtils.isBlank(jkt)) {
+            return;
+        }
+
+        try {
+            final String dpopJwkThumbprint = DpopService.getDpopJwkThumbprint(dpop);
+            if (jkt.equals(dpopJwkThumbprint)) {
+                return;
+            } else {
+                log.debug("Unable to match dpopJkt: {} with sessionJkt: {}", dpopJwkThumbprint, jkt);
+            }
+        } catch (Exception e) {
+            String msg = String.format("Failed to validate dpop jtk. jkt: %s, dpop: %s", jkt, dpop);
+            log.debug(msg, e);
+        }
+
+        throw new WebApplicationException(errorResponseFactory
+                .newErrorResponse(Response.Status.BAD_REQUEST)
+                .entity(errorResponseFactory.getErrorAsJson(TokenErrorResponseType.INVALID_DPOP_PROOF, "", "Invalid DPoP."))
+                .build());
+    }
 
     public void validateGrantType(Client client, String state) {
         if (client == null) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequest.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequest.java
@@ -55,6 +55,7 @@ public class AuthzRequest {
     private String claims;
     private String authReqId;
     private String dpopJkt;
+    private String dpop;
     private String authzDetailsString;
     private AuthzDetails authzDetails;
     private String httpMethod;
@@ -93,6 +94,15 @@ public class AuthzRequest {
 
     public void setDpopJkt(String dpopJkt) {
         this.dpopJkt = dpopJkt;
+    }
+
+    public String getDpop() {
+        return dpop;
+    }
+
+    public AuthzRequest setDpop(String dpop) {
+        this.dpop = dpop;
+        return this;
     }
 
     public AuthorizationChallengeSession getAuthorizationChallengeSessionObject() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AbstractAuthorizationGrant.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AbstractAuthorizationGrant.java
@@ -79,6 +79,7 @@ public abstract class AbstractAuthorizationGrant implements IAuthorizationGrant 
 
     private String acrValues;
     private String sessionDn;
+    private boolean isAuthorizationChallenge;
 
     protected final ConcurrentMap<String, TxToken> txTokens = new ConcurrentHashMap<>();
     protected final ConcurrentMap<String, AccessToken> accessTokens = new ConcurrentHashMap<>();
@@ -108,6 +109,15 @@ public abstract class AbstractAuthorizationGrant implements IAuthorizationGrant 
 
     public void setReferenceId(String referenceId) {
         this.referenceId = referenceId;
+    }
+
+    public boolean isAuthorizationChallenge() {
+        return isAuthorizationChallenge;
+    }
+
+    public AbstractAuthorizationGrant setAuthorizationChallenge(boolean authorizationChallenge) {
+        isAuthorizationChallenge = authorizationChallenge;
+        return this;
     }
 
     public Integer getStatusListIndex() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
@@ -201,6 +201,7 @@ public abstract class AuthorizationGrant extends AbstractAuthorizationGrant {
         }
 
         token.getAttributes().setAuthorizationDetails(getAuthzDetailsAsString());
+        token.getAttributes().setAuthorizationChallenge(isAuthorizationChallenge());
         token.setScope(getScopesAsString());
         token.setAuthMode(getAcrValues());
         token.setSessionDn(getSessionDn());

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrantList.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrantList.java
@@ -354,6 +354,7 @@ public class AuthorizationGrantList implements IAuthorizationGrantList {
                 result.setTokenEntity(tokenEntity);
                 result.setReferenceId(tokenEntity.getReferenceId());
                 result.setStatusListIndex(tokenEntity.getAttributes().getStatusListIndex());
+                result.setAuthorizationChallenge(tokenEntity.getAttributes().isAuthorizationChallenge());
                 if (StringUtils.isNotBlank(grantId)) {
                     result.setGrantId(grantId);
                 }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceValidator.java
@@ -82,7 +82,7 @@ public class TokenRestWebServiceValidator {
     }
 
     public void validateParams(String grantType, String code,
-                               String redirectUri, String refreshToken, OAuth2AuditLog auditLog) {
+                               String refreshToken, OAuth2AuditLog auditLog) {
         log.debug("Starting to validate request parameters");
         if (grantType == null || grantType.isEmpty()) {
             final String msg = "Grant Type is not set.";
@@ -95,11 +95,6 @@ public class TokenRestWebServiceValidator {
         if (gt == GrantType.AUTHORIZATION_CODE) {
             if (StringUtils.isBlank(code)) {
                 final String msg = "Code is not set for AUTHORIZATION_CODE.";
-                log.trace(msg);
-                throw new WebApplicationException(response(error(400, TokenErrorResponseType.INVALID_REQUEST, msg), auditLog));
-            }
-            if (StringUtils.isBlank(redirectUri)) {
-                final String msg = "redirect_uri is not set for AUTHORIZATION_CODE.";
                 log.trace(msg);
                 throw new WebApplicationException(response(error(400, TokenErrorResponseType.INVALID_REQUEST, msg), auditLog));
             }
@@ -171,6 +166,14 @@ public class TokenRestWebServiceValidator {
 
     public void validateGrant(AuthorizationGrant grant, Client client, Object identifier, OAuth2AuditLog auditLog) {
         validateGrant(grant, client, identifier, auditLog, null);
+    }
+
+    public void validateRedirectUri(String redirectUri, OAuth2AuditLog auditLog) {
+        if (StringUtils.isBlank(redirectUri)) {
+            final String msg = "redirect_uri is not set for AUTHORIZATION_CODE.";
+            log.trace(msg);
+            throw new WebApplicationException(response(error(400, TokenErrorResponseType.INVALID_REQUEST, msg), auditLog));
+        }
     }
 
 

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceValidatorTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceValidatorTest.java
@@ -172,7 +172,7 @@ public class TokenRestWebServiceValidatorTest {
     @Test
     public void validateParams_whenGrantTypeIsBlank_shouldRaiseError() {
         try {
-            validator.validateParams("", "some_code", "https://my.redirect", "refresh_token", AUDIT_LOG);
+            validator.validateParams("", "some_code", "refresh_token", AUDIT_LOG);
         } catch (WebApplicationException e) {
             assertBadRequest(e.getResponse());
             return;
@@ -183,7 +183,7 @@ public class TokenRestWebServiceValidatorTest {
     @Test
     public void validateParams_whenGrantTypeIsAuthorizationCodeAndCodeIsBlank_shouldRaiseError() {
         try {
-            validator.validateParams(GrantType.AUTHORIZATION_CODE.getValue(), "", "https://my.redirect", "refresh_token", AUDIT_LOG);
+            validator.validateParams(GrantType.AUTHORIZATION_CODE.getValue(), "", "refresh_token", AUDIT_LOG);
         } catch (WebApplicationException e) {
             assertBadRequest(e.getResponse());
             return;
@@ -191,22 +191,10 @@ public class TokenRestWebServiceValidatorTest {
         fail("No error for blank code for AUTHORIZATION_CODE grant type.");
     }
 
-
-    @Test
-    public void validateParams_whenGrantTypeIsAuthorizationCodeAndRedirectUriIsBlank_shouldRaiseError() {
-        try {
-            validator.validateParams(GrantType.AUTHORIZATION_CODE.getValue(), "some_code", "", "refresh_token", AUDIT_LOG);
-        } catch (WebApplicationException e) {
-            assertBadRequest(e.getResponse());
-            return;
-        }
-        fail("No error for blank redirect_uri for AUTHORIZATION_CODE grant type.");
-    }
-
     @Test
     public void validateParams_whenGrantTypeIsRefreshTokenAndRefreshTokenIsBlank_shouldRaiseError() {
         try {
-            validator.validateParams(GrantType.REFRESH_TOKEN.getValue(), "some_code", "https://my.redirect", "", AUDIT_LOG);
+            validator.validateParams(GrantType.REFRESH_TOKEN.getValue(), "some_code", "", AUDIT_LOG);
         } catch (WebApplicationException e) {
             assertBadRequest(e.getResponse());
             return;
@@ -217,7 +205,7 @@ public class TokenRestWebServiceValidatorTest {
     @Test
     public void validateParams_whenGrantTypeIsAuthorizationCodeAndCodeIsNotBlank_shouldNotRaiseError() {
         try {
-            validator.validateParams(GrantType.AUTHORIZATION_CODE.getValue(), "some_code", "https://my.redirect", "", AUDIT_LOG);
+            validator.validateParams(GrantType.AUTHORIZATION_CODE.getValue(), "some_code", "", AUDIT_LOG);
         } catch (WebApplicationException e) {
             fail("Error occurs. We should not get it.");
         }
@@ -226,7 +214,7 @@ public class TokenRestWebServiceValidatorTest {
     @Test
     public void validateParams_whenGrantTypeIsRefreshTokenAndRefreshTokenIsNotBlank_shouldNotRaiseError() {
         try {
-            validator.validateParams(GrantType.REFRESH_TOKEN.getValue(), "", "https://my.redirect", "refresh_token", AUDIT_LOG);
+            validator.validateParams(GrantType.REFRESH_TOKEN.getValue(), "", "refresh_token", AUDIT_LOG);
         } catch (WebApplicationException e) {
             fail("Error occurs. We should not get it.");
         }

--- a/jans-core/service/src/main/java/io/jans/model/token/TokenAttributes.java
+++ b/jans-core/service/src/main/java/io/jans/model/token/TokenAttributes.java
@@ -26,6 +26,8 @@ public class TokenAttributes implements Serializable {
     private String x5cs256;
     @JsonProperty("online_access")
     private boolean onlineAccess;
+    @JsonProperty("authorization_challenge")
+    private boolean authorizationChallenge;
     @JsonProperty("attributes")
     private Map<String, String> attributes;
     @JsonProperty("dpopJkt")
@@ -34,6 +36,15 @@ public class TokenAttributes implements Serializable {
     private String authorizationDetails;
     @JsonProperty("statusListIndex")
     private Integer statusListIndex;
+
+    public boolean isAuthorizationChallenge() {
+        return authorizationChallenge;
+    }
+
+    public TokenAttributes setAuthorizationChallenge(boolean authorizationChallenge) {
+        this.authorizationChallenge = authorizationChallenge;
+        return this;
+    }
 
     public Integer getStatusListIndex() {
         return statusListIndex;
@@ -92,6 +103,7 @@ public class TokenAttributes implements Serializable {
                 "onlineAccess='" + onlineAccess + '\'' +
                 "dpopJkt='" + dpopJkt + '\'' +
                 "authorizationDetails='" + authorizationDetails + '\'' +
+                "authorizationChallenge='" + authorizationChallenge + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
### Description

Update first party native authn implementation.
It must be updated in backwards compatibilty way because it is already in use.

https://datatracker.ietf.org/doc/draft-parecki-oauth-first-party-apps/02/

#### Target issue
  
closes #10380

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
