### PR TITLE
fix(jans-linux-setup): data type of jansScr is LONGTEXT

### DIFF
--- a/jans-linux-setup/jans_setup/static/rdbm/sql_data_types.json
+++ b/jans-linux-setup/jans_setup/static/rdbm/sql_data_types.json
@@ -119,7 +119,10 @@
     }
   },
   "jansScr": {
-    "mysql": {
+        "mysql": {
+      "type": "LONGTEXT"
+    },
+    "pgsql": {
       "type": "TEXT"
     }
   },


### PR DESCRIPTION
Closes #11762

- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
