### PR TITLE
docs(lock): fix broken Cedarling links in More Information section

### DIFF
--- a/docs/janssen-server/lock/README.md
+++ b/docs/janssen-server/lock/README.md
@@ -130,8 +130,8 @@ is no data for the policies to evaluate. The Cedarling creates the Resource and
 ## More information
 
 * Lock Server configuration and operation [docs](./lock-server.md) 
-* Cedarling [docs](../../../docs/cedarling.md)
-* Cedarling [Readme](https://github.com/JanssenProject/jans/blob/main/jans-lock/cedarling/README.md)
+* Cedarling [docs](../../../docs/cedarling/README.md)
+* Cedarling [Readme](https://github.com/JanssenProject/jans/blob/main/jans-cedarling/README.md)
 * Cedarling [Training](.) (coming soon)
 
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
closes #11916

#### Implementation Details

This PR fixes two broken links in the "More Information" section of the Lock server documentation:

- **Cedarling docs**  
  The link was pointing to `https://docs.jans.io/docs/cedarling.md`, which returned 404.  
  ✅ Fixed to point to `https://docs.jans.io/stable/cedarling/` by updating the relative path to:  
  `../../../docs/cedarling/README.md`

- **Cedarling README on GitHub**  
  The link was pointing to `https://github.com/JanssenProject/jans/blob/main/jans-lock/cedarling/README.md`, which does not exist.  
  ✅ Updated to point to the correct repository path:  
  `https://github.com/JanssenProject/jans/blob/main/jans-cedarling/README.md`

-------------------

### Test and Document the changes

- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
