### PR TITLE
fix(jans-linux-setup): lock client creation with setup.properties

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/base.py
@@ -102,7 +102,8 @@ class BaseInstaller:
 
             self.logIt("Checking ID for client {}".format(client_var_name))
             rv = 1
-            if not Config.get(client_var_name):
+
+            if Config.get(client_var_name):
                 result = self.dbUtils.search('ou={},o=jans'.format(ou), '(&({}={}*)(objectClass=jansClnt))'.format(field_name, client_id_prefix))
                 if result:
                     setattr(Config, client_var_name, result[field_name])
@@ -112,6 +113,9 @@ class BaseInstaller:
                         setattr(Config, client_pw, self.unobscure(result['jansClntSecret']))
                 else:
                     rv = -1
+            else:
+                rv = -1
+
 
             ret_val[client_id_prefix] = rv
 

--- a/jans-linux-setup/jans_setup/setup_app/installers/jans_lock.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans_lock.py
@@ -91,7 +91,7 @@ class JansLockInstaller(JettyInstaller):
                 display_name="Jans Lock Config Api Client"
                 )
 
-        self.dbUtils.import_ldif([self.clients_ldif_fn])
+            self.dbUtils.import_ldif([self.clients_ldif_fn])
 
     def install_as_server(self):
         self.install_jettyService(self.jetty_app_configuration[self.service_name], True)


### PR DESCRIPTION
Closes #10928

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
