### PR TITLE
fix(jans-auth-server): set sub claim to client identifier for "client credentials grant" for AT as JWT #11413

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/common/AuthorizationGrant.java
@@ -602,7 +602,12 @@ public abstract class AuthorizationGrant extends AbstractAuthorizationGrant {
     }
 
     public String getSub() {
-        return sectorIdentifierService.getSub(this);
+        final String sub = sectorIdentifierService.getSub(this);
+        if (StringUtils.isBlank(sub)) {
+            final String clientId = getClientId();
+            return StringUtils.isNotBlank(clientId) ? clientId : "";
+        }
+        return sub;
     }
 
     public boolean isCachedWithNoPersistence() {


### PR DESCRIPTION
### Description

fix(jans-auth-server): set sub claim to client identifier for "client credentials grant" for AT as JWT 

#### Target issue
  
closes #11413

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
