### PR TITLE
feat(jans-config-api): disable jetty ee9-jsp module in jans-config-api

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/data/jetty_app_configuration.json
+++ b/jans-linux-setup/jans_setup/setup_app/data/jetty_app_configuration.json
@@ -42,7 +42,7 @@
       "ratio": 0.10
     },
     "jetty": {
-      "modules": "server,resources,http,http-forwarded,console-capture,ee9-jsp,ee9-deploy,ee9-websocket-jakarta,ee9-cdi-decorate"
+      "modules": "server,resources,http,http-forwarded,console-capture,ee9-deploy,ee9-websocket-jakarta,ee9-cdi-decorate"
     },
     "installed": false,
     "name": "jans-config-api"


### PR DESCRIPTION
#11276

closes #11276

- [X] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #11325, 