### PR TITLE
fix(jans-core): reverted back CleanerEvent (used by fido2) #11113

### DIFF
--- a/jans-core/service/src/main/java/io/jans/service/cdi/event/CleanerEvent.java
+++ b/jans-core/service/src/main/java/io/jans/service/cdi/event/CleanerEvent.java
@@ -1,0 +1,13 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.service.cdi.event;
+
+/**
+ * @author Yuriy Movchan Date: 04/13/2017
+ */
+public class CleanerEvent {
+}


### PR DESCRIPTION
### Description

fix(jans-core): reverted back CleanerEvent (used by fido2) 

#### Target issue
  
closes #11113

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
