### PR TITLE
feat(jans-auth-server): added refresh token lifetime to Token Endpoint response #11400

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -543,6 +543,9 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Boolean value specifying whether to include sessionId in response", defaultValue = "false")
     private Boolean includeSidInResponse = false;
 
+    @DocProperty(description = "Boolean value specifying whether to include refresh token lifetime in token response", defaultValue = "false")
+    private Boolean includeRefreshTokenLifetimeInTokenResponse = false;
+
     @DocProperty(description = "Boolean value specifying whether to disable prompt=login", defaultValue = "false")
     private Boolean disablePromptLogin = false;
 
@@ -1393,6 +1396,16 @@ public class AppConfiguration implements Configuration {
 
     public void setIncludeSidInResponse(Boolean includeSidInResponse) {
         this.includeSidInResponse = includeSidInResponse;
+    }
+
+    public Boolean getIncludeRefreshTokenLifetimeInTokenResponse() {
+        if (includeRefreshTokenLifetimeInTokenResponse == null) includeRefreshTokenLifetimeInTokenResponse = false;
+        return includeRefreshTokenLifetimeInTokenResponse;
+    }
+
+    public AppConfiguration setIncludeRefreshTokenLifetimeInTokenResponse(Boolean includeRefreshTokenLifetimeInTokenResponse) {
+        this.includeRefreshTokenLifetimeInTokenResponse = includeRefreshTokenLifetimeInTokenResponse;
+        return this;
     }
 
     public Boolean getSessionIdPersistInCache() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AbstractToken.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AbstractToken.java
@@ -314,7 +314,8 @@ public abstract class AbstractToken implements Serializable, Deletable {
 
         checkExpired();
         if (isValid()) {
-            long diff = expirationDate.getTime() - new Date().getTime();
+            Date start = creationDate != null ? creationDate : new Date();
+            long diff = expirationDate.getTime() - start.getTime();
             expiresIn = diff != 0 ? (int) (diff / 1000) : 0;
         }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
@@ -640,11 +640,18 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
         JSONObject jsonObj = new JSONObject();
         try {
             fillJsonObject(jsonObj, accessToken, tokenType, expiresIn, refreshToken, scope, idToken, checkedAuthzDetails);
+            addRefreshTokenLifetime(jsonObj, refreshToken, appConfiguration.getIncludeRefreshTokenLifetimeInTokenResponse());
         } catch (JSONException e) {
             log.error(e.getMessage(), e);
         }
 
         return jsonObj.toString();
+    }
+
+    public static void addRefreshTokenLifetime(JSONObject jsonObj, RefreshToken refreshToken, boolean includeRefreshTokenLifetimeInResponse) {
+        if (refreshToken != null && includeRefreshTokenLifetimeInResponse) {
+            jsonObj.put("refresh_token_expires_in", refreshToken.getExpiresIn());
+        }
     }
 
     public static void fillJsonObject(JSONObject jsonObj, AccessToken accessToken, TokenType tokenType,

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImplTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImplTest.java
@@ -1,0 +1,137 @@
+package io.jans.as.server.token.ws.rs;
+
+import io.jans.as.common.service.AttributeService;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.server.audit.ApplicationAuditLogger;
+import io.jans.as.server.auth.DpopService;
+import io.jans.as.server.authorize.ws.rs.AuthzDetailsService;
+import io.jans.as.server.model.common.AuthorizationGrantList;
+import io.jans.as.server.model.common.RefreshToken;
+import io.jans.as.server.security.Identity;
+import io.jans.as.server.service.*;
+import io.jans.as.server.service.ciba.CibaRequestService;
+import io.jans.as.server.service.external.ExternalResourceOwnerPasswordCredentialsService;
+import io.jans.as.server.service.external.ExternalUpdateTokenService;
+import io.jans.as.server.service.stat.StatService;
+import io.jans.as.server.uma.service.UmaTokenService;
+import org.json.JSONObject;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class TokenRestWebServiceImplTest {
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private Identity identity;
+
+    @Mock
+    private ApplicationAuditLogger applicationAuditLogger;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private AuthorizationGrantList authorizationGrantList;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private GrantService grantService;
+
+    @Mock
+    private AuthenticationFilterService authenticationFilterService;
+
+    @Mock
+    private AuthenticationService authenticationService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private UmaTokenService umaTokenService;
+
+    @Mock
+    private ExternalResourceOwnerPasswordCredentialsService externalResourceOwnerPasswordCredentialsService;
+
+    @Mock
+    private AttributeService attributeService;
+
+    @Mock
+    private SessionIdService sessionIdService;
+
+    @Mock
+    private CibaRequestService cibaRequestService;
+
+    @Mock
+    private DeviceAuthorizationService deviceAuthorizationService;
+
+    @Mock
+    private ExternalUpdateTokenService externalUpdateTokenService;
+
+    @Mock
+    private TokenRestWebServiceValidator tokenRestWebServiceValidator;
+
+    @Mock
+    private TokenExchangeService tokenExchangeService;
+
+    @Mock
+    private TokenCreatorService tokenCreatorService;
+
+    @Mock
+    private StatService statService;
+
+    @Mock
+    private DpopService dPoPService;
+
+    @Mock
+    private AuthzDetailsService authzDetailsService;
+
+    @Mock
+    private TxTokenService txTokenService;
+
+    @InjectMocks
+    private TokenRestWebServiceImpl tokenRestWebServiceImpl;
+
+    @Test
+    public void addRefreshTokenLifetime_whenIncludePropertyIsTrue_shouldIncludeRefreshTokenLifetime() {
+        final int refreshTokenLifetime = 5;
+        RefreshToken refreshToken = new RefreshToken(refreshTokenLifetime);
+        JSONObject json = new JSONObject();
+        TokenRestWebServiceImpl.addRefreshTokenLifetime(json, refreshToken, true);
+
+        assertEquals(refreshTokenLifetime, json.getInt("refresh_token_expires_in"));
+    }
+
+    @Test
+    public void addRefreshTokenLifetime_whenIncludePropertyIsFalse_shouldNotIncludeRefreshTokenLifetime() {
+        final int refreshTokenLifetime = 5;
+        RefreshToken refreshToken = new RefreshToken(refreshTokenLifetime);
+        JSONObject json = new JSONObject();
+        TokenRestWebServiceImpl.addRefreshTokenLifetime(json, refreshToken, false);
+
+        assertFalse(json.has("refresh_token_expires_in"));
+    }
+
+    @Test
+    public void addRefreshTokenLifetime_whenRefreshTokenIsNull_shouldNotIncludeRefreshTokenLifetime() {
+        JSONObject json = new JSONObject();
+        TokenRestWebServiceImpl.addRefreshTokenLifetime(json, null, true);
+
+        assertFalse(json.has("refresh_token_expires_in"));
+    }
+}

--- a/jans-auth-server/server/src/test/resources/testng.xml
+++ b/jans-auth-server/server/src/test/resources/testng.xml
@@ -24,6 +24,7 @@
             <class name="io.jans.as.server.service.external.ExternalAuthenticationServiceTest" />
             <class name="io.jans.as.server.servlet.OpenIdConfigurationTest" />
             <class name="io.jans.as.server.service.net.UriServiceTest" />
+            <class name="io.jans.as.server.service.net.UriServiceTest" />
             <class name="io.jans.as.server.service.GrantServiceTest" />
             <class name="io.jans.as.server.service.LocalResponseCacheTest" />
             <class name="io.jans.as.server.service.SessionIdServiceTest" />
@@ -37,6 +38,7 @@
             <class name="io.jans.as.server.token.ws.rs.TxTokenServiceTest" />
             <class name="io.jans.as.server.token.ws.rs.TxTokenValidatorTest" />
             <class name="io.jans.as.server.token.ws.rs.TokenRestWebServiceValidatorTest" />
+            <class name="io.jans.as.server.token.ws.rs.TokenRestWebServiceImplTest" />
             <class name="io.jans.as.server.ws.rs.stat.MonthsTest" />
 
             <!-- AUTHORIZE -->


### PR DESCRIPTION
### Description

feat(jans-auth-server): added refresh token lifetime to Token Endpoint response 

#### Target issue
  
closes #11400

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
