### PR TITLE
fix(jans-auth-server): client registration script jwks is not used during validation #12036

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/register/ws/rs/RegisterValidator.java
@@ -242,6 +242,7 @@ public class RegisterValidator {
                 log.error("No jwks provided in Dynamic Client Registration script (method getDcrJwks didn't return actual jwks). ");
                 throw errorResponseFactory.createWebApplicationException(Response.Status.BAD_REQUEST, RegisterErrorResponseType.INVALID_SOFTWARE_STATEMENT, "");
             }
+            return jwks;
         }
         return null;
     }


### PR DESCRIPTION
### Description

fix(jans-auth-server): client registration script jwks is not used during validation

#### Target issue
  
closes #12036

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
