### PR TITLE
fix(jans-cedarling): Fix auth0 trailing slash issue in issuer validation

### DIFF
--- a/jans-cedarling/cedarling/src/common/issuer_utils.rs
+++ b/jans-cedarling/cedarling/src/common/issuer_utils.rs
@@ -1,0 +1,50 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+/// Normalizes an issuer URL by removing trailing slashes
+/// This handles cases where IDPs like Auth0 return issuers with trailing slashes
+/// but the policy store configuration might not have them
+pub fn normalize_issuer(issuer: &str) -> String {
+    issuer.trim_end_matches('/').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_issuer() {
+        // Test that trailing slashes are removed
+        assert_eq!(
+            normalize_issuer("https://dev-1e737fn2gji0j3fe.us.auth0.com/"),
+            "https://dev-1e737fn2gji0j3fe.us.auth0.com"
+        );
+        
+        // Test that issuers without trailing slashes are unchanged
+        assert_eq!(
+            normalize_issuer("https://dev-1e737fn2gji0j3fe.us.auth0.com"),
+            "https://dev-1e737fn2gji0j3fe.us.auth0.com"
+        );
+        
+        // Test that multiple trailing slashes are removed
+        assert_eq!(
+            normalize_issuer("https://example.com///"),
+            "https://example.com"
+        );
+        
+        // Test that non-URL strings are handled correctly
+        assert_eq!(normalize_issuer("test///"), "test");
+        assert_eq!(normalize_issuer("test"), "test");
+        
+        // Test edge cases
+        assert_eq!(normalize_issuer(""), "");
+        assert_eq!(normalize_issuer("/"), "");
+        assert_eq!(normalize_issuer("///"), "");
+        assert_eq!(normalize_issuer("https://example.com"), "https://example.com");
+        assert_eq!(normalize_issuer("https://example.com/"), "https://example.com");
+        assert_eq!(normalize_issuer("https://example.com/path"), "https://example.com/path");
+        assert_eq!(normalize_issuer("https://example.com/path/"), "https://example.com/path");
+    }
+}

--- a/jans-cedarling/cedarling/src/common/mod.rs
+++ b/jans-cedarling/cedarling/src/common/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod app_types;
 pub(crate) mod cedar_schema;
 pub(crate) mod json_rules;
 
+pub mod issuer_utils;
 pub mod policy_store;
 
 /// Used for decoding the policy and schema metadata

--- a/jans-cedarling/cedarling/src/entity_builder/mod.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/mod.rs
@@ -24,6 +24,7 @@ use crate::authz::AuthorizeEntitiesData;
 use crate::authz::request::EntityData;
 use crate::common::PartitionResult;
 use crate::common::policy_store::{ClaimMappings, TrustedIssuer};
+use crate::common::issuer_utils::normalize_issuer;
 use crate::entity_builder::build_principal_entity::BuiltPrincipalUnsigned;
 use crate::jwt::Token;
 use crate::{RequestUnsigned, entity_builder_config::*};
@@ -57,7 +58,7 @@ impl EntityBuilder {
         let (ok, errs) = trusted_issuers
             .values()
             .map(|iss| {
-                let iss_id = iss.oidc_endpoint.origin().ascii_serialization();
+                let iss_id = normalize_issuer(&iss.oidc_endpoint.origin().ascii_serialization());
                 build_iss_entity(&config.entity_names.iss, &iss_id, iss, schema.as_ref())
             })
             .partition_result();

--- a/jans-cedarling/cedarling/src/jwt/validation/validator_cache.rs
+++ b/jans-cedarling/cedarling/src/jwt/validation/validator_cache.rs
@@ -5,6 +5,7 @@
 
 use crate::jwt::log_entry::JwtLogEntry;
 use crate::jwt::{IssuerConfig, StatusListCache};
+use crate::common::issuer_utils::normalize_issuer;
 use crate::log::Logger;
 use crate::{JwtConfig, LogLevel, LogWriter};
 
@@ -44,13 +45,13 @@ impl JwtValidatorCache {
         let iss = iss_config
             .openid_config
             .as_ref()
-            .map(|oidc| oidc.issuer.clone())
+            .map(|oidc| normalize_issuer(&oidc.issuer))
             .unwrap_or_else(|| {
-                iss_config
+                normalize_issuer(&iss_config
                     .policy
                     .oidc_endpoint
                     .origin()
-                    .ascii_serialization()
+                    .ascii_serialization())
             });
 
         for (token_name, tkn_metadata) in iss_config.policy.token_metadata.iter() {
@@ -240,7 +241,7 @@ impl OwnedValidatorInfo {
             return false;
         }
 
-        if self.token_kind.is_equal_to(&other.token_kind) {
+        if !self.token_kind.is_equal_to(&other.token_kind) {
             return false;
         }
 

--- a/jans-cedarling/cedarling/src/lock/mod.rs
+++ b/jans-cedarling/cedarling/src/lock/mod.rs
@@ -93,6 +93,7 @@ mod register_client;
 pub mod ssa_validation;
 
 use crate::app_types::PdpID;
+use crate::common::issuer_utils::normalize_issuer;
 use crate::log::LoggerWeak;
 use crate::log::interface::Loggable;
 use crate::{LockServiceConfig, LogWriter};
@@ -168,7 +169,7 @@ impl LockService {
             // Get the JWKS URI from the IDP URL (not the lock server URL)
             let jwks_uri = format!(
                 "{}/jans-auth/restv1/jwks",
-                lock_config.issuer_oidc_url.0.origin().ascii_serialization()
+                normalize_issuer(&lock_config.issuer_oidc_url.0.origin().ascii_serialization())
             );
 
             // Validate the SSA JWT


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Cedarling was failing to validate JWT tokens from Auth0 because Auth0 returns the `iss` claim with trailing slash.

#### Target issue
  
closes #11990

#### Implementation Details

Implement issuer URL normalization to automatically remove trailing slashes during JWT validation.

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
