### PR TITLE
fix(jans-linux-setup): jans-scim-model.jar is not a provider for KC

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans_saml.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans_saml.py
@@ -177,7 +177,7 @@ class JansSamlInstaller(BaseInstaller, SetupUtils):
 
 
     def deploy_jans_keycloak_providers(self):
-        self.copyFile(self.source_files[0][0], self.idp_config_providers_dir)
+        #self.copyFile(self.source_files[0][0], self.idp_config_providers_dir)
         self.copyFile(self.source_files[5][0], self.idp_config_providers_dir)
         base.unpack_zip(self.source_files[6][0], self.idp_config_providers_dir)
 

--- a/jans-linux-setup/jans_setup/static/system/systemd/kc.service
+++ b/jans-linux-setup/jans_setup/static/system/systemd/kc.service
@@ -9,6 +9,7 @@ Environment="KEYCLOAK_ADMIN=admin"
 Environment="KEYCLOAK_ADMIN_PASSWORD=admin"
 Environment="JAVA_OPTS_APPEND=-Djans.base=%(jansBaseFolder)s"
 ExecStart=%(idp_config_data_dir)s/bin/kc.sh start-dev
+StandardError=file:%(idp_config_data_dir)s/logs/stderr.log
 
 User=jetty
 Group=jetty


### PR DESCRIPTION
Closes #11967

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
