### PR TITLE
refactor(jans-cedarling): update AuthZ interface to use `tokens` for all JWTs sent as input

### DIFF
--- a/docs/cedarling/cedarling-authz.md
+++ b/docs/cedarling/cedarling-authz.md
@@ -56,24 +56,25 @@ this is a sample request from a hypothetical application:
 
 ```js
 input = { 
-           "access_token": "eyJhbGc....", 
-           "id_token": "eyJjbGc...", 
-           "userinfo_token": "eyJjbGc...",
-           "tx_token": "eyJjbGc...",
-           "action": "View",
-           "resource": {
-                          "id": "ticket-10101",
-                          "type" : "Ticket",
-                          "owner": "bob@acme.com", 
-                          "org_id": "Acme"
-                        },
-           "context": {
-                       "ip_address": "54.9.21.201",
-                       "network_type": "VPN",
-                       "user_agent": "Chrome 125.0.6422.77 (Official Build) (arm64)",
-                       "time": "1719266610.98636",
-                      }
-         }
+  "tokens": {
+    "access_token": "eyJhbGc....", 
+    "id_token": "eyJjbGc...", 
+    "userinfo_token": "eyJjbGc...",
+  },
+    "action": "View",
+    "resource": {
+      "id": "ticket-10101",
+      "type" : "Ticket",
+      "owner": "bob@acme.com", 
+      "org_id": "Acme"
+    },
+      "context": {
+        "ip_address": "54.9.21.201",
+        "network_type": "VPN",
+        "user_agent": "Chrome 125.0.6422.77 (Official Build) (arm64)",
+        "time": "1719266610.98636",
+      }
+    }
 
 decision_result = authz(input)
 ```

--- a/jans-cedarling/bindings/cedarling_python/PYTHON_TYPES.md
+++ b/jans-cedarling/bindings/cedarling_python/PYTHON_TYPES.md
@@ -113,7 +113,7 @@ authorization data with access token, action, resource, and context.
 
 Attributes
 ----------  
-:param tokens: Python dictionary with additional context.  
+:param tokens: A class containing the JWTs what will be used for the request.  
 :param action: The action to be authorized.  
 :param resource: Resource data (wrapped `ResourceData` object).  
 :param context: Python dictionary with additional context.

--- a/jans-cedarling/bindings/cedarling_python/PYTHON_TYPES.md
+++ b/jans-cedarling/bindings/cedarling_python/PYTHON_TYPES.md
@@ -113,12 +113,10 @@ authorization data with access token, action, resource, and context.
 
 Attributes
 ----------  
+:param tokens: Python dictionary with additional context.  
 :param action: The action to be authorized.  
 :param resource: Resource data (wrapped `ResourceData` object).  
-:param context: Python dictionary with additional context.  
-:param access_token: (Optional) The access token string.  
-:param id_token: (Optional) The id token string.  
-:param userinfo_token: (Optional) The userinfo token string.
+:param context: Python dictionary with additional context.
 
 Example
 -------

--- a/jans-cedarling/bindings/cedarling_python/cedarling_python.pyi
+++ b/jans-cedarling/bindings/cedarling_python/cedarling_python.pyi
@@ -128,6 +128,7 @@ class Cedarling:
 
 @final
 class Request:
+    tokens: Tokens
     action: str
     resource: ResourceData
     context: Dict[str, Any]
@@ -136,12 +137,21 @@ class Request:
     userinfo_token: str | None
 
     def __init__(self,
-                 access_token: str,
-                 id_token: str,
-                 userinfo_token: str,
+                 tokens: Tokens,
                  action: str,
                  resource: ResourceData,
                  context: Dict[str, Any]) -> None: ...
+
+@final
+class Tokens:
+    access_token: str | None
+    id_token: str | None
+    userinfo_token: str | None
+
+    def __init__(self,
+                 access_token: str | None,
+                 id_token: str | None,
+                 userinfo_token: str | None) -> None: ...
 
 
 @final

--- a/jans-cedarling/bindings/cedarling_python/cedarling_python.pyi
+++ b/jans-cedarling/bindings/cedarling_python/cedarling_python.pyi
@@ -132,9 +132,6 @@ class Request:
     action: str
     resource: ResourceData
     context: Dict[str, Any]
