### PR TITLE
fix: not being able to find the TrustedIssuer entity when there are m…

### DIFF
--- a/jans-cedarling/cedarling/src/entity_builder/build_principal_entity/user.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/build_principal_entity/user.rs
@@ -194,7 +194,7 @@ mod test {
                 "attrs": {
                     "iss": {"__entity": {
                         "type": "Jans::TrustedIssuer",
-                        "id": "some_iss",
+                        "id": "https://test.jans.org",
                     }},
                     "sub": "some_sub",
                     "id_token": {"__entity": {
@@ -268,7 +268,7 @@ mod test {
                 "attrs": {
                     "iss": {"__entity": {
                         "type": "Jans::TrustedIssuer",
-                        "id": "some_iss",
+                        "id": "https://test.jans.org",
                     }},
                     "sub": "some_sub",
                     "userinfo_token": {"__entity": {
@@ -360,7 +360,7 @@ mod test {
                 "attrs": {
                     "iss": {"__entity": {
                         "type": "Jans::TrustedIssuer",
-                        "id": "some_iss",
+                        "id": "https://test.jans.org",
                     }},
                     "sub": "id_tkn_sub",
                     "from_id_tkn": "from_id_tkn",

--- a/jans-cedarling/cedarling/src/entity_builder/build_principal_entity/workload.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/build_principal_entity/workload.rs
@@ -200,7 +200,7 @@ mod test {
                 "attrs": {
                     "iss": {"__entity": {
                         "type": "Jans::TrustedIssuer",
-                        "id": "some_iss",
+                        "id": "https://test.jans.org",
                     }},
                     "aud": "some_aud",
                     "access_token": {"__entity": {
@@ -271,7 +271,7 @@ mod test {
                 "attrs": {
                     "iss": {"__entity": {
                         "type": "Jans::TrustedIssuer",
-                        "id": "some_iss",
+                        "id": "https://test.jans.org",
                     }},
                     "client_id": "some_client_id",
                     "access_token": {"__entity": {

--- a/jans-cedarling/cedarling/src/entity_builder/build_token_entities.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/build_token_entities.rs
@@ -151,7 +151,7 @@ mod test {
                 "attrs": {
                     "iss": {"__entity": {
                         "type": "Jans::TrustedIssuer",
-                        "id": "some_iss",
+                        "id": "https://test.jans.org",
                     }},
                     "jti": "some_jti",
                 },

--- a/jans-cedarling/cedarling/src/entity_builder/mod.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/mod.rs
@@ -7,11 +7,11 @@
 //!
 //! This module is responsible for mapping JWTs to Cedar entities
 
+mod build_cedar_entity;
 mod build_entity_attrs;
 mod build_expr;
 mod build_iss_entity;
 mod build_principal_entity;
-mod build_cedar_entity;
 mod build_role_entity;
 mod build_token_entities;
 mod built_entities;
@@ -54,9 +54,10 @@ impl EntityBuilder {
         let schema = schema.map(MappingSchema::try_from).transpose()?;
 
         let (ok, errs) = trusted_issuers
-            .iter()
-            .map(|(iss_id, iss)| {
-                build_iss_entity(&config.entity_names.iss, iss_id, iss, schema.as_ref())
+            .values()
+            .map(|iss| {
+                let iss_id = iss.oidc_endpoint.origin().ascii_serialization();
+                build_iss_entity(&config.entity_names.iss, &iss_id, iss, schema.as_ref())
             })
             .partition_result();
 

--- a/jans-cedarling/test_files/policy-store_ok.yaml
+++ b/jans-cedarling/test_files/policy-store_ok.yaml
@@ -28,6 +28,10 @@ policy_stores:
             user_id: "sub"
             principal_mapping:
               - "Jans::User"
+      AnotherIssuer:
+        name: "Another Issuer"
+        description: "This is a placeholder issuer used to test if Cedarling still works with multiple issuers"
+        openid_configuration_endpoint: "https://another.jans.org/.well-known/openid-configuration"
     policies:
       840da5d85403f35ea76519ed1a18a33989f855bf1cf8:
         description: simple policy example for principal workload


### PR DESCRIPTION
…ultiple

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

This PR fixes the issue where the `iss` attribute could not be found when there are multiple trusted issuers.

#### Target issue
 
closes #11233

#### Implementation Details

The entity id for the `TrustedIssuer` entities was changed from it's id on the policy store to it's origin. e.g.:
```
Jans::TrustedIssuer::"SomeIssuer" -> Jans::TrustedIssuer::"https://test.idp.com"
```

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
