### PR TITLE
(jans-fido2): removed unused fields and fix the typo issue

### DIFF
--- a/docker-jans-fido2/scripts/upgrade.py
+++ b/docker-jans-fido2/scripts/upgrade.py
@@ -22,8 +22,6 @@ def _transform_fido2_dynamic_config(conf):
 
     # add missing top-level config (if not exist)
     for k, v in [
-        ("errorReasonEnabled", False),
-        ("sessionIdPersistInCache", False),
     ]:
         # update if key not exist
         if k not in conf:
@@ -38,7 +36,7 @@ def _transform_fido2_dynamic_config(conf):
         ("enterpriseAttestation", False),
         ("hints", ["security-key", "client-device", "hybrid"]),
         ("rp", conf["fido2Configuration"].pop("requestedParties", [])),
-        ("metadataRefreshInterval", 180),
+
         ("disableMetadataService", conf["fido2Configuration"].pop("skipDownloadMdsEnabled", False)),
     ]:
         # update if key not exist

--- a/docs/janssen-server/reference/json/properties/fido2-properties.md
+++ b/docs/janssen-server/reference/json/properties/fido2-properties.md
@@ -21,7 +21,7 @@ tags:
 | issuer                          | URL using the https scheme for Issuer identifier                                              | [Details](#issuer)                          |
 | loggingLayout                   | Logging layout used for Fido2                                                                 | [Details](#logginglayout)                   |
 | loggingLevel                    | Logging level for Fido2 logger                                                                | [Details](#logginglevel)                    |
-| mdsAccessToken                  | MDS access token                                                                              | [Details](#mdsaccesstoken)                  |
+
 | mdsCertsFolder                  | MDS TOC root certificates folder                                                              | [Details](#mdscertsfolder)                  |
 | mdsTocsFolder                   | MDS TOC files folder                                                                          | [Details](#mdstocsfolder)                   |
 | metadataUrlsProvider            | String value to provide source of URLs with external metadata                                 | [Details](#metadataurlsprovider)            |
@@ -32,7 +32,7 @@ tags:
 | enabledFidoAlgorithms           | List of Requested Credential Types                                                            | [Details](#enabledFidoAlgorithms)           |
 | rp                              | Requested Parties Authenticators metadata in json format                                      | [Details](#rp)                              |
 | serverMetadataFolder            | Authenticators metadata in json format                                                        | [Details](#servermetadatafolder)            |
-| sessionIdPersistInCache         | Boolean value specifying whether to persist session_id in cache                               | [Details](#sessionidpersistincache)         |
+
 | unfinishedRequestExpiration     | Expiration time in seconds for pending enrollment/authentication requests                     | [Details](#unfinishedrequestexpiration)     |
 | useLocalCache                   | Boolean value to indicate if Local Cache is to be used                                        | [Details](#uselocalcache)                   |
 | debugUserAutoEnrollment         | Allow to enroll users on enrollment/authentication requests                                   | [Details](#userautoenrollment)              |
@@ -137,13 +137,7 @@ tags:
 - Default value: None
 
 
-### mdsAccessToken
 
-- Description: MDS access token
-
-- Required: No
-
-- Default value: None
 
 
 ### mdsCertsFolder
@@ -237,13 +231,7 @@ tags:
 
 
 
-### sessionIdPersistInCache
 
-- Description: Boolean value specifying whether to persist session_id in cache
-
-- Required: No
-
-- Default value: false
 
 
 ### unfinishedRequestExpiration

--- a/jans-cli-tui/cli_tui/plugins/020_fido/main.py
+++ b/jans-cli-tui/cli_tui/plugins/020_fido/main.py
@@ -172,7 +172,7 @@ class Plugin(DialogUtils):
 
         self.tabs['static'] = HSplit([
                                 self.app.getTitledText(_("Authenticator Certificates Folder"), name='authenticatorCertsFolder', value=fido2_static_config.get('authenticatorCertsFolder',''), jans_help=self.app.get_help_from_schema(static_schema, 'authenticatorCertsFolder'), style='class:outh-scope-text',widget_style=cli_style.black_bg_widget),
-                                self.app.getTitledText(_("MDS Access Token"), name='mdsAccessToken', value=fido2_static_config.get('mdsAccessToken',''), jans_help=self.app.get_help_from_schema(static_schema, 'mdsAccessToken'), style='class:outh-scope-text',widget_style=cli_style.black_bg_widget),
+
                                 self.app.getTitledText(_("MDS TOC Certificates Folder"), name='mdsCertsFolder', value=fido2_static_config.get('mdsCertsFolder',''), jans_help=self.app.get_help_from_schema(static_schema, 'mdsCertsFolder'), style='class:outh-scope-text',widget_style=cli_style.black_bg_widget),
                                 self.app.getTitledText(_("MDS TOC Files Folder"), name='mdsTocsFolder', value=fido2_static_config.get('mdsTocsFolder',''), jans_help=self.app.get_help_from_schema(static_schema, 'mdsTocsFolder'), style='class:outh-scope-text',widget_style=cli_style.black_bg_widget),
                                 self.app.getTitledCheckBox(_("Check U2f Attestations"), name='checkU2fAttestations', checked=fido2_static_config.get('checkU2fAttestations'), jans_help=self.app.get_help_from_schema(static_schema, 'checkU2fAttestations'), style=cli_style.check_box,widget_style=cli_style.black_bg_widget),

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/AppConfiguration.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/AppConfiguration.java
@@ -72,11 +72,9 @@ public class AppConfiguration implements Configuration, Serializable {
     private List<String> personCustomObjectClassList;
 	
 	
-    @DocProperty(description = "Boolean value specifying whether to persist session_id in cache", defaultValue = "false")
-    private Boolean sessionIdPersistInCache = false;
+
 	
-	@DocProperty(description = "Boolean value specifying whether to return detailed reason of the error from Fido2. Default value is false", defaultValue = "false")
-	private Boolean errorReasonEnabled = false;
+
 
     private Fido2Configuration fido2Configuration;
 
@@ -193,20 +191,7 @@ public class AppConfiguration implements Configuration, Serializable {
 	}
 
 	
-    public Boolean getSessionIdPersistInCache() {
-        if (sessionIdPersistInCache == null) sessionIdPersistInCache = false;
-        return sessionIdPersistInCache;
-    }
 
-    public void setSessionIdPersistInCache(Boolean sessionIdPersistInCache) {
-        this.sessionIdPersistInCache = sessionIdPersistInCache;
-    }
 
-	public Boolean getErrorReasonEnabled() {
-		return errorReasonEnabled;
-	}
 
-	public void setErrorReasonEnabled(Boolean errorReasonEnabled) {
-		this.errorReasonEnabled = errorReasonEnabled;
-	}
 }

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
@@ -34,7 +34,8 @@ public class Fido2Configuration {
 	@DocProperty(description = "Expiration time in seconds for pending enrollment/authentication requests")
 	private int unfinishedRequestExpiration = 120; // 120 seconds
 	@DocProperty(description = "Expiration time in seconds for approved authentication requests")
-	private int metadataRefreshInterval = 15 * 24 * 3600; // 15 days
+	private int authenticationHistoryExpiration = 15 * 24 * 3600; // 15 days
+
 	@DocProperty(description = "Authenticators metadata in json format")
 	private String serverMetadataFolder;
 	@DocProperty(description = "List of Requested Credential Types")
@@ -117,12 +118,14 @@ public class Fido2Configuration {
 		this.enterpriseAttestation = enterpriseOnly;
 	}
 
-	public int getMetadataRefreshInterval() {
-		return metadataRefreshInterval;
+
+
+	public int getAuthenticationHistoryExpiration() {
+		return authenticationHistoryExpiration;
 	}
 
-	public void setMetadataRefreshInterval(int metadataRefreshInterval) {
-		this.metadataRefreshInterval = metadataRefreshInterval;
+	public void setAuthenticationHistoryExpiration(int authenticationHistoryExpiration) {
+		this.authenticationHistoryExpiration = authenticationHistoryExpiration;
 	}
 
 	
@@ -167,9 +170,9 @@ public class Fido2Configuration {
 		this.attestationMode = attestationMode;
 	}
 
-	public Fido2Configuration(String authenticatorCertsFolder, String mdsAccessToken, String mdsCertsFolder,
+	public Fido2Configuration(String authenticatorCertsFolder, String mdsCertsFolder,
 			String mdsTocsFolder, boolean checkU2fAttestations, boolean debugUserAutoEnrollment,
-			int unfinishedRequestExpiration, int metadataRefreshInterval, String serverMetadataFolder,
+			int unfinishedRequestExpiration, int authenticationHistoryExpiration, String serverMetadataFolder,
 			List<String> enabledFidoAlgorithms, List<RequestedParty> requestedParties,
 			List<MetadataServer> metadataServers, boolean disableMetadataService, String attestationMode,
 			List<String> hints, boolean enterpriseAttestation) {
@@ -181,7 +184,7 @@ public class Fido2Configuration {
 
 		this.userAutoEnrollment = debugUserAutoEnrollment;
 		this.unfinishedRequestExpiration = unfinishedRequestExpiration;
-		this.metadataRefreshInterval = metadataRefreshInterval;
+		this.authenticationHistoryExpiration = authenticationHistoryExpiration;
 		this.serverMetadataFolder = serverMetadataFolder;
 		this.enabledFidoAlgorithms = enabledFidoAlgorithms;
 		this.requestedParties = requestedParties;
@@ -200,7 +203,7 @@ public class Fido2Configuration {
 		return "Fido2Configuration [authenticatorCertsFolder=" + authenticatorCertsFolder + ", mdsCertsFolder="
 				+ mdsCertsFolder + ", mdsTocsFolder=" + mdsTocsFolder + ", userAutoEnrollment="
 				+ userAutoEnrollment + ", unfinishedRequestExpiration=" + unfinishedRequestExpiration
-				+ ", metadataRefreshInterval=" + metadataRefreshInterval + ", serverMetadataFolder="
+				+ ", authenticationHistoryExpiration=" + authenticationHistoryExpiration + ", serverMetadataFolder="
 				+ serverMetadataFolder + ", enabledFidoAlgorithms=" + enabledFidoAlgorithms + ", requestedParties="
 				+ requestedParties + ", metadataServers=" + metadataServers + ", disableMetadataService="
 				+ disableMetadataService + ", hints=" + hints + ", enterpriseAttestation=" + enterpriseAttestation

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/error/ErrorResponseFactory.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/error/ErrorResponseFactory.java
@@ -91,7 +91,7 @@ public class ErrorResponseFactory implements Configuration {
 
     private String errorAsJson(IErrorType type, String reason) {
         final DefaultErrorResponse error = getErrorResponse(type);
-        error.setReason(BooleanUtils.isTrue(appConfiguration.getErrorReasonEnabled()) ? reason : "");
+        error.setReason(reason);
         return error.toJSonString();
     }
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
@@ -332,8 +332,8 @@ public class AssertionService {
 		authenticationData.setStatus(Fido2AuthenticationStatus.authenticated);
 
 		// Set expiration
-		int unfinishedRequestExpiration = appConfiguration.getFido2Configuration().getMetadataRefreshInterval();
-		authenticationEntity.setExpiration(unfinishedRequestExpiration);
+		int authenticationHistoryExpiration = appConfiguration.getFido2Configuration().getAuthenticationHistoryExpiration();
+		authenticationEntity.setExpiration(authenticationHistoryExpiration);
 
 		authenticationPersistenceService.update(authenticationEntity);
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/UserSessionIdService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/UserSessionIdService.java
@@ -118,19 +118,8 @@ public class UserSessionIdService {
     }
 
     public void updateSessionId(SessionId entity) {
-        if (isTrue(appConfiguration.getSessionIdPersistInCache())) {
-        	// Reuse existing expiration
-        	int expirationInSeconds = (int) ((entity.getExpirationDate().getTime() - new Date().getTime()) / 1000);
-        	
-        	// Make sure that expiration is bigger than zero
-        	if (expirationInSeconds <= 0) {
-        		expirationInSeconds = CacheService.DEFAULT_EXPIRATION;
-        	}
-            cacheService.put(expirationInSeconds, entity.getDn(), entity);
-        } else {
-        	entity.setLastUsedAt(new Date());
-	        persistenceEntryManager.merge(entity);
-        }
+    	entity.setLastUsedAt(new Date());
+        persistenceEntryManager.merge(entity);
 	}
 
     private SessionId getSessionId(String sessionId) {
@@ -141,13 +130,9 @@ public class UserSessionIdService {
         final SessionId entity;
         try {
         	String sessionDn = buildDn(sessionId);
-            if (isTrue(appConfiguration.getSessionIdPersistInCache())) {
-            	entity = (SessionId) cacheService.get(sessionDn);
-            } else {
-	            entity = persistenceEntryManager.find(SessionId.class, sessionDn);
-	            if (entity == null) {
-	                log.warn("Failed to load session id '{}'", sessionId);
-	            }
+            entity = persistenceEntryManager.find(SessionId.class, sessionDn);
+            if (entity == null) {
+                log.warn("Failed to load session id '{}'", sessionId);
             }
         } catch (Exception ex) {
             log.trace(ex.getMessage(), ex);

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/AttestationVerifierTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/AttestationVerifierTest.java
@@ -175,7 +175,7 @@ class AttestationVerifierTest {
         when(authenticatorDataParser.parseAttestationData(authDataText)).thenReturn(authData);
         when(attestationProcessorFactory.getCommandProcessor(fmt)).thenReturn(attestationProcessor);
 
-        Fido2Configuration fido2Configuration = new Fido2Configuration(null, null, null,
+        Fido2Configuration fido2Configuration = new Fido2Configuration(null, null,
                 null, false, false,
                 0, 0, null,
                 null, null, null, false,
@@ -215,7 +215,7 @@ class AttestationVerifierTest {
         when(authenticatorDataParser.parseAttestationData(authDataText)).thenReturn(authData);
         when(attestationProcessorFactory.getCommandProcessor(fmt)).thenReturn(attestationProcessor);
 
-        Fido2Configuration fido2Configuration = new Fido2Configuration(null, null, null,
+        Fido2Configuration fido2Configuration = new Fido2Configuration(null, null,
                 null, false, false,
                 0, 0, null,
                 null, null, null, false,
@@ -253,7 +253,7 @@ class AttestationVerifierTest {
         when(authenticatorDataParser.parseAttestationData(authDataText)).thenReturn(authData);
         when(attestationProcessorFactory.getCommandProcessor(fmt)).thenReturn(attestationProcessor);
 
-        Fido2Configuration fido2Configuration = new Fido2Configuration(null, null, null,
+        Fido2Configuration fido2Configuration = new Fido2Configuration(null, null,
                 null, false, false,
                 0, 0, null,
                 null, null, null, false,
@@ -291,7 +291,7 @@ class AttestationVerifierTest {
         when(authenticatorDataParser.parseAttestationData(authDataText)).thenReturn(authData);
         when(attestationProcessorFactory.getCommandProcessor(fmt)).thenReturn(attestationProcessor);
 
-        Fido2Configuration fido2Configuration = new Fido2Configuration(null, null, null,
+        Fido2Configuration fido2Configuration = new Fido2Configuration(null, null,
                 null, false, false,
                 0, 0, null,
                 null, null, null, false,

--- a/jans-fido2/server/src/test/java/io/jans/fido2/test/integration/Fido2DeviceRegistrationEnhancedTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/test/integration/Fido2DeviceRegistrationEnhancedTest.java
@@ -205,9 +205,7 @@ public class Fido2DeviceRegistrationEnhancedTest {
         assertNotNull(appConfiguration.getFido2Configuration().getAttestationMode(), 
                     "Attestation mode should be configured");
         
-        // Verify metadata settings
-        assertNotNull(appConfiguration.getFido2Configuration().getMetadataRefreshInterval(), 
-                    "Metadata refresh interval should be configured");
+
         
         log.info("Comprehensive configuration validation passed");
         log.info("Requested Parties: {}", requestedParties.size());
@@ -328,11 +326,7 @@ public class Fido2DeviceRegistrationEnhancedTest {
         log.info("Testing FIDO2 security settings validation");
         
         try {
-            // Verify error reason is enabled for detailed error messages
-            assertTrue(appConfiguration.getErrorReasonEnabled(), "Error reason should be enabled for testing");
-            
-            // Verify session persistence settings
-            assertFalse(appConfiguration.getSessionIdPersistInCache(), "Session ID should not persist in cache for security");
+            // Verify logging settings
             
             // Verify logging settings
             assertNotNull(appConfiguration.getLoggingLevel(), "Logging level should be configured");
@@ -345,8 +339,6 @@ public class Fido2DeviceRegistrationEnhancedTest {
             assertNotNull(appConfiguration.getMetricReporterInterval(), "Metric reporter interval should be configured");
             
             log.info("Security settings validation passed");
-            log.info("Error Reason Enabled: {}", appConfiguration.getErrorReasonEnabled());
-            log.info("Session ID Persist in Cache: {}", appConfiguration.getSessionIdPersistInCache());
             log.info("Logging Level: {}", appConfiguration.getLoggingLevel());
             log.info("Metric Reporter Enabled: {}", appConfiguration.getMetricReporterEnabled());
             

--- a/jans-linux-setup/jans_setup/templates/jans-fido2/dynamic-conf.json
+++ b/jans-linux-setup/jans_setup/templates/jans-fido2/dynamic-conf.json
@@ -15,8 +15,7 @@
       "jansCustomPerson",
       "jansPerson"
    ],
-   "sessionIdPersistInCache": false,
-   "errorReasonEnabled": false,
+
    "fido2Configuration":{
       "authenticatorCertsFolder":"%(fido2ConfigFolder)s/authenticator_cert",
       "mdsCertsFolder":"%(fido2ConfigFolder)s/mds/cert",
@@ -38,7 +37,7 @@
 	  
       "userAutoEnrollment":false,
       "unfinishedRequestExpiration":180,
-	  "metadataRefreshInterval":180,
+	  
       "disableMetadataService":false,
       "attestationMode":"monitor",
       "enterpriseAttestation":"false",


### PR DESCRIPTION
### Description
This PR removes deprecated and unused FIDO2 configuration fields (mdsAccessToken, sessionIdPersistInCache, errorReasonEnabled, metadataRefreshInterval) from both Config API and Jans TUI, while fixing a critical typo where metadataRefreshInterval was incorrectly used instead of authenticationHistoryExpiration for setting authentication entry expiration times. The authenticationHistoryExpiration field is now properly implemented with a 15-day default value.

#### Target issue

FIDO2 configuration contains deprecated fields that are no longer used but still appear in API responses and UI components, plus a critical typo where metadataRefreshInterval is incorrectly used instead of authenticationHistoryExpiration for setting authentication entry expiration times, causing the wrong configuration value to be applied.
    
closes #12031  

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
