### PR TITLE
fix(jans-auth-server): second authorization challenge call does not invoke the right script #10745

### DIFF
--- a/docs/script-catalog/authorization_challenge/AgamaChallenge.java
+++ b/docs/script-catalog/authorization_challenge/AgamaChallenge.java
@@ -178,6 +178,9 @@ public class AuthorizationChallenge implements AuthorizationChallengeType {
             deviceSessionObjectAttrs.put("scope", servletRequest.getParameter("scope"));
             
             deviceSessionService.persist(deviceSessionObject);
+
+            authRequest.setAuthorizationChallengeSessionObject(deviceSessionObject);
+            authRequest.setAuthorizationChallengeSession(deviceSessionObject.getId());
             
         } else {
             sessionId = deviceSessionObject.getId();

--- a/docs/script-catalog/authorization_challenge/AuthorizationChallenge.java
+++ b/docs/script-catalog/authorization_challenge/AuthorizationChallenge.java
@@ -130,6 +130,8 @@ public class AuthorizationChallenge implements AuthorizationChallengeType {
         boolean newSave = authorizationChallengeSessionObject == null;
         if (newSave) {
             authorizationChallengeSessionObject = authorizationChallengeSessionService.newAuthorizationChallengeSession();
+            context.getAuthzRequest().setAuthorizationChallengeSessionObject(authorizationChallengeSessionObject);
+            context.getAuthzRequest().setAuthorizationChallengeSession(authorizationChallengeSessionObject.getId());
         }
 
         final String dpop = context.getHttpRequest().getHeader(DpopService.DPOP);

--- a/docs/script-catalog/authorization_challenge/multi_step/AuthorizationChallenge.java
+++ b/docs/script-catalog/authorization_challenge/multi_step/AuthorizationChallenge.java
@@ -130,6 +130,8 @@ public class AuthorizationChallenge implements AuthorizationChallengeType {
         boolean newSave = sessionObject == null;
         if (newSave) {
             sessionObject = authorizationChallengeSessionService.newAuthorizationChallengeSession();
+            context.getAuthzRequest().setAuthorizationChallengeSessionObject(authorizationChallengeSessionObject);
+            context.getAuthzRequest().setAuthorizationChallengeSession(authorizationChallengeSessionObject.getId());
         }
 
         String username = context.getHttpRequest().getParameter(USERNAME_PARAMETER);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequest.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthzRequest.java
@@ -109,6 +109,10 @@ public class AuthzRequest {
         return authorizationChallengeSessionObject;
     }
 
+    public Map<String, String> getAuthorizationChallengeSessionAttributesSafely() {
+        return authorizationChallengeSessionObject != null ? authorizationChallengeSessionObject.getAttributes().getAttributes() : new HashMap<>();
+    }
+
     public void setAuthorizationChallengeSessionObject(AuthorizationChallengeSession authorizationChallengeSessionObject) {
         this.authorizationChallengeSessionObject = authorizationChallengeSessionObject;
     }


### PR DESCRIPTION
### Description

fix(jans-auth-server): second authorization challenge call does not invoke the right script 

#### Target issue
  
closes #10745

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
