### PR TITLE
feat(jans-auth-server): adding interception script for PAR #10556

### DIFF
--- a/jans-core/script/src/main/java/io/jans/model/custom/script/CustomScriptType.java
+++ b/jans-core/script/src/main/java/io/jans/model/custom/script/CustomScriptType.java
@@ -51,6 +51,8 @@ import io.jans.model.custom.script.type.logout.DummyEndSessionType;
 import io.jans.model.custom.script.type.logout.EndSessionType;
 import io.jans.model.custom.script.type.owner.DummyResourceOwnerPasswordCredentialsType;
 import io.jans.model.custom.script.type.owner.ResourceOwnerPasswordCredentialsType;
+import io.jans.model.custom.script.type.par.DummyParType;
+import io.jans.model.custom.script.type.par.ParType;
 import io.jans.model.custom.script.type.persistence.DummyPeristenceType;
 import io.jans.model.custom.script.type.persistence.PersistenceType;
 import io.jans.model.custom.script.type.postauthn.DummyPostAuthnType;
@@ -130,6 +132,7 @@ public enum CustomScriptType implements AttributeEnum {
     AUTHZ_DETAIL("authz_detail", "Authorization Detail", AuthzDetailType.class, CustomScript.class, "AuthzDetail", new DummyAuthzDetail()),
     UPDATE_TOKEN("update_token", "Update Token", UpdateTokenType.class, CustomScript.class, "UpdateToken", new DummyUpdateTokenType()),
     LOGOUT_STATUS_JWT("logout_status_jwt", "Logout Status Jwt", LogoutStatusJwtType.class, CustomScript.class, "LogoutStatusJwt", new DummyLogoutStatusJwtType()),
+    PAR("par", "Pushed Authorization Request", ParType.class, CustomScript.class, "Par", new DummyParType()),
     CONFIG_API("config_api_auth", "Config Api Auth", ConfigApiType.class, CustomScript.class,"ConfigApiAuthorization", new DummyConfigApiType()),
     MODIFY_SSA_RESPONSE("modify_ssa_response", "Modify SSA Response", ModifySsaResponseType.class, CustomScript.class, "ModifySsaResponse", new DummyModifySsaResponseType()),
     FIDO2_EXTENSION("fido2_extension", "Fido2 Extension", Fido2ExtensionType.class, CustomScript.class, "Fido2Extension", new DummyFido2ExtensionType()),

--- a/jans-core/script/src/main/java/io/jans/model/custom/script/type/par/DummyParType.java
+++ b/jans-core/script/src/main/java/io/jans/model/custom/script/type/par/DummyParType.java
@@ -1,0 +1,42 @@
+package io.jans.model.custom.script.type.par;
+
+import io.jans.model.SimpleCustomProperty;
+import io.jans.model.custom.script.model.CustomScript;
+
+import java.util.Map;
+
+/**
+ * @author Yuriy Z
+ */
+public class DummyParType implements ParType {
+
+    @Override
+    public boolean init(Map<String, SimpleCustomProperty> configurationAttributes) {
+        return true;
+    }
+
+    @Override
+    public boolean init(CustomScript customScript, Map<String, SimpleCustomProperty> configurationAttributes) {
+        return true;
+    }
+
+    @Override
+    public boolean destroy(Map<String, SimpleCustomProperty> configurationAttributes) {
+        return true;
+    }
+
+    @Override
+    public int getApiVersion() {
+        return 1;
+    }
+
+    @Override
+    public boolean createPar(Object par, Object context) {
+        return true;
+    }
+
+    @Override
+    public boolean modifyParResponse(Object responseAsJsonObject, Object context) {
+        return true;
+    }
+}

--- a/jans-core/script/src/main/java/io/jans/model/custom/script/type/par/ParType.java
+++ b/jans-core/script/src/main/java/io/jans/model/custom/script/type/par/ParType.java
@@ -1,0 +1,15 @@
+package io.jans.model.custom.script.type.par;
+
+import io.jans.model.custom.script.type.BaseExternalType;
+
+/**
+ * @author Yuriy Z
+ */
+public interface ParType extends BaseExternalType {
+
+
+    // par - io.jans.as.persistence.model.Par
+    boolean createPar(Object par, Object context);
+
+    boolean modifyParResponse(Object responseAsJsonObject, Object context);
+}


### PR DESCRIPTION
### Description

feat(jans-auth-server): adding interception script for PAR 

Script will allow:
- modify PAR before it's pushed to DB
- forbid PAR if needed (return true/false)
- modify response from PAR endpoint

#### Target issue
  
closes ##10556

### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
