### PR TITLE
fix(jans-linux-setup): jans command linked to /usr/sbin

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans.py
@@ -318,14 +318,14 @@ class JansInstaller(BaseInstaller, SetupUtils):
                 continue
             self.run([paths.cmd_chmod, '700', scr_path])
 
-        # link jans script to /usr/local/bin
+        # link jans script to /usr/sbin
         self.run([
                 paths.cmd_ln, '-s',
                 os.path.join(
                     Config.jansOptBinFolder,
                     os.path.basename(Config.jansScriptFiles[1])
                 ),
-                '/usr/local/bin'
+                '/usr/sbin'
                 ])
 
 


### PR DESCRIPTION
Closes #12330

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
