### PR TITLE
feat(jans-cedarling): implement CEDARLING_ID_TOKEN_TRUST_MODE

### DIFF
--- a/jans-cedarling/bindings/cedarling_python/src/authorize/errors.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/errors.rs
@@ -122,6 +122,13 @@ create_exception!(
 
 create_exception!(
     authorize_errors,
+    IdTokenTrustModeError,
+    AuthorizeError,
+    "Error encountered while parsing all entities to json for logging"
+);
+
+create_exception!(
+    authorize_errors,
     AddEntitiesIntoContextError,
     AuthorizeError,
     "Error encountered while adding entities into context"
@@ -179,7 +186,8 @@ errors_functions! {
     UserRequestValidation => UserRequestValidationError,
     BuildContext => AddEntitiesIntoContextError,
     Entities => EntitiesError,
-    EntitiesToJson => EntitiesToJsonError
+    EntitiesToJson => EntitiesToJsonError,
+    IdTokenTrustMode => IdTokenTrustModeError
 }
 
 pub fn authorize_errors_module(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/jans-cedarling/cedarling/examples/authorize_with_jwt_validation.rs
+++ b/jans-cedarling/cedarling/examples/authorize_with_jwt_validation.rs
@@ -3,14 +3,13 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
-use std::collections::{HashMap, HashSet};
-
 use cedarling::{
-    AuthorizationConfig, BootstrapConfig, Cedarling, IdTokenTrustMode, JwtConfig, LogConfig,
-    LogLevel, LogTypeConfig, PolicyStoreConfig, PolicyStoreSource, Request, ResourceData,
-    TokenValidationConfig, Tokens, WorkloadBoolOp,
+    AuthorizationConfig, BootstrapConfig, Cedarling, JwtConfig, LogConfig, LogLevel, LogTypeConfig,
+    PolicyStoreConfig, PolicyStoreSource, Request, ResourceData, TokenValidationConfig, Tokens,
+    WorkloadBoolOp,
 };
 use jsonwebtoken::Algorithm;
+use std::collections::{HashMap, HashSet};
 
 static POLICY_STORE_RAW_YAML: &str =
     include_str!("../../test_files/policy-store_with_trusted_issuers_ok.yaml");
@@ -23,7 +22,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         jwks: None,
         jwt_sig_validation: true,
         jwt_status_validation: false,
-        id_token_trust_mode: IdTokenTrustMode::None,
         signature_algorithms_supported: HashSet::from_iter([Algorithm::HS256, Algorithm::RS256]),
         access_token_config: TokenValidationConfig::access_token(),
         id_token_config: TokenValidationConfig::id_token(),

--- a/jans-cedarling/cedarling/src/authz/trust_mode.rs
+++ b/jans-cedarling/cedarling/src/authz/trust_mode.rs
@@ -1,0 +1,321 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+use super::entities::DecodedTokens;
+use crate::{
+    common::policy_store::TokenKind,
+    jwt::{Token, TokenClaimTypeError},
+};
+
+pub fn enforce_id_tkn_trust_mode(tokens: &DecodedTokens) -> Result<(), IdTokenTrustModeError> {
+    let access_tkn = tokens
+        .access_token
+        .as_ref()
+        .ok_or(IdTokenTrustModeError::MissingAccessToken)?;
+    let id_tkn = tokens
+        .id_token
+        .as_ref()
+        .ok_or(IdTokenTrustModeError::MissingIdToken)?;
+
+    let access_tkn_client_id = get_tkn_claim_as_str(access_tkn, "client_id")?;
+    let id_tkn_aud = get_tkn_claim_as_str(id_tkn, "aud")?;
+
+    if access_tkn_client_id != id_tkn_aud {
+        return Err(IdTokenTrustModeError::ClientIdIdTokenAudMismatch);
+    }
+
+    let userinfo_tkn = match tokens.userinfo_token.as_ref() {
+        Some(token) => token,
+        None => return Ok(()),
+    };
+    let userinfo_tkn_aud = get_tkn_claim_as_str(userinfo_tkn, "aud")?;
+
+    if userinfo_tkn_aud != id_tkn_aud {
+        return Err(IdTokenTrustModeError::SubMismatchIdTokenUserinfo);
+    }
+    if userinfo_tkn_aud != access_tkn_client_id {
+        return Err(IdTokenTrustModeError::ClientIdUserinfoAudMismatch);
+    }
+
+    Ok(())
+}
+
+fn get_tkn_claim_as_str(
+    token: &Token,
+    claim_name: &str,
+) -> Result<Box<str>, IdTokenTrustModeError> {
+    let claim = token
+        .get_claim(claim_name)
+        .ok_or(IdTokenTrustModeError::MissingRequiredClaim(
+            claim_name.to_string(),
+            token.kind,
+        ))?;
+    let claim_str = claim
+        .as_str()
+        .map_err(|e| IdTokenTrustModeError::TokenClaimTypeError(token.kind, e))?;
+    Ok(claim_str.into())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IdTokenTrustModeError {
+    #[error("the access token's `client_id` does not match with the id token's `aud`")]
+    ClientIdIdTokenAudMismatch,
+    #[error("an access token is required when using strict mode")]
+    MissingAccessToken,
+    #[error("an id token is required when using strict mode")]
+    MissingIdToken,
+    #[error("the id token's `sub` does not match with the userinfo token's `sub`")]
+    SubMismatchIdTokenUserinfo,
+    #[error("the access token's `client_id` does not match with the userinfo token's `aud`")]
+    ClientIdUserinfoAudMismatch,
+    #[error("missing a required claim `{0}` from `{1}` token")]
+    MissingRequiredClaim(String, TokenKind),
+    #[error("invalid claim type in {0} token: {1}")]
+    TokenClaimTypeError(TokenKind, TokenClaimTypeError),
+}
+
+#[cfg(test)]
+mod test {
+    use super::{enforce_id_tkn_trust_mode, IdTokenTrustModeError};
+    use crate::authz::entities::DecodedTokens;
+    use crate::common::policy_store::TokenKind;
+    use crate::jwt::{Token, TokenClaims};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn success_without_userinfo_tkn() {
+        let access_token = Token::new_access(
+            TokenClaims::new(HashMap::from([(
+                "client_id".to_string(),
+                json!("some-id-123"),
+            )])),
+            None,
+        );
+        let id_token = Token::new_id(
+            TokenClaims::new(HashMap::from([("aud".to_string(), json!("some-id-123"))])),
+            None,
+        );
+        let tokens = DecodedTokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: None,
+        };
+        enforce_id_tkn_trust_mode(&tokens).expect("should not error");
+    }
+
+    #[test]
+    fn errors_when_missing_access_tkn() {
+        let id_token = Token::new_id(
+            TokenClaims::new(HashMap::from([("aud".to_string(), json!("some-id-123"))])),
+            None,
+        );
+        let tokens = DecodedTokens {
+            access_token: None,
+            id_token: Some(id_token),
+            userinfo_token: None,
+        };
+        let err = enforce_id_tkn_trust_mode(&tokens).expect_err("should error");
+        assert!(
+            matches!(err, IdTokenTrustModeError::MissingAccessToken),
+            "expected error due to missing access token, got: {:?}",
+            err
+        )
+    }
+
+    #[test]
+    fn errors_when_access_tkn_missing_required_claim() {
+        let access_token = Token::new_access(TokenClaims::new(HashMap::new()), None);
+        let id_token = Token::new_id(
+            TokenClaims::new(HashMap::from([("aud".to_string(), json!("some-id-123"))])),
+            None,
+        );
+        let tokens = DecodedTokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: None,
+        };
+        let err = enforce_id_tkn_trust_mode(&tokens).expect_err("should error");
+        assert!(
+            matches!(
+                err,
+                IdTokenTrustModeError::MissingRequiredClaim(ref claim_name, tkn_kind)
+                    if claim_name == "client_id" &&
+                        tkn_kind == TokenKind::Access
+            ),
+            "expected error due to access token missing a required claim, got: {:?}",
+            err
+        )
+    }
+
+    #[test]
+    fn errors_when_missing_id_tkn() {
+        let access_token = Token::new_id(
+            TokenClaims::new(HashMap::from([(
+                "client_id".to_string(),
+                json!("some-id-123"),
+            )])),
+            None,
+        );
+        let tokens = DecodedTokens {
+            access_token: Some(access_token),
+            id_token: None,
+            userinfo_token: None,
+        };
+        let err = enforce_id_tkn_trust_mode(&tokens).expect_err("should error");
+        assert!(
+            matches!(err, IdTokenTrustModeError::MissingIdToken),
+            "expected error due to missing id token, got: {:?}",
+            err
+        )
+    }
+
+    #[test]
+    fn errors_when_id_tkn_missing_required_claim() {
+        let access_token = Token::new_access(
+            TokenClaims::new(HashMap::from([(
+                "client_id".to_string(),
+                json!("some-id-123"),
+            )])),
+            None,
+        );
+        let id_token = Token::new_id(TokenClaims::new(HashMap::new()), None);
+        let tokens = DecodedTokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: None,
+        };
+        let err = enforce_id_tkn_trust_mode(&tokens).expect_err("should error");
+        assert!(
+            matches!(
+                err,
+                IdTokenTrustModeError::MissingRequiredClaim(ref claim_name, tkn_kind)
+                    if claim_name == "aud" &&
+                        tkn_kind == TokenKind::Id
+            ),
+            "expected error due to id token missing a required claim, got: {:?}",
+            err
+        )
+    }
+
+    #[test]
+    fn errors_when_access_tkn_client_id_id_tkn_aud_mismatch() {
+        let access_token = Token::new_access(
+            TokenClaims::new(HashMap::from([(
+                "client_id".to_string(),
+                json!("some-id-123"),
+            )])),
+            None,
+        );
+        let id_token = Token::new_id(
+            TokenClaims::new(HashMap::from([(
+                "aud".to_string(),
+                json!("another-id-123"),
+            )])),
+            None,
+        );
+        let tokens = DecodedTokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: None,
+        };
+        let err = enforce_id_tkn_trust_mode(&tokens).expect_err("should error");
+        assert!(
+            matches!(err, IdTokenTrustModeError::ClientIdIdTokenAudMismatch),
+            "expected error due to the access_token's `client_id` not matching with the id_token's `aud`, got: {:?}",
+            err
+        )
+    }
+
+    #[test]
+    fn success_with_userinfo_tkn() {
+        let access_token = Token::new_access(
+            TokenClaims::new(HashMap::from([(
+                "client_id".to_string(),
+                json!("some-id-123"),
+            )])),
+            None,
+        );
+        let id_token = Token::new_id(
+            TokenClaims::new(HashMap::from([("aud".to_string(), json!("some-id-123"))])),
+            None,
+        );
+        let userinfo_token = Token::new_userinfo(
+            TokenClaims::new(HashMap::from([("aud".to_string(), json!("some-id-123"))])),
+            None,
+        );
+        let tokens = DecodedTokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: Some(userinfo_token),
+        };
+        enforce_id_tkn_trust_mode(&tokens).expect("should not error");
+    }
+
+    #[test]
+    fn errors_when_userinfo_tkn_missing_required_claim() {
+        let access_token = Token::new_access(
+            TokenClaims::new(HashMap::from([(
+                "client_id".to_string(),
+                json!("some-id-123"),
+            )])),
+            None,
+        );
+        let id_token = Token::new_id(
+            TokenClaims::new(HashMap::from([("aud".to_string(), json!("some-id-123"))])),
+            None,
+        );
+        let userinfo_token = Token::new_userinfo(TokenClaims::new(HashMap::new()), None);
+        let tokens = DecodedTokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: Some(userinfo_token),
+        };
+        let err = enforce_id_tkn_trust_mode(&tokens).expect_err("should error");
+        assert!(
+            matches!(
+                err,
+                IdTokenTrustModeError::MissingRequiredClaim(ref claim_name, tkn_kind)
+                    if claim_name == "aud" &&
+                        tkn_kind == TokenKind::Userinfo
+            ),
+            "expected error due to id token missing a required claim, got: {:?}",
+            err
+        )
+    }
+
+    #[test]
+    fn errors_when_access_tkn_client_id_userinfo_tkn_aud_mismatch() {
+        let access_token = Token::new_access(
+            TokenClaims::new(HashMap::from([(
+                "client_id".to_string(),
+                json!("some-id-123"),
+            )])),
+            None,
+        );
+        let id_token = Token::new_id(
+            TokenClaims::new(HashMap::from([("aud".to_string(), json!("some-id-123"))])),
+            None,
+        );
+        let userinfo_token = Token::new_userinfo(
+            TokenClaims::new(HashMap::from([(
+                "aud".to_string(),
+                json!("another-id-123"),
+            )])),
+            None,
+        );
+        let tokens = DecodedTokens {
+            access_token: Some(access_token),
+            id_token: Some(id_token),
+            userinfo_token: Some(userinfo_token),
+        };
+        let err = enforce_id_tkn_trust_mode(&tokens).expect_err("should error");
+        assert!(
+            matches!(err, IdTokenTrustModeError::SubMismatchIdTokenUserinfo),
+            "expected error due to the id_token's `aud` not matching with the userinfo_token's `aud`, got: {:?}",
+            err
+        )
+    }
+}

