### PR TITLE
fix(jans-cli-tui): adjust entries per page dynamiccally

### DIFF
--- a/jans-cli-tui/cli_tui/jans_cli_tui.py
+++ b/jans-cli-tui/cli_tui/jans_cli_tui.py
@@ -147,7 +147,6 @@ def do_exit(*c) -> None:
 
 class JansCliApp(Application):
 
-    entries_per_page = 20 # we can make this configurable
 
     def __init__(self):
 
@@ -229,6 +228,13 @@ class JansCliApp(Application):
 
         self.create_background_task(self.check_jans_cli_ini())
 
+    @property
+    def entries_per_page(self):
+        if self.output.get_size().rows > 31:
+            return 20
+        if self.output.get_size().rows > 26:
+            return 15
+        return 10
 
     async def progress_coroutine(self) -> None:
         """asyncio corotune for progress bar

--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/main.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/main.py
@@ -652,7 +652,7 @@ class Plugin(DialogUtils):
             data.sort()
             buttons = []
 
-            if len(data) > 20:
+            if len(data) > self.app.entries_per_page:
 
                 if start_index!=0:
                     handler_partial = partial(self.oauth_update_properties, start_index-1, pattern)
@@ -660,13 +660,13 @@ class Plugin(DialogUtils):
                     prev_button.window.jans_help = _("Displays previous %d entries") % self.app.entries_per_page
                     buttons.append(prev_button)
 
-                if start_index< int(len(data)/ 20) :
+                if start_index< int(len(data)/ self.app.entries_per_page) :
                     handler_partial = partial(self.oauth_update_properties, start_index+1, pattern)
                     next_button = Button(_("Next"), handler=handler_partial)
                     next_button.window.jans_help = _("Displays next %d entries") % self.app.entries_per_page
                     buttons.append(next_button)
 
-            data_now = data[start_index*20:start_index*20+20]
+            data_now = data[start_index*self.app.entries_per_page:start_index*self.app.entries_per_page+self.app.entries_per_page]
 
             properties =VSplit([
                 Label(text=" ",width=1),

--- a/jans-cli-tui/cli_tui/plugins/070_users/edit_user_dialog.py
+++ b/jans-cli-tui/cli_tui/plugins/070_users/edit_user_dialog.py
@@ -215,7 +215,7 @@ class EditUserDialog(JansGDialog, DialogUtils):
         for claim in common_data.jans_attributes:
             if not claim['oxMultiValuedAttribute'] and claim['name'] in cur_claims:
                 continue
-            if claim['name'] in ('memberOf', 'userPassword', 'uid', 'status', 'jansActive', 'updatedAt', 'jansAdminUIRole'):
+            if claim['name'] in ('memberOf', 'userPassword', 'uid', 'status', 'jansActive', 'updatedAt', 'jansAdminUIRole', 'jansStatus'):
                 continue
             if claim.get('status') == 'active':
                 claims_list.append((claim['name'], claim['displayName']))


### PR DESCRIPTION
Closes #11790

In this PR, **jansStatus** is removed from available claims for users as mentioned in #8258

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