-    access_token: str | None
-    id_token: str | None
-    userinfo_token: str | None
 
     def __init__(self,
                  tokens: Tokens,

--- a/jans-cedarling/bindings/cedarling_python/example.py
+++ b/jans-cedarling/bindings/cedarling_python/example.py
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2024, Gluu, Inc.
 
-from cedarling_python import BootstrapConfig
+from cedarling_python import BootstrapConfig, Tokens
 from cedarling_python import Cedarling
 from cedarling_python import ResourceData, Request
 import time
@@ -189,9 +189,7 @@ context = {
 action = 'Jans::Action::"Read"'
 
 request = Request(
-    access_token,
-    id_token,
-    userinfo_token,
+    tokens=Tokens(access_token, id_token, userinfo_token),
     action=action,
     resource=resource, context=context)
 

--- a/jans-cedarling/bindings/cedarling_python/pyproject.toml
+++ b/jans-cedarling/bindings/cedarling_python/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "maturin"
 
 [project]
 name = "cedarling_python"
-version = "0.0.0"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/mod.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/mod.rs
@@ -22,6 +22,7 @@ pub fn register_entities(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<decision::Decision>()?;
     m.add_class::<resource_data::ResourceData>()?;
     m.add_class::<request::Request>()?;
+    m.add_class::<request::Tokens>()?;
     m.add_class::<authorize_result_response::AuthorizeResultResponse>()?;
     m.add_class::<authorize_result::AuthorizeResult>()?;
 

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/request.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/request.rs
@@ -20,12 +20,10 @@ use serde_pyobject::from_pyobject;
 ///
 /// Attributes
 /// ----------
+/// :param tokens: Python dictionary with additional context.
 /// :param action: The action to be authorized.
 /// :param resource: Resource data (wrapped `ResourceData` object).
 /// :param context: Python dictionary with additional context.
-/// :param access_token: (Optional) The access token string.
-/// :param id_token: (Optional) The id token string.
-/// :param userinfo_token: (Optional) The userinfo token string.
 ///
 /// Example
 /// -------
@@ -35,12 +33,7 @@ use serde_pyobject::from_pyobject;
 /// ```
 #[pyclass(get_all, set_all)]
 pub struct Request {
-    /// Access token raw value
-    pub access_token: Option<String>,
-    /// Id token raw value
-    pub id_token: Option<String>,
-    /// Userinfo token raw value
-    pub userinfo_token: Option<String>,
+    pub tokens: Tokens,
     /// cedar_policy action
     pub action: String,
     /// cedar_policy resource data
@@ -49,14 +42,39 @@ pub struct Request {
     pub context: Py<PyDict>,
 }
 
+/// Tokens
+/// =======
+///
+/// A Python wrapper for the Rust `cedarling::Token` struct. Contains the JWTs
+/// that will be used for the AuthZ request.
+///
+/// Attributes
+/// ----------
+/// :param access_token: (Optional) The access token string.
+/// :param id_token: (Optional) The id token string.
+/// :param userinfo_token: (Optional) The userinfo token string.
+///
+/// Example
+/// -------
+/// ```python
+/// tokens = Request("your_access_tkn", "your_id_tkn", "your_userinfo_tkn")
+/// ```
+#[derive(Clone)]
+#[pyclass(get_all, set_all)]
+pub struct Tokens {
+    /// Access token raw value
+    pub access_token: Option<String>,
+    /// Id token raw value
+    pub id_token: Option<String>,
+    /// Userinfo token raw value
+    pub userinfo_token: Option<String>,
+}
+
 #[pymethods]
-impl Request {
+impl Tokens {
     #[new]
-    #[pyo3(signature = (action, resource, context, access_token=None, id_token=None, userinfo_token=None))]
+    #[pyo3(signature = (access_token, id_token, userinfo_token))]
     fn new(
-        action: String,
-        resource: ResourceData,
-        context: Py<PyDict>,
         access_token: Option<String>,
         id_token: Option<String>,
         userinfo_token: Option<String>,
@@ -65,9 +83,30 @@ impl Request {
             access_token,
             id_token,
             userinfo_token,
+        }
+    }
+}
+
+#[pymethods]
+impl Request {
+    #[new]
+    #[pyo3(signature = (tokens, action, resource, context))]
+    fn new(tokens: Tokens, action: String, resource: ResourceData, context: Py<PyDict>) -> Self {
+        Self {
+            tokens,
             action,
             resource,
             context,
+        }
+    }
+}
+
+impl From<Tokens> for cedarling::Tokens {
+    fn from(tokens: Tokens) -> Self {
+        Self {
+            access_token: tokens.access_token,
+            id_token: tokens.id_token,
+            userinfo_token: tokens.userinfo_token,
         }
     }
 }
@@ -82,9 +121,7 @@ impl Request {
         })?;
 
         Ok(cedarling::Request {
-            access_token: self.access_token.clone(),
-            id_token: self.id_token.clone(),
-            userinfo_token: self.userinfo_token.clone(),
+            tokens: self.tokens.clone().into(),
             action: self.action.clone(),
             resource: self.resource.clone().into(),
             context,

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/request.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/request.rs
@@ -20,7 +20,7 @@ use serde_pyobject::from_pyobject;
 ///
 /// Attributes
 /// ----------
-/// :param tokens: Python dictionary with additional context.
+/// :param tokens: A class containing the JWTs what will be used for the request.
 /// :param action: The action to be authorized.
 /// :param resource: Resource data (wrapped `ResourceData` object).
 /// :param context: Python dictionary with additional context.

--- a/jans-cedarling/bindings/cedarling_python/tests/test_authorize.py
+++ b/jans-cedarling/bindings/cedarling_python/tests/test_authorize.py
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2024, Gluu, Inc.
 
-from cedarling_python import Cedarling
+from cedarling_python import Cedarling, Tokens
 from cedarling_python import ResourceData, Request, authorize_errors
 from config import load_bootstrap_config
 
@@ -115,9 +115,7 @@ def test_authorize_ok():
     })
 
     request = Request(
-        access_token=ACCESS_TOKEN,
-        id_token=ID_TOKEN,
-        userinfo_token=USERINFO_TOKEN,
+        tokens=Tokens(ACCESS_TOKEN, ID_TOKEN, USERINFO_TOKEN),
         action='Jans::Action::"Update"',
         context={}, 
         resource=resource,
@@ -172,9 +170,7 @@ def raise_authorize_error(bootstrap_config):
     })
 
     request = Request(
-        access_token=ACCESS_TOKEN,
-        id_token=ID_TOKEN,
-        userinfo_token=USERINFO_TOKEN,
+        tokens=Tokens(ACCESS_TOKEN, ID_TOKEN, USERINFO_TOKEN),
         action='Jans::Action::"Update"',
         context={}, resource=resource)
 

--- a/jans-cedarling/cedarling/examples/authorize_with_jwt_validation.rs
+++ b/jans-cedarling/cedarling/examples/authorize_with_jwt_validation.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use cedarling::{
     AuthorizationConfig, BootstrapConfig, Cedarling, IdTokenTrustMode, JwtConfig, LogConfig,
     LogLevel, LogTypeConfig, PolicyStoreConfig, PolicyStoreSource, Request, ResourceData,
-    TokenValidationConfig, WorkloadBoolOp,
+    TokenValidationConfig, Tokens, WorkloadBoolOp,
 };
 use jsonwebtoken::Algorithm;
 
@@ -61,9 +61,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // on a specific resource. Each token (access, ID, and userinfo) is required for the
     // authorization process, alongside resource and action details.
     let result = cedarling.authorize(Request {
-        access_token: Some(access_token),
-        id_token: Some(id_token),
-        userinfo_token: Some(userinfo_token),
+        tokens: Tokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: Some(userinfo_token),
+        },
         action: "Jans::Action::\"Update\"".to_string(),
         context: serde_json::json!({}),
         resource: ResourceData {

--- a/jans-cedarling/cedarling/examples/authorize_without_jwt_validation.rs
+++ b/jans-cedarling/cedarling/examples/authorize_without_jwt_validation.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use cedarling::{
     AuthorizationConfig, BootstrapConfig, Cedarling, JwtConfig, LogConfig, LogLevel, LogTypeConfig,
-    PolicyStoreConfig, PolicyStoreSource, Request, ResourceData, WorkloadBoolOp,
+    PolicyStoreConfig, PolicyStoreSource, Request, ResourceData, Tokens, WorkloadBoolOp,
 };
 
 static POLICY_STORE_RAW: &str = include_str!("../../test_files/policy-store_ok.yaml");
@@ -112,9 +112,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let userinfo_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FkbWluLXVpLXRlc3QuZ2x1dS5vcmciLCJzdWIiOiJib0c4ZGZjNU1LVG4zN283Z3NkQ2V5cUw4THBXUXRnb080MW0xS1p3ZHEwIiwiY2xpZW50X2lkIjoiNWI0NDg3YzQtOGRiMS00MDlkLWE2NTMtZjkwN2I4MDk0MDM5IiwiYXVkIjoiNWI0NDg3YzQtOGRiMS00MDlkLWE2NTMtZjkwN2I4MDk0MDM5IiwidXNlcm5hbWUiOiJhZG1pbkBnbHV1Lm9yZyIsIm5hbWUiOiJEZWZhdWx0IEFkbWluIFVzZXIiLCJlbWFpbCI6ImFkbWluQGdsdXUub3JnIiwiY291bnRyeSI6IlVTIiwianRpIjoidXNyaW5mb190a25fanRpIn0.NoR53vPZFpfb4vFk85JH9RPx7CHsaJMZwrH3fnB-N60".to_string();
 
     let result = cedarling.authorize(Request {
-        access_token: Some(access_token),
-        id_token: Some(id_token),
-        userinfo_token: Some(userinfo_token),
+        tokens: Tokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: Some(userinfo_token),
+        },
         action: "Jans::Action::\"Update\"".to_string(),
         context: serde_json::json!({}),
         resource: ResourceData {

--- a/jans-cedarling/cedarling/src/authz/entities/create.rs
+++ b/jans-cedarling/cedarling/src/authz/entities/create.rs
@@ -435,6 +435,6 @@ pub enum CreateCedarEntityError {
     UnavailableToken,
 
     /// Missing claim
-    #[error("{0} Entity creation failed: no available token to build the entity from")]
+    #[error("missing claim: {0}")]
     MissingClaim(String),
 }

--- a/jans-cedarling/cedarling/src/authz/entities/workload.rs
+++ b/jans-cedarling/cedarling/src/authz/entities/workload.rs
@@ -43,7 +43,6 @@ pub fn create_workload_entity(
     for (token_kind, token, key) in [
         (TokenKind::Access, tokens.access_token.as_ref(), "client_id"),
         (TokenKind::Id, tokens.id_token.as_ref(), "aud"),
-        (TokenKind::Userinfo, tokens.userinfo_token.as_ref(), "aud"),
     ] {
         match try_create_entity(token_kind, token, key) {
             Ok(entity) => return Ok(entity),

--- a/jans-cedarling/cedarling/src/authz/entities/workload.rs
+++ b/jans-cedarling/cedarling/src/authz/entities/workload.rs
@@ -232,7 +232,7 @@ mod test {
         let result = create_workload_entity(entity_mapping, &policy_store, &tokens)
             .expect_err("expected to error while creating workload entity");
 
-        assert_eq!(result.errors.len(), 3);
+        assert_eq!(result.errors.len(), 2);
         for (_tkn_kind, err) in result.errors.iter() {
             assert!(
                 matches!(err, CreateCedarEntityError::UnavailableToken),

--- a/jans-cedarling/cedarling/src/authz/mod.rs
+++ b/jans-cedarling/cedarling/src/authz/mod.rs
@@ -34,12 +34,12 @@ use std::time::Instant;
 pub use authorize_result::AuthorizeResult;
 use cedar_policy::{ContextJsonError, Entities, Entity, EntityUid};
 use entities::{
-    CEDAR_POLICY_SEPARATOR, CreateCedarEntityError, CreateUserEntityError,
-    CreateWorkloadEntityError, DecodedTokens, ResourceEntityError, RoleEntityError,
     create_resource_entity, create_role_entities, create_token_entities, create_user_entity,
-    create_workload_entity,
+    create_workload_entity, CreateCedarEntityError, CreateUserEntityError,
+    CreateWorkloadEntityError, DecodedTokens, ResourceEntityError, RoleEntityError,
+    CEDAR_POLICY_SEPARATOR,
 };
-use merge_json::{MergeError, merge_json_values};
+use merge_json::{merge_json_values, MergeError};
 use request::Request;
 use serde_json::Value;
 
@@ -87,16 +87,19 @@ impl Authz {
         request: &'a Request,
     ) -> Result<DecodedTokens<'a>, AuthorizeError> {
         let access_token = request
+            .tokens
             .access_token
             .as_ref()
             .map(|tkn| self.config.jwt_service.process_token(TokenStr::Access(tkn)))
             .transpose()?;
         let id_token = request
+            .tokens
             .id_token
             .as_ref()
             .map(|tkn| self.config.jwt_service.process_token(TokenStr::Id(tkn)))
             .transpose()?;
         let userinfo_token = request
+            .tokens
             .userinfo_token
             .as_ref()
             .map(|tkn| {

--- a/jans-cedarling/cedarling/src/authz/request.rs
+++ b/jans-cedarling/cedarling/src/authz/request.rs
@@ -11,18 +11,28 @@ use cedar_policy::{EntityId, EntityTypeName, EntityUid, ParseErrors};
 /// Box to store authorization data
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Request {
-    /// Access token raw value
-    pub access_token: Option<String>,
-    /// Id Token raw value
-    pub id_token: Option<String>,
-    /// Userinfo Token raw value
-    pub userinfo_token: Option<String>,
+    /// Contains the JWTs that will be used for the AuthZ request
+    pub tokens: Tokens,
     /// cedar_policy action
     pub action: String,
     /// cedar_policy resource data
     pub resource: ResourceData,
     /// context to be used in cedar_policy
     pub context: serde_json::Value,
+}
+
+/// Contains the JWTs that will be used for the AuthZ request
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Tokens {
+    /// Access token raw value
+    #[serde(default)]
+    pub access_token: Option<String>,
+    /// Id Token raw value
+    #[serde(default)]
+    pub id_token: Option<String>,
+    /// Userinfo Token raw value
+    #[serde(default)]
+    pub userinfo_token: Option<String>,
 }
 
 /// Cedar policy resource data

--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -27,7 +27,7 @@ mod tests;
 
 use std::sync::Arc;
 
-pub use authz::request::{Request, ResourceData};
+pub use authz::request::{Request, ResourceData, Tokens};
 #[cfg(test)]
 use authz::AuthorizeEntitiesData;
 use authz::Authz;

--- a/jans-cedarling/cedarling/src/tests/cases_authorize_different_principals.rs
+++ b/jans-cedarling/cedarling/src/tests/cases_authorize_different_principals.rs
@@ -20,27 +20,29 @@ static POLICY_STORE_RAW_YAML: &str = include_str!("../../../test_files/policy-st
 lazy_static! {
     pub(crate) static ref AuthRequestBase: Request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "country": "US",
                     "sub": "some_sub",
                     "iss": "some_iss",
                     "client_id": "some_client_id",
                     "role": "Admin",
-                  })),
+                })),
+            },
             // we need specify action name in each test case
             "action": "",
             "resource": {

--- a/jans-cedarling/cedarling/src/tests/cases_authorize_namespace_jans2.rs
+++ b/jans-cedarling/cedarling/src/tests/cases_authorize_namespace_jans2.rs
@@ -21,27 +21,29 @@ fn test_namespace_jans2() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "country": "US",
                     "sub": "some_sub",
                     "iss": "some_iss",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "role": ["Admin"],
-                  })),
+                })),
+            },
             "action": "Jans2::Action::\"Update\"",
             "resource": {
                 "id": "random_id",

--- a/jans-cedarling/cedarling/src/tests/cases_authorize_without_check_jwt.rs
+++ b/jans-cedarling/cedarling/src/tests/cases_authorize_without_check_jwt.rs
@@ -24,27 +24,29 @@ fn success_test_role_string() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "country": "US",
                     "sub": "some_sub",
                     "iss": "some_iss",
                     "client_id": "some_client_id",
                     "role": "Admin",
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -100,27 +102,29 @@ fn forbid_test_role_guest() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "country": "US",
                     "sub": "some_sub",
                     "iss": "some_iss",
                     "client_id": "some_client_id",
                     "role": "Guest",
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -176,27 +180,29 @@ fn success_test_role_array() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "country": "US",
                     "sub": "some_sub",
                     "iss": "some_iss",
                     "client_id": "some_client_id",
                     "role": ["Admin"],
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -253,20 +259,21 @@ fn success_test_no_role() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "country": "US",
                     "sub": "some_sub",
@@ -274,7 +281,8 @@ fn success_test_no_role() {
                     "client_id": "some_client_id",
                     // comment role field (removed)
                     // "role": ["Admin"],
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -332,28 +340,30 @@ fn success_test_user_data_in_id_token() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
                     "country": "US",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "sub": "some_sub",
                     "iss": "some_iss",
                     "client_id": "some_client_id",
                     "role": ["Admin"],
                     "country": "US",
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -405,21 +415,22 @@ fn all_forbid() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
-                  // org_id different from resource
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
+                    // org_id different from resource
                     "org_id": "some_long_id_2",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                   // country different from resource
                     "country": "UK",
@@ -429,7 +440,8 @@ fn all_forbid() {
                     "client_id": "some_client_id",
                     // role not Admin
                     "role": ["Guest"],
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -481,20 +493,21 @@ fn only_workload_permit() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                   // country different from resource
                     "country": "UK",
@@ -503,7 +516,8 @@ fn only_workload_permit() {
                     "client_id": "some_client_id",
                     // role not Admin
                     "role": ["Guest"],
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -561,21 +575,22 @@ fn only_person_permit() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
-                  // org_id different from resource
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
+                    // org_id different from resource
                     "org_id": "some_long_id_2",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                   // country different from resource
                     "country": "US",
@@ -584,7 +599,8 @@ fn only_person_permit() {
                     "client_id": "some_client_id",
                     // role not present, commented line
                     // "role": ["Guest"],
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -636,21 +652,22 @@ fn only_user_role_permit() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
-                  // org_id different from resource
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
+                    // org_id different from resource
                     "org_id": "some_long_id_2",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                   // country different from resource
                     "country": "UK",
@@ -658,7 +675,8 @@ fn only_user_role_permit() {
                     "iss": "some_iss",
                     "client_id": "some_client_id",
                     "role": ["Admin"],
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -710,20 +728,21 @@ fn only_workload_and_person_permit() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "country": "US",
                     "sub": "some_sub",
@@ -731,7 +750,8 @@ fn only_workload_and_person_permit() {
                     "client_id": "some_client_id",
                     // role vector is empty
                     "role": [],
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -783,28 +803,30 @@ fn only_workload_and_role_permit() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
-                  // country different from resource
+                    // country different from resource
                     "country": "UK",
                     "sub": "some_sub",
                     "iss": "some_iss",
                     "client_id": "some_client_id",
                     "role": ["Admin"],
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -855,7 +877,8 @@ fn success_test_role_string_with_abac() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "token1",
                     "client_id": "some_client_id",
@@ -864,8 +887,8 @@ fn success_test_role_string_with_abac() {
                     "exp": i64::MAX,
                     "iat": 0,
                     "name": "Worker123",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "token2",
                     "iss": "https://account.gluu.org",
                     "aud": "client123",
@@ -874,8 +897,8 @@ fn success_test_role_string_with_abac() {
                     "iat": 0,
                     "amr": "some_amr",
                     "acr": "some_acr",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "token3",
                     "iss": "https://account.gluu.org",
                     "sub": "some_sub",
@@ -886,7 +909,8 @@ fn success_test_role_string_with_abac() {
                     "username": "worker123",
                     "exp": i64::MAX,
                     "iat": 0,
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",

--- a/jans-cedarling/cedarling/src/tests/mapping_entities.rs
+++ b/jans-cedarling/cedarling/src/tests/mapping_entities.rs
@@ -28,27 +28,29 @@ static REQUEST: LazyLock<Request> = LazyLock::new(|| {
     // deserialize `Request` from json
     Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "some_iss",
                     "aud": "some_aud",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "some_iss",
                     "aud": "some_aud",
                     "sub": "some_sub",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "country": "US",
                     "sub": "some_sub",
                     "iss": "some_iss",
                     "client_id": "some_client_id",
                     "role": "Admin",
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",
@@ -355,29 +357,31 @@ fn test_role_many_tokens_mapping() {
     let request = // deserialize `Request` from json
     Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "org_id": "some_long_id",
                     "jti": "some_jti",
                     "client_id": "some_client_id",
                     "iss": "https://test-casa.gluu.info",
                     "aud": "some_aud",
                     "role": "Guest",
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "iss": "https://test-casa.gluu.info",
                     "aud": "some_aud",
                     "sub": "some_sub",
                     "role": "User",
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "jti": "some_jti",
                     "country": "US",
                     "sub": "some_sub",
                     "iss": "https://test-casa.gluu.info",
                     "client_id": "some_client_id",
                     "role": "Admin",
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",

--- a/jans-cedarling/cedarling/src/tests/mapping_entities.rs
+++ b/jans-cedarling/cedarling/src/tests/mapping_entities.rs
@@ -224,7 +224,7 @@ fn test_failed_workload_mapping() {
 
     match err {
         AuthorizeError::CreateWorkloadEntity(error) => {
-            assert_eq!(error.errors.len(), 3, "there should be 3 errors");
+            assert_eq!(error.errors.len(), 2, "there should be 2 errors");
 
             // check for access token error
             let (token_kind, err) = &error.errors[0];
@@ -244,15 +244,6 @@ fn test_failed_workload_mapping() {
                 "expected CouldNotFindEntity(\"{}\"), got: {:?}",
                 &entity_type,
                 err,
-            );
-
-            // check for userinfo token error
-            let (token_kind, err) = &error.errors[2];
-            assert_eq!(token_kind, &TokenKind::Userinfo);
-            assert!(
-                matches!(err, CreateCedarEntityError::MissingClaim(ref claim) if claim == "aud"),
-                "expected MissinClaim(\"aud\"), got: {:?}",
-                err
             );
         },
         _ => panic!("expected error CreateWorkloadEntity"),

--- a/jans-cedarling/cedarling/src/tests/schema_type_mapping.rs
+++ b/jans-cedarling/cedarling/src/tests/schema_type_mapping.rs
@@ -18,68 +18,70 @@ fn check_mapping_tokens_data() {
     // JWT tokens payload from using `tarp` with `https://test-casa.gluu.info/.well-known/openid-configuration`
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
-                "sub": "J3BmtnPPB8BjMbScWmR8cjT9gWCCTHKfSf0dkbOvhGg",
-                "code": "697da80d-16ad-41f8-ad8e-c71f881c5473",
-                "iss": "https://test-casa.gluu.info",
-                "token_type": "Bearer",
-                "client_id": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
-                "aud": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
-                "acr": "simple_password_auth",
-                "x5t#S256": "",
-                "nbf": 1730494543,
-                "scope": [
-                    "role",
-                    "openid"
-                ],
-                "auth_time": 1730494542,
-                "exp": 1730574245,
-                "iat": 1730494543,
-                "jti": "qpCu52Z0S8ynfZ7ufCXQow",
-                "username": "John Smith",
-                "status": {
-                    "status_list": {
-                        "idx": 1003,
-                        "uri": "https://test-casa.gluu.info/jans-auth/restv1/status_list"
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
+                    "sub": "J3BmtnPPB8BjMbScWmR8cjT9gWCCTHKfSf0dkbOvhGg",
+                    "code": "697da80d-16ad-41f8-ad8e-c71f881c5473",
+                    "iss": "https://test-casa.gluu.info",
+                    "token_type": "Bearer",
+                    "client_id": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
+                    "aud": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
+                    "acr": "simple_password_auth",
+                    "x5t#S256": "",
+                    "nbf": 1730494543,
+                    "scope": [
+                        "role",
+                        "openid"
+                    ],
+                    "auth_time": 1730494542,
+                    "exp": 1730574245,
+                    "iat": 1730494543,
+                    "jti": "qpCu52Z0S8ynfZ7ufCXQow",
+                    "username": "John Smith",
+                    "status": {
+                        "status_list": {
+                            "idx": 1003,
+                            "uri": "https://test-casa.gluu.info/jans-auth/restv1/status_list"
+                        }
                     }
-                }
-            })),
-            "id_token": generate_token_using_claims(json!({
-                "at_hash": "zajL-IEPbJ7XprbAgi5LAg",
-                "sub": "J3BmtnPPB8BjMbScWmR8cjT9gWCCTHKfSf0dkbOvhGg",
-                "amr": [],
-                "iss": "https://test-casa.gluu.info",
-                "nonce": "b9b6df51-a04a-475a-9141-3fe589c2aab8",
-                "sid": "71eedb3a-7c18-420c-9fea-37d6532990e6",
-                "jansOpenIDConnectVersion": "openidconnect-1.0",
-                "aud": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
-                "acr": "simple_password_auth",
-                "c_hash": "pQi9rYqmSCVc3tK--2AgiA",
-                "nbf": 1730494543,
-                "auth_time": 1730494542,
-                "exp": 1730498143,
-                "grant": "authorization_code",
-                "iat": 1730494543,
-                "jti": "v2SWGfAEQGWZ1mPDSJPvbg",
-                "status": {
-                    "status_list": {
-                        "idx": 1004,
-                        "uri": "https://test-casa.gluu.info/jans-auth/restv1/status_list"
+                })),
+                "id_token": generate_token_using_claims(json!({
+                    "at_hash": "zajL-IEPbJ7XprbAgi5LAg",
+                    "sub": "J3BmtnPPB8BjMbScWmR8cjT9gWCCTHKfSf0dkbOvhGg",
+                    "amr": [],
+                    "iss": "https://test-casa.gluu.info",
+                    "nonce": "b9b6df51-a04a-475a-9141-3fe589c2aab8",
+                    "sid": "71eedb3a-7c18-420c-9fea-37d6532990e6",
+                    "jansOpenIDConnectVersion": "openidconnect-1.0",
+                    "aud": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
+                    "acr": "simple_password_auth",
+                    "c_hash": "pQi9rYqmSCVc3tK--2AgiA",
+                    "nbf": 1730494543,
+                    "auth_time": 1730494542,
+                    "exp": 1730498143,
+                    "grant": "authorization_code",
+                    "iat": 1730494543,
+                    "jti": "v2SWGfAEQGWZ1mPDSJPvbg",
+                    "status": {
+                        "status_list": {
+                            "idx": 1004,
+                            "uri": "https://test-casa.gluu.info/jans-auth/restv1/status_list"
+                        }
                     }
-                }
-            })),
-            "userinfo_token":  generate_token_using_claims(json!({
-                "sub": "J3BmtnPPB8BjMbScWmR8cjT9gWCCTHKfSf0dkbOvhGg",
-                "aud": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
-                "role": [
-                    "Manager",
-                    "Support"
-                ],
-                "iss": "https://test-casa.gluu.info",
-                "jti": "qOxklMYfSfqdYgXl01j9wA",
-                "client_id": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
-                "email":"user@example.com",
-            })),
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
+                    "sub": "J3BmtnPPB8BjMbScWmR8cjT9gWCCTHKfSf0dkbOvhGg",
+                    "aud": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
+                    "role": [
+                        "Manager",
+                        "Support"
+                    ],
+                    "iss": "https://test-casa.gluu.info",
+                    "jti": "qOxklMYfSfqdYgXl01j9wA",
+                    "client_id": "95bd63d2-85ed-40ad-bd03-3c18af797ca4",
+                    "email":"user@example.com",
+                })),
+            },
             "action": "Test::Action::\"Search\"",
             "resource": {
                 "id": "SomeID",

--- a/jans-cedarling/cedarling/src/tests/success_test_json.rs
+++ b/jans-cedarling/cedarling/src/tests/success_test_json.rs
@@ -19,7 +19,8 @@ fn success_test_json() {
     // deserialize `Request` from json
     let request = Request::deserialize(serde_json::json!(
         {
-            "access_token": generate_token_using_claims(json!({
+            "tokens": {
+                "access_token": generate_token_using_claims(json!({
                     "sub": "boG8dfc5MKTn37o7gsdCeyqL8LpWQtgoO41m1KZwdq0",
                     "code": "bf1934f6-3905-420a-8299-6b2e3ffddd6e",
                     "iss": "https://admin-ui-test.gluu.org",
@@ -44,8 +45,8 @@ fn success_test_json() {
                         "uri": "https://admin-ui-test.gluu.org/jans-auth/restv1/status_list"
                       }
                     }
-                  })),
-            "id_token": generate_token_using_claims(json!({
+                })),
+                "id_token": generate_token_using_claims(json!({
                     "acr": "basic",
                     "amr": "10",
                     "aud": "5b4487c4-8db1-409d-a653-f907b8094039",
@@ -67,8 +68,8 @@ fn success_test_json() {
                       }
                     },
                     "role":"Admin"
-                  })),
-            "userinfo_token":  generate_token_using_claims(json!({
+                })),
+                "userinfo_token":  generate_token_using_claims(json!({
                     "country": "US",
                     "email": "user@example.com",
                     "username": "UserNameExample",
@@ -88,7 +89,8 @@ fn success_test_json() {
                         "api-admin"
                     ],
                     "exp": 1724945978
-                  })),
+                })),
+            },
             "action": "Jans::Action::\"Update\"",
             "resource": {
                 "id": "random_id",


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
 
target issue: #10437
  
closes #10437

#### Implementation Details

moves the tokens in the AuthZ interface into a `tokens` field:

```js
input = { 
  "tokens": {
      "access_token": "encoded_token_str", 
      "id_token": "encoded_token_str", 
      "userinfo_token": "encoded_token_str", 
      "tx_token": "encoded_token_str" 
  },
  "resource": {"id": "12345", "type": "Ticket", "creator": "mike@gluu.org", "organization": "gluu"},
  "action": "View",
  "context": {
    "ip_address": "54.9.21.201",
    "network_type": "VPN",
    "user_agent": "Chrome 125.0.6422.77 (Official Build) (arm64)",
    "time": "1719266610.98636",
  }
}

decision_result = authz(input)
```

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
