### PR TITLE
feat(jans-cedarling): add RS256, EC256, and EdDSA algs in the benchmark tests

### DIFF
--- a/jans-cedarling/cedarling/benches/authz_benchmark.rs
+++ b/jans-cedarling/cedarling/benches/authz_benchmark.rs
@@ -3,17 +3,14 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
-use cedarling::{
-    AuthorizationConfig, BootstrapConfig, Cedarling, IdTokenTrustMode, InitCedarlingError,
-    JsonRule, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig, Request,
-    TokenValidationConfig,
-};
+use cedarling::*;
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use jsonwebtoken::Algorithm;
+use jsonwebtoken::jwk::JwkSet;
 use serde::Deserialize;
-use serde_json::json;
-use std::collections::{HashMap, HashSet};
-use test_utils::token_claims::generate_token_using_claims;
+use std::collections::HashMap;
+use std::error::Error;
+use test_utils::generate_token;
 use tokio::runtime::Runtime;
 
 const POLICY_STORE: &str = include_str!("../../test_files/policy-store_ok.yaml");
@@ -21,37 +18,130 @@ const POLICY_STORE: &str = include_str!("../../test_files/policy-store_ok.yaml")
 fn without_jwt_validation_benchmark(c: &mut Criterion) {
     let runtime = Runtime::new().expect("init tokio runtime");
 
-    let cedarling = runtime
-        .block_on(prepare_cedarling_without_jwt_validation())
-        .expect("should initialize Cedarling");
+    let (request, _jwk_set) = prepare_cedarling_request(generate_token::Algorithm::HS256)
+        .expect("should prepare r:equest");
 
-    let request = prepare_cedarling_request().expect("should prepare r:equest");
+    let cedarling = runtime
+        .block_on(prepare_cedarling_config(false, &[Algorithm::HS256], None))
+        .expect("should initialize Cedarling");
 
     c.bench_with_input(
         BenchmarkId::new("authz_without_jwt_validation", "tokio runtime"),
         &runtime,
         |b, rt| {
-            b.to_async(rt)
-                .iter(|| cedarling.authorize(black_box(request.clone())));
+            b.to_async(rt).iter(|| async {
+                let cloned_request = request.clone();
+                let result = black_box(cedarling.authorize(cloned_request).await);
+                assert!(result.is_ok(), "succesful authz: {:?}", result);
+            });
         },
     );
 }
 
