### PR TITLE
fix(jans-linux-setup): KC version 26.3.2

### DIFF
--- a/debian-13-mysql.txt
+++ b/debian-13-mysql.txt
@@ -1,0 +1,9 @@
+wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-server_9.2.0-1debian13_amd64.deb
+wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-server_9.2.0-1debian12_amd64.deb
+wget https://downloads.mysql.com/archives/get/p/23/file/mysql-common_9.2.0-1debian12_amd64.deb
+wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-server-core_9.2.0-1debian12_amd64.deb
+wget https://downloads.mysql.com/archives/get/p/23/file/mysql-client_9.2.0-1debian12_amd64.deb
+wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client_9.2.0-1debian12_amd64.deb
+wget http://ftp.de.debian.org/debian/pool/main/liba/libaio/libaio1_0.3.113-4_amd64.deb
+wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-core_9.2.0-1debian12_amd64.deb
+wget https://downloads.mysql.com/archives/get/p/23/file/mysql-community-client-plugins_9.2.0-1debian12_amd64.deb

--- a/jans-linux-setup/jans_setup/app_info.json
+++ b/jans-linux-setup/jans_setup/app_info.json
@@ -18,6 +18,6 @@
   "PYCRONTAB": "https://gitlab.com/doctormo/python-crontab/-/archive/v3.2.0/python-crontab-v3.2.0.zip",
   "TWILIO_MAVEN": "https://repo1.maven.org/maven2/com/twilio/sdk/twilio/",
   "TWILIO_VERSION": "7.17.0",
-  "KC_VERSION": "26.0.6",
+  "KC_VERSION": "26.3.2",
   "OPA_VERSION": "v0.60.0"
 }


### PR DESCRIPTION
Closes #11891 

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
