### PR TITLE
feat(jans-cedarling): implement log buffer for batching logs

### DIFF
--- a/jans-cedarling/cedarling/benches/authz_benchmark.rs
+++ b/jans-cedarling/cedarling/benches/authz_benchmark.rs
@@ -69,6 +69,7 @@ async fn prepare_cedarling_without_jwt_validation() -> Result<Cedarling, InitCed
         log_config: LogConfig {
             log_type: LogTypeConfig::Off,
             log_level: LogLevel::DEBUG,
+            lock_enabled: false,
         },
         policy_store_config: PolicyStoreConfig {
             source: cedarling::PolicyStoreSource::Yaml(POLICY_STORE.to_string()),
@@ -104,6 +105,7 @@ async fn prepare_cedarling_with_jwt_validation() -> Result<Cedarling, InitCedarl
         log_config: LogConfig {
             log_type: LogTypeConfig::Off,
             log_level: LogLevel::DEBUG,
+            lock_enabled: false,
         },
         policy_store_config: PolicyStoreConfig {
             source: cedarling::PolicyStoreSource::Yaml(POLICY_STORE.to_string()),

--- a/jans-cedarling/cedarling/benches/startup_benchmark.rs
+++ b/jans-cedarling/cedarling/benches/startup_benchmark.rs
@@ -36,6 +36,7 @@ lazy_static! {
         log_config: LogConfig {
             log_type: LogTypeConfig::Off,
             log_level: LogLevel::DEBUG,
+            lock_enabled: false,
         },
         policy_store_config: PolicyStoreConfig {
             source: cedarling::PolicyStoreSource::Yaml(POLICY_STORE.to_string()),

--- a/jans-cedarling/cedarling/examples/authorize_with_jwt_validation.rs
+++ b/jans-cedarling/cedarling/examples/authorize_with_jwt_validation.rs
@@ -50,6 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_config: LogConfig {
             log_type: LogTypeConfig::StdOut,
             log_level: LogLevel::INFO,
+            lock_enabled: false,
         },
         policy_store_config: PolicyStoreConfig {
             source: PolicyStoreSource::Yaml(POLICY_STORE_RAW_YAML.to_string()),

--- a/jans-cedarling/cedarling/examples/authorize_without_jwt_validation.rs
+++ b/jans-cedarling/cedarling/examples/authorize_without_jwt_validation.rs
@@ -19,6 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_config: LogConfig {
             log_type: LogTypeConfig::StdOut,
             log_level: LogLevel::INFO,
+            lock_enabled: false,
         },
         policy_store_config: PolicyStoreConfig {
             source: PolicyStoreSource::Yaml(POLICY_STORE_RAW.to_string()),

--- a/jans-cedarling/cedarling/examples/log_init.rs
+++ b/jans-cedarling/cedarling/examples/log_init.rs
@@ -36,7 +36,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let log_type = match log_type_arg.as_str() {
         "off" => LogTypeConfig::Off,
         "stdout" => LogTypeConfig::StdOut,
-        "lock" => LogTypeConfig::Lock,
         "memory" => extract_memory_config(args),
         _ => {
             eprintln!("Invalid log type, defaulting to StdOut.");

--- a/jans-cedarling/cedarling/examples/log_init.rs
+++ b/jans-cedarling/cedarling/examples/log_init.rs
@@ -50,6 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_config: LogConfig {
             log_type,
             log_level: LogLevel::INFO,
+            lock_enabled: false,
         },
         policy_store_config: PolicyStoreConfig {
             source: PolicyStoreSource::Yaml(POLICY_STORE_RAW.to_string()),

--- a/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
@@ -53,7 +53,6 @@ impl BootstrapConfig {
                     .ok_or(BootstrapConfigLoadingError::MissingLogTTL)?,
             }),
             LoggerType::StdOut => LogTypeConfig::StdOut,
-            LoggerType::Lock => LogTypeConfig::Lock,
         };
         let log_config = LogConfig {
             log_type,

--- a/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
@@ -58,6 +58,7 @@ impl BootstrapConfig {
         let log_config = LogConfig {
             log_type,
             log_level: raw.log_level,
+            lock_enabled: raw.lock.into(),
         };
 
         // Decode policy store

--- a/jans-cedarling/cedarling/src/bootstrap_config/log_config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/log_config.rs
@@ -14,6 +14,9 @@ pub struct LogConfig {
     /// Log level filter for logging. TRACE is lowest. FATAL is highest.
     /// `CEDARLING_LOG_LEVEL` in [bootstrap properties](https://github.com/JanssenProject/jans/wiki/Cedarling-Nativity-Plan#bootstrap-properties) documentation.
     pub log_level: LogLevel,
+
+    /// Toggle for sending logs to the lock server
+    pub lock_enabled: bool,
 }
 
 ///  Log type configuration.

--- a/jans-cedarling/cedarling/src/bootstrap_config/log_config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/log_config.rs
@@ -30,8 +30,6 @@ pub enum LogTypeConfig {
     Memory(MemoryLogConfig),
     /// Logger writes log information to std output stream.
     StdOut,
-    /// The logger sends log data to the server (corporate feature).
-    Lock,
 }
 
 /// Configuration for memory log.

--- a/jans-cedarling/cedarling/src/bootstrap_config/mod.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/mod.rs
@@ -179,6 +179,7 @@ mod test {
             log_config: LogConfig {
                 log_type: LogTypeConfig::StdOut,
                 log_level: crate::LogLevel::DEBUG,
+                lock_enabled: false,
             },
             policy_store_config: PolicyStoreConfig {
                 source: crate::PolicyStoreSource::FileJson(
@@ -245,6 +246,7 @@ mod test {
             log_config: LogConfig {
                 log_type: LogTypeConfig::Memory(MemoryLogConfig { log_ttl: 60 }),
                 log_level: crate::LogLevel::DEBUG,
+                lock_enabled: false,
             },
             policy_store_config: PolicyStoreConfig {
                 source: crate::PolicyStoreSource::FileJson(

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/feature_types.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/feature_types.rs
@@ -20,8 +20,6 @@ pub enum LoggerType {
     /// Logger that print logs to stdout
     #[serde(rename = "std_out")]
     StdOut,
-    /// Logger send log messages to `Lock` server
-    Lock,
 }
 
 impl FromStr for LoggerType {
@@ -33,7 +31,6 @@ impl FromStr for LoggerType {
         match s.as_str() {
             "memory" => Ok(Self::Memory),
             "std_out" => Ok(Self::StdOut),
-            "lock" => Ok(Self::Lock),
             "off" => Ok(Self::Off),
             _ => Err(Self::Err { logger_type: s }),
         }
@@ -47,7 +44,6 @@ impl Display for LoggerType {
             LoggerType::Off => write!(f, "off"),
             LoggerType::Memory => write!(f, "memory"),
             LoggerType::StdOut => write!(f, "stdout"),
-            LoggerType::Lock => write!(f, "lock"),
         }
     }
 }

--- a/jans-cedarling/cedarling/src/log/interface.rs
+++ b/jans-cedarling/cedarling/src/log/interface.rs
@@ -113,3 +113,26 @@ pub trait LogStorage {
     fn get_logs_by_request_id_and_tag(&self, request_id: &str, tag: &str)
     -> Vec<serde_json::Value>;
 }
+
+/// Implementation for buffering logs.
+///
+/// # Usage
+///
+/// 1.  Call [`LogBuffer::batch_logs`] then try to send it to the lock server
+/// 2a. If sending the logs is successful, call [`LogBuffer::flush_batch`]
+/// 2b. If sending the logs failed, and you want to clear the batch but not
+///     lose the logs, call [`LogBuffer::clear_batch`]
+// will be used for lock server integration
+#[allow(dead_code)]
+pub(crate) trait LogBuffer {
+    /// Batches some logs to send to lock master
+    fn batch_logs(&self) -> Vec<serde_json::Value>;
+
+    /// Clear the current batch then remove the logs from log storage if
+    /// they are being stored.
+    fn flush_batch(&mut self);
+
+    /// Clear the current batch but don't get rid of the logs if they are
+    /// being stored.
+    fn clear_batch(&mut self);
+}

--- a/jans-cedarling/cedarling/src/log/log_strategy.rs
+++ b/jans-cedarling/cedarling/src/log/log_strategy.rs
@@ -26,7 +26,9 @@ impl LogStrategy {
             LogTypeConfig::Memory(memory_config) => {
                 Self::MemoryLogger(MemoryLogger::new(memory_config, config.log_level))
             },
-            LogTypeConfig::StdOut => Self::StdOut(StdOutLogger::new(config.log_level)),
+            LogTypeConfig::StdOut => {
+                Self::StdOut(StdOutLogger::new(config.log_level, config.lock_enabled))
+            },
             LogTypeConfig::Lock => todo!(),
         }
     }

--- a/jans-cedarling/cedarling/src/log/log_strategy.rs
+++ b/jans-cedarling/cedarling/src/log/log_strategy.rs
@@ -29,7 +29,6 @@ impl LogStrategy {
             LogTypeConfig::StdOut => {
                 Self::StdOut(StdOutLogger::new(config.log_level, config.lock_enabled))
             },
-            LogTypeConfig::Lock => todo!(),
         }
     }
 }

--- a/jans-cedarling/cedarling/src/log/stdout_logger/native_logger.rs
+++ b/jans-cedarling/cedarling/src/log/stdout_logger/native_logger.rs
@@ -6,32 +6,58 @@
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 
+use serde_json::Value;
+
 use crate::log::LogLevel;
-use crate::log::interface::{LogWriter, Loggable};
+use crate::log::interface::{LogBuffer, LogWriter, Loggable};
 
 /// A logger that write to std output.
 pub(crate) struct StdOutLogger {
     // we use `dyn Write`` trait to make it testable and mockable.
     writer: Mutex<Box<dyn Write + Send + Sync>>,
     log_level: LogLevel,
+    lock_queued_logs: Mutex<Vec<Value>>,
+    // will be used for lock integration
+    #[allow(dead_code)]
+    current_lock_buf_size: Mutex<usize>,
+    queue_logs_for_lock: bool,
 }
 
 impl StdOutLogger {
-    pub(crate) fn new(log_level: LogLevel) -> Self {
+    pub(crate) fn new(log_level: LogLevel, queue_logs_for_lock: bool) -> Self {
         Self {
             writer: Mutex::new(Box::new(std::io::stdout())),
             log_level,
+            lock_queued_logs: vec![].into(),
+            current_lock_buf_size: 0.into(),
+            queue_logs_for_lock,
         }
     }
 
     // Create a new StdOutLogger with custom writer.
     // is used in tests.
     #[allow(dead_code)]
-    pub(crate) fn new_with(writer: Box<dyn Write + Send + Sync>, log_level: LogLevel) -> Self {
+    pub(crate) fn new_with(
+        writer: Box<dyn Write + Send + Sync>,
+        log_level: LogLevel,
+        queue_logs_for_lock: bool,
+    ) -> Self {
         Self {
             writer: Mutex::new(Box::new(writer)),
             log_level,
+            lock_queued_logs: vec![].into(),
+            current_lock_buf_size: 0.into(),
+            queue_logs_for_lock,
         }
+    }
+
+    // will be used for lock server integration
+    #[allow(dead_code)]
+    fn queued_logs_len(&self) -> usize {
+        self.lock_queued_logs
+            .lock()
+            .expect("should acquire lock queud logs lock")
+            .len()
     }
 }
 
@@ -45,6 +71,15 @@ impl LogWriter for StdOutLogger {
         }
 
         let json_str = serde_json::json!(&entry).to_string();
+
+        if self.queue_logs_for_lock {
+            let mut lock_queued_logs = self
+                .lock_queued_logs
+                .lock()
+                .expect("should obtain lock queued logs lock");
+            lock_queued_logs.push(serde_json::to_value(entry).expect("should serialize log entry"));
+        }
+
         // we can't handle error here or test it so we just panic if it happens.
         // we should have specific platform to get error
         writeln!(
@@ -63,6 +98,46 @@ impl LogWriter for StdOutLogger {
             // do nothing
             return;
         }
+    }
+}
+
+impl LogBuffer for StdOutLogger {
+    fn batch_logs(&self) -> Vec<serde_json::Value> {
+        let mut buf_size_lock = self
+            .current_lock_buf_size
+            .lock()
+            .expect("should acquire lock for current log buf size");
+        let buf_logs_lock = self
+            .lock_queued_logs
+            .lock()
+            .expect("should acquire lock for buffered logs");
+        *buf_size_lock = buf_logs_lock.len();
+        let logs = buf_logs_lock
+            .get(0..*buf_size_lock)
+            .map(|x| x.iter().cloned().collect::<Vec<serde_json::Value>>())
+            .unwrap_or_else(|| vec![]);
+        logs
+    }
+
+    fn flush_batch(&mut self) {
+        let mut buf_size_lock = self
+            .current_lock_buf_size
+            .lock()
+            .expect("should acquire lock for current log buf size");
+        let mut buf_logs_lock = self
+            .lock_queued_logs
+            .lock()
+            .expect("should acquire lock for buffered logs");
+        buf_logs_lock.drain(0..*buf_size_lock);
+        *buf_size_lock = 0;
+    }
+
+    fn clear_batch(&mut self) {
+        let mut buf_size_lock = self
+            .current_lock_buf_size
+            .lock()
+            .expect("should acquire lock for current log buf size");
+        *buf_size_lock = 0;
     }
 }
 
@@ -103,7 +178,7 @@ mod tests {
     use std::io::Write;
 
     use super::*;
-    use crate::common::app_types::PdpID;
+    use crate::common::app_types::{self, PdpID};
     use crate::log::{LogEntry, LogType, gen_uuid7};
 
     #[test]
@@ -127,7 +202,7 @@ mod tests {
         let buffer = Box::new(test_writer.clone()) as Box<dyn Write + Send + Sync + 'static>;
 
         // Create logger with test writer
-        let logger = StdOutLogger::new_with(buffer, LogLevel::TRACE);
+        let logger = StdOutLogger::new_with(buffer, LogLevel::TRACE, false);
 
         // Log the entry
         logger.log_any(log_entry);
@@ -140,5 +215,43 @@ mod tests {
 
         // Verify that the log entry was logged correctly
         assert_eq!(logged_content, json_str + "\n");
+    }
+
+    #[test]
+    fn test_buffering_logs() {
+        let mut logger = StdOutLogger::new(LogLevel::DEBUG, true);
+
+        let first_entry =
+            LogEntry::new_with_data(app_types::PdpID::new(), None, LogType::Metric, None);
+        logger.log_any(first_entry.clone());
+        let batch = logger.batch_logs();
+        assert_eq!(batch.len(), 1, "batch should have 1 entry");
+
+        logger.clear_batch();
+        assert_eq!(
+            logger.queued_logs_len(),
+            1,
+            "clearing the batch should not dispose of the logs"
+        );
+
+        let batch = logger.batch_logs();
+        let second_entry =
+            LogEntry::new_with_data(app_types::PdpID::new(), None, LogType::Metric, None);
+        logger.log_any(second_entry.clone());
+        assert_eq!(logger.queued_logs_len(), 2, "logger should have 2 logs");
+        assert_eq!(batch.len(), 1, "batch should have 1 entry");
+        assert_eq!(
+            batch[0],
+            serde_json::to_value(first_entry).expect("should serialize first log entry")
+        );
+
+        logger.flush_batch();
+        let batch = logger.batch_logs();
+
+        assert_eq!(batch.len(), 1, "batch should have 1 entry");
+        assert_eq!(
+            batch[0],
+            serde_json::to_value(second_entry).expect("should serialize second log entry")
+        );
     }
 }

--- a/jans-cedarling/cedarling/src/log/test.rs
+++ b/jans-cedarling/cedarling/src/log/test.rs
@@ -25,6 +25,7 @@ fn test_new_log_strategy_off() {
     let config = LogConfig {
         log_type: log_config::LogTypeConfig::Off,
         log_level: crate::LogLevel::DEBUG,
+        lock_enabled: false,
     };
 
     // Act
@@ -40,6 +41,7 @@ fn test_new_log_strategy_memory() {
     let config = LogConfig {
         log_type: log_config::LogTypeConfig::Memory(log_config::MemoryLogConfig { log_ttl: 60 }),
         log_level: crate::LogLevel::DEBUG,
+        lock_enabled: false,
     };
 
     // Act
@@ -55,6 +57,7 @@ fn test_new_logstrategy_stdout() {
     let config = LogConfig {
         log_type: log_config::LogTypeConfig::StdOut,
         log_level: crate::LogLevel::DEBUG,
+        lock_enabled: false,
     };
 
     // Act
@@ -70,6 +73,7 @@ fn test_log_memory_logger() {
     let config = LogConfig {
         log_type: log_config::LogTypeConfig::Memory(log_config::MemoryLogConfig { log_ttl: 60 }),
         log_level: crate::LogLevel::TRACE,
+        lock_enabled: false,
     };
     let strategy = LogStrategy::new(&config);
     let entry = LogEntry {
@@ -168,7 +172,7 @@ fn test_log_stdout_logger() {
 
     let test_writer = TestWriter::new();
     let buffer = Box::new(test_writer.clone()) as Box<dyn Write + Send + Sync + 'static>;
-    let logger = StdOutLogger::new_with(buffer, LogLevel::TRACE);
+    let logger = StdOutLogger::new_with(buffer, LogLevel::TRACE, false);
     let strategy = LogStrategy::StdOut(logger);
 
     // Act

--- a/jans-cedarling/cedarling/src/tests/utils/cedarling_util.rs
+++ b/jans-cedarling/cedarling/src/tests/utils/cedarling_util.rs
@@ -39,6 +39,7 @@ pub fn get_config(policy_source: PolicyStoreSource) -> BootstrapConfig {
         log_config: LogConfig {
             log_type: LogTypeConfig::StdOut,
             log_level: crate::LogLevel::DEBUG,
+            lock_enabled: false,
         },
         policy_store_config: PolicyStoreConfig {
             source: policy_source,
@@ -83,6 +84,7 @@ pub async fn get_cedarling_with_authorization_conf(
         log_config: LogConfig {
             log_type: LogTypeConfig::StdOut,
             log_level: crate::LogLevel::DEBUG,
+            lock_enabled: false,
         },
         policy_store_config: PolicyStoreConfig {
             source: policy_source,


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

This PR implements some additional functionalities to the loggers so we could implement batching logs.

#### Target issue

closes: #10817

#### Implementation Details

##### `LogBuffer` trait

The 1. `LogBuffer` trait has been implemented for `StdOutLogger` and `MemoryLogger`.

```rs
/// # Usage
///
/// 1.  Call [`LogBuffer::batch_logs`] then try to send it to the lock server
/// 2a. If sending the logs is successful, call [`LogBuffer::flush_batch`]
/// 2b. If sending the logs failed, and you want to clear the batch but not
///     lose the logs, call [`LogBuffer::clear_batch`]
pub trait LogBuffer {
    // Batches some logs to send to lock master
    fn batch_logs(&self) -> Vec<&serde_json::Value>;

    // Clears the current batch then removes the logs from log storage if
    // they are being stored.
    fn flush_batch(&mut self);

    // Clears the current batch but won't get rid of the logs if they are
    // being stored.
    fn clear_batch(&mut self);
}
```

##### 2. The `LockTypeConfig::Lock` enum variant has been removed

Logs to the lock server should not be a separate logging strategy but a supplementary one to the existing loggers; thus, this variant is no longer necessary.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
