### PR TITLE
chore(jans-bom): dependency upgrade org.eclipse.angus:smtp 2.0.3 -> 2.0.4 #11999

### DIFF
--- a/jans-bom/pom.xml
+++ b/jans-bom/pom.xml
@@ -345,7 +345,7 @@
 			<dependency>
 				<groupId>org.eclipse.angus</groupId>
 				<artifactId>angus-mail</artifactId>
-				<version>2.0.3</version>
+				<version>2.0.4</version>
 			</dependency>
 			<dependency>
 				<groupId>com.sun.mail</groupId>


### PR DESCRIPTION
### Description

chore(jans-bom): dependency upgrade org.eclipse.angus:smtp 2.0.3 -> 2.0.4 

#### Target issue
  
closes #11999

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
