### PR TITLE
fix(jans-cli-tui): hide logging plain text password when changing user password

### DIFF
--- a/jans-cli-tui/cli_tui/cli/config_cli.py
+++ b/jans-cli-tui/cli_tui/cli/config_cli.py
@@ -377,9 +377,14 @@ class JCA_CLI:
 
         log_data = copy.deepcopy(data)
         # don't log passwords
+        hpass = '*****'
         for prop in log_data:
             if prop in ('userPassword', 'clientSecret'):
-                log_data[prop] = '*****'
+                log_data[prop] = hpass
+
+        for cad in log_data.get('customAttributes', []):
+            if cad.get('name') == 'userPassword':
+                cad['value'] = hpass
 
         cmdl = [sys.executable, __file__, '--operation-id', operation_id]
         if url_suffix:


### PR DESCRIPTION
Closes #12123

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
