### PR TITLE
fix(jans-linux-setup): pass -n to setup.py when invoked by -yes

### DIFF
--- a/jans-linux-setup/jans_setup/install.py
+++ b/jans-linux-setup/jans_setup/install.py
@@ -342,6 +342,9 @@ def do_install():
     if argsp.download_exit:
         setup_args += ' --download-exit'
 
+    if argsp.yes:
+        setup_args += ' -n'
+
     if setup_args:
         setup_cmd += ' ' + setup_args
 


### PR DESCRIPTION
Closes #11179

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
