### PR TITLE
docs(jans-cedarling): Updated Cedarling bootstrap properties docs

### DIFF
--- a/docs/cedarling/cedarling-properties.md
+++ b/docs/cedarling/cedarling-properties.md
@@ -12,12 +12,36 @@ tags:
 
 These Bootstrap Properties control default application level behavior.
 
-* **`CEDARLING_APPLICATION_NAME`** : Human friendly identifier for this application
-* **`CEDARLING_POLICY_STORE_URI`** : Location of policy store JSON, used if policy store is not local.
-* **`CEDARLING_POLICY_STORE_ID`** : The identifier of the policy store in case there is more than one policy_store_id in the policy store.
-* **`CEDARLING_USER_AUTHZ`** : When `enabled`, Cedar engine authorization is queried for a User principal.
+## Required properties for startup
+
+* **`CEDARLING_APPLICATION_NAME`** : Human friendly identifier for this Cedarling instance.
+
+To enable usage of principals at least one of the following keys must be provided:
+
 * **`CEDARLING_WORKLOAD_AUTHZ`** : When `enabled`, Cedar engine authorization is queried for a Workload principal.
-* **`CEDARLING_PRINCIPAL_BOOLEAN_OPERATION`** : property specifies what boolean operation to use for the `USER` and `WORKLOAD` when making authz (authorization) decisions. [See here](#user-workload-boolean-operation).
+
+* **`CEDARLING_USER_AUTHZ`** : When `enabled`, Cedar engine authorization is queried for a User principal.
+
+To load policy store one of the following keys must be provided:
+
+* **`CEDARLING_POLICY_STORE_LOCAL`** : JSON object as string with policy store. You can use [this](https://jsontostring.com/) converter.
+
+* **`CEDARLING_POLICY_STORE_URI`** : Location of policy store JSON, used if policy store is not local.
+
+* **`CEDARLING_POLICY_STORE_LOCAL_FN`** : Local file with JSON object with policy store
+
+[! NOTE]
+All other fields are optional and can be omitted. If a field is not provided, Cedarling will use the default value specified in the property definition.
+
+**Auxilliary properties**
+
+* **`CEDARLING_POLICY_STORE_ID`** : The identifier of the policy store in case there is more than one policy_store_id in the policy store.
+
+* **`CEDARLING_PRINCIPAL_BOOLEAN_OPERATION`** : property specifies whether to authorize the `USER`, `WORKLOAD` or both when making authorization decisions. 
+Use `"===": [{"var": "Jans::User"}, "ALLOW"]` if you only want user authorization. Use `"===": [{"var": "Jans::Workload"}, "ALLOW"]` if you only want workload authorization. [See here](#user-workload-boolean-operation) if you want anything more complicated.
+
+**Cedar Entity Mapping properties** 
+
 * **`CEDARLING_MAPPING_USER`** : Name of Cedar User schema entity if we don't want to use default. When specified Cedarling try build defined entity (from schema) as user instead of default `User` entity defined in `cedar` schema. Works in namespace defined in the policy store.
 * **`CEDARLING_MAPPING_WORKLOAD`** : Name of Cedar Workload schema entity
 * **`CEDARLING_MAPPING_ROLE`** : Name of Cedar Role schema entity
@@ -37,8 +61,7 @@ These Bootstrap Properties control default application level behavior.
 **The following bootstrap properties are needed to configure JWT and cryptographic behavior:**
 
 * **`CEDARLING_LOCAL_JWKS`** : JWKS file with public keys
-* **`CEDARLING_POLICY_STORE_LOCAL`** : JSON object as string with policy store. You can use [this](https://jsontostring.com/) converter.
-* **`CEDARLING_POLICY_STORE_LOCAL_FN`** : Local file with JSON object with policy store
+
 * **`CEDARLING_JWT_SIG_VALIDATION`** : `enabled` | `disabled` -- Whether to check the signature of all JWT tokens. This requires an `iss` is present.
 * **`CEDARLING_JWT_STATUS_VALIDATION`** : `enabled` | `disabled` -- Whether to check the status of the JWT. On startup, the Cedarling should fetch and retreive the latest Status List JWT from the `.well-known/openid-configuration` via the `status_list_endpoint` claim and cache it. See the [IETF Draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/) for more info.
 * **`CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED`** : Only tokens signed with these algorithms are acceptable to the Cedarling.
@@ -57,21 +80,3 @@ These Bootstrap Properties control default application level behavior.
 * **`CEDARLING_LOCK_LISTEN_SSE`** : `enabled` | `disabled`: controls whether Cedarling should listen for updates from the Lock Server.
 * **`CEDARLING_LOCK_ACCEPT_INVALID_CERTS`** : `enabled` | `disabled`: Allows interaction with a Lock server with invalid certificates. Mainly used for testing. Doesn't work for WASM builds.
 
-controls whether Cedarling should listen for updates from the Lock Server.
-
-## Required properties for startup
-
-* **`CEDARLING_APPLICATION_NAME`**
-
-To enable usage of principals at least one of the following keys must be provided:
-
-* **`CEDARLING_WORKLOAD_AUTHZ`**
-* **`CEDARLING_USER_AUTHZ`**
-
-To load policy store one of the following keys must be provided:
-
-* **`CEDARLING_POLICY_STORE_LOCAL`**
-* **`CEDARLING_POLICY_STORE_URI`**
-* **`CEDARLING_POLICY_STORE_LOCAL_FN`**
-
-All other fields are optional and can be omitted. If a field is not provided, Cedarling will use the default value specified in the property definition.


### PR DESCRIPTION
Moved required properties to the top.

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
https://github.com/JanssenProject/jans/issues/8831


#### Implementation Details

Moved the required bootstrap properties to the top, removed some duplication, and made the boolean property more clear. 

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
