### PR TITLE
fix(cloud-native): applications are failing to start when prometheus metrics are enabled

### DIFF
--- a/docker-jans-all-in-one/app/bin/entrypoint.sh
+++ b/docker-jans-all-in-one/app/bin/entrypoint.sh
@@ -4,10 +4,10 @@ set -e
 
 get_prometheus_lib() {
     if [ -n "${CN_PROMETHEUS_PORT}" ]; then
-        prom_agent_version="0.17.2"
+        agent_version=${PROMETHEUS_AGENT_VERSION:-1.0.1}
 
         if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
-            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+            curl -sS "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${agent_version}/jmx_prometheus_javaagent-${agent_version}.jar" -o /opt/prometheus/jmx_prometheus_javaagent.jar
         fi
     fi
 }

--- a/docker-jans-auth-server/scripts/entrypoint.sh
+++ b/docker-jans-auth-server/scripts/entrypoint.sh
@@ -28,10 +28,10 @@ get_prometheus_opt() {
 
 get_prometheus_lib() {
     if [ -n "${CN_PROMETHEUS_PORT}" ]; then
-        prom_agent_version="0.17.2"
+        agent_version=${PROMETHEUS_AGENT_VERSION:-1.0.1}
 
         if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
-            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+            curl -sS "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${agent_version}/jmx_prometheus_javaagent-${agent_version}.jar" -o /opt/prometheus/jmx_prometheus_javaagent.jar
         fi
     fi
 }

--- a/docker-jans-casa/Dockerfile
+++ b/docker-jans-casa/Dockerfile
@@ -6,7 +6,7 @@ FROM bellsoft/liberica-openjre-alpine:17.0.12@sha256:29cb2ee552c7c7a924b6a1b5980
 
 RUN apk update \
     && apk upgrade --available \
-    && apk add --no-cache python3 openssl tini py3-cryptography py3-psycopg2 py3-grpcio \
+    && apk add --no-cache python3 openssl tini py3-cryptography py3-psycopg2 py3-grpcio curl \
     && apk add --no-cache --virtual .build-deps git wget zip
 
 # =====

--- a/docker-jans-casa/scripts/entrypoint.sh
+++ b/docker-jans-casa/scripts/entrypoint.sh
@@ -18,10 +18,10 @@ get_prometheus_opt() {
 
 get_prometheus_lib() {
     if [ -n "${CN_PROMETHEUS_PORT}" ]; then
-        prom_agent_version="0.17.2"
+        agent_version=${PROMETHEUS_AGENT_VERSION:-1.0.1}
 
         if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
-            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+            curl -sS "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${agent_version}/jmx_prometheus_javaagent-${agent_version}.jar" -o /opt/prometheus/jmx_prometheus_javaagent.jar
         fi
     fi
 }

--- a/docker-jans-config-api/scripts/entrypoint.sh
+++ b/docker-jans-config-api/scripts/entrypoint.sh
@@ -27,10 +27,10 @@ get_prometheus_opt() {
 
 get_prometheus_lib() {
     if [ -n "${CN_PROMETHEUS_PORT}" ]; then
-        prom_agent_version="0.17.2"
+        agent_version=${PROMETHEUS_AGENT_VERSION:-1.0.1}
 
         if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
-            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+            curl -sS "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${agent_version}/jmx_prometheus_javaagent-${agent_version}.jar" -o /opt/prometheus/jmx_prometheus_javaagent.jar
         fi
     fi
 }

--- a/docker-jans-fido2/scripts/entrypoint.sh
+++ b/docker-jans-fido2/scripts/entrypoint.sh
@@ -18,10 +18,10 @@ get_prometheus_opt() {
 
 get_prometheus_lib() {
     if [ -n "${CN_PROMETHEUS_PORT}" ]; then
-        prom_agent_version="0.17.2"
+        agent_version=${PROMETHEUS_AGENT_VERSION:-1.0.1}
 
         if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
-            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+            curl -sS "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${agent_version}/jmx_prometheus_javaagent-${agent_version}.jar" -o /opt/prometheus/jmx_prometheus_javaagent.jar
         fi
     fi
 }

--- a/docker-jans-keycloak-link/scripts/entrypoint.sh
+++ b/docker-jans-keycloak-link/scripts/entrypoint.sh
@@ -18,10 +18,10 @@ get_prometheus_opt() {
 
 get_prometheus_lib() {
     if [ -n "${CN_PROMETHEUS_PORT}" ]; then
-        prom_agent_version="0.17.2"
+        agent_version=${PROMETHEUS_AGENT_VERSION:-1.0.1}
 
         if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
-            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+            curl -sS "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${agent_version}/jmx_prometheus_javaagent-${agent_version}.jar" -o /opt/prometheus/jmx_prometheus_javaagent.jar
         fi
     fi
 }

--- a/docker-jans-link/scripts/entrypoint.sh
+++ b/docker-jans-link/scripts/entrypoint.sh
@@ -18,10 +18,10 @@ get_prometheus_opt() {
 
 get_prometheus_lib() {
     if [ -n "${CN_PROMETHEUS_PORT}" ]; then
-        prom_agent_version="0.17.2"
+        agent_version=${PROMETHEUS_AGENT_VERSION:-1.0.1}
 
         if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
-            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+            curl -sS "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${agent_version}/jmx_prometheus_javaagent-${agent_version}.jar" -o /opt/prometheus/jmx_prometheus_javaagent.jar
         fi
     fi
 }

--- a/docker-jans-scim/scripts/entrypoint.sh
+++ b/docker-jans-scim/scripts/entrypoint.sh
@@ -18,10 +18,10 @@ get_prometheus_opt() {
 
 get_prometheus_lib() {
     if [ -n "${CN_PROMETHEUS_PORT}" ]; then
-        prom_agent_version="0.17.2"
+        agent_version=${PROMETHEUS_AGENT_VERSION:-1.0.1}
 
         if [ ! -f /opt/prometheus/jmx_prometheus_javaagent.jar ]; then
-            wget -q https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${prom_agent_version}/jmx_prometheus_javaagent-${prom_agent_version}.jar -O /opt/prometheus/jmx_prometheus_javaagent.jar
+            curl -sS "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${agent_version}/jmx_prometheus_javaagent-${agent_version}.jar" -o /opt/prometheus/jmx_prometheus_javaagent.jar
         fi
     fi
 }


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #10224

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

- use `curl` command to download `prometheus` java agent; this replaces `wget` command that may not work when running behind a proxy
- upgrade prometheus agent to v1.0.1 (the older version is vulnerable)

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
