### PR TITLE
fix(jans-config-api): admin UI unable to fetch MAU _threshold on restart of config-api

### DIFF
--- a/jans-config-api/plugins/admin-ui-plugin/src/test/java/io/jans/ca/plugin/adminui/test/services/LicenseServiceTest.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/test/java/io/jans/ca/plugin/adminui/test/services/LicenseServiceTest.java
@@ -5,6 +5,9 @@ import io.jans.as.model.config.adminui.LicenseConfig;
 import io.jans.as.model.config.adminui.MainSettings;
 import io.jans.as.model.config.adminui.OIDCClientSettings;
 import io.jans.ca.plugin.adminui.model.auth.GenericResponse;
+import io.jans.ca.plugin.adminui.model.config.AUIConfiguration;
+import io.jans.ca.plugin.adminui.model.config.LicenseConfiguration;
+import io.jans.ca.plugin.adminui.service.config.AUIConfigurationService;
 import io.jans.ca.plugin.adminui.service.license.LicenseDetailsService;
 import io.jans.ca.plugin.adminui.utils.AppConstants;
 import io.jans.ca.plugin.adminui.utils.ErrorResponse;
@@ -27,25 +30,32 @@ import java.time.LocalDate;
 public class LicenseServiceTest {
     @Mock
     private PersistenceEntryManager entryManager;
-
     @Mock
     private Logger log;
-
     @InjectMocks
     private LicenseDetailsService licenseDetailsService;
+    @Mock
+    private AUIConfigurationService auiConfigurationService;
+    @Mock
+    private LicenseConfiguration licenseConfiguration;
 
     private AdminConf adminConf;
     private LicenseConfig licenseConfig;
+    private AUIConfiguration auiConfiguration;
 
     @BeforeMethod
     public void setUp() {
+
         MockitoAnnotations.openMocks(this);  // Initialize mocks
 
         adminConf = mock(AdminConf.class);
         licenseConfig = mock(LicenseConfig.class);
-        when(entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN)).thenReturn(adminConf);
-        when(adminConf.getMainSettings()).thenReturn(mock(MainSettings.class));
-        when(adminConf.getMainSettings().getLicenseConfig()).thenReturn(licenseConfig);
+        auiConfiguration = mock(AUIConfiguration.class);
+        //licenseConfiguration = mock(LicenseConfiguration.class);
+        lenient().when(entryManager.find(AdminConf.class, AppConstants.ADMIN_UI_CONFIG_DN)).thenReturn(adminConf);
+        lenient().when(adminConf.getMainSettings()).thenReturn(mock(MainSettings.class));
+        lenient().when(adminConf.getMainSettings().getLicenseConfig()).thenReturn(licenseConfig);
+
     }
 
     @Test
@@ -96,15 +106,16 @@ public class LicenseServiceTest {
     }
 
     @Test
-    public void testCheckLicense_ValidLicense() {
+    public void testCheckLicense_ValidLicense() throws Exception {
         // Mock the admin config and license config
-
-        when(licenseConfig.getLicenseHardwareKey()).thenReturn("hardware-key-123");
-        when(licenseConfig.getLicenseKey()).thenReturn("valid-license-key");
-        when(licenseConfig.getScanLicenseApiHostname()).thenReturn("https://scan.api.hostname");
-        when(licenseConfig.getLicenseValidUpto()).thenReturn(LocalDate.now().plusDays(30).toString());
-        when(licenseConfig.getLicenseDetailsLastUpdatedOn()).thenReturn(LocalDate.now().minusDays(5).toString());
-        when(licenseConfig.getIntervalForSyncLicenseDetailsInDays()).thenReturn(10L);
+        lenient().when(auiConfigurationService.getAUIConfiguration()).thenReturn(auiConfiguration);
+        lenient().when(auiConfiguration.getLicenseConfiguration()).thenReturn(licenseConfiguration);
+        lenient().when(licenseConfiguration.getHardwareId()).thenReturn("hardware-key-123");
+        lenient().when(licenseConfiguration.getLicenseKey()).thenReturn("valid-license-key");//License key missing
+        lenient().when(licenseConfiguration.getScanApiHostname()).thenReturn("https://scan.api.hostname");
+        lenient().when(licenseConfiguration.getLicenseValidUpto()).thenReturn(LocalDate.now().plusDays(30).toString());
+        lenient().when(licenseConfiguration.getLicenseDetailsLastUpdatedOn()).thenReturn(LocalDate.now().minusDays(5).toString());
+        lenient().when(licenseConfiguration.getIntervalForSyncLicenseDetailsInDays()).thenReturn(10L);
 
         // Call the method under test
         GenericResponse response = licenseDetailsService.checkLicense();
@@ -116,14 +127,16 @@ public class LicenseServiceTest {
     }
 
     @Test
-    public void testCheckLicense_NoLicenseKey() {
+    public void testCheckLicense_NoLicenseKey() throws Exception {
         // Mock missing license key
-        lenient().when(licenseConfig.getLicenseHardwareKey()).thenReturn("hardware-key-123");
-        lenient().when(licenseConfig.getLicenseKey()).thenReturn("");//License key missing
-        lenient().when(licenseConfig.getScanLicenseApiHostname()).thenReturn("https://scan.api.hostname");
-        lenient().when(licenseConfig.getLicenseValidUpto()).thenReturn(LocalDate.now().plusDays(30).toString());
-        lenient().when(licenseConfig.getLicenseDetailsLastUpdatedOn()).thenReturn(LocalDate.now().minusDays(5).toString());
-        lenient().when(licenseConfig.getIntervalForSyncLicenseDetailsInDays()).thenReturn(10L);
+        lenient().when(auiConfigurationService.getAUIConfiguration()).thenReturn(auiConfiguration);
+        lenient().when(auiConfiguration.getLicenseConfiguration()).thenReturn(licenseConfiguration);
+        lenient().when(licenseConfiguration.getHardwareId()).thenReturn("hardware-key-123");
+        lenient().when(licenseConfiguration.getLicenseKey()).thenReturn("");//License key missing
+        lenient().when(licenseConfiguration.getScanApiHostname()).thenReturn("https://scan.api.hostname");
+        lenient().when(licenseConfiguration.getLicenseValidUpto()).thenReturn(LocalDate.now().plusDays(30).toString());
+        lenient().when(licenseConfiguration.getLicenseDetailsLastUpdatedOn()).thenReturn(LocalDate.now().minusDays(5).toString());
+        lenient().when(licenseConfiguration.getIntervalForSyncLicenseDetailsInDays()).thenReturn(10L);
 
         // Call the method under test
         GenericResponse response = licenseDetailsService.checkLicense();


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #10968

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