-fn with_jwt_validation_benchmark(c: &mut Criterion) {
+fn with_jwt_validation_benchmark_hs256(c: &mut Criterion) {
     let runtime = Runtime::new().expect("init tokio runtime");
 
+    let (request, jwk_set) = prepare_cedarling_request(generate_token::Algorithm::HS256)
+        .expect("should prepare request");
+
     let cedarling = runtime
-        .block_on(prepare_cedarling_with_jwt_validation())
+        .block_on(prepare_cedarling_config(
+            true,
+            &[Algorithm::HS256],
+            Some(jwk_set),
+        ))
         .expect("should initialize Cedarling");
 
-    let request = prepare_cedarling_request().expect("should prepare r:equest");
-
     c.bench_with_input(
-        BenchmarkId::new("authz_with_jwt_validation", "tokio runtime"),
+        BenchmarkId::new("authz_with_jwt_validation_hs256", "tokio runtime"),
         &runtime,
         |b, rt| {
-            b.to_async(rt)
-                .iter(|| cedarling.authorize(black_box(request.clone())));
+            b.to_async(rt).iter(|| async {
+                let cloned_request = request.clone();
+                let result = black_box(cedarling.authorize(cloned_request).await);
+                assert!(result.is_ok(), "succesful authz: {:?}", result);
+            });
+        },
+    );
+}
+
+fn with_jwt_validation_benchmark_rs256(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("init tokio runtime");
+
+    let (request, jwk_set) = prepare_cedarling_request(generate_token::Algorithm::RS256)
+        .expect("should prepare request");
+
+    let cedarling = runtime
+        .block_on(prepare_cedarling_config(
+            true,
+            &[Algorithm::RS256],
+            Some(jwk_set),
+        ))
+        .expect("should initialize Cedarling");
+
+    c.bench_with_input(
+        BenchmarkId::new("authz_with_jwt_validation_rs256", "tokio runtime"),
+        &runtime,
+        |b, rt| {
+            b.to_async(rt).iter(|| async {
+                let cloned_request = request.clone();
+                let result = black_box(cedarling.authorize(cloned_request).await);
+                assert!(result.is_ok(), "succesful authz: {:?}", result);
+            });
+        },
+    );
+}
+
+fn with_jwt_validation_benchmark_es256(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("init tokio runtime");
+
+    let (request, jwk_set) = prepare_cedarling_request(generate_token::Algorithm::ES256)
+        .expect("should prepare request");
+
+    let cedarling = runtime
+        .block_on(prepare_cedarling_config(
+            true,
+            &[Algorithm::ES256],
+            Some(jwk_set),
+        ))
+        .expect("should initialize Cedarling");
+
+    c.bench_with_input(
+        BenchmarkId::new("authz_with_jwt_validation_es256", "tokio runtime"),
+        &runtime,
+        |b, rt| {
+            b.to_async(rt).iter(|| async {
+                let cloned_request = request.clone();
+                let result = black_box(cedarling.authorize(cloned_request).await);
+                assert!(result.is_ok(), "succesful authz: {:?}", result);
+            });
+        },
+    );
+}
+
+fn with_jwt_validation_benchmark_eddsa(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("init tokio runtime");
+
+    let (request, jwk_set) = prepare_cedarling_request(generate_token::Algorithm::EdDSA)
+        .expect("should prepare request");
+
+    let cedarling = runtime
+        .block_on(prepare_cedarling_config(
+            true,
+            &[Algorithm::EdDSA],
+            Some(jwk_set),
+        ))
+        .expect("should initialize Cedarling");
+
+    c.bench_with_input(
+        BenchmarkId::new("authz_with_jwt_validation_eddsa", "tokio runtime"),
+        &runtime,
+        |b, rt| {
+            b.to_async(rt).iter(|| async {
+                let cloned_request = request.clone();
+                let result = black_box(cedarling.authorize(cloned_request).await);
+                assert!(result.is_ok(), "succesful authz: {:?}", result);
+            });
         },
     );
 }
@@ -59,11 +149,27 @@ fn with_jwt_validation_benchmark(c: &mut Criterion) {
 criterion_group!(
     authz_benchmark,
     without_jwt_validation_benchmark,
-    with_jwt_validation_benchmark,
+    with_jwt_validation_benchmark_hs256,
+    with_jwt_validation_benchmark_rs256,
+    with_jwt_validation_benchmark_es256,
+    with_jwt_validation_benchmark_eddsa,
 );
 criterion_main!(authz_benchmark);
 
-async fn prepare_cedarling_without_jwt_validation() -> Result<Cedarling, InitCedarlingError> {
+async fn prepare_cedarling_config(
+    sig_validation: bool,
+    algs_supported: &[Algorithm],
+    jwk_set: Option<JwkSet>,
+) -> Result<Cedarling, Box<dyn Error>> {
+    // Edit JWT validation configs
+    let mut jwt_config = JwtConfig::new_without_validation();
+    jwt_config.jwt_sig_validation = sig_validation;
+    jwt_config.signature_algorithms_supported = algs_supported.iter().copied().collect();
+    jwt_config.jwks = jwk_set
+        .map(|jwk_set| serde_json::to_string(&jwk_set))
+        .transpose()
+        .map_err(|e| format!("failed to parse jwk set: {e}"))?;
+
     let bootstrap_config = BootstrapConfig {
         application_name: "test_app".to_string(),
         log_config: LogConfig {
@@ -73,7 +179,7 @@ async fn prepare_cedarling_without_jwt_validation() -> Result<Cedarling, InitCed
         policy_store_config: PolicyStoreConfig {
             source: cedarling::PolicyStoreSource::Yaml(POLICY_STORE.to_string()),
         },
-        jwt_config: JwtConfig::new_without_validation(),
+        jwt_config,
         authorization_config: AuthorizationConfig {
             use_user_principal: true,
             use_workload_principal: true,
@@ -95,134 +201,111 @@ async fn prepare_cedarling_without_jwt_validation() -> Result<Cedarling, InitCed
         },
     };
 
-    Cedarling::new(&bootstrap_config).await
+    let cedarling = Cedarling::new(&bootstrap_config).await?;
+
+    Ok(cedarling)
 }
 
-async fn prepare_cedarling_with_jwt_validation() -> Result<Cedarling, InitCedarlingError> {
-    let bootstrap_config = BootstrapConfig {
-        application_name: "test_app".to_string(),
-        log_config: LogConfig {
-            log_type: LogTypeConfig::Off,
-            log_level: LogLevel::DEBUG,
-        },
-        policy_store_config: PolicyStoreConfig {
-            source: cedarling::PolicyStoreSource::Yaml(POLICY_STORE.to_string()),
-        },
-        jwt_config: JwtConfig {
-            jwks: None,
-            jwt_sig_validation: false,
-            jwt_status_validation: false,
-            signature_algorithms_supported: HashSet::from([Algorithm::HS256]),
-            token_validation_settings: HashMap::from([
-                (
-                    "access_token".to_string(),
-                    TokenValidationConfig::access_token(),
-                ),
-                ("id_token".to_string(), TokenValidationConfig::id_token()),
-                (
-                    "userinfo_token".to_string(),
-                    TokenValidationConfig::userinfo_token(),
-                ),
-            ]),
-        },
-        authorization_config: AuthorizationConfig {
-            use_user_principal: true,
-            use_workload_principal: true,
-            principal_bool_operator: JsonRule::default(),
-            mapping_user: Some("Jans::User".to_string()),
-            mapping_workload: Some("Jans::Workload".to_string()),
-            mapping_role: Some("Jans::Role".to_string()),
-            mapping_tokens: HashMap::from([
-                ("access_token".to_string(), "Jans::Access_token".to_string()),
-                ("id_token".to_string(), "Jans::id_token".to_string()),
-                (
-                    "userinfo_token".to_string(),
-                    "Jans::Userinfo_token".to_string(),
-                ),
-            ])
-            .into(),
-            id_token_trust_mode: IdTokenTrustMode::None,
-            ..Default::default()
-        },
+pub fn prepare_cedarling_request(
+    jwt_algorithm: generate_token::Algorithm,
+) -> Result<(Request, JwkSet), Box<dyn Error>> {
+    let access_token = test_utils::jwt!(
+        jwt_algorithm,
+        {
+            "sub": "boG8dfc5MKTn37o7gsdCeyqL8LpWQtgoO41m1KZwdq0",
+            "code": "bf1934f6-3905-420a-8299-6b2e3ffddd6e",
+            "iss": "https://admin-ui-test.gluu.org",
+            "token_type": "Bearer",
+            "client_id": "5b4487c4-8db1-409d-a653-f907b8094039",
+            "aud": "5b4487c4-8db1-409d-a653-f907b8094039",
+            "acr": "basic",
+            "x5t#S256": "",
+            "scope": [
+              "openid",
+              "profile"
+            ],
+            "org_id": "some_long_id",
+            "auth_time": 1724830746,
+            "exp": 1724945978,
+            "iat": 1724832259,
+            "jti": "lxTmCVRFTxOjJgvEEpozMQ",
+            "name": "Default Admin User",
+            "status": {
+              "status_list": {
+                "idx": 201,
+                "uri": "https://admin-ui-test.gluu.org/jans-auth/restv1/status_list"
+                }
+            }
+        }
+    )?;
+
+    let id_token = test_utils::jwt!(
+        jwt_algorithm,
+        {
+            "acr": "basic",
+            "amr": "10",
+            "aud": "5b4487c4-8db1-409d-a653-f907b8094039",
+            "exp": 1724835859,
+            "iat": 1724832259,
+            "sub": "boG8dfc5MKTn37o7gsdCeyqL8LpWQtgoO41m1KZwdq0",
+            "iss": "https://admin-ui-test.gluu.org",
+            "jti": "sk3T40NYSYuk5saHZNpkZw",
+            "nonce": "c3872af9-a0f5-4c3f-a1af-f9d0e8846e81",
+            "sid": "6a7fe50a-d810-454d-be5d-549d29595a09",
+            "jansOpenIDConnectVersion": "openidconnect-1.0",
+            "c_hash": "pGoK6Y_RKcWHkUecM9uw6Q",
+            "auth_time": 1724830746,
+            "grant": "authorization_code",
+            "status": {
+              "status_list": {
+                "idx": 202,
+                "uri": "https://admin-ui-test.gluu.org/jans-auth/restv1/status_list"
+                }
+            },
+            "role":"Admin"
+        }
+    )?;
+
+    let userinfo_token = test_utils::jwt!(
+        jwt_algorithm,
+        {
+            "country": "US",
+            "email": "user@example.com",
+            "username": "UserNameExample",
+            "sub": "boG8dfc5MKTn37o7gsdCeyqL8LpWQtgoO41m1KZwdq0",
+            "iss": "https://admin-ui-test.gluu.org",
+            "given_name": "Admin",
+            "middle_name": "Admin",
+            "inum": "8d1cde6a-1447-4766-b3c8-16663e13b458",
+            "client_id": "5b4487c4-8db1-409d-a653-f907b8094039",
+            "aud": "5b4487c4-8db1-409d-a653-f907b8094039",
+            "updated_at": 1724778591,
+            "name": "Default Admin User",
+            "nickname": "Admin",
+            "family_name": "User",
+            "jti": "faiYvaYIT0cDAT7Fow0pQw",
+            "jansAdminUIRole": [
+                "api-admin"
+            ],
+            "exp": 1724945978
+        }
+    )?;
+
+    let jwks = JwkSet {
+        keys: [access_token.jwk, id_token.jwk, userinfo_token.jwk]
+            .iter()
+            // transfromation from `josekit::jwk:Jwk` to `jsonwebtoken::jwk::Jwk`
+            .map(|k| serde_json::to_value(k).unwrap())
+            .map(|k| serde_json::from_value::<jsonwebtoken::jwk::Jwk>(k).unwrap())
+            .collect(),
     };
 
-    Cedarling::new(&bootstrap_config).await
-}
-
-pub fn prepare_cedarling_request() -> Result<Request, serde_json::Error> {
-    Request::deserialize(serde_json::json!(
+    let request = Request::deserialize(serde_json::json!(
         {
             "tokens": {
-                "access_token": generate_token_using_claims(json!({
-                    "sub": "boG8dfc5MKTn37o7gsdCeyqL8LpWQtgoO41m1KZwdq0",
-                    "code": "bf1934f6-3905-420a-8299-6b2e3ffddd6e",
-                    "iss": "https://admin-ui-test.gluu.org",
-                    "token_type": "Bearer",
-                    "client_id": "5b4487c4-8db1-409d-a653-f907b8094039",
-                    "aud": "5b4487c4-8db1-409d-a653-f907b8094039",
-                    "acr": "basic",
-                    "x5t#S256": "",
-                    "scope": [
-                      "openid",
-                      "profile"
-                    ],
-                    "org_id": "some_long_id",
-                    "auth_time": 1724830746,
-                    "exp": 1724945978,
-                    "iat": 1724832259,
-                    "jti": "lxTmCVRFTxOjJgvEEpozMQ",
-                    "name": "Default Admin User",
-                    "status": {
-                      "status_list": {
-                        "idx": 201,
-                        "uri": "https://admin-ui-test.gluu.org/jans-auth/restv1/status_list"
-                      }
-                    }
-                })),
-                "id_token": generate_token_using_claims(json!({
-                    "acr": "basic",
-                    "amr": "10",
-                    "aud": "5b4487c4-8db1-409d-a653-f907b8094039",
-                    "exp": 1724835859,
-                    "iat": 1724832259,
-                    "sub": "boG8dfc5MKTn37o7gsdCeyqL8LpWQtgoO41m1KZwdq0",
-                    "iss": "https://admin-ui-test.gluu.org",
-                    "jti": "sk3T40NYSYuk5saHZNpkZw",
-                    "nonce": "c3872af9-a0f5-4c3f-a1af-f9d0e8846e81",
-                    "sid": "6a7fe50a-d810-454d-be5d-549d29595a09",
-                    "jansOpenIDConnectVersion": "openidconnect-1.0",
-                    "c_hash": "pGoK6Y_RKcWHkUecM9uw6Q",
-                    "auth_time": 1724830746,
-                    "grant": "authorization_code",
-                    "status": {
-                      "status_list": {
-                        "idx": 202,
-                        "uri": "https://admin-ui-test.gluu.org/jans-auth/restv1/status_list"
-                      }
-                    },
-                    "role":"Admin"
-                })),
-                "userinfo_token":  generate_token_using_claims(json!({
-                    "country": "US",
-                    "email": "user@example.com",
-                    "username": "UserNameExample",
-                    "sub": "boG8dfc5MKTn37o7gsdCeyqL8LpWQtgoO41m1KZwdq0",
-                    "iss": "https://admin-ui-test.gluu.org",
-                    "given_name": "Admin",
-                    "middle_name": "Admin",
-                    "inum": "8d1cde6a-1447-4766-b3c8-16663e13b458",
-                    "client_id": "5b4487c4-8db1-409d-a653-f907b8094039",
-                    "aud": "5b4487c4-8db1-409d-a653-f907b8094039",
-                    "updated_at": 1724778591,
-                    "name": "Default Admin User",
-                    "nickname": "Admin",
-                    "family_name": "User",
-                    "jti": "faiYvaYIT0cDAT7Fow0pQw",
-                    "jansAdminUIRole": [
-                        "api-admin"
-                    ],
-                    "exp": 1724945978
-                })),
+                "access_token": access_token.token,
+                "id_token": id_token.token,
+                "userinfo_token":userinfo_token.token,
             },
             "action": "Jans::Action::\"Update\"",
             "resource": {
@@ -233,5 +316,7 @@ pub fn prepare_cedarling_request() -> Result<Request, serde_json::Error> {
             },
             "context": {},
         }
-    ))
+    ))?;
+
+    Ok((request, jwks))
 }

--- a/jans-cedarling/test_utils/Cargo.toml
+++ b/jans-cedarling/test_utils/Cargo.toml
@@ -9,3 +9,4 @@ serde_json = { workspace = true }
 jsonwebtoken = { workspace = true }
 jsonwebkey = { workspace = true, features = ["generate", "jwt-convert"] }
 serde = { workspace = true }
+josekit = "0.10.1"

--- a/jans-cedarling/test_utils/src/generate_token.rs
+++ b/jans-cedarling/test_utils/src/generate_token.rs
@@ -1,0 +1,121 @@
+use josekit::Value;
+use josekit::jwk::Jwk;
+use josekit::jwk::alg::ec::EcCurve;
+use josekit::jwk::alg::ed::EdCurve;
+use josekit::jws::JwsHeader;
+use josekit::jws::alg::{
+    ecdsa::EcdsaJwsAlgorithm::Es256, eddsa::EddsaJwsAlgorithm::Eddsa,
+    hmac::HmacJwsAlgorithm::Hs256, rsassa::RsassaJwsAlgorithm::Rs256,
+};
+use josekit::jwt::{JwtPayload, encode_with_signer};
+use std::error::Error;
+
+#[derive(Eq, Hash, PartialEq, Clone, Copy)]
+pub enum Algorithm {
+    HS256,
+    RS256,
+    ES256,
+    EdDSA,
+}
+
+/// A signed JWT and the Key used to sign it
+#[derive(Debug)]
+pub struct SignedToken {
+    pub token: String,
+    pub jwk: Jwk,
+}
+
+/// Generates a JWT signed with the given algorithm. Shorthand for [`generate_token`].
+///
+/// # Usage
+///
+/// ```
+/// use test_utils::Algorithm;
+///
+/// let jwt = jwt!(
+///     Algorithm::RS256,
+///     {
+///         "iss": "https://example.test.com/",
+///         "sub": "bob",
+///         "jti": "abc123",
+///     }
+/// ).unwrap();
+/// ```
+#[macro_export]
+macro_rules! jwt {
+    ($alg:expr, $($payload:tt)*) => {{
+        let payload = serde_json::json!($($payload)*);
+        $crate::generate_token::generate_token(payload, $alg)
+    }};
+}
+
+/// Creates a JWT from a [`serde_json::Value`].
+pub fn generate_token(payload: Value, algorithm: Algorithm) -> Result<SignedToken, Box<dyn Error>> {
+    let Value::Object(payload) = payload else {
+        return Err("value must be an object to be a JWT payload".into());
+    };
+    let payload = JwtPayload::from_map(payload)?;
+
+    let jwk = match algorithm {
+        Algorithm::HS256 => Jwk::generate_oct_key(255),
+        Algorithm::RS256 => Jwk::generate_rsa_key(2048),
+        Algorithm::ES256 => Jwk::generate_ec_key(EcCurve::P256),
+        Algorithm::EdDSA => Jwk::generate_ed_key(EdCurve::Ed25519),
+    }?;
+
+    let mut header = JwsHeader::new();
+    header.set_token_type("JWT");
+
+    let token = match algorithm {
+        Algorithm::HS256 => sign_token_hs256(&payload, &header, &jwk),
+        Algorithm::RS256 => sign_token_rs256(&payload, &header, &jwk),
+        Algorithm::ES256 => sign_token_es256(&payload, &header, &jwk),
+        Algorithm::EdDSA => sign_token_eddsa(&payload, &header, &jwk),
+    }?;
+
+    let jwk = match algorithm {
+        Algorithm::HS256 => jwk,
+        _ => jwk.to_public_key()?,
+    };
+    Ok(SignedToken { token, jwk })
+}
+
+fn sign_token_hs256(
+    payload: &JwtPayload,
+    header: &JwsHeader,
+    jwk: &Jwk,
+) -> Result<String, Box<dyn Error>> {
+    let signer = Hs256.signer_from_jwk(&jwk)?;
+    let token = encode_with_signer(&payload, &header, &signer)?;
+    Ok(token)
+}
+
+fn sign_token_rs256(
+    payload: &JwtPayload,
+    header: &JwsHeader,
+    jwk: &Jwk,
+) -> Result<String, Box<dyn Error>> {
+    let signer = Rs256.signer_from_jwk(&jwk)?;
+    let token = encode_with_signer(&payload, &header, &signer)?;
+    Ok(token)
+}
+
+fn sign_token_es256(
+    payload: &JwtPayload,
+    header: &JwsHeader,
+    jwk: &Jwk,
+) -> Result<String, Box<dyn Error>> {
+    let signer = Es256.signer_from_jwk(&jwk)?;
+    let token = encode_with_signer(&payload, &header, &signer)?;
+    Ok(token)
+}
+
+fn sign_token_eddsa(
+    payload: &JwtPayload,
+    header: &JwsHeader,
+    jwk: &Jwk,
+) -> Result<String, Box<dyn Error>> {
+    let signer = Eddsa.signer_from_jwk(&jwk)?;
+    let token = encode_with_signer(&payload, &header, &signer)?;
+    Ok(token)
+}

--- a/jans-cedarling/test_utils/src/lib.rs
+++ b/jans-cedarling/test_utils/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod sort_json;
 pub mod token_claims;
+pub mod generate_token;
 
 pub use pretty_assertions::*;
 pub use sort_json::SortedJson;


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

This PR adds additional benchmarks with token that were signed  using the following algorithms:
- RS256
- EC256
- EdDSA

#### Target issue
  
target: #11042
  
closes #11042

#### Implementation Details

Running the benchmarks is the same as before, just use `cargo bench`, preferably while inside `/jans-cedarling/cedarling` so there will be less text printed on the screen.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
