### PR TITLE
fix(jans-linux-setup): missing python libs for rhel-8

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/data/package_list.json
+++ b/jans-linux-setup/jans_setup/setup_app/data/package_list.json
@@ -14,7 +14,9 @@
     "optional": "",
     "mandatory": "httpd mod_ssl mod_auth_openidc rsyslog postgresql postgresql-contrib postgresql-server",
     "python": {
-      
+      "zipp": "python3-zipp",
+      "typing_extensions": "python3-typing-extensions",
+      "importlib_metadata": "python3-importlib-metadata",
       "requests": "python3-requests",
       "ruamel.yaml": "python3-ruamel-yaml",
       "certifi": "python3-certifi",


### PR DESCRIPTION
Closes #12055

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
