### PR TITLE
 Remove "Forgot Password" link from login pages

### DIFF
--- a/jans-auth-server/server/src/main/webapp/auth/apple/login.xhtml
+++ b/jans-auth-server/server/src/main/webapp/auth/apple/login.xhtml
@@ -75,16 +75,7 @@
 									action="#{authenticator.authenticate}" />
 							</div>
 						</div>
-						<div class="form-group row">
-							<div class="col-sm-offset-3 offset-md-3 col-sm-7 col-md-7">
-								<div class="forgot_link">
-									<a href="/identity/person/passwordReminder.htm"
-										style="color: blue;"> <h:outputText
-											value="#{msgs['login.forgotYourPassword']}" />
-									</a>
-								</div>
-							</div>
-						</div>
+						
 						<h:inputHidden id="platform" />
 						<div id="appleid-signin" data-color="black" data-border="true" data-type="sign in"></div>
         

--- a/jans-auth-server/server/src/main/webapp/auth/google/login.xhtml
+++ b/jans-auth-server/server/src/main/webapp/auth/google/login.xhtml
@@ -73,16 +73,7 @@
 									action="#{authenticator.authenticate}" />
 							</div>
 						</div>
-						<div class="form-group row">
-							<div class="col-sm-offset-3 offset-md-3 col-sm-7 col-md-7">
-								<div class="forgot_link">
-									<a href="/identity/person/passwordReminder.htm"
-										style="color: blue;"> <h:outputText
-											value="#{msgs['login.forgotYourPassword']}" />
-									</a>
-								</div>
-							</div>
-						</div>
+						
 						<h:panelGroup layout="block" rendered="#{not empty facesContext.messageList and cookie['X-Correlation-Id'] != null}">
 							<br/>
 							<p style="font-size: 0.7em">


### PR DESCRIPTION
 Removed "Forgot Password" link from login pages named logon.xhtml under the file location jans-auth-server\server\src\main\webapp\auth\apple\login.xhtml  and  jans-auth-server\server\src\main\webapp\auth\google\login.xhtml

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
