### PR TITLE
fix(jans-cli-tui): user jansStatus is in body not custom attrbiute

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/070_users/edit_user_dialog.py
+++ b/jans-cli-tui/cli_tui/plugins/070_users/edit_user_dialog.py
@@ -161,7 +161,7 @@ class EditUserDialog(JansGDialog, DialogUtils):
 
         for ca in custom_attributes:
 
-            if ca['name'] in ('middleName', 'sn', 'status', 'nickname', 'jansActive', 'userPassword', 'jansAdminUIRole'):
+            if ca['name'] in ('middleName', 'sn', 'status', 'nickname', 'jansActive', 'userPassword', 'jansAdminUIRole', 'jansStatus'):
                 continue
 
             claim_prop = self.get_claim_properties(ca['name'])


### PR DESCRIPTION
Closes #11605

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
