### PR TITLE
fix: correct broken links in External Libraries documentation

### DIFF
--- a/docs/janssen-server/developer/external-libraries.md
+++ b/docs/janssen-server/developer/external-libraries.md
@@ -8,12 +8,12 @@ tags:
 
 # Using External Libraries In Interception Scripts
 
-Janssen Server [Interception script](./interception-scripts.md) is a very powerful tool that enables developers to 
+Janssen Server [Interception script](../../janssen-server/developer/scripts/README.md) is a very powerful tool that enables developers to 
 control many different aspects of the authentication process.
 
 It is possible to use external libraries in interception scripts. It is possible to use external libraries Java 
-libraries in [pure Java](./interception-scripts.md#using-java-libraries-in-a-script) based interception script. If the
+libraries in [pure Java](../../janssen-server/developer/scripts/README.md#using-java-libraries-in-a-script) based interception script. If the
 interception script is implemented in Jython then it is possible to 
-[use external Java libraries](./interception-scripts.md#using-java-libraries-in-a-jython-script) as well as
-[external Python libraries](./interception-scripts.md#using-python-libraries-in-a-script).
+[use external Java libraries](../../janssen-server/developer/scripts/README.md#using-java-libraries-in-a-jython-script) as well as
+[external Python libraries](../../janssen-server/developer/scripts/README.md#using-python-libraries-in-a-script).
 


### PR DESCRIPTION
### Description
This PR fixes broken links in the External Libraries documentation page. The previous links to interception-scripts.md and its anchors were causing 404 errors. All links now point to the correct scripts/README.md paths.

#### Target issue
closes #12268

#### Implementation Details
Updated Markdown links:
          - [Interception script](./interception-scripts.md) → [Interception script](../../janssen-server/developer/scripts/README.md)
          - [pure Java](./interception-scripts.md#using-java-libraries-in-a-script) → [pure Java](../../janssen-server/developer/scripts/README.md#using-java-libraries-in-a-script)
          - [use external Java libraries](./interception-scripts.md#using-java-libraries-in-a-jython-script) → [use external Java libraries](../../janssen-server/developer/scripts/README.md#using-java-libraries-in-a-jython-script)
          - [external Python libraries](./interception-scripts.md#using-python-libraries-in-a-script) → [external Python libraries](../../janssen-server/developer/scripts/README.md#using-python-libraries-in-a-script)

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
