### PR TITLE
docs: javadocs are now consistent with code, issue#4120

### DIFF
--- a/jans-auth-server/client/src/main/java/io/jans/as/client/uma/UmaPermissionService.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/uma/UmaPermissionService.java
@@ -19,7 +19,7 @@ import jakarta.ws.rs.Produces;
  * The endpoint at which the host registers permissions that it anticipates a
  * requester will shortly be asking for from the AM. This AM's endpoint is part
  * of resource registration API.
- * <p/>
+ * <p>
  * In response to receiving an access request accompanied by an RPT that is
  * invalid or has insufficient authorization data, the host SHOULD register a
  * permission with the AS that would be sufficient for the type of access

--- a/jans-auth-server/client/src/main/java/io/jans/as/client/util/KeyExporter.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/util/KeyExporter.java
@@ -30,11 +30,11 @@ import java.security.PrivateKey;
 /**
  * Export private key from JKS Command example: java -cp
  * KeyExporter -h
- * <p/>
+ * <p>
  * KeyExporter -keystore /Users/yuriy/tmp/mykeystore.jks -keypasswd secret
  * -alias "2d4817e7-5fe8-4b6b-8f64-fe3723625122"
  * -exportfile=/Users/yuriy/tmp/mykey.pem
- * <p/>
+ * <p>
  *
  * @author Yuriy Movchan
  * @version February 12, 2019

--- a/jans-auth-server/client/src/main/java/io/jans/as/client/util/KeyGenerator.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/util/KeyGenerator.java
@@ -32,9 +32,9 @@ import static io.jans.as.model.jwk.JWKParameter.*;
 /**
  * Command example:
  * java -cp bcprov-jdk15on-1.54.jar:.jar:bcpkix-jdk15on-1.54.jar:commons-cli-1.2.jar:commons-codec-1.5.jar:commons-lang-2.6.jar:jettison-1.3.jar:log4j-1.2.14.jar:oxauth-model.jar:oxauth.jar KeyGenerator -h
- * <p/>
+ * <p>
  * KeyGenerator -sig_keys RS256 RS384 RS512 ES256 ES256K ES384 ES512 PS256 PS384 PS512 EdDSA -enc_keys RSA1_5 RSA-OAEP RSA-OAEP-256 ECDH-ES ECDH-ES+A128KW ECDH-ES+A192KW ECDH-ES+A256KW -keystore /Users/JAVIER/tmp/mykeystore.jks -keypasswd secret -dnname "CN=Jans Auth CA Certificates" -expiration 365
- * <p/>
+ * <p>
  * Note that EdDSA is not allowed in FIPS mode
  *
  * @author Javier Rojas Blum

--- a/jans-auth-server/common/src/main/java/io/jans/as/common/service/common/ConfigurationService.java
+++ b/jans-auth-server/common/src/main/java/io/jans/as/common/service/common/ConfigurationService.java
@@ -62,7 +62,6 @@ public class ConfigurationService {
      *
      * @param inum Configuration Inum
      * @return Configuration
-     * @throws Exception
      */
     public GluuConfiguration getConfigurationByInum(String inum) {
         return persistenceEntryManager.find(GluuConfiguration.class, getDnForConfiguration(inum));
@@ -72,7 +71,6 @@ public class ConfigurationService {
      * Get configuration
      *
      * @return Configuration
-     * @throws Exception
      */
     public GluuConfiguration getConfiguration() {
         String configurationDn = staticConfiguration.getBaseDn().getConfiguration();
@@ -88,7 +86,6 @@ public class ConfigurationService {
      *
      * @param inum Inum
      * @return DN string for specified configuration or DN for configurations branch if inum is null
-     * @throws Exception
      */
     public String getDnForConfiguration(String inum) {
         String baseDn = staticConfiguration.getBaseDn().getConfiguration();

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/binding/TokenBinding.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/binding/TokenBinding.java
@@ -12,11 +12,11 @@ import java.util.Arrays;
  * struct {
  * TokenBindingType tokenbinding_type;
  * TokenBindingID tokenbindingid;
- * opaque signature<64..2^16-1>;  Signature over the concatenation
+ * opaque signature&lt;64..2^16-1&gt;;  Signature over the concatenation
  * of tokenbinding_type,
  * key_parameters and exported
  * keying material (EKM)
- * TB_Extension extensions<0..2^16-1>;
+ * TB_Extension extensions&lt;0..2^16-1&gt;;
  * } TokenBinding;
  *
  * @author Yuriy Zabrovarnyy

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/binding/TokenBindingExtension.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/binding/TokenBindingExtension.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 /**
  * struct {
  * TB_ExtensionType extension_type;
- * opaque extension_data<0..2^16-1>;
+ * opaque extension_data&lt;0..2^16-1&gt;;
  * } TB_Extension;
  *
  * @author Yuriy Zabrovarnyy

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/binding/TokenBindingMessage.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/binding/TokenBindingMessage.java
@@ -18,7 +18,7 @@ import java.util.List;
 /**
  * <pre>
  * struct {
- *     TokenBinding tokenbindings<132..2^16-1>;
+ *     TokenBinding tokenbindings&lt;132..2^16-1&gt;;
  * } TokenBindingMessage;
  * </pre>
  *

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/signature/EDDSAKeyFactory.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/signature/EDDSAKeyFactory.java
@@ -123,11 +123,7 @@ public class EDDSAKeyFactory extends KeyFactory<EDDSAPrivateKey, EDDSAPublicKey>
      * @param expirationDate
      * @param dnName
      * @return
-     * @throws CertificateEncodingException
-     * @throws InvalidKeyException
      * @throws IllegalStateException
-     * @throws NoSuchProviderException
-     * @throws NoSuchAlgorithmException
      * @throws SignatureException
      */
     public Certificate generateV3Certificate(final Date startDate, final Date expirationDate, final String dnName) throws SignatureException {

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/signature/EDDSAPublicKey.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/crypto/signature/EDDSAPublicKey.java
@@ -33,7 +33,7 @@ public class EDDSAPublicKey extends PublicKey {
      * Constructor
      *
      * @param signatureAlgorithm
-     * @param publicKeyData
+     * @param xEncoded
      */
     public EDDSAPublicKey(final SignatureAlgorithm signatureAlgorithm, byte[] xEncoded) {
         setSignatureAlgorithm(signatureAlgorithm);

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebService.java
@@ -110,7 +110,7 @@ public interface AuthorizeRestWebService {
      * If the state parameter was present in the client authorization
      * request. The exact value received from the client.</dd>
      * </dl>
-     * <p/>
+     * <p>
      * <p>
      * When the responseType parameter is set to <strong>token</strong>:
      * </p>
@@ -245,7 +245,7 @@ public interface AuthorizeRestWebService {
      * If the state parameter was present in the client authorization
      * request. The exact value received from the client.</dd>
      * </dl>
-     * <p/>
+     * <p>
      * <p>
      * When the responseType parameter is set to <strong>token</strong>:
      * </p>

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/SectorIdentifierService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/SectorIdentifierService.java
@@ -71,7 +71,6 @@ public class SectorIdentifierService {
      *
      * @param jsId Sector Identifier jsId
      * @return DN string for specified sector identifier or DN for sector identifiers branch if jsId is null
-     * @throws Exception
      */
     public String getDnForSectorIdentifier(String jsId) {
         String sectorIdentifierDn = staticConfiguration.getBaseDn().getSectorIdentifiers();

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/ssa/ws/rs/SsaRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/ssa/ws/rs/SsaRestWebServiceImpl.java
@@ -42,7 +42,7 @@ public class SsaRestWebServiceImpl implements SsaRestWebService {
      * Creates an SSA from the requested parameters.
      * <p>
      * Method calls the action where the SSA creation logic is implemented.
-     * <p/>
+     * <p>
      *
      * @param requestParams Valid json
      * @param httpRequest   Http request object
@@ -57,7 +57,7 @@ public class SsaRestWebServiceImpl implements SsaRestWebService {
      * Get existing active SSA based on "jti" or "org_id".
      * <p>
      * Method calls the action where the SSA get logic is implemented.
-     * <p/>
+     * <p>
      *
      * @param jti         Unique identifier
      * @param orgId       Organization ID
@@ -73,7 +73,7 @@ public class SsaRestWebServiceImpl implements SsaRestWebService {
      * Validate existing active SSA based on "jti".
      * <p>
      * Method calls the action where the SSA validate logic is implemented.
-     * <p/>
+     * <p>
      *
      * @param jti Unique identifier
      * @return {@link Response} with status {@code 200} (Ok) if SSA has been validated.

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/ssa/ws/rs/SsaRestWebServiceValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/ssa/ws/rs/SsaRestWebServiceValidator.java
@@ -123,7 +123,7 @@ public class SsaRestWebServiceValidator {
      * </p>
      *
      * @param createRequest SSA Metadata
-     * @throws WebApplicationException with status {@code 400 (Bad Request)} with <b>invalid_ssa_metadata<b/> key, when lifetime is invalid
+     * @throws WebApplicationException with status {@code 400 (Bad Request)} with <b>invalid_ssa_metadata</b> key, when lifetime is invalid
      */
     public void validateSsaCreateRequest(SsaCreateRequest createRequest) {
         if (createRequest.getLifetime() != null && createRequest.getLifetime() < 1) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/ssa/ws/rs/action/SsaCreateAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/ssa/ws/rs/action/SsaCreateAction.java
@@ -87,7 +87,7 @@ public class SsaCreateAction {
      * request has to have at least scope "ssa.admin",
      * it will also return a {@link WebApplicationException} with status {@code 500} in case an uncontrolled
      * error occurs when processing the method.
-     * <p/>
+     * <p>
      * <p>
      * Response of this method can be modified using the following custom script
      * <a href="https://github.com/JanssenProject/jans/blob/main/jans-linux-setup/jans_setup/static/extension/ssa_modify_response/ssa_modify_response.py">SSA Custom Script</a>,
@@ -95,7 +95,7 @@ public class SsaCreateAction {
      * </p>
      * <p>
      * SSA returned by this method is stored in the corresponding database, so it can be later retrieved, validated or revoked.
-     * <p/>
+     * <p>
      *
      * @param requestParams Valid json request
      * @param httpRequest   Http request

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/uma/ws/rs/UmaResourceRegistrationWS.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/uma/ws/rs/UmaResourceRegistrationWS.java
@@ -49,7 +49,7 @@ import static io.jans.as.model.util.Util.escapeLog;
  * The API available at the resource registration endpoint enables the resource server to put resources under
  * the protection of an authorization server on behalf of the resource owner and manage them over time.
  * Protection of a resource at the authorization server begins on successful registration and ends on successful deregistration.
- * <p/>
+ * <p>
  * The resource server uses a RESTful API at the authorization server's resource registration endpoint
  * to create, read, update, and delete resource descriptions, along with retrieving lists of such descriptions.
  * The descriptions consist of JSON documents that are maintained as web resources at the authorization server.


### PR DESCRIPTION
### Prepare

- [ x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Javadoc was inconsistent with the code, and did not properly follow javadoc syntax, causing the "mvn javadoc:javadoc" command to fail build.

#### Target issue
#4120 
  
closes #4120 

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
