### PR TITLE
feat(jans-linux-setup): LDAP Link installation is optional

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -65,12 +65,14 @@ class JansInstaller(BaseInstaller, SetupUtils):
                 for prompt_str, install_var in (
                         ('Install Fido2 Server', 'install_fido2'),
                         ('Install Scim Server', 'install_scim_server'),
-                        ('Install Jans LDAP Link Server', 'install_jans_ldap_link'),
                         ('Install Jans KC Link Server', 'install_jans_keycloak_link'),
                         ('Install Jans Casa', 'install_casa'),
                         ('Install Jans Lock', 'install_jans_lock'),
                         ('Install Jans KC', 'install_jans_saml')):
                     txt += get_install_string(prompt_str, install_var)
+
+                if base.argsp.install_jans_ldap_link:
+                    txt += get_install_string('Install Jans LDAP Link Server', 'install_jans_ldap_link')
 
             if base.argsp.t:
                 txt += 'Load Test Data '.ljust(30) + repr( base.argsp.t).rjust(35) + "\n"

--- a/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/properties_utils.py
@@ -613,7 +613,7 @@ class PropertiesUtils(SetupUtils):
             self.promptForConfigApi()
             self.promptForScimServer()
             self.promptForFido2Server()
-            self.prompt_for_jans_link()
+            #self.prompt_for_jans_link()
             self.prompt_for_jans_keycloak_link()
             self.prompt_for_casa()
             self.pompt_for_jans_lock()


### PR DESCRIPTION
Closes #10963

With this PR, installation of Jans LDAP Link Server is not prompted. But you can still install by passing argument `--install-jans-ldap-link` to `setup.py`

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
