### PR TITLE
fix(jans-fido2): fix persistence entity manager issue

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -11,6 +11,7 @@ import io.jans.fido2.model.metric.Fido2MetricsAggregation;
 import io.jans.fido2.model.metric.Fido2MetricsConstants;
 import io.jans.fido2.model.metric.Fido2MetricsData;
 import io.jans.fido2.model.metric.Fido2MetricsEntry;
+import io.jans.as.common.service.common.ApplicationFactory;
 import io.jans.orm.PersistenceEntryManager;
 import io.jans.orm.search.filter.Filter;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -41,7 +42,7 @@ public class Fido2MetricsService {
     private AppConfiguration appConfiguration;
 
     @Inject
-    @Named("fido2MetricsEntryManager")
+    @Named(ApplicationFactory.PERSISTENCE_ENTRY_MANAGER_NAME)
     private PersistenceEntryManager persistenceEntryManager;
 
     private static final String METRICS_ENTRY_BASE_DN = "ou=fido2-metrics,o=jans";

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2UserMetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2UserMetricsService.java
@@ -8,6 +8,7 @@ package io.jans.fido2.service.metric;
 
 import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.metric.Fido2UserMetrics;
+import io.jans.as.common.service.common.ApplicationFactory;
 import io.jans.fido2.model.metric.UserMetricsUpdateRequest;
 import io.jans.orm.PersistenceEntryManager;
 import io.jans.orm.search.filter.Filter;
@@ -37,7 +38,7 @@ public class Fido2UserMetricsService {
     private AppConfiguration appConfiguration;
 
     @Inject
-    @Named("fido2UserMetricsEntryManager")
+    @Named(ApplicationFactory.PERSISTENCE_ENTRY_MANAGER_NAME)
     private PersistenceEntryManager persistenceEntryManager;
 
     private static final ResourceBundle METRICS_CONFIG = ResourceBundle.getBundle("fido2-metrics");


### PR DESCRIPTION
### Description

Fixed CDI injection qualifier mismatch in FIDO2 metrics services that prevented server startup. Updated Fido2MetricsService and Fido2UserMetricsService to use correct ApplicationFactory.PERSISTENCE_ENTRY_MANAGER_NAME qualifier instead of non-existent custom qualifiers, resolving Weld deployment exceptions and enabling proper FIDO2 server initialization.

#### Target issue

Resolves FIDO2 service startup failure caused by unsatisfied CDI dependencies in metrics implementation. Fixes HTTP 503/404 errors by correcting PersistenceEntryManager injection qualifiers to match available beans from AppInitializer producer methods.
  

  
closes #12312 


-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
