### PR TITLE
fix(jans-keycloak-integration): keycloak versioning issues #12019

### DIFF
--- a/jans-keycloak-integration/pom.xml
+++ b/jans-keycloak-integration/pom.xml
@@ -19,7 +19,8 @@
       <maven.min-version>3.3.9</maven.min-version>
       <maven.compiler.source>17</maven.compiler.source>
       <maven.compiler.target>17</maven.compiler.target>
-      <keycloak-client.version>26.0.6</keycloak-client.version>
+      <keycloak-admin-client.version>26.0.6</keycloak-admin-client.version>
+      <keycloak-server.version>26.3.2</keycloak-server.version>
       <nimbus.oauth-sdk.version>11.13</nimbus.oauth-sdk.version>
       <nimbus.oauth2-oidc-sdk.version>11.13</nimbus.oauth2-oidc-sdk.version>
       <jackson.coreutils.version>1.8</jackson.coreutils.version>
@@ -95,49 +96,49 @@
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-core</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-client.version}</version>
+          <version>${keycloak-server.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-server-spi</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-client.version}</version>
+          <version>${keycloak-server.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-server-spi-private</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-client.version}</version>
+          <version>${keycloak-server.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-services</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-client.version}</version>
+          <version>${keycloak-server.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-model-legacy</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-client.version}</version>
+          <version>${keycloak-server.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-admin-client</artifactId>
           <scope>compile</scope>
-          <version>${keycloak-client.version}</version>
+          <version>${keycloak-admin-client.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-saml-core-public</artifactId>
           <scope>provided</scope>
-          <version>${keycloak-client.version}</version>
+          <version>${keycloak-server.version}</version>
         </dependency>
 
         <!-- end keycloak dependencies-->


### PR DESCRIPTION
* split the keycloak server jar version from the keycloak admin api jar version

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
