### PR TITLE
fix(jans-auth-server): typo in determineConsentFlow method #10758

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/ConsentGatheringSessionService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/ConsentGatheringSessionService.java
@@ -179,9 +179,9 @@ public class ConsentGatheringSessionService {
             return null;
         }
 
-        final Map<String, String> acrToConsent = appConfiguration.getAcrToConsentScriptNameMapping();
+        final Map<String, String> acrToConsent = appConfiguration.getAcrToAgamaConsentFlowMapping();
         if (acrToConsent == null || acrToConsent.isEmpty()) {
-            log.debug("determineConsentFlow - 'acrToConsentScriptNameMapping' configuration property is empty, return null for 'consent_flow'");
+            log.debug("determineConsentFlow - 'acrToAgamaConsentFlowMapping' configuration property is empty, return null for 'consent_flow'");
             return null;
         }
 


### PR DESCRIPTION
### Description

fix(jans-auth-server): typo in determineConsentFlow method 

#### Target issue
  
closes #10758


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
