### PR TITLE
fix(jans-auth-server): improve logging - do not print that user is logged in in logs if it failed to login #11475

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/auth/Authenticator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/auth/Authenticator.java
@@ -314,6 +314,7 @@ public class Authenticator {
         initCustomAuthenticatorVariables(sessionIdAttributes);
         boolean useExternalAuthenticator = externalAuthenticationService
                 .isEnabled(AuthenticationScriptUsageType.INTERACTIVE);
+        final String sanitizedUsername = sanitizeUsernameForLog(credentials.getUsername());
         if (useExternalAuthenticator && !StringHelper.isEmpty(this.authAcr) &&
                 !OxConstants.SCRIPT_TYPE_INTERNAL_RESERVED_NAME.equalsIgnoreCase(authAcr)) {
             initCustomAuthenticatorVariables(sessionIdAttributes);
@@ -446,10 +447,10 @@ public class Authenticator {
                 authenticationService.quietLogin(credentials.getUsername());
 
                 // Redirect to authorization workflow
-                logger.debug("Sending event to trigger user redirection: '{}'", sanitizeUsernameForLog(credentials.getUsername()));
+                logger.debug("Sending event to trigger user redirection: '{}'", sanitizedUsername);
                 authenticationService.onSuccessfulLogin(eventSessionId);
 
-                logger.info(AUTHENTICATION_SUCCESS_FOR_USER, sanitizeUsernameForLog(credentials.getUsername()));
+                logger.info(AUTHENTICATION_SUCCESS_FOR_USER, sanitizedUsername);
                 return Constants.RESULT_SUCCESS;
             }
         } else {
@@ -461,15 +462,15 @@ public class Authenticator {
                             sessionIdAttributes);
 
                     // Redirect to authorization workflow
-                    logger.debug("Sending event to trigger user redirection: '{}'", sanitizeUsernameForLog(credentials.getUsername()));
+                    logger.info("Sending event to trigger user redirection: '{}'", sanitizedUsername);
                     authenticationService.onSuccessfulLogin(eventSessionId);
+                    logger.info(AUTHENTICATION_SUCCESS_FOR_USER, sanitizedUsername);
+                    return Constants.RESULT_SUCCESS;
                 } else {
                     // Force session lastUsedAt update if authentication attempt is failed
                     sessionIdService.updateSessionId(sessionId);
+                    logger.info("Authentication failed for user: {}", sanitizedUsername);
                 }
-
-                logger.info(AUTHENTICATION_SUCCESS_FOR_USER, sanitizeUsernameForLog(credentials.getUsername()));
-                return Constants.RESULT_SUCCESS;
             }
         }
 


### PR DESCRIPTION
### Description

fix(jans-auth-server): improve logging - do not print that user is logged in in logs if it failed to login 

#### Target issue
  
closes #11475

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
