### PR TITLE
test(jans-auth-server): access evaluation tests are failing on jenkins

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
+++ b/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
@@ -273,6 +273,7 @@ class TestDataLoader(BaseInstaller, SetupUtils):
                                     'forceIdTokenHintPresence': False,
                                     'introspectionScriptBackwardCompatibility': False,
                                     'allowSpontaneousScopes': True,
+                                    'accessEvaluationAllowBasicClientAuthorization': True,
                                     'spontaneousScopeLifetime': 0,
                                     'tokenEndpointAuthMethodsSupported': [ 'client_secret_basic', 'client_secret_post', 'client_secret_jwt', 'private_key_jwt', 'tls_client_auth', 'self_signed_tls_client_auth', 'none' ],
                                     'sessionIdRequestParameterEnabled': True,


### PR DESCRIPTION
### Description

fix(jans-auth-server): access evaluation tests are failing on jenkins

#### Target issue
  
closes #10629


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
