### PR TITLE
chore(jans-keycloak-integration): bump keycloak client version to 26.0.6

### DIFF
--- a/jans-keycloak-integration/pom.xml
+++ b/jans-keycloak-integration/pom.xml
@@ -19,7 +19,7 @@
       <maven.min-version>3.3.9</maven.min-version>
       <maven.compiler.source>17</maven.compiler.source>
       <maven.compiler.target>17</maven.compiler.target>
-      <keycloak-server.version>26.0.5</keycloak-server.version>
+      <keycloak-client.version>26.0.6</keycloak-client.version>
       <nimbus.oauth-sdk.version>11.13</nimbus.oauth-sdk.version>
       <nimbus.oauth2-oidc-sdk.version>11.13</nimbus.oauth2-oidc-sdk.version>
       <jackson.coreutils.version>1.8</jackson.coreutils.version>
@@ -95,49 +95,49 @@
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-core</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-server.version}</version>
+          <version>${keycloak-client.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-server-spi</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-server.version}</version>
+          <version>${keycloak-client.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-server-spi-private</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-server.version}</version>
+          <version>${keycloak-client.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-services</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-server.version}</version>
+          <version>${keycloak-client.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-model-legacy</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-server.version}</version>
+          <version>${keycloak-client.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-admin-client</artifactId>
           <scope>compile</scope>
-          <version>${keycloak-server.version}</version>
+          <version>${keycloak-client.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-saml-core-public</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-server.version}</version>
+          <version>${keycloak-client.version}</version>
         </dependency>
 
         <!-- end keycloak dependencies-->


### PR DESCRIPTION
Bump keycloak client version to 26.0.6.

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #11815 