### PR TITLE
fix(jans-casa): resolve multiple device registration and passkey imag…

### DIFF
--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/Fido2Service.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/Fido2Service.java
@@ -174,6 +174,15 @@ public class Fido2Service extends BaseService {
         AttestationOptions attestationOptions = new AttestationOptions();
         attestationOptions.setUsername(userName);
         attestationOptions.setDisplayName(displayName);
+        
+        // Set authenticatorSelection to allow users to choose authenticator type
+        // This prevents forcing platform authenticators and shows "Select another device" option
+        io.jans.fido2.model.attestation.AuthenticatorSelection authenticatorSelection = 
+            new io.jans.fido2.model.attestation.AuthenticatorSelection();
+        // Don't set authenticatorAttachment - leave it null to allow user choice
+        authenticatorSelection.setUserVerification(io.jans.orm.model.fido2.UserVerification.preferred);
+        authenticatorSelection.setRequireResidentKey(false);
+        attestationOptions.setAuthenticatorSelection(authenticatorSelection);
 
         try (Response response = attestationService.register(attestationOptions)) {
             String content = response.readEntity(String.class);

--- a/jans-casa/app/src/main/java/io/jans/casa/ui/vm/user/PasskeysViewModel.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/ui/vm/user/PasskeysViewModel.java
@@ -181,7 +181,7 @@ public class PasskeysViewModel extends UserViewModel {
 
 	}
 
-	@NotifyChange({ "uiEnrolled", "newDevice", "devices" })
+	@NotifyChange({ "uiEnrolled", "uiAwaiting", "newDevice", "devices" })
 	public void add() {
 		logger.debug("add - ");
 		FidoDevice dev = null;
@@ -255,7 +255,7 @@ public class PasskeysViewModel extends UserViewModel {
 		logger.debug("Allow list cookie added for credential : "+ newCredential.toJSONString());
 	}
 
-	@NotifyChange({ "uiEnrolled", "newDevice" })
+	@NotifyChange({ "uiEnrolled", "uiAwaiting", "newDevice" })
 	public void cancel() {
 
 		boolean success = false;
@@ -361,6 +361,7 @@ public class PasskeysViewModel extends UserViewModel {
 	private void resetAddSettings() {
 		logger.debug("resetAddSettings");
 		uiEnrolled = false;
+		uiAwaiting = false;
 		newDevice = new FidoDevice();
 	}
 }

--- a/jans-casa/app/src/main/webapp/user/fido2-detail.zul
+++ b/jans-casa/app/src/main/webapp/user/fido2-detail.zul
@@ -31,13 +31,13 @@
                             <div class="flex items-start">
                                
                                 <zk:zk if="${FidoDevice.isPlatformAuthenticator(each)}">
-								    <img src="${zkService.contextPath}${assetsService.prefix}/images/touchid.png" />
+								    <img src="${zkService.contextPath}${assetsService.prefix}/images/touchid.png" class="w3" />
 								</zk:zk>
 								<zk:zk if="${FidoDevice.isMultideviceAuthenticator(each)}">
-								    <img src="${zkService.contextPath}${assetsService.prefix}/images/passkey.png" />
+								    <img src="${zkService.contextPath}${assetsService.prefix}/images/passkey.png" class="w3" />
 								</zk:zk>
 								<zk:zk if="${FidoDevice.isSecurityKey(each)}">
-								    <img src="${zkService.contextPath}${assetsService.prefix}/images/u2fkey.png" />
+								    <img src="${zkService.contextPath}${assetsService.prefix}/images/u2fkey.png" class="w3" />
 								</zk:zk>
 								
                                 <p class="ml3 mb0">


### PR DESCRIPTION
### Description

This PR fixes the passkey registration UX in Casa by allowing users to choose their preferred authenticator type instead of forcing platform authenticators (Touch ID/Windows Hello). Previously, users had to press ESC to cancel the forced platform prompt before seeing options for USB security keys or cross-platform passkeys.

#### Target issue

Fixes the UX issue where Casa passkey registration forced platform authenticators, requiring users to press ESC to access other authenticator options. This improves user experience and makes the feature suitable for customer demonstrations.  
closes #12500



-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #12502, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now choose their preferred authenticator type during passkey registration.

* **Improvements**
  * Enhanced UI responsiveness during passkey enrollment and cancellation operations.
  * Improved visual styling of authentication device icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->