### PR TITLE
fix(jans-linux-setup): session argument for get_sqlalchObj_for_dn

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/db_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/db_utils.py
@@ -319,7 +319,7 @@ class DBUtils:
 
             if backend_location in (BackendTypes.MYSQL, BackendTypes.PGSQL):
                 with self.local_session.begin() as session:
-                    sqlalchemy_obj = self.get_sqlalchObj_for_dn(dn)
+                    sqlalchemy_obj = self.get_sqlalchObj_for_dn(dn, session)
                     if sqlalchemy_obj:
                         session.delete(sqlalchemy_obj)
 


### PR DESCRIPTION
Closes #11934 

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
