### PR TITLE
fix(jans-auth-server): correction after removing CleanerTimer from AS (replaced by independent clean service) #10935

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/AppInitializer.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/AppInitializer.java
@@ -6,20 +6,7 @@
 
 package io.jans.as.server.service;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.jboss.weld.util.reflection.ParameterizedTypeImpl;
-import org.slf4j.Logger;
-
 import com.google.common.collect.Lists;
-
 import io.jans.as.common.service.common.ApplicationFactory;
 import io.jans.as.model.common.FeatureFlagType;
 import io.jans.as.model.configuration.AppConfiguration;
@@ -84,6 +71,13 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.servlet.ServletContext;
+import org.jboss.weld.util.reflection.ParameterizedTypeImpl;
+import org.slf4j.Logger;
+
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Javier Rojas Blum
@@ -163,9 +157,6 @@ public class AppInitializer {
 
     @Inject
     private ConfigurationFactory configurationFactory;
-
-    @Inject
-    private CleanerTimer cleanerTimer;
 
     @Inject
     private ClientLastUpdateAtTimer clientLastUpdateAtTimer;
@@ -266,7 +257,6 @@ public class AppInitializer {
         configurationFactory.initTimer();
         loggerService.initTimer(true);
         ldapStatusTimer.initTimer();
-        cleanerTimer.initTimer();
         clientLastUpdateAtTimer.initTimer();
         customScriptManager.initTimer(supportedCustomScriptTypes);
         keyGeneratorTimer.initTimer();

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/BaseComponentTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/BaseComponentTest.java
@@ -13,7 +13,6 @@ import io.jans.as.model.crypto.AbstractCryptoProvider;
 import io.jans.as.server.idgen.ws.rs.InumGenerator;
 import io.jans.as.server.model.common.AuthorizationGrantList;
 import io.jans.as.server.model.config.ConfigurationFactory;
-import io.jans.as.server.service.CleanerTimer;
 import io.jans.as.server.service.ClientService;
 import io.jans.as.server.service.GrantService;
 import io.jans.as.server.service.SessionIdService;
@@ -57,10 +56,6 @@ public abstract class BaseComponentTest extends BaseTest {
 
     public InumService getInumService() {
         return CdiUtil.bean(InumService.class);
-    }
-
-    public CleanerTimer getCleanerTimer() {
-        return CdiUtil.bean(CleanerTimer.class);
     }
 
     public CacheService getCacheService() {

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -325,12 +325,6 @@
 		</classes>
 	</test>
 
-    <test name="Cleaner timer test" enabled="true">
-        <classes>
-            <class name="io.jans.as.server.comp.CleanerTimerTest" />
-        </classes>
-    </test>
-
 	<test name="Remove unused clients test" enabled="true">
 		<classes>
 			<class name="io.jans.as.server.comp.CleanUpClientTest" />


### PR DESCRIPTION
### Description

fix(jans-auth-server): correction after removing CleanerTimer from AS (replaced by independent clean service) 

#### Target issue
  
closes #10935

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #11109, 