### PR TITLE
fix: validate license configuration in the database when fetching license details from Agama Lab server upon expiry (Admin UI)

### DIFF
--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/license/LicenseDetailsService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/license/LicenseDetailsService.java
@@ -120,6 +120,16 @@ public class LicenseDetailsService extends BaseService {
         if (daysDiffOfLicenseDetailsLastUpdated > intervalForSyncLicenseDetailsInDays) {
             return syncLicenseOIDCClientDetails(licenseConfiguration);
         }
+        //calculate if license is expired
+        if (!Strings.isNullOrEmpty(licenseConfiguration.getLicenseValidUpto())) {
+            long daysDiffOfLicenseValidity = ChronoUnit.DAYS.between(LocalDate.now(), CommonUtils.convertStringToLocalDate(licenseConfiguration.getLicenseValidUpto()));
+            log.info("License will expire after {} days", daysDiffOfLicenseValidity);
+            //make sure that license oidc client is valid e
+            if (daysDiffOfLicenseValidity < 0) {
+                return syncLicenseOIDCClientDetails(licenseConfiguration);
+            }
+        }
+
         return CommonUtils.createGenericResponse(true, 200, "No error in license configuration.");
     }
 

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/license/LicenseDetailsService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/license/LicenseDetailsService.java
@@ -120,11 +120,13 @@ public class LicenseDetailsService extends BaseService {
         if (daysDiffOfLicenseDetailsLastUpdated > intervalForSyncLicenseDetailsInDays) {
             return syncLicenseOIDCClientDetails(licenseConfiguration);
         }
-        //calculate if license is expired
+        // Check if the 'licenseValidUpto' field is not null or empty
         if (!Strings.isNullOrEmpty(licenseConfiguration.getLicenseValidUpto())) {
+            // Calculate the number of days between today and the license expiry date
             long daysDiffOfLicenseValidity = ChronoUnit.DAYS.between(LocalDate.now(), CommonUtils.convertStringToLocalDate(licenseConfiguration.getLicenseValidUpto()));
             log.info("License will expire after {} days", daysDiffOfLicenseValidity);
-            //make sure that license oidc client is valid e
+            // If the license has already expired (daysDiffOfLicenseValidity < 0),
+            // sync the license OIDC client details to update or renew the license
             if (daysDiffOfLicenseValidity < 0) {
                 return syncLicenseOIDCClientDetails(licenseConfiguration);
             }


### PR DESCRIPTION


### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #11244

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