--- a/jans-cedarling/cedarling/src/bootstrap_config/authorization_config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/authorization_config.rs
@@ -4,6 +4,8 @@
 // Copyright (c) 2024, Gluu, Inc.
 
 use super::WorkloadBoolOp;
+use serde::Deserialize;
+use std::str::FromStr;
 
 /// Configuration to specify authorization workflow.
 /// - If we use user entity as principal.
@@ -54,4 +56,60 @@ pub struct AuthorizationConfig {
 
     /// Name of Cedar userinfo schema entity
     pub mapping_userinfo_token: Option<String>,
+
+    /// Sets the validation level for ID tokens.
+    ///
+    /// The available levels are [`None`] and [`Strict`].
+    ///
+    /// # Strict Mode
+    ///
+    /// In `Strict` mode, the following conditions must be met for a token
+    /// to be considered valid:
+    ///
+    /// - The `id_token`'s `aud` (audience) must match the `access_token`'s `client_id`
+    /// - If a Userinfo token is present:
+    ///     - Its `sub` (subject) must match the `id_token`'s `sub`.
+    ///     - Its `aud` (audience) must match the `access_token`'s `client_id`.
+    ///
+    /// [`None`]: IdTokenTrustMode::None
+    /// [`Strict`]: IdTokenTrustMode::Strict
+    pub id_token_trust_mode: IdTokenTrustMode,
+}
+
+/// Defines the level of validation for ID tokens.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum IdTokenTrustMode {
+    /// No validation is performed on the ID token.
+    None,
+    /// Strict validation of the ID token.
+    ///
+    /// In this mode, the following conditions must be met:
+    ///
+    /// - The `id_token`'s `aud` (audience) must match the `access_token`'s `client_id`.
+    /// - If a Userinfo token is present:
+    ///   - Its `sub` (subject) must match the `id_token`'s `sub`.
+    ///   - Its `aud` must match the `access_token`'s `client_id`.
+    #[default]
+    Strict,
+}
+
+impl FromStr for IdTokenTrustMode {
+    type Err = IdTknTrustModeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.to_lowercase();
+        match s.as_str() {
+            "strict" => Ok(IdTokenTrustMode::Strict),
+            "none" => Ok(IdTokenTrustMode::None),
+            _ => Err(IdTknTrustModeParseError { trust_mode: s }),
+        }
+    }
+}
+
+/// Error when parsing [`IdTokenTrustMode`]
+#[derive(Default, Debug, derive_more::Display, derive_more::Error)]
+#[display("Invalid `IdTokenTrustMode`: {trust_mode}. should be `strict` or `none`")]
+pub struct IdTknTrustModeParseError {
+    trust_mode: String,
 }

