### PR TITLE
fix(jans-cli-tui): Admin UI Roles

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/070_users/edit_user_dialog.py
+++ b/jans-cli-tui/cli_tui/plugins/070_users/edit_user_dialog.py
@@ -97,7 +97,7 @@ class EditUserDialog(JansGDialog, DialogUtils):
         widget = JansLabelWidget(
                         title = _(title),
                         values = values,
-                        data = [],
+                        data = data,
                         label_width=100,
                         add_handler=add_handler,
                         jans_name = jans_name

--- a/jans-cli-tui/cli_tui/utils/background_tasks.py
+++ b/jans-cli-tui/cli_tui/utils/background_tasks.py
@@ -1,3 +1,4 @@
+import json
 from prompt_toolkit.eventloop import get_event_loop
 
 from utils.utils import common_data
@@ -79,6 +80,7 @@ async def get_admin_ui_roles() -> None:
         return
 
     common_data.admin_ui_roles = response.json()
+    common_data.app.logger.info(f"Backrgound Task: admin-ui-roles: {json.dumps(common_data.admin_ui_roles)}")
 
 
 async def get_persistence_type() -> None:


### PR DESCRIPTION
Closes

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
