### PR TITLE
feat(jans-cedarling): add data structure for multi-token issuer support

### DIFF
--- a/jans-cedarling/cedarling/src/authz/build_ctx.rs
+++ b/jans-cedarling/cedarling/src/authz/build_ctx.rs
@@ -7,9 +7,11 @@ use super::AuthzConfig;
 use crate::common::cedar_schema::cedar_json::CedarSchemaJson;
 use crate::common::cedar_schema::cedar_json::attribute::Attribute;
 use crate::entity_builder::BuiltEntities;
-use cedar_policy::{ContextJsonError, EntityTypeName, ParseErrors};
+use cedar_policy::EntityTypeName;
 use serde_json::{Value, json, map::Entry};
 use smol_str::ToSmolStr;
+
+use super::errors::BuildContextError;
 
 /// Constructs the authorization context by adding the built entities from the tokens
 pub fn build_context(
@@ -150,27 +152,6 @@ fn map_entity_id(
     } else {
         Err(BuildContextError::MissingEntityId(name.to_string()))
     }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum BuildContextError {
-    /// Error encountered while validating context according to the schema
-    #[error("failed to merge JSON objects due to conflicting keys: {0}")]
-    KeyConflict(String),
-    /// Error encountered while deserializing the Context from JSON
-    #[error(transparent)]
-    DeserializeFromJson(#[from] ContextJsonError),
-    /// Error encountered if the action being used as the reference to build the Context
-    /// is not in the schema
-    #[error("failed to find the action `{0}` in the schema")]
-    UnknownAction(String),
-    /// Error encountered while building entity references in the Context
-    #[error("failed to build entity reference for `{0}` since an entity id was not provided")]
-    MissingEntityId(String),
-    #[error("invalid action context type: {0}. expected: {1}")]
-    InvalidKind(String, String),
-    #[error("failed to parse the entity name `{0}`: {1}")]
-    ParseEntityName(String, ParseErrors),
 }
 
 pub fn merge_json_values(mut base: Value, other: Value) -> Result<Value, BuildContextError> {

--- a/jans-cedarling/cedarling/src/authz/errors.rs
+++ b/jans-cedarling/cedarling/src/authz/errors.rs
@@ -1,0 +1,170 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+use cedar_policy::{ContextJsonError, ParseErrors, RequestValidationError};
+use serde_json::Error as SerdeJsonError;
+
+// Re-export commonly used error types
+pub use crate::common::json_rules::ApplyRuleError;
+pub use crate::entity_builder::{
+    BuildEntityError, BuildUnsignedEntityError, InitEntityBuilderError,
+};
+pub use crate::jwt::{JwtProcessingError, TokenClaimTypeError};
+pub use cedar_policy::entities_errors::EntitiesError;
+
+/// Error type for multi-issuer validation
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub enum MultiIssuerValidationError {
+    #[error("Token input validation failed: {0}")]
+    TokenInput(#[from] TokenInputError),
+
+    #[error("Empty token array")]
+    EmptyTokenArray,
+
+    #[error("Invalid JSON in resource field")]
+    InvalidResourceJson,
+
+    #[error("Invalid JSON in action field")]
+    InvalidActionJson,
+
+    #[error("Invalid JSON in context field")]
+    InvalidContextJson,
+
+    #[error("Invalid token mapping format: {mapping}")]
+    InvalidMappingFormat { mapping: String },
+}
+
+/// Error type for token input validation
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub enum TokenInputError {
+    #[error("Empty mapping string")]
+    EmptyMapping,
+
+    #[error("Invalid mapping format: {mapping}. Expected format: 'Namespace::TokenType'")]
+    InvalidMappingFormat { mapping: String },
+
+    #[error("Empty payload")]
+    EmptyPayload,
+
+    #[error("Invalid JWT format")]
+    InvalidJwtFormat,
+}
+
+/// Error type for Authorization Service initialization
+#[derive(Debug, thiserror::Error)]
+pub enum AuthzServiceInitError {
+    #[error(transparent)]
+    InitEntityBuilder(#[from] InitEntityBuilderError),
+}
+
+/// Error type for Authorization Service
+#[derive(thiserror::Error, Debug)]
+pub enum AuthorizeError {
+    /// Error encountered while processing JWT token data
+    #[error(transparent)]
+    ProcessTokens(#[from] JwtProcessingError),
+    /// Error encountered while parsing Action to EntityUid
+    #[error("could not parse action: {0}")]
+    Action(ParseErrors),
+    /// Error encountered while validating context according to the schema
+    #[error("could not create context: {0}")]
+    CreateContext(#[from] ContextJsonError),
+    /// Error encountered while creating [`cedar_policy::Request`] for entity principal
+    #[error(transparent)]
+    InvalidPrincipal(#[from] InvalidPrincipalError),
+    /// Error encountered while checking if the Entities adhere to the schema
+    #[error("failed to validate Cedar entities: {0:?}")]
+    ValidateEntities(#[from] EntitiesError),
+    /// Error encountered while parsing all entities to json for logging
+    #[error("could convert entities to json: {0}")]
+    EntitiesToJson(SerdeJsonError),
+    /// Error encountered while building the context for the request
+    #[error("Failed to build context: {0}")]
+    BuildContext(#[from] BuildContextError),
+    /// Error encountered while building the context for the request
+    #[error("error while running on strict id token trust mode: {0}")]
+    IdTokenTrustMode(#[from] IdTokenTrustModeError),
+    /// Error encountered while building Cedar Entities
+    #[error(transparent)]
+    BuildEntity(#[from] BuildEntityError),
+    /// Error encountered while executing the rule for principals
+    #[error(transparent)]
+    ExecuteRule(#[from] ApplyRuleError),
+    #[error("failed to build role entities for unsigned request: {0}")]
+    /// Error encountered while building Role entity in an unsigned request
+    BuildUnsignedRoleEntity(#[from] BuildUnsignedEntityError),
+}
+
+/// Error type for ID token trust mode validation
+#[derive(Debug, thiserror::Error)]
+pub enum IdTokenTrustModeError {
+    #[error("the access token's `client_id` does not match with the id token's `aud`")]
+    AccessTokenClientIdMismatch,
+    #[error("an access token is required when using strict mode")]
+    MissingAccessToken,
+    #[error("an id token is required when using strict mode")]
+    MissingIdToken,
+    #[error("the id token's `sub` does not match with the userinfo token's `sub`")]
+    SubMismatchIdTokenUserinfo,
+    #[error("the access token's `client_id` does not match with the userinfo token's `aud`")]
+    ClientIdUserinfoAudMismatch,
+    #[error("missing a required claim `{0}` from `{1}` token")]
+    MissingRequiredClaim(String, String),
+    #[error("invalid claim type in {0} token: {1}")]
+    TokenClaimTypeError(String, TokenClaimTypeError),
+}
+
+/// Error type for building context
+#[derive(Debug, thiserror::Error)]
+pub enum BuildContextError {
+    /// Error encountered while validating context according to the schema
+    #[error("failed to merge JSON objects due to conflicting keys: {0}")]
+    KeyConflict(String),
+    /// Error encountered while deserializing the Context from JSON
+    #[error(transparent)]
+    DeserializeFromJson(#[from] ContextJsonError),
+    /// Error encountered if the action being used as the reference to build the Context
+    /// is not in the schema
+    #[error("failed to find the action `{0}` in the schema")]
+    UnknownAction(String),
+    /// Error encountered while building entity references in the Context
+    #[error("failed to build entity reference for `{0}` since an entity id was not provided")]
+    MissingEntityId(String),
+    #[error("invalid action context type: {0}. expected: {1}")]
+    InvalidKind(String, String),
+    #[error("failed to parse the entity name `{0}`: {1}")]
+    ParseEntityName(String, ParseErrors),
+}
+
+/// Error for creating request role entities
+#[derive(Debug, derive_more::Error, derive_more::Display)]
+#[display("could not create request user entity principal for {uid}: {err}")]
+pub struct CreateRequestRoleError {
+    /// Error value
+    pub err: RequestValidationError,
+    /// Role ID [`EntityUid`] value used for authorization request
+    pub uid: cedar_policy::EntityUid,
+}
+
+/// Error for invalid principal in authorization request
+#[derive(Debug, derive_more::Error, derive_more::Display)]
+#[display("The request for `{principal}` does not conform to the schema: {err}")]
+pub struct InvalidPrincipalError {
+    /// Principal [`EntityUid`] value used for authorization request
+    pub principal: cedar_policy::EntityUid,
+    /// Error value
+    pub err: RequestValidationError,
+}
+
+impl InvalidPrincipalError {
+    pub fn new(principal: &cedar_policy::EntityUid, err: RequestValidationError) -> Self {
+        InvalidPrincipalError {
+            principal: principal.clone(),
+            err,
+        }
+    }
+}

--- a/jans-cedarling/cedarling/src/authz/request.rs
+++ b/jans-cedarling/cedarling/src/authz/request.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 use serde::{Deserialize, Deserializer, Serialize, de};
 use serde_json::Value;
 
+use super::errors::{MultiIssuerValidationError, TokenInputError};
+
 /// Box to store authorization data
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Request {
@@ -109,5 +111,317 @@ impl EntityData {
     /// Deserializes a JSON string into [`EntityData`]
     pub fn from_json(entity_data: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str::<Self>(entity_data)
+    }
+}
+
+/// Token input for multi-issuer authorization
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TokenInput {
+    /// Token mapping type (e.g., "Jans::Access_Token", "Acme::DolphinToken")
+    pub mapping: String,
+    /// JWT token string
+    pub payload: String,
+}
+
+#[allow(dead_code)]
+impl TokenInput {
+    /// Create a new TokenInput
+    pub fn new(mapping: String, payload: String) -> Self {
+        Self { mapping, payload }
+    }
+
+    /// Validate the token input
+    pub fn validate(&self) -> Result<(), TokenInputError> {
+        // Check if mapping is empty
+        if self.mapping.trim().is_empty() {
+            return Err(TokenInputError::EmptyMapping);
+        }
+
+        // Check if mapping follows the expected format "Namespace::TokenType"
+        if !self.mapping.contains("::") {
+            return Err(TokenInputError::InvalidMappingFormat {
+                mapping: self.mapping.clone(),
+            });
+        }
+
+        // Check if payload is empty
+        if self.payload.trim().is_empty() {
+            return Err(TokenInputError::EmptyPayload);
+        }
+
+        // Basic JWT format check - should contain exactly 2 dots
+        let dot_count = self.payload.matches('.').count();
+        if dot_count != 2 {
+            return Err(TokenInputError::InvalidJwtFormat);
+        }
+
+        Ok(())
+    }
+}
+
+/// Multi-issuer authorization request
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AuthorizeMultiIssuerRequest {
+    /// Array of JWT tokens with explicit type mappings
+    pub tokens: Vec<TokenInput>,
+    /// Optional resource being accessed (JSON format)
+    pub resource: Option<Value>,
+    /// Optional action being performed (JSON format)
+    pub action: Option<Value>,
+    /// Optional additional context for policy evaluation (JSON format)
+    pub context: Option<Value>,
+}
+
+#[allow(dead_code)]
+impl AuthorizeMultiIssuerRequest {
+    /// Create a new AuthorizeMultiIssuerRequest
+    pub fn new(tokens: Vec<TokenInput>) -> Self {
+        Self {
+            tokens,
+            resource: None,
+            action: None,
+            context: None,
+        }
+    }
+
+    /// Create a new AuthorizeMultiIssuerRequest with all fields
+    pub fn new_with_fields(
+        tokens: Vec<TokenInput>,
+        resource: Option<Value>,
+        action: Option<Value>,
+        context: Option<Value>,
+    ) -> Self {
+        Self {
+            tokens,
+            resource,
+            action,
+            context,
+        }
+    }
+
+    /// Validate the request
+    pub fn validate(&self) -> Result<(), MultiIssuerValidationError> {
+        // Check if tokens array is empty
+        if self.tokens.is_empty() {
+            return Err(MultiIssuerValidationError::EmptyTokenArray);
+        }
+
+        // Validate each token
+        for token in &self.tokens {
+            token.validate().map_err(MultiIssuerValidationError::from)?;
+        }
+
+        // Validate JSON fields if provided
+        if let Some(ref resource) = self.resource {
+            if !resource.is_object() && !resource.is_string() {
+                return Err(MultiIssuerValidationError::InvalidResourceJson);
+            }
+        }
+
+        if let Some(ref action) = self.action {
+            if !action.is_string() {
+                return Err(MultiIssuerValidationError::InvalidActionJson);
+            }
+        }
+
+        if let Some(ref context) = self.context {
+            if !context.is_object() {
+                return Err(MultiIssuerValidationError::InvalidContextJson);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_token_input_creation() {
+        let token = TokenInput::new(
+            "Jans::Access_Token".to_string(),
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".to_string(),
+        );
+
+        assert_eq!(token.mapping, "Jans::Access_Token");
+        assert!(token.payload.starts_with("eyJ"));
+    }
+
+    #[test]
+    fn test_token_input_validation_success() {
+        let token = TokenInput::new(
+            "Jans::Access_Token".to_string(),
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".to_string(),
+        );
+
+        assert!(token.validate().is_ok());
+    }
+
+    #[test]
+    fn test_token_input_validation_empty_mapping() {
+        let token = TokenInput::new("".to_string(), "valid.jwt.token".to_string());
+
+        let result = token.validate();
+        assert!(matches!(result, Err(TokenInputError::EmptyMapping)));
+    }
+
+    #[test]
+    fn test_token_input_validation_invalid_mapping_format() {
+        let token = TokenInput::new("InvalidFormat".to_string(), "valid.jwt.token".to_string());
+
+        let result = token.validate();
+        assert!(
+            matches!(result, Err(TokenInputError::InvalidMappingFormat { mapping }) if mapping == "InvalidFormat")
+        );
+    }
+
+    #[test]
+    fn test_token_input_validation_empty_payload() {
+        let token = TokenInput::new("Jans::Access_Token".to_string(), "".to_string());
+
+        let result = token.validate();
+        assert!(matches!(result, Err(TokenInputError::EmptyPayload)));
+    }
+
+    #[test]
+    fn test_token_input_validation_invalid_jwt_format() {
+        let token = TokenInput::new("Jans::Access_Token".to_string(), "invalid-jwt".to_string());
+
+        let result = token.validate();
+        assert!(matches!(result, Err(TokenInputError::InvalidJwtFormat)));
+    }
+
+    #[test]
+    fn test_authorize_multi_issuer_request_creation() {
+        let tokens = vec![
+            TokenInput::new(
+                "Jans::Access_Token".to_string(),
+                "valid.jwt.token".to_string(),
+            ),
+            TokenInput::new("Jans::Id_Token".to_string(), "valid.jwt.token".to_string()),
+        ];
+
+        let request = AuthorizeMultiIssuerRequest::new(tokens.clone());
+
+        assert_eq!(request.tokens.len(), 2);
+        assert!(request.resource.is_none());
+        assert!(request.action.is_none());
+        assert!(request.context.is_none());
+    }
+
+    #[test]
+    fn test_authorize_multi_issuer_request_with_fields() {
+        let tokens = vec![TokenInput::new(
+            "Jans::Access_Token".to_string(),
+            "valid.jwt.token".to_string(),
+        )];
+
+        let resource = Some(json!({"type": "Document", "id": "doc123"}));
+        let action = Some(json!("Read"));
+        let context = Some(json!({"location": "miami"}));
+
+        let request = AuthorizeMultiIssuerRequest::new_with_fields(
+            tokens,
+            resource.clone(),
+            action.clone(),
+            context.clone(),
+        );
+
+        assert_eq!(request.tokens.len(), 1);
+        assert_eq!(request.resource, resource);
+        assert_eq!(request.action, action);
+        assert_eq!(request.context, context);
+    }
+
+    #[test]
+    fn test_authorize_multi_issuer_request_validation_success() {
+        let tokens = vec![
+            TokenInput::new(
+                "Jans::Access_Token".to_string(),
+                "valid.jwt.token".to_string(),
+            ),
+            TokenInput::new("Jans::Id_Token".to_string(), "valid.jwt.token".to_string()),
+        ];
+
+        let request = AuthorizeMultiIssuerRequest::new(tokens);
+
+        assert!(request.validate().is_ok());
+    }
+
+    #[test]
+    fn test_authorize_multi_issuer_request_validation_empty_tokens() {
+        let request = AuthorizeMultiIssuerRequest::new(vec![]);
+
+        let result = request.validate();
+        assert!(matches!(
+            result,
+            Err(MultiIssuerValidationError::EmptyTokenArray)
+        ));
+    }
+
+    #[test]
+    fn test_authorize_multi_issuer_request_validation_invalid_token() {
+        let tokens = vec![TokenInput::new(
+            "InvalidFormat".to_string(),
+            "valid.jwt.token".to_string(),
+        )];
+
+        let request = AuthorizeMultiIssuerRequest::new(tokens);
+
+        let result = request.validate();
+        assert!(matches!(
+            result,
+            Err(MultiIssuerValidationError::TokenInput(
+                TokenInputError::InvalidMappingFormat { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_authorize_multi_issuer_request_validation_invalid_json_fields() {
+        let tokens = vec![TokenInput::new(
+            "Jans::Access_Token".to_string(),
+            "valid.jwt.token".to_string(),
+        )];
+
+        let request = AuthorizeMultiIssuerRequest::new_with_fields(
+            tokens,
+            Some(json!(123)), // Invalid resource (should be object or string)
+            Some(json!(123)), // Invalid action (should be string)
+            Some(json!(123)), // Invalid context (should be object)
+        );
+
+        let result = request.validate();
+        assert!(matches!(
+            result,
+            Err(MultiIssuerValidationError::InvalidResourceJson)
+        ));
+    }
+
+    #[test]
+    fn test_serialization_deserialization() {
+        let tokens = vec![TokenInput::new(
+            "Jans::Access_Token".to_string(),
+            "valid.jwt.token".to_string(),
+        )];
+
+        let request = AuthorizeMultiIssuerRequest::new_with_fields(
+            tokens,
+            Some(json!({"type": "Document"})),
+            Some(json!("Read")),
+            Some(json!({"location": "miami"})),
+        );
+
+        // Test serialization
+        let json = serde_json::to_string(&request).expect("Should serialize");
+
+        // Test deserialization
+        let deserialized: AuthorizeMultiIssuerRequest =
+            serde_json::from_str(&json).expect("Should deserialize");
+
+        assert_eq!(request, deserialized);
     }
 }


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
This is the first PR for multi-token issuer support, adding core data structure and interfaces.
It's supposed to be merged into `jans-cedarling-11834` branch which will keep all changes for full functionalities of `authorize_multi_issuer`.

#### Target issue

closes #12112

#### Implementation Details

Added `TokenInput` and `AuthorizeMultiIssuerRequest` with validation logic, and centralized all `authz` module error types into `errors.rs`.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