--- a/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
@@ -3,21 +3,19 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
+use super::authorization_config::{AuthorizationConfig, IdTokenTrustMode};
+use super::{
+    BootstrapConfig, BootstrapConfigLoadingError, JwtConfig, LogConfig, LogTypeConfig,
+    MemoryLogConfig, PolicyStoreConfig, PolicyStoreSource, TokenValidationConfig,
+};
+use crate::log::LogLevel;
+use jsonwebtoken::Algorithm;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
-
-use jsonwebtoken::Algorithm;
-use serde::{Deserialize, Deserializer, Serialize};
-
-use super::authorization_config::AuthorizationConfig;
-use super::{
-    BootstrapConfig, BootstrapConfigLoadingError, IdTokenTrustMode, JwtConfig, LogConfig,
-    LogTypeConfig, MemoryLogConfig, PolicyStoreConfig, PolicyStoreSource, TokenValidationConfig,
-};
-use crate::log::LogLevel;
 
 #[derive(Deserialize, PartialEq, Debug, Default)]
 /// Struct that represent mapping mapping `Bootstrap properties` to be JSON and YAML compatible
@@ -503,7 +501,6 @@ impl BootstrapConfig {
             jwks,
             jwt_sig_validation: raw.jwt_sig_validation.into(),
             jwt_status_validation: raw.jwt_status_validation.into(),
-            id_token_trust_mode: raw.id_token_trust_mode,
             signature_algorithms_supported: raw.jwt_signature_algorithms_supported.clone(),
             access_token_config: TokenValidationConfig {
                 iss_validation: raw.at_iss_validation.into(),
@@ -541,6 +538,7 @@ impl BootstrapConfig {
             mapping_id_token: raw.mapping_id_token.clone(),
             mapping_access_token: raw.mapping_access_token.clone(),
             mapping_userinfo_token: raw.mapping_userinfo_token.clone(),
+            id_token_trust_mode: raw.id_token_trust_mode,
         };
 
         Ok(Self {

--- a/jans-cedarling/cedarling/src/bootstrap_config/jwt_config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/jwt_config.rs
@@ -3,11 +3,8 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
-use std::collections::HashSet;
-use std::str::FromStr;
-
 use jsonwebtoken::Algorithm;
-use serde::Deserialize;
+use std::collections::HashSet;
 
 /// The set of Bootstrap properties related to JWT validation.
 #[derive(Debug, PartialEq)]
@@ -38,23 +35,6 @@ pub struct JwtConfig {
     ///
     /// [`IETF Draft`]: https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/
     pub jwt_status_validation: bool,
-    /// Sets the validation level for ID tokens.
-    ///
-    /// The available levels are [`None`] and [`Strict`].
-    ///
-    /// # Strict Mode
-    ///
-    /// In `Strict` mode, the following conditions must be met for a token
-    /// to be considered valid:
-    ///
-    /// - The `id_token`'s `aud` (audience) must match the `access_token`'s `client_id`
-    /// - If a Userinfo token is present:
-    ///     - Its `sub` (subject) must match the `id_token`'s `sub`.
-    ///     - Its `aud` (audience) must match the `access_token`'s `client_id`.
-    ///
-    /// [`None`]: IdTokenTrustMode::None
-    /// [`Strict`]: IdTokenTrustMode::Strict
-    pub id_token_trust_mode: IdTokenTrustMode,
     /// Only tokens signed with algorithms in this list can be valid.
     pub signature_algorithms_supported: HashSet<Algorithm>,
     /// Validation options related to the Access token
@@ -177,44 +157,6 @@ impl TokenValidationConfig {
     }
 }
 
-/// Defines the level of validation for ID tokens.
-#[derive(Debug, Clone, PartialEq, Default, Deserialize, Copy)]
-#[serde(rename_all = "lowercase")]
-pub enum IdTokenTrustMode {
-    /// No validation is performed on the ID token.
-    None,
-    /// Strict validation of the ID token.
-    ///
-    /// In this mode, the following conditions must be met:
-    ///
-    /// - The `id_token`'s `aud` (audience) must match the `access_token`'s `client_id`.
-    /// - If a Userinfo token is present:
-    ///   - Its `sub` (subject) must match the `id_token`'s `sub`.
-    ///   - Its `aud` must match the `access_token`'s `client_id`.
-    #[default]
-    Strict,
-}
-
-impl FromStr for IdTokenTrustMode {
-    type Err = IdTknTrustModeParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.to_lowercase();
-        match s.as_str() {
-            "strict" => Ok(IdTokenTrustMode::Strict),
-            "none" => Ok(IdTokenTrustMode::None),
-            _ => Err(IdTknTrustModeParseError { trust_mode: s }),
-        }
-    }
-}
-
-/// Error when parsing [`IdTokenTrustMode`]
-#[derive(Default, Debug, derive_more::Display, derive_more::Error)]
-#[display("Invalid `IdTokenTrustMode`: {trust_mode}. should be `strict` or `none`")]
-pub struct IdTknTrustModeParseError {
-    trust_mode: String,
-}
-
 impl Default for JwtConfig {
     /// Cedarling will use the strictest validation options by default.
     fn default() -> Self {
@@ -222,7 +164,6 @@ impl Default for JwtConfig {
             jwks: None,
             jwt_sig_validation: true,
             jwt_status_validation: true,
-            id_token_trust_mode: IdTokenTrustMode::Strict,
             signature_algorithms_supported: HashSet::new(),
             access_token_config: TokenValidationConfig::access_token(),
             id_token_config: TokenValidationConfig::id_token(),
@@ -238,7 +179,6 @@ impl JwtConfig {
             jwks: None,
             jwt_sig_validation: false,
             jwt_status_validation: false,
-            id_token_trust_mode: IdTokenTrustMode::None,
             signature_algorithms_supported: HashSet::new(),
             access_token_config: TokenValidationConfig::default(),
             id_token_config: TokenValidationConfig::default(),

--- a/jans-cedarling/cedarling/src/bootstrap_config/mod.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/mod.rs
@@ -182,7 +182,6 @@ mod test {
                 jwks: None,
                 jwt_sig_validation: true,
                 jwt_status_validation: false,
-                id_token_trust_mode: IdTokenTrustMode::Strict,
                 signature_algorithms_supported: HashSet::from([Algorithm::HS256, Algorithm::RS256]),
                 access_token_config: TokenValidationConfig {
                     exp_validation: true,
@@ -237,7 +236,6 @@ mod test {
                 jwks: None,
                 jwt_sig_validation: true,
                 jwt_status_validation: false,
-                id_token_trust_mode: IdTokenTrustMode::Strict,
                 signature_algorithms_supported: HashSet::from([Algorithm::HS256, Algorithm::RS256]),
                 access_token_config: TokenValidationConfig {
                     exp_validation: true,

--- a/jans-cedarling/cedarling/src/jwt/mod.rs
+++ b/jans-cedarling/cedarling/src/jwt/mod.rs
@@ -28,7 +28,7 @@ pub use token::{Token, TokenClaim, TokenClaimTypeError, TokenClaims, TokenStr};
 use validator::{JwtValidator, JwtValidatorConfig, JwtValidatorError};
 
 use crate::common::policy_store::TrustedIssuer;
-use crate::{IdTokenTrustMode, JwtConfig};
+use crate::JwtConfig;
 
 /// Type alias for Trusted Issuers' ID.
 type TrustedIssuerId = Arc<str>;
@@ -92,10 +92,6 @@ pub struct JwtService {
     access_tkn_validator: JwtValidator,
     id_tkn_validator: JwtValidator,
     userinfo_tkn_validator: JwtValidator,
-    // TODO: implement the usage of this bootstrap property in
-    // the authz module.
-    #[allow(dead_code)]
-    id_token_trust_mode: IdTokenTrustMode,
 }
 
 impl JwtService {
@@ -173,7 +169,6 @@ impl JwtService {
             access_tkn_validator,
             id_tkn_validator,
             userinfo_tkn_validator,
-            id_token_trust_mode: config.id_token_trust_mode,
         })
     }
 
@@ -220,7 +215,7 @@ mod test {
 
     use super::test_utils::*;
     use super::{JwtService, Token, TokenClaims, TokenStr};
-    use crate::{IdTokenTrustMode, JwtConfig, TokenValidationConfig};
+    use crate::{JwtConfig, TokenValidationConfig};
 
     #[test]
     pub fn can_validate_token() {
@@ -262,7 +257,6 @@ mod test {
                 jwks: Some(local_jwks),
                 jwt_sig_validation: true,
                 jwt_status_validation: false,
-                id_token_trust_mode: IdTokenTrustMode::Strict,
                 signature_algorithms_supported: HashSet::from_iter([Algorithm::HS256]),
                 access_token_config: TokenValidationConfig::access_token(),
                 id_token_config: TokenValidationConfig::id_token(),

--- a/jans-cedarling/cedarling/src/tests/cases_authorize_different_principals.rs
+++ b/jans-cedarling/cedarling/src/tests/cases_authorize_different_principals.rs
@@ -13,7 +13,7 @@ use lazy_static::lazy_static;
 use test_utils::assert_eq;
 
 use super::utils::*;
-use crate::{cmp_decision, cmp_policy, WorkloadBoolOp}; /* macros is defined in the cedarling\src\tests\utils\cedarling_util.rs */
+use crate::{authorization_config::IdTokenTrustMode, cmp_decision, cmp_policy, WorkloadBoolOp}; /* macros is defined in the cedarling\src\tests\utils\cedarling_util.rs */
 
 static POLICY_STORE_RAW_YAML: &str = include_str!("../../../test_files/policy-store_ok_2.yaml");
 
@@ -104,6 +104,7 @@ fn success_test_for_principal_workload() {
             use_user_principal: false,
             use_workload_principal: true,
             user_workload_operator: Default::default(),
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );
@@ -140,6 +141,7 @@ fn success_test_for_principal_user() {
             use_user_principal: true,
             use_workload_principal: false,
             user_workload_operator: Default::default(),
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );
@@ -180,6 +182,7 @@ fn success_test_for_principal_person_role() {
             use_user_principal: true,
             use_workload_principal: false,
             user_workload_operator: Default::default(),
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );
@@ -220,6 +223,7 @@ fn success_test_for_principal_workload_role() {
             use_user_principal: true,
             use_workload_principal: true,
             user_workload_operator: WorkloadBoolOp::And,
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );
@@ -266,6 +270,7 @@ fn success_test_for_principal_workload_true_or_user_false() {
             use_user_principal: true,
             use_workload_principal: true,
             user_workload_operator: WorkloadBoolOp::Or,
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );
@@ -312,6 +317,7 @@ fn success_test_for_principal_workload_false_or_user_true() {
             use_user_principal: true,
             use_workload_principal: true,
             user_workload_operator: WorkloadBoolOp::Or,
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );
@@ -358,6 +364,7 @@ fn success_test_for_principal_workload_false_or_user_false() {
             use_user_principal: true,
             use_workload_principal: true,
             user_workload_operator: WorkloadBoolOp::Or,
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );
@@ -403,6 +410,7 @@ fn test_where_principal_workload_cant_be_applied() {
             use_user_principal: true,
             use_workload_principal: true,
             user_workload_operator: Default::default(),
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );
@@ -429,6 +437,7 @@ fn test_where_principal_user_cant_be_applied() {
             use_user_principal: true,
             use_workload_principal: false,
             user_workload_operator: Default::default(),
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     );

--- a/jans-cedarling/cedarling/src/tests/utils/cedarling_util.rs
+++ b/jans-cedarling/cedarling/src/tests/utils/cedarling_util.rs
@@ -3,7 +3,9 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
-use crate::{AuthorizationConfig, JwtConfig, WorkloadBoolOp};
+use crate::{
+    authorization_config::IdTokenTrustMode, AuthorizationConfig, JwtConfig, WorkloadBoolOp,
+};
 pub use crate::{
     BootstrapConfig, BootstrapConfigRaw, Cedarling, FeatureToggle, LogConfig, LogTypeConfig,
     PolicyStoreConfig, PolicyStoreSource,
@@ -23,6 +25,7 @@ pub fn get_raw_config(local_policy_store: &str) -> BootstrapConfigRaw {
         log_type: crate::LoggerType::StdOut,
         local_policy_store: Some(local_policy_store_json.to_string()),
         jwt_status_validation: FeatureToggle::Disabled,
+        id_token_trust_mode: IdTokenTrustMode::None,
         ..Default::default()
     }
 }
@@ -43,6 +46,7 @@ pub fn get_config(policy_source: PolicyStoreSource) -> BootstrapConfig {
             use_user_principal: true,
             use_workload_principal: true,
             user_workload_operator: WorkloadBoolOp::And,
+            id_token_trust_mode: IdTokenTrustMode::None,
             ..Default::default()
         },
     }

--- a/jans-cedarling/cedarling/src/tests/utils/cedarling_util.rs
+++ b/jans-cedarling/cedarling/src/tests/utils/cedarling_util.rs
@@ -23,7 +23,6 @@ pub fn get_raw_config(local_policy_store: &str) -> BootstrapConfigRaw {
         log_type: crate::LoggerType::StdOut,
         local_policy_store: Some(local_policy_store_json.to_string()),
         jwt_status_validation: FeatureToggle::Disabled,
-        id_token_trust_mode: crate::IdTokenTrustMode::None,
         ..Default::default()
     }
 }


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description 

This PR implements ID token trust mode which can be set via the `CEDARLING_ID_TOKEN_TRUST_MODE` bootstrap property. The trust mode implements additional checks done on the input token's claims. This PR introduces two modes: `None` and `Strict` (more info [below](#implementation-details)).

#### Target issue

target issue: #10479

closes: #10479

#### Implementation Details

##### `None` Mode

No additional validations checks on the tokens are implemented.

##### `Strict` Mode

- `id_token.aud` must match the `access_token.client_id`.
- If a Userinfo token is present:
    - The `sub` must match the `id_token.sub`.
    - The `aud` must match the `access_token.client_id`.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
