### PR TITLE
feat(jans-cedarling): policy store implement core data models and error types

### DIFF
--- a/jans-cedarling/cedarling/src/common/policy_store/errors.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/errors.rs
@@ -1,0 +1,249 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+//! Error types for policy store operations.
+
+/// Errors that can occur during policy store operations.
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub enum PolicyStoreError {
+    /// IO error during file operations
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Validation error
+    #[error("Validation error: {0}")]
+    Validation(#[from] ValidationError),
+
+    /// Archive handling error
+    #[error("Archive error: {0}")]
+    Archive(#[from] ArchiveError),
+
+    /// JSON parsing error
+    #[error("JSON parsing error in {file}: {message}")]
+    JsonParsing { file: String, message: String },
+
+    /// YAML parsing error
+    #[error("YAML parsing error in {file}: {message}")]
+    YamlParsing { file: String, message: String },
+
+    /// Cedar parsing error
+    #[error("Cedar parsing error in {file}: {message}")]
+    CedarParsing { file: String, message: String },
+}
+
+/// Validation errors for policy store components.
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub enum ValidationError {
+    /// Invalid metadata
+    #[error("Invalid metadata in file {file}: {message}")]
+    InvalidMetadata { file: String, message: String },
+
+    /// Invalid policy
+    #[error("Invalid policy in file {file}{}: {message}", .line.map(|l| format!(" at line {}", l)).unwrap_or_default())]
+    InvalidPolicy {
+        file: String,
+        line: Option<u32>,
+        message: String,
+    },
+
+    /// Invalid template
+    #[error("Invalid template in file {file}{}: {message}", .line.map(|l| format!(" at line {}", l)).unwrap_or_default())]
+    InvalidTemplate {
+        file: String,
+        line: Option<u32>,
+        message: String,
+    },
+
+    /// Invalid entity
+    #[error("Invalid entity in file {file}: {message}")]
+    InvalidEntity { file: String, message: String },
+
+    /// Invalid trusted issuer
+    #[error("Invalid trusted issuer in file {file}: {message}")]
+    InvalidTrustedIssuer { file: String, message: String },
+
+    /// Invalid schema
+    #[error("Invalid schema in file {file}: {message}")]
+    InvalidSchema { file: String, message: String },
+
+    /// Manifest validation failed
+    #[error("Manifest validation failed: {message}")]
+    ManifestValidation { message: String },
+
+    /// File checksum mismatch
+    #[error("Checksum mismatch for file {file}: expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        file: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// Missing required file
+    #[error("Missing required file: {file}")]
+    MissingRequiredFile { file: String },
+
+    /// Missing required directory
+    #[error("Missing required directory: {directory}")]
+    MissingRequiredDirectory { directory: String },
+
+    /// Duplicate entity UID
+    #[error("Duplicate entity UID found: {uid} in files {file1} and {file2}")]
+    DuplicateEntityUid {
+        uid: String,
+        file1: String,
+        file2: String,
+    },
+
+    /// Missing @id() annotation
+    #[error("Missing @id() annotation in {file}: {policy_type} must have an @id() annotation")]
+    MissingIdAnnotation { file: String, policy_type: String },
+
+    /// Invalid file extension
+    #[error("Invalid file extension for {file}: expected {expected}, got {actual}")]
+    InvalidFileExtension {
+        file: String,
+        expected: String,
+        actual: String,
+    },
+}
+
+/// Errors related to archive (.cjar) handling.
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub enum ArchiveError {
+    /// Invalid archive format
+    #[error("Invalid archive format: {message}")]
+    InvalidFormat { message: String },
+
+    /// Archive extraction failed
+    #[error("Failed to extract archive: {message}")]
+    ExtractionFailed { message: String },
+
+    /// Invalid archive structure
+    #[error("Invalid archive structure: {message}")]
+    InvalidStructure { message: String },
+
+    /// Archive corruption detected
+    #[error("Archive appears to be corrupted: {message}")]
+    Corrupted { message: String },
+
+    /// Path traversal attempt detected
+    #[error("Potential path traversal detected in archive: {path}")]
+    PathTraversal { path: String },
+}
+
+/// Errors related to JWT token validation.
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub enum TokenError {
+    /// Token from untrusted issuer
+    #[error("Token from untrusted issuer: {issuer}")]
+    UntrustedIssuer { issuer: String },
+
+    /// Missing required claim
+    #[error("Missing required claim '{claim}' in token from issuer {issuer}")]
+    MissingRequiredClaim { claim: String, issuer: String },
+
+    /// Token signature validation failed
+    #[error("Token signature validation failed for issuer {issuer}: {message}")]
+    SignatureValidation { issuer: String, message: String },
+
+    /// JWKS fetch failed
+    #[error("Failed to fetch JWKS from endpoint {endpoint}: {message}")]
+    JwksFetchFailed { endpoint: String, message: String },
+
+    /// Invalid token format
+    #[error("Invalid token format: {message}")]
+    InvalidFormat { message: String },
+
+    /// Token expired
+    #[error("Token has expired")]
+    Expired,
+
+    /// Token not yet valid
+    #[error("Token is not yet valid")]
+    NotYetValid,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validation_error_messages() {
+        let err = ValidationError::InvalidMetadata {
+            file: "metadata.json".to_string(),
+            message: "missing field 'name'".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Invalid metadata in file metadata.json: missing field 'name'"
+        );
+
+        let err = ValidationError::InvalidPolicy {
+            file: "policy1.cedar".to_string(),
+            line: Some(42),
+            message: "syntax error".to_string(),
+        };
+        assert!(err.to_string().contains("policy1.cedar"));
+        assert!(err.to_string().contains("at line 42"));
+
+        let err = ValidationError::MissingRequiredFile {
+            file: "schema.cedarschema".to_string(),
+        };
+        assert_eq!(err.to_string(), "Missing required file: schema.cedarschema");
+    }
+
+    #[test]
+    fn test_archive_error_messages() {
+        let err = ArchiveError::InvalidFormat {
+            message: "not a zip file".to_string(),
+        };
+        assert_eq!(err.to_string(), "Invalid archive format: not a zip file");
+
+        let err = ArchiveError::PathTraversal {
+            path: "../../../etc/passwd".to_string(),
+        };
+        assert!(err.to_string().contains("path traversal"));
+        assert!(err.to_string().contains("../../../etc/passwd"));
+    }
+
+    #[test]
+    fn test_token_error_messages() {
+        let err = TokenError::UntrustedIssuer {
+            issuer: "https://evil.com".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Token from untrusted issuer: https://evil.com"
+        );
+
+        let err = TokenError::MissingRequiredClaim {
+            claim: "sub".to_string(),
+            issuer: "https://issuer.com".to_string(),
+        };
+        assert!(err.to_string().contains("sub"));
+        assert!(err.to_string().contains("https://issuer.com"));
+    }
+
+    #[test]
+    fn test_policy_store_error_from_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let ps_err: PolicyStoreError = io_err.into();
+        assert!(ps_err.to_string().contains("IO error"));
+    }
+
+    #[test]
+    fn test_policy_store_error_from_validation() {
+        let val_err = ValidationError::InvalidMetadata {
+            file: "test.json".to_string(),
+            message: "invalid".to_string(),
+        };
+        let ps_err: PolicyStoreError = val_err.into();
+        assert!(ps_err.to_string().contains("Validation error"));
+    }
+}

--- a/jans-cedarling/cedarling/src/common/policy_store/metadata.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/metadata.rs
@@ -1,0 +1,173 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+//! Policy store metadata types for identification, versioning, and integrity validation.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
+
+/// Helper module for serializing Optional DateTime
+mod datetime_option {
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match date {
+            Some(dt) => serializer.serialize_some(&dt.to_rfc3339()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<String> = Option::deserialize(deserializer)?;
+        match opt {
+            Some(s) => DateTime::parse_from_rfc3339(&s)
+                .map(|dt| Some(dt.with_timezone(&Utc)))
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Helper module for serializing DateTime
+mod datetime {
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&date.to_rfc3339())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        DateTime::parse_from_rfc3339(&s)
+            .map(|dt| dt.with_timezone(&Utc))
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Metadata for a policy store.
+///
+/// Contains identification, versioning, and descriptive information about a policy store.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PolicyStoreMetadata {
+    /// The version of the Cedar policy language used in this policy store
+    pub cedar_version: String,
+    /// Policy store configuration
+    pub policy_store: PolicyStoreInfo,
+}
+
+/// Core information about a policy store.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PolicyStoreInfo {
+    /// Unique identifier for the policy store (hex hash)
+    #[serde(default)]
+    pub id: String,
+    /// Human-readable name for the policy store
+    pub name: String,
+    /// Optional description of the policy store
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Semantic version of the policy store content
+    #[serde(default)]
+    pub version: String,
+    /// ISO 8601 timestamp when created
+    #[serde(skip_serializing_if = "Option::is_none", with = "datetime_option")]
+    pub created_date: Option<DateTime<Utc>>,
+    /// ISO 8601 timestamp when last modified
+    #[serde(skip_serializing_if = "Option::is_none", with = "datetime_option")]
+    pub updated_date: Option<DateTime<Utc>>,
+}
+
+/// Manifest file for policy store integrity validation.
+///
+/// Contains checksums and metadata for all files in the policy store.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PolicyStoreManifest {
+    /// Reference to the policy store ID this manifest belongs to
+    pub policy_store_id: String,
+    /// ISO 8601 timestamp when the manifest was generated
+    #[serde(with = "datetime")]
+    pub generated_date: DateTime<Utc>,
+    /// Map of file paths to their metadata
+    pub files: HashMap<String, FileInfo>,
+}
+
+/// Information about a file in the policy store manifest.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FileInfo {
+    /// File size in bytes
+    pub size: u64,
+    /// SHA-256 checksum of the file content (format: "sha256:<hex>")
+    pub checksum: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_policy_store_metadata_serialization() {
+        let metadata = PolicyStoreMetadata {
+            cedar_version: "4.4.0".to_string(),
+            policy_store: PolicyStoreInfo {
+                id: "abc123".to_string(),
+                name: "test_store".to_string(),
+                description: Some("A test policy store".to_string()),
+                version: "1.0.0".to_string(),
+                created_date: Some(Utc::now()),
+                updated_date: Some(Utc::now()),
+            },
+        };
+
+        // Test serialization
+        let json = serde_json::to_string(&metadata).unwrap();
+        assert!(json.contains("cedar_version"));
+        assert!(json.contains("4.4.0"));
+
+        // Test deserialization
+        let deserialized: PolicyStoreMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.cedar_version, metadata.cedar_version);
+        assert_eq!(deserialized.policy_store.name, metadata.policy_store.name);
+    }
+
+    #[test]
+    fn test_policy_store_manifest_serialization() {
+        let mut files = HashMap::new();
+        files.insert("metadata.json".to_string(), FileInfo {
+            size: 245,
+            checksum: "sha256:abc123".to_string(),
+        });
+
+        let manifest = PolicyStoreManifest {
+            policy_store_id: "test123".to_string(),
+            generated_date: Utc::now(),
+            files,
+        };
+
+        // Test serialization
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(json.contains("policy_store_id"));
+        assert!(json.contains("test123"));
+
+        // Test deserialization
+        let deserialized: PolicyStoreManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.policy_store_id, manifest.policy_store_id);
+        assert_eq!(deserialized.files.len(), 1);
+    }
+}

