### PR TITLE
fix(docs): remove the link to the converting data document from left nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,7 +175,6 @@ nav:
       - PostgreSQL Indexes: janssen-server/reference/database/pgsql-schema-indexes.md
       - PostgreSQL Configuration: janssen-server/reference/database/pgsql-config.md
       - PostgreSQL Operation: janssen-server/reference/database/pgsql-ops.md
-    - Converting Data: janssen-server/reference/database/converting-data.md
   - Auth Server Admin Guide:
     - janssen-server/auth-server/README.md
     - Auth Server Config: janssen-server/auth-server/config.md


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Nav link is returning 404 as the underlying document has long been removed. 

Removing the nav link as well now. 

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
