### PR TITLE
fix(docs): correct jans api swagger reference

### DIFF
--- a/docs/janssen-server/config-guide/config-tools/curl-guide.md
+++ b/docs/janssen-server/config-guide/config-tools/curl-guide.md
@@ -380,7 +380,7 @@ You will need:
 
 #### Steps
 
- * Refer to [API documentation]((https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/vreplace-janssen-version/jans-config-api/docs/jans-config-api-swagger.yaml)) to know the endpoint path and required OAuth scopes to access that 
+ * Refer to [API documentation](https://gluu.org/swagger-ui/?url=https://raw.githubusercontent.com/JanssenProject/jans/vreplace-janssen-version/jans-config-api/docs/jans-config-api-swagger.yaml) to know the endpoint path and required OAuth scopes to access that 
  endpoint. Example: Attribute Endpoint.
 
     ![image](../../../assets/jans-attribute.png)
@@ -392,7 +392,7 @@ You will need:
 
     Syntax:
     ```
-    curl -k  https://<my.jans.server.domian>/jans-auth/restv1/token -H "Accept: application/json" -u "<clientId>:<decryptedClientSecret>" -d "grant_type=client_credentials" -d "scope= <apce separated oAuth Scope List>"
+    curl -k  https://<my.jans.server.domain>/jans-auth/restv1/token -H "Accept: application/json" -u "<clientId>:<decryptedClientSecret>" -d "grant_type=client_credentials" -d "scope= <apce separated oAuth Scope List>"
     ```
 
     Example: generate token for attribute:
@@ -408,7 +408,7 @@ You will need:
     Syntax:
 
     ```
-    curl -k -i -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization:Bearer <accessToken>" -X GET https://< my.jans.server.domian >/jans-config-api/api/v1/attributes
+    curl -k -i -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization:Bearer <accessToken>" -X GET https://< my.jans.server.domain >/jans-config-api/api/v1/attributes
     ```
 
     Example: Invoke attribute GET endpoint:


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
This small PR simply fixes the broken jans API Swagger reference. It also fixes a few typos along the way.

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
