### PR TITLE
fix(jans-linux-setup): path of cedarling_core.json

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/installers/jans_lock.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/jans_lock.py
@@ -130,7 +130,7 @@ class JansLockInstaller(JettyInstaller):
                     'creation_date': datetime.datetime.utcnow().isoformat(),
                     'policy_content': self.generate_base64_file(policy_fn)
                 }
-            schema_fn = base.extract_file(base.current_app.jans_zip, 'jans-lock_cedarling/jans-cedarling/schema/cedarling_core.json', tmpdirname)
+            schema_fn = base.extract_file(base.current_app.jans_zip, 'jans-cedarling/schema/cedarling_core.json', tmpdirname)
             policy_tmp['policy_stores']['%(policy_store_id)s']['schema'] = self.generate_base64_file(schema_fn)
 
         policy_tmp['policy_stores']['%(policy_store_id)s']['policies'] = policies


### PR DESCRIPTION
Closes #12475

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected schema file resolution during Jans Lock installation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->