### PR TITLE
fix(jans-casa): enrollment of a passkey implies the enrollment…

### DIFF
--- a/jans-casa/app/src/main/java/io/jans/casa/core/PersistenceService.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/core/PersistenceService.java
@@ -101,13 +101,16 @@ public class PersistenceService implements IPersistenceService {
     }
 
     public <T> List<T> find(Class<T> clazz, String baseDn, Filter filter) {
-
+    	logger.debug(baseDn);
+    	logger.debug(clazz.toString());
+    	logger.debug(filter.toString());
         try {
             return entryManager.findEntries(baseDn, clazz, filter);
         } catch (Exception e) {
             //logger.error(e.getMessage(), e);
             //TODO: uncomment the above once https://github.com/GluuFederation/oxCore/issues/160 is solved
             logger.error(e.getMessage());
+            e.printStackTrace();
             return Collections.emptyList();
         }
 

--- a/jans-casa/app/src/main/java/io/jans/casa/core/model/Fido2RegistrationData.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/core/model/Fido2RegistrationData.java
@@ -4,28 +4,39 @@ package io.jans.casa.core.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+
 public class Fido2RegistrationData {
 
+	private static final long serialVersionUID = 4599467930864459334L;
+
 	private String username;
-	private String domain;
+	private String origin;
 	private String userId;
 	private String challenge;
-
-	private String attenstationRequest;
-	private String attenstationResponse;
-
+	private String attestationRequest;
+	private String attestationResponse;
 	private String uncompressedECPoint;
 	private String publicKeyId;
-
 	private String type;
-
+	private String status;
 	private int counter;
-
 	private String attestationType;
-
 	private int signatureAlgorithm;
+	private String rpId;
+	// Credential backup eligibility and current backup state is conveyed by the
+	// backupStateFlag and backupEligibilityFlag flags in the authenticator data.
+	// See https://w3c.github.io/webauthn/#sctn-authenticator-data
+	private boolean backupStateFlag;
+	private boolean backupEligibilityFlag;
+	private boolean attestedCredentialDataFlag;
+	private boolean extensionDataFlag;
+	private boolean userVerifiedFlag;
+	private boolean userPresentFlag;
 
-	private String applicationId;
+	private String authentictatorAttachment;
+
+	private String credId;
+	private String transports[];
 
 	public String getUsername() {
 		return username;
@@ -33,14 +44,6 @@ public class Fido2RegistrationData {
 
 	public void setUsername(String username) {
 		this.username = username;
-	}
-
-	public String getDomain() {
-		return domain;
-	}
-
-	public void setDomain(String domain) {
-		this.domain = domain;
 	}
 
 	public String getUserId() {
@@ -59,20 +62,20 @@ public class Fido2RegistrationData {
 		this.challenge = challenge;
 	}
 
-	public String getAttenstationRequest() {
-		return attenstationRequest;
+	public String getAttestationRequest() {
+		return attestationRequest;
 	}
 
-	public void setAttenstationRequest(String attenstationRequest) {
-		this.attenstationRequest = attenstationRequest;
+	public void setAttestationRequest(String attestationRequest) {
+		this.attestationRequest = attestationRequest;
 	}
 
-	public String getAttenstationResponse() {
-		return attenstationResponse;
+	public String getAttestationResponse() {
+		return attestationResponse;
 	}
 
-	public void setAttenstationResponse(String attenstationResponse) {
-		this.attenstationResponse = attenstationResponse;
+	public void setAttestationResponse(String attestationResponse) {
+		this.attestationResponse = attestationResponse;
 	}
 
 	public String getUncompressedECPoint() {
@@ -99,6 +102,14 @@ public class Fido2RegistrationData {
 		this.type = type;
 	}
 
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
 	public int getCounter() {
 		return counter;
 	}
@@ -123,21 +134,92 @@ public class Fido2RegistrationData {
 		this.signatureAlgorithm = signatureAlgorithm;
 	}
 
-	public String getApplicationId() {
-		return applicationId;
+	public boolean getBackupStateFlag() {
+		return this.backupStateFlag;
 	}
 
-	public void setApplicationId(String applicationId) {
-		this.applicationId = applicationId;
+	public void setBackupStateFlag(boolean backupStateFlag) {
+		this.backupStateFlag = backupStateFlag;
 	}
 
-	@Override
-	public String toString() {
-		return "Fido2RegistrationData [username=" + username + ", domain=" + domain + ", userId=" + userId
-				+ ", challenge=" + challenge + ", attenstationRequest=" + attenstationRequest
-				+ ", attenstationResponse=" + attenstationResponse + ", uncompressedECPoint=" + uncompressedECPoint
-				+ ", publicKeyId=" + publicKeyId + ", type=" + type + ", counter=" + counter
-				+ ", attestationType=" + attestationType + ", signatureAlgorithm=" + signatureAlgorithm
-				+ ", applicationId=" + applicationId + "]";
+	public boolean getBackupEligibilityFlag() {
+		return this.backupEligibilityFlag;
 	}
+
+	public void setBackupEligibilityFlag(boolean backupEligibilityFlag) {
+		this.backupEligibilityFlag = backupEligibilityFlag;
+	}
+
+	public String getOrigin() {
+		return origin;
+	}
+
+	public void setOrigin(String origin) {
+		this.origin = origin;
+	}
+
+	public String getRpId() {
+		return rpId;
+	}
+
+	public void setRpId(String rpId) {
+		this.rpId = rpId;
+	}
+
+	public boolean isAttestedCredentialDataFlag() {
+		return attestedCredentialDataFlag;
+	}
+
+	public void setAttestedCredentialDataFlag(boolean attestedCredentialDataFlag) {
+		this.attestedCredentialDataFlag = attestedCredentialDataFlag;
+	}
+
+	public boolean isExtensionDataFlag() {
+		return extensionDataFlag;
+	}
+
+	public void setExtensionDataFlag(boolean extensionDataFlag) {
+		this.extensionDataFlag = extensionDataFlag;
+	}
+
+	public boolean isUserVerifiedFlag() {
+		return userVerifiedFlag;
+	}
+
+	public void setUserVerifiedFlag(boolean userVerifiedFlag) {
+		this.userVerifiedFlag = userVerifiedFlag;
+	}
+
+	public boolean isUserPresentFlag() {
+		return userPresentFlag;
+	}
+
+	public void setUserPresentFlag(boolean userPresentFlag) {
+		this.userPresentFlag = userPresentFlag;
+	}
+
+	public String getAuthentictatorAttachment() {
+		return authentictatorAttachment;
+	}
+
+	public void setAuthentictatorAttachment(String authentictatorAttachment) {
+		this.authentictatorAttachment = authentictatorAttachment;
+	}
+
+	public String getCredId() {
+		return credId;
+	}
+
+	public void setCredId(String credId) {
+		this.credId = credId;
+	}
+
+	public String[] getTransports() {
+		return transports;
+	}
+
+	public void setTransports(String[] transports) {
+		this.transports = transports;
+	}
+
 }

--- a/jans-casa/app/src/main/java/io/jans/casa/core/model/Fido2RegistrationEntry.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/core/model/Fido2RegistrationEntry.java
@@ -1,79 +1,77 @@
 package io.jans.casa.core.model;
+
+import java.util.Date;
+
 import io.jans.as.model.fido.u2f.protocol.DeviceData;
 import io.jans.orm.annotation.AttributeName;
 import io.jans.orm.annotation.DataEntry;
-import io.jans.orm.annotation.ObjectClass;
 import io.jans.orm.annotation.JsonObject;
+import io.jans.orm.annotation.ObjectClass;
 import io.jans.orm.model.base.Entry;
-
-import java.util.Date;
 
 //Using Fido2RegistrationEntry directly from fido2-model artifact does not work well!
 @DataEntry
 @ObjectClass(value = "jansFido2RegistrationEntry")
 public class Fido2RegistrationEntry extends Entry {
 
-    @AttributeName
-    private String displayName;
+	@AttributeName
+	private String displayName;
 
-    @AttributeName
-    private Date creationDate;
+	@AttributeName
+	private Date creationDate;
 
-    @AttributeName(name = "jansId")
-    private String id;
-    
-    @AttributeName(name = "jansApp")
-    private String application;
+	@AttributeName(name = "jansId")
+	private String id;
 
-    @JsonObject
-    @AttributeName(name = "jansRegistrationData" , ignoreDuringUpdate = true)
-    private Fido2RegistrationData registrationData;
-    
-    @AttributeName(name = "jansCounter", ignoreDuringUpdate = true)
+	@AttributeName(name = "jansApp")
+	private String application;
+
+	@JsonObject
+	@AttributeName(name = "jansRegistrationData", ignoreDuringUpdate = true)
+	private Fido2RegistrationData registrationData;
+
+	@AttributeName(name = "jansCounter", ignoreDuringUpdate = true)
 	private int counter;
 
-    @JsonObject
-   	@AttributeName(name = "jansDeviceData", ignoreDuringUpdate = true)
-   	private DeviceData deviceData;
-       
-    
-    @JsonObject
-    @AttributeName(name = "jansStatus" , ignoreDuringUpdate = true)
-    private String registrationStatus;
+	@JsonObject
+	@AttributeName(name = "jansDeviceData", ignoreDuringUpdate = true)
+	private DeviceData deviceData;
 
-    
-   
-    public String getDisplayName() {
-            return displayName;
-    }
+	@JsonObject
+	@AttributeName(name = "jansStatus", ignoreDuringUpdate = true)
+	private String registrationStatus;
 
-    public void setDisplayName(String displayName) {
-            this.displayName = displayName;
-    }
+	public String getDisplayName() {
+		return displayName;
+	}
 
-    public Date getCreationDate() {
-            return creationDate;
-    }
+	public void setDisplayName(String displayName) {
+		this.displayName = displayName;
+	}
 
-    public void setCreationDate(Date creationDate) {
-            this.creationDate = creationDate;
-    }
+	public Date getCreationDate() {
+		return creationDate;
+	}
 
-    public String getId() {
-            return id;
-    }
+	public void setCreationDate(Date creationDate) {
+		this.creationDate = creationDate;
+	}
 
-    public void setId(String id) {
-            this.id = id;
-    }
+	public String getId() {
+		return id;
+	}
 
-    public Fido2RegistrationData getRegistrationData() {
-            return registrationData;
-    }
+	public void setId(String id) {
+		this.id = id;
+	}
 
-    public void setRegistrationData(Fido2RegistrationData registrationData) {
-            this.registrationData = registrationData;
-    }
+	public Fido2RegistrationData getRegistrationData() {
+		return registrationData;
+	}
+
+	public void setRegistrationData(Fido2RegistrationData registrationData) {
+		this.registrationData = registrationData;
+	}
 
 	public int getCounter() {
 		return counter;
@@ -106,7 +104,5 @@ public class Fido2RegistrationEntry extends Entry {
 	public void setApplication(String application) {
 		this.application = application;
 	}
-
-
 
 }

--- a/jans-casa/app/src/main/java/io/jans/casa/core/pojo/FidoDevice.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/core/pojo/FidoDevice.java
@@ -13,7 +13,7 @@ public class FidoDevice extends RegisteredCredential implements Comparable<FidoD
     private Date lastAccessTime;
     private String status;
     private String application;
-    
+    private String [] transports; 
     public String getId() {
         return id;
     }
@@ -62,6 +62,16 @@ public class FidoDevice extends RegisteredCredential implements Comparable<FidoD
         this.id = id;
     }
 
+    public String [] getTransports()
+    {
+    	return transports;
+    }
+    
+    public void setTransports(String t[])
+    {
+    	this.transports = t;
+    }
+    
     public int compareTo(FidoDevice k) {
         long date1 = getCreationDate().getTime();
         long date2 = k.getCreationDate().getTime();
@@ -70,6 +80,16 @@ public class FidoDevice extends RegisteredCredential implements Comparable<FidoD
     
     public static boolean isPlatformAuthenticator(FidoDevice device) {
         if (device instanceof PlatformAuthenticator)
+            return true;
+        return false;
+    }
+    public static boolean isMultideviceAuthenticator(FidoDevice device) {
+        if (device instanceof MultideviceAuthenticator)
+            return true;
+        return false;
+    }
+    public static boolean isSecurityKey(FidoDevice device) {
+        if (device instanceof SecurityKey)
             return true;
         return false;
     }

--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/PasskeysExtension.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/PasskeysExtension.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Extension
-public class SecurityKey2Extension implements AuthnMethod {
+public class PasskeysExtension implements AuthnMethod {
 
     public static final String ACR = "io.jans.casa.authn.fido2";
 
@@ -21,7 +21,7 @@ public class SecurityKey2Extension implements AuthnMethod {
 
     private Fido2Service fido2Service;
 
-    public SecurityKey2Extension() {
+    public PasskeysExtension() {
         fido2Service = Utils.managedBean(Fido2Service.class);
     }
 

--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/rs/PasskeysEnrollingWS.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/rs/PasskeysEnrollingWS.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 @ProtectedApi(scopes = "https://jans.io/casa.enroll")
 @Path("/enrollment/fido2")
 @Produces(MediaType.APPLICATION_JSON)
-public class SecurityKey2EnrollingWS {
+public class PasskeysEnrollingWS {
 
     private static final String USERS_PENDING_REG_PREFIX = "casa_upreg_";    //Users with pending registrations
     private static final String RECENT_DEVICES_PREFIX = "casa_recdev_";     //Recently enrolled devices
@@ -52,8 +52,7 @@ public class SecurityKey2EnrollingWS {
 
     @GET
     @Path("attestation")
-    public Response getAttestationMessage(@QueryParam("userid") String userId,
-                                          @QueryParam("platformAuthn") boolean platformAuthenticatorAvailable) {
+    public Response getAttestationMessage(@QueryParam("userid") String userId) {
 
         String request = null;
         RegisterMessageCode result;
@@ -69,7 +68,7 @@ public class SecurityKey2EnrollingWS {
                 try {
                     String userName = person.getUid();
                     request = fido2Service.doRegister(userName,
-                                Optional.ofNullable(person.getGivenName()).orElse(userName), platformAuthenticatorAvailable);
+                                Optional.ofNullable(person.getGivenName()).orElse(userName));
                     result = RegisterMessageCode.SUCCESS;
                     cacheProvider.put(EXPIRATION, USERS_PENDING_REG_PREFIX + userId, "");
                 } catch (Exception e) {
@@ -100,7 +99,7 @@ public class SecurityKey2EnrollingWS {
             } else {
                 try {
                     if (fido2Service.verifyRegistration(body)) {
-                        newDevice = fido2Service.getLatestSecurityKey(userId, System.currentTimeMillis());
+                        newDevice = fido2Service.getLatestPasskey(userId, System.currentTimeMillis());
 
                         if (newDevice == null){
                             logger.info("Entry of recently registered fido 2 key could not be found for user {}", userId);

--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/Fido2Service.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/Fido2Service.java
@@ -1,31 +1,36 @@
 package io.jans.casa.plugins.authnmethod.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import io.jans.fido2.ctap.AttestationConveyancePreference;
-import io.jans.fido2.model.attestation.AttestationOptions;
-import io.jans.orm.search.filter.Filter;
-import io.jans.fido2.client.AttestationService;
-import io.jans.orm.model.fido2.Fido2RegistrationStatus;
-
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.jans.casa.core.model.Fido2RegistrationEntry;
+import io.jans.casa.core.pojo.FidoDevice;
+import io.jans.casa.core.pojo.MultideviceAuthenticator;
+import io.jans.casa.core.pojo.PlatformAuthenticator;
+import io.jans.casa.core.pojo.SecurityKey;
+import io.jans.casa.misc.Utils;
+import io.jans.casa.rest.RSUtils;
+import io.jans.entry.Transports;
+import io.jans.fido2.client.AttestationService;
+import io.jans.fido2.model.attestation.AttestationOptions;
+import io.jans.orm.model.fido2.Fido2RegistrationStatus;
+import io.jans.orm.search.filter.Filter;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.core.Response;
-
-import io.jans.casa.core.pojo.FidoDevice;
-import io.jans.casa.core.pojo.PlatformAuthenticator;
-import io.jans.casa.core.pojo.SecurityKey;
-import io.jans.casa.misc.Utils;
-import io.jans.casa.plugins.authnmethod.SecurityKey2Extension;
-import io.jans.casa.rest.RSUtils;
-import io.jans.casa.core.model.Fido2RegistrationEntry;
-
-import org.json.JSONObject;
-import org.slf4j.Logger;
 
 @Named
 @ApplicationScoped
@@ -77,22 +82,31 @@ public class Fido2Service extends BaseService {
                 Filter.createEqualityFilter("jansStatus", state),
                 Filter.createEqualityFilter("personInum", userId),
                 Filter.createEqualityFilter("jansApp", appId));
-        
+        logger.trace("Filter:"+filter);
         List<FidoDevice> devices = new ArrayList<>();
         try {
             List<Fido2RegistrationEntry> list = persistenceService.find(Fido2RegistrationEntry.class,
             	String.format("ou=%s,%s", FIDO2_OU, persistenceService.getPersonDn(userId)), filter);
 
+            logger.trace(list.toString()+list.size());
             for (Fido2RegistrationEntry entry : list) {
             	FidoDevice device = null;
-            	if (Optional.ofNullable(entry.getRegistrationData().getAttenstationRequest())
-            	       .map(ar -> ar.contains("platform")).orElse(false)) {
-            		device = new PlatformAuthenticator();
-            		
-            	} else {
-            		device = new SecurityKey();
-            		
-            	}
+            	Set<String> transports = new HashSet<>(Arrays.asList(entry.getRegistrationData().getTransports()));
+            	
+            	// internal implies platform auth
+				if (transports.contains(Transports.INTERNAL.getValue()) && transports.size() == 1) {
+					device = new PlatformAuthenticator();
+				} 
+				// internal and hybrid implies multidev
+				else if (transports.contains(Transports.HYBRID.getValue())) {
+					device = new MultideviceAuthenticator();
+				} else if (transports.contains(Transports.USB.getValue())
+						|| transports.contains(Transports.NFC.getValue())
+						|| transports.contains(Transports.BLE.getValue())) {
+					device = new SecurityKey();
+				} else {
+					logger.trace("Transports was not set, ideally flow should never reach here");
+				}
             	device.setId(entry.getId());
             	device.setCreationDate(entry.getCreationDate());
             	device.setNickName(entry.getDisplayName());
@@ -176,11 +190,10 @@ public class Fido2Service extends BaseService {
 
     }
 
-    public String doRegister(String userName, String displayName, boolean platformAuthenticator) throws Exception {
+    public String doRegister(String userName, String displayName) throws Exception {
         AttestationOptions attestationOptions = new AttestationOptions();
         attestationOptions.setUsername(userName);
         attestationOptions.setDisplayName(displayName);
-        attestationOptions.setAttestation(AttestationConveyancePreference.direct);
 
         try (Response response = attestationService.register(attestationOptions)) {
             String content = response.readEntity(String.class);
@@ -200,6 +213,7 @@ public class Fido2Service extends BaseService {
         JsonNode jsonObj=mapper.readTree(tokenResponse);
     	try (Response response = attestationService.verify(mapper.convertValue(jsonObj, io.jans.fido2.model.attestation.AttestationResult.class))) {
             int status = response.getStatus();
+            logger.debug("Status of attestation: "+status);
             boolean verified = status == Response.Status.OK.getStatusCode();
             
             if (!verified) {
@@ -212,7 +226,7 @@ public class Fido2Service extends BaseService {
         
     }
 
-    public FidoDevice getLatestSecurityKey(String userId, long time) {
+    public FidoDevice getLatestPasskey(String userId, long time) {
 
     	FidoDevice sk = null;
         try {

--- a/jans-casa/app/src/main/resources/labels/user.properties
+++ b/jans-casa/app/src/main/resources/labels/user.properties
@@ -23,7 +23,7 @@ usr.mfa_notenough=You cannot turn on 2FA until you register at least {0} credent
 #fido 2 security keys
 usr.fido2_label=Passkeys
 usr.fido2_title=Passkeys
-usr.fido2_text=
+usr.fido2_text= Use device biometrics, screen locks, or security keys to protect your account against unauthorized access.
 #Protect your online account against unauthorized access by using two-factor authentication with Security keys (USB / NFC) and built-in Platform authenticators (Apple's PassKey).
 
 usr.fido2_buy_title=Buy security keys from <a class="link" href="${usr.fido2_buy_link1}" target="_blank">Amazon</a> or <a class="link" href="${usr.fido2_buy_link2}" target="_blank">Yubico</a>
@@ -31,19 +31,11 @@ usr.fido2_buy_link1=https://www.amazon.com/fido2/s?k=fido2
 usr.fido2_buy_link2=https://www.yubico.com/store
 
 usr.fido2_manage=Manage passkeys
-usr.fido2_add=Register a security key
-usr.fido2_touch=Touch your key button
-usr.fido2_pressready=Insert your security key and press the "${general.ready}" button below
-usr.fido2_edit=Change nickname of your security key
+usr.fido2_add=Register your passkey
+usr.fido2_touch=Follow the instructions on your browser
+usr.fido2_pressready=Have your passkey handy and click the "${general.ready}" button 
+usr.fido2_edit=Change nickname of your passkey
 usr.fido2_del=Remove this key from your credentials
-
-usr.fido2_add_touchId=Register a PassKey
-usr.fido2_touchId=Place your finger on the PassKey
-usr.fido2_pressready_touchId=A PassKey on a MacBook Pro or MacBook Air lets you use it to sign in to some third-party apps. 
-usr.fido2_del_touchId=Remove the PassKey from your credentials
-usr.fido2.use_touchID=Enroll PassKey
-usr.fido2_enroll_fingerprint_apple_help=See the link on <a class="link" href="${usr.fido2_apple_support_site}" target="_blank">Apple's support site</a> to know how you register a fingerprint on your device.
-usr.fido2_apple_support_site=https://support.apple.com/en-in/guide/mac-help/mchl16fbf90a/mac
 
 usr.fido2.error_exclude=Credential creation failed, probably because an already registered credential is available
 usr.fido2.error_cancel=Operation cancelled by user

--- a/jans-casa/app/src/main/webapp/user/fido2-detail.zul
+++ b/jans-casa/app/src/main/webapp/user/fido2-detail.zul
@@ -9,7 +9,7 @@
 
     <h:title self="@define(title)">${zkService.appName} - ${labels.usr.fido2_title}</h:title>
 
-    <z:div if="${empty pageScope.error}" viewModel="@('io.jans.casa.ui.vm.user.SecurityKey2ViewModel')"
+    <z:div if="${empty pageScope.error}" viewModel="@('io.jans.casa.ui.vm.user.PasskeysViewModel')"
            self="@define(maincontent)">
 
         <z:include src="/back-home.zul" />
@@ -33,10 +33,13 @@
                                 <zk:zk if="${FidoDevice.isPlatformAuthenticator(each)}">
 								    <img src="${zkService.contextPath}${assetsService.prefix}/images/touchid.png" />
 								</zk:zk>
-								<zk:zk unless="${FidoDevice.isPlatformAuthenticator(each)}">
+								<zk:zk if="${FidoDevice.isMultideviceAuthenticator(each)}">
+								    <img src="${zkService.contextPath}${assetsService.prefix}/images/passkey.png" />
+								</zk:zk>
+								<zk:zk if="${FidoDevice.isSecurityKey(each)}">
 								    <img src="${zkService.contextPath}${assetsService.prefix}/images/u2fkey.png" />
 								</zk:zk>
-
+								
                                 <p class="ml3 mb0">
                                     <z:label sclass="f5 dark-blue2" value="@load(empty each.nickName ? c:l('general.no_named') : each.nickName)" />
                                     <br />
@@ -86,32 +89,7 @@
                 </div>
                 
                 
-                <!-- loaded when platform Authenticator exists -->
-                 <z:div class="${css.panel} bg-near-white" id="platformAuthenticator" visible="@load(vm.showUIPlatformAuthenticator)">
-                    <h2 class="f5 dark-blue2 pt1">${labels.usr.fido2_add_touchId}</h2>
-                    <div class="alert alert-success dn" id="feedback-key-platform" role="alert" />
-					
-                    <div class="pb2">
-                        <span class="mr2">${labels.usr.fido2_pressready_touchId}</span>
-                        <span class="mr2">${labels.usr.fido2_enroll_fingerprint_apple_help}</span>
-                        
-                        <z:image src="${assetsService.prefix}/images/throbber.gif" visible="@load(vm.uiAwaitingPlatformAuthenticator)" />
-                    </div> 
-                    <z:button id="readyPlatformButton" label="${labels.general.ready}" sclass="${css.primaryButton}"
-                              w:onClick="alertRef = $('#feedback-key-platform'); initialize(this)" onClick="@('triggerAttestationRequestPlatformAuthenticator')" />
-					
-                    <z:div sclass="flex flex-wrap pt2" visible="@load(vm.uiEnrolledPlatformAuthenticator)">
-                        <div class="relative w5 mt3 pr3">
-                            <z:textbox sclass="focused-text w-100 pb1" onOK="@('add')" value="@bind(vm.newTouchId.nickName)" ca:required="required" />
-                            <label class="focused-label">${labels.usr.enter_nick}</label>
-                        </div>
-
-                        <div class="pt2">
-                            <z:button label="${labels.general.add}" sclass="${css.primaryButton} mr2" onClick="@('add')"/>
-                            <z:button label="${labels.general.cancel}" sclass="${css.tertiaryButton}" onClick="@('cancel')"/>
-                        </div>
-                    </z:div>
-                </z:div>
+                
             </section>
         </div>
 
@@ -137,25 +115,5 @@
     <z:div self="@define(extra)">
         <z:script src="/scripts/gluu/fido2-util.js" />
     </z:div>
-    <z:div self="@define(extra)">
-        <script>
-        <![CDATA[ 
-           $( document ).ready( function() {
-        	   
-        	   if(!(zAu && zAu.send)) {alert ("zAu not initialized"); return;}
-    			PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
-				  .then(function(available){
-					  
-					  zAu.send(new zk.Event(zk.Widget.$(jq('$platformAuthenticator')[0]), "onData", available, {toServer:true}));
-				    
-				  }).catch(function(err){
-				    console.error("Error in detecting platform authenticator : "+err);
-				  });
-				  
-	         		
-	          	
-           });
-           ]]>
-        </script>
-    </z:div>
+   
 </zk:zk>


### PR DESCRIPTION
… of all three types of authenticator - client-device, hybrid, security-key

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes # 10470

#### Implementation Details
  fido2-details.zul, FIDOService methods changed and refactoring

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [X] **I confirm that there is no impact on the docs due to the code changes in this PR.**