--- a/jans-cedarling/cedarling/src/common/policy_store/source.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/source.rs
@@ -1,0 +1,71 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+//! Policy store source and format types.
+
+use std::path::PathBuf;
+
+/// Source of a policy store, supporting multiple input formats.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum PolicyStoreSource {
+    /// Directory structure format (for development)
+    Directory(PathBuf),
+    /// Compressed archive format (.cjar file for distribution)
+    Archive(PathBuf),
+    /// Legacy JSON/YAML format (backward compatibility)
+    Legacy(String),
+}
+
+/// Format of a policy store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum PolicyStoreFormat {
+    /// Directory structure format
+    Directory,
+    /// Compressed .cjar archive format
+    Archive,
+    /// Legacy format
+    Legacy,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_policy_store_source_variants() {
+        let dir_source = PolicyStoreSource::Directory(PathBuf::from("/path/to/store"));
+        let archive_source = PolicyStoreSource::Archive(PathBuf::from("/path/to/store.cjar"));
+        let legacy_source = PolicyStoreSource::Legacy("{}".to_string());
+
+        // Verify we can create all variants
+        match dir_source {
+            PolicyStoreSource::Directory(path) => {
+                assert_eq!(path.to_str().unwrap(), "/path/to/store")
+            },
+            _ => panic!("Expected Directory variant"),
+        }
+
+        match archive_source {
+            PolicyStoreSource::Archive(path) => {
+                assert_eq!(path.to_str().unwrap(), "/path/to/store.cjar")
+            },
+            _ => panic!("Expected Archive variant"),
+        }
+
+        match legacy_source {
+            PolicyStoreSource::Legacy(content) => assert_eq!(content, "{}"),
+            _ => panic!("Expected Legacy variant"),
+        }
+    }
+
+    #[test]
+    fn test_policy_store_format_enum() {
+        assert_eq!(PolicyStoreFormat::Directory, PolicyStoreFormat::Directory);
+        assert_ne!(PolicyStoreFormat::Directory, PolicyStoreFormat::Archive);
+        assert_ne!(PolicyStoreFormat::Archive, PolicyStoreFormat::Legacy);
+    }
+}


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Set up core policy store infrastructure and data models
#### Target issue
  
closes #12320

#### Implementation Details
 - Added PolicyStoreMetadata and PolicyStoreManifest with serialization
- Implemented PolicyStoreSource enum for directory/archive/legacy inputs
- Created comprehensive error types with contextual messages
- Added PolicyStoreFormat enum for format detection

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
