### PR TITLE
fix(jans-keycloak-integration): kc health and metrics endpoint throw error #12001

### DIFF
--- a/jans-keycloak-integration/pom.xml
+++ b/jans-keycloak-integration/pom.xml
@@ -369,8 +369,13 @@
                 <excludeTransitive>false</excludeTransitive>
                 <excludeGroupIds>
                   com.sun.activation,
+                  com.sun.mail,
                   jakarta.activation,
                   jakarta.annotation,
+                  jakarta.enterprise,
+                  jakarta.inject,
+                  jakarta.interceptor,
+                  jakarta.mail,
                   jakarta.servlet,
                   jakarta.validation,
                   jakarta.xml.bind,


### PR DESCRIPTION


added exclusions for dependencies already provided by quarkus which created a conflict

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
