### PR TITLE
fix(jans-linux-setup): typo in Line 551 of scritps.ldif cookie -> logout_status_jwt #12077

### DIFF
--- a/jans-linux-setup/jans_setup/templates/scripts.ldif
+++ b/jans-linux-setup/jans_setup/templates/scripts.ldif
@@ -548,7 +548,7 @@ jansModuleProperty: {"value1":"location_type","value2":"db","description":""}
 jansProgLng: java
 jansRevision: 1
 jansScr::%(logout_status_jwt_logoutstatusjwt)s
-jansScrTyp: cookie
+jansScrTyp: logout_status_jwt
 
 dn: inum=0300-BA90,ou=scripts,o=jans
 objectClass: jansCustomScr


### PR DESCRIPTION
### Description

typo(jans-linux-setup): typo in Line 551 of scritps.ldif cookie -> logout_status_jwt 

#### Target issue
  
closes #12077

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
