### PR TITLE
fix(jans-auth): duplicate entry exception in start login flow #9322

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/AcrService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/AcrService.java
@@ -180,7 +180,7 @@ public class AcrService {
 
                     sessionUser.setState(SessionIdState.UNAUTHENTICATED);
                     sessionUser.getSessionAttributes().put("prompt", authzRequest.getPrompt());
-                    if (!sessionIdService.persistSessionId(sessionUser)) {
+                    if (!sessionIdService.persistSessionId(sessionUser, false, true)) {
                         log.trace("Unable persist session_id, trying to update it.");
                         sessionIdService.updateSessionId(sessionUser);
                     }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/SessionIdService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/SessionIdService.java
@@ -573,6 +573,11 @@ public class SessionIdService {
     }
 
     public boolean persistSessionId(final SessionId sessionId, boolean forcePersistence) {
+        return persistSessionId(sessionId, forcePersistence, false);
+    }
+
+
+    public boolean persistSessionId(final SessionId sessionId, boolean forcePersistence, boolean silent) {
         List<Prompt> prompts = getPromptsFromSessionId(sessionId);
 
         try {
@@ -594,7 +599,9 @@ public class SessionIdService {
                 return true;
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            if (!silent) { // do not log anything if method is explicitly called with silent=true
+                log.error(e.getMessage(), e);
+            }
         }
 
         return false;


### PR DESCRIPTION
### Description

fix(jans-auth): duplicate entry exception in start login flow 

#### Target issue
  
closes #9322

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
