### PR TITLE
fix(jans-linux-setup): fido document store paths

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/fido.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/fido.py
@@ -43,6 +43,7 @@ class FidoInstaller(JettyInstaller):
 
         self.fido_document_certs_dir = os.path.join(self.fido2ConfigFolder, 'mds/cert')
         self.fido_document_tocs_dir = os.path.join(self.fido2ConfigFolder, 'mds/toc')
+        self.fido_document_authenticator_cert_dir = os.path.join(self.fido2ConfigFolder, 'authenticator_cert')
 
     def install(self):
 

--- a/jans-linux-setup/jans_setup/templates/jans-fido2/docuemts.ldif
+++ b/jans-linux-setup/jans_setup/templates/jans-fido2/docuemts.ldif
@@ -33,7 +33,7 @@ displayName: yubico-u2f-ca-cert.crt
 document: %(yubico_u2f_ca_cert_base64)s
 inum: %(yubico_u2f_ca_cert_inum)s
 jansEnabled: true
-jansFilePath: %(fido_document_tocs_dir)s
+jansFilePath: %(fido_document_certs_dir)s
 jansLevel: 0
 jansService: Fido2 MDS
 
@@ -46,7 +46,7 @@ displayName: HyperFIDO_CA_Cert_V1.pem
 document: %(HyperFIDO_CA_Cert_V1_base64)s
 inum: %(HyperFIDO_CA_Cert_V1_inum)s
 jansEnabled: true
-jansFilePath: %(fido_document_tocs_dir)s
+jansFilePath: %(fido_document_authenticator_cert_dir)s
 jansLevel: 0
 jansService: Fido2 MDS
 
@@ -59,7 +59,7 @@ displayName: HyperFIDO_CA_Cert_V2.pem
 document: %(HyperFIDO_CA_Cert_V2_base64)s
 inum: %(HyperFIDO_CA_Cert_V2_inum)s
 jansEnabled: true
-jansFilePath: %(fido_document_tocs_dir)s
+jansFilePath: %(fido_document_authenticator_cert_dir)s
 jansLevel: 0
 jansService: Fido2 MDS
 
@@ -72,7 +72,7 @@ displayName: Apple_WebAuthn_Root_CA.pem
 document: %(Apple_WebAuthn_Root_CA_base64)s
 inum: %(Apple_WebAuthn_Root_CA_inum)s
 jansEnabled: true
-jansFilePath: %(fido_document_tocs_dir)s
+jansFilePath: %(fido_document_certs_dir)s
 jansLevel: 0
 jansService: Fido2 MDS
 


### PR DESCRIPTION
Closes #10752

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
