### PR TITLE
bug(jans-cedarling): cedarling wasm app has wrong default bootstrap properties

### DIFF
--- a/jans-cedarling/bindings/cedarling_wasm/example_data.js
+++ b/jans-cedarling/bindings/cedarling_wasm/example_data.js
@@ -19,9 +19,9 @@ const BOOTSTRAP_CONFIG = {
         "RS256"
     ],
     "CEDARLING_TOKEN_CONFIGS": {
-        "access_token": { "entity_type_name": "Access_token" },
-        "id_token": { "entity_type_name": "id_token" },
-        "userinfo_token": { "entity_type_name": "Userinfo_token" },
+        "access_token": { "entity_type_name": "Jans::Access_token" },
+        "id_token": { "entity_type_name": "Jans::id_token" },
+        "userinfo_token": { "entity_type_name": "Jans::Userinfo_token" },
     },
     "CEDARLING_ID_TOKEN_TRUST_MODE": "strict",
     "CEDARLING_LOCK": "disabled",


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Fix bootstrap property for wasm app

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
[link](https://github.com/JanssenProject/jans/issues/10981)
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #10981

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->
Added namespace to `cedar-policy` type

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
