### PR TITLE
feat(jans-config-api): restore jans-config-api plugins jans-link-plugin

### DIFF
--- a/jans-config-api/plugins/pom.xml
+++ b/jans-config-api/plugins/pom.xml
@@ -17,10 +17,12 @@
 
 	<modules>
 		<module>admin-ui-plugin</module>
+		<module>jans-link-plugin</module>
 		<module>scim-plugin</module>
 		<module>user-mgt-plugin</module>
 		<module>fido2-plugin</module>
 		<module>kc-saml-plugin</module>
+		<module>kc-link-plugin</module>
 	    <module>lock-plugin</module>		
 	</modules>
 


### PR DESCRIPTION
#11837
  
closes #11837

- [X] **I confirm that there is no impact on the docs due to the code changes in this PR.**
