### PR TITLE
fix(jans-auth-server): NPE during client name rendering #10663

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -86,6 +86,7 @@ import static org.apache.commons.lang3.BooleanUtils.isTrue;
 @Named
 public class AuthorizeAction {
 
+    public static final String UNKNOWN = "Unknown";
     @Inject
     private Logger log;
 
@@ -985,7 +986,7 @@ public class AuthorizeAction {
         log.trace("client {}", clientId);
 
         if (StringUtils.isBlank(clientId)) {
-            return "Unknown";
+            return UNKNOWN;
         }
 
         final Client client = clientService.getClient(clientId);
@@ -994,15 +995,19 @@ public class AuthorizeAction {
 
     public String getClientDisplayName(final Client client) {
         log.trace("client {}", client);
-        
+
         if (client == null) {
-        	getClientDisplayName();
+            return UNKNOWN;
         }
 
         return getCheckedClientDisplayName(client);
     }
 
 	private String getCheckedClientDisplayName(final Client client) {
+        if (client == null) {
+            return UNKNOWN;
+        }
+
         if (StringUtils.isNotBlank(client.getClientName())) {
             return client.getClientName();
         }
@@ -1011,7 +1016,7 @@ public class AuthorizeAction {
             return client.getClientId();
         }
 
-        return "Unknown";
+        return UNKNOWN;
 	}
 
     public String getAuthReqId() {


### PR DESCRIPTION
### Description

fix(jans-auth-server): NPE during client name rendering 

#### Target issue
  
closes #10663


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
