### PR TITLE
fix(jans-auth-server): Access Token from and OIDC flow should not contain the code #11181

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
@@ -17,8 +17,10 @@ import io.jans.as.model.common.ScopeConstants;
 import io.jans.as.model.config.WebKeysConfiguration;
 import io.jans.as.model.crypto.signature.SignatureAlgorithm;
 import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.exception.CryptoProviderException;
 import io.jans.as.model.jwt.Jwt;
 import io.jans.as.model.jwt.JwtClaimName;
+import io.jans.as.model.jwt.JwtClaims;
 import io.jans.as.model.token.JsonWebResponse;
 import io.jans.as.model.token.TokenErrorResponseType;
 import io.jans.as.model.util.JwtUtil;
@@ -43,6 +45,7 @@ import io.jans.model.metric.MetricType;
 import io.jans.model.token.TokenEntity;
 import io.jans.model.token.TokenType;
 import io.jans.service.CacheService;
+import io.jans.util.security.StringEncrypter;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -282,8 +285,7 @@ public abstract class AuthorizationGrant extends AbstractAuthorizationGrant {
         }
     }
 
-    public JwtSigner createAccessTokenAsJwt(AccessToken accessToken, ExecutionContext context) throws Exception {
-        final User user = getUser();
+    public JwtSigner createAccessTokenAsJwt(AccessToken accessToken, ExecutionContext context) throws StringEncrypter.EncryptionException, CryptoProviderException {
         final Client client = getClient();
 
         context.initFromGrantIfNeeded(this);
@@ -298,33 +300,7 @@ public abstract class AuthorizationGrant extends AbstractAuthorizationGrant {
         final JwtSigner jwtSigner = new JwtSigner(appConfiguration, webKeysConfiguration, signatureAlgorithm,
                 client.getClientId(), clientService.decryptSecret(client.getClientSecret()));
         final Jwt jwt = jwtSigner.newJwt();
-        jwt.getClaims().setClaim("scope", Lists.newArrayList(getScopes()));
-        jwt.getClaims().setClaim("client_id", getClientId());
-        jwt.getClaims().setClaim("username", user != null ? user.getAttribute("displayName") : null);
-        jwt.getClaims().setClaim("token_type", accessToken.getTokenType().getName());
-        jwt.getClaims().setClaim("code", accessToken.getCode()); // guarantee uniqueness : without it we can get race condition
-        jwt.getClaims().setClaim("acr", getAcrValues());
-        jwt.getClaims().setClaim("auth_time", ServerUtil.dateToSeconds(getAuthenticationTime()));
-        jwt.getClaims().setExpirationTime(accessToken.getExpirationDate());
-        jwt.getClaims().setIat(accessToken.getCreationDate());
-        jwt.getClaims().setNbf(accessToken.getCreationDate());
-        jwt.getClaims().setSubjectIdentifier(getSub());
-        jwt.getClaims().setClaim("x5t#S256", accessToken.getX5ts256());
-        jwt.getClaims().setClaim("jti", context.getTokenReferenceId());
-
-        final AuthzDetails authzDetails = getAuthzDetails();
-        if (!AuthzDetails.isEmpty(authzDetails)) {
-            jwt.getClaims().setClaim("authorization_details", authzDetails.asJsonArray());
-        }
-
-        // DPoP
-        final String dpop = context.getDpop();
-        if (StringUtils.isNotBlank(dpop)) {
-            jwt.getClaims().setNotBefore(accessToken.getCreationDate());
-            JSONObject cnf = new JSONObject();
-            cnf.put("jkt", dpop);
-            jwt.getClaims().setClaim("cnf", cnf);
-        }
+        fillPayloadOfAccessTokenJwt(jwt.getClaims(), accessToken, context);
 
         Audience.setAudience(jwt.getClaims(), getClient());
         statusListService.addStatusClaimWithIndex(jwt, context);
@@ -334,6 +310,38 @@ public abstract class AuthorizationGrant extends AbstractAuthorizationGrant {
         }
 
         return jwtSigner;
+    }
+
+    public void fillPayloadOfAccessTokenJwt(JwtClaims claims, AccessToken accessToken, ExecutionContext context) {
+        final User user = getUser();
+
+        claims.setClaim("scope", Lists.newArrayList(getScopes()));
+        claims.setClaim("client_id", getClientId());
+        claims.setClaim("username", user != null ? user.getAttribute("displayName") : null);
+        claims.setClaim("token_type", accessToken.getTokenType().getName());
+        claims.setClaim("acr", getAcrValues());
+        claims.setClaim("auth_time", ServerUtil.dateToSeconds(getAuthenticationTime()));
+        claims.setExpirationTime(accessToken.getExpirationDate());
+        claims.setIat(accessToken.getCreationDate());
+        claims.setNbf(accessToken.getCreationDate());
+        claims.setSubjectIdentifier(getSub());
+        claims.setClaim("x5t#S256", accessToken.getX5ts256());
+        // jti also guarantees uniqueness : without it we can get race condition
+        claims.setClaim("jti", context.getTokenReferenceId());
+
+        final AuthzDetails authzDetails = getAuthzDetails();
+        if (!AuthzDetails.isEmpty(authzDetails)) {
+            claims.setClaim("authorization_details", authzDetails.asJsonArray());
+        }
+
+        // DPoP
+        final String dpop = context.getDpop();
+        if (StringUtils.isNotBlank(dpop)) {
+            claims.setNotBefore(accessToken.getCreationDate());
+            JSONObject cnf = new JSONObject();
+            cnf.put("jkt", dpop);
+            claims.setClaim("cnf", cnf);
+        }
     }
 
     private void runIntrospectionScriptAndInjectValuesIntoJwt(Jwt jwt, ExecutionContext executionContext) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/model/common/AuthorizationGrantTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/model/common/AuthorizationGrantTest.java
@@ -1,0 +1,111 @@
+package io.jans.as.server.model.common;
+
+import com.google.common.collect.Lists;
+import io.jans.as.common.model.common.User;
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.service.AttributeService;
+import io.jans.as.model.common.GrantType;
+import io.jans.as.model.config.WebKeysConfiguration;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.jwt.JwtClaims;
+import io.jans.as.server.model.authorize.ScopeChecker;
+import io.jans.as.server.model.token.IdTokenFactory;
+import io.jans.as.server.service.*;
+import io.jans.as.server.service.external.ExternalIntrospectionService;
+import io.jans.as.server.service.external.ExternalUpdateTokenService;
+import io.jans.as.server.service.stat.StatService;
+import io.jans.as.server.service.token.StatusListIndexService;
+import io.jans.as.server.service.token.StatusListService;
+import io.jans.service.CacheService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class AuthorizationGrantTest {
+
+    @InjectMocks
+    private SimpleAuthorizationGrant authorizationGrant;
+
+    @Mock
+    private CacheService cacheService;
+
+    @Mock
+    private GrantService grantService;
+
+    @Mock
+    private IdTokenFactory idTokenFactory;
+
+    @Mock
+    private WebKeysConfiguration webKeysConfiguration;
+
+    @Mock
+    private ClientService clientService;
+
+    @Mock
+    private ExternalIntrospectionService externalIntrospectionService;
+
+    @Mock
+    private ExternalUpdateTokenService externalUpdateTokenService;
+
+    @Mock
+    private AttributeService attributeService;
+
+    @Mock
+    private SectorIdentifierService sectorIdentifierService;
+
+    @Mock
+    private MetricService metricService;
+
+    @Mock
+    private StatService statService;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private StatusListService statusListService;
+
+    @Mock
+    private StatusListIndexService statusListIndexService;
+
+    @Mock
+    protected AppConfiguration appConfiguration;
+
+    @Mock
+    protected ScopeChecker scopeChecker;
+
+    @Mock
+    private KeyGeneratorTimer keyGeneratorTimer;
+
+    @Test
+    public void getGrantType_forSimpleGrantType_shouldReturnNone() {
+        assertEquals(GrantType.NONE, authorizationGrant.getGrantType());
+    }
+
+    @Test
+    public void fillPayloadOfAccessTokenJwt_whenCalled_shouldNotPutCode() {
+        ExecutionContext context = new ExecutionContext();
+        context.generateRandomTokenReferenceId();
+
+        AccessToken accessToken = new AccessToken(100);
+        JwtClaims claims = new JwtClaims();
+
+        authorizationGrant.init(new User(), AuthorizationGrantType.AUTHORIZATION_CODE, new Client(), new Date());
+        authorizationGrant.setScopes(Lists.newArrayList("openid"));
+        authorizationGrant.fillPayloadOfAccessTokenJwt(claims, accessToken, context);
+
+        assertNull(claims.getClaim("code"));
+    }
+}

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -15,6 +15,7 @@
             <class name="io.jans.as.server.model.registration.RegisterParamsValidatorTest" />
             <class name="io.jans.as.server.model.common.ExecutionContextTest" />
             <class name="io.jans.as.server.model.common.TxTokenTest" />
+            <class name="io.jans.as.server.model.common.AuthorizationGrantTest" />
 
             <class name="io.jans.as.server.service.MTLSServiceTest" />
             <class name="io.jans.as.server.service.ScopeServiceTest" />


### PR DESCRIPTION
### Description

fix(jans-auth-server): Access Token from and OIDC flow should not contain the code 

#### Target issue
  
closes #11181

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
