### PR TITLE
fix(jans-cli-tui): Catch errors when changing user password

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/070_users/main.py
+++ b/jans-cli-tui/cli_tui/plugins/070_users/main.py
@@ -177,6 +177,9 @@ class Plugin(DialogUtils):
                 response = await get_event_loop().run_in_executor(self.app.executor, self.app.cli_requests, cli_args)
                 self.app.stop_progressing()
 
+                if response.status_code not in (200, 201):
+                    self.app.show_message(_('Error'), response.text + '\n' + response.reason, tobefocused=self.app.center_container)
+
             asyncio.ensure_future(coroutine())
 
         self.new_password = self.app.getTitledText(


### PR DESCRIPTION
Closes #11152

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #11155, 