### PR TITLE
fix(docs): update broken Cedarling TBAC quickstart link

### DIFF
--- a/docs/cedarling/cedarling-quick-start.md
+++ b/docs/cedarling/cedarling-quick-start.md
@@ -13,7 +13,7 @@ tags:
 
 This quick start guide shows how to quickly test authorization of a user action
 using the Cedarling. We will be using [the application asserted identity approach](./README.md#token-based-access-control-tbac-v-application-asserted-identity) 
-in this guide to implement role based access control(RBAC). Refer to [this section](#implement-tbac-using-cedarling) to understand how to use Cedarling
+in this guide to implement role based access control(RBAC). Refer to [this section](#implement-rbac-using-signed-tokens-tbac) to understand how to use Cedarling
 with TBAC approach.
 
 

--- a/docs/cedarling/cedarling-rust.md
+++ b/docs/cedarling/cedarling-rust.md
@@ -406,7 +406,7 @@ let config = BootstrapConfig {
 ## See Also
 
 - [Getting Started with Cedarling Rust](getting-started/rust.md)
-- [Cedarling TBAC quickstart](cedarling-quick-start.md#implement-tbac-using-cedarling)
+- [Cedarling TBAC quickstart](cedarling-quick-start.md#implement-rbac-using-signed-tokens-tbac)
 - [Cedarling Unsigned quickstart](cedarling-quick-start.md#authorization-using-the-cedarling)
 - [Cedarling Sidecar Tutorial](cedarling-sidecar-tutorial.md)
 - [Cedarling Properties](cedarling-properties.md)

--- a/docs/cedarling/getting-started/java.md
+++ b/docs/cedarling/getting-started/java.md
@@ -226,6 +226,6 @@ Defined APIs are listed [here](https://janssenproject.github.io/developer-docs/j
 
 ## See Also
 
-- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-tbac-using-cedarling)
+- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-rbac-using-signed-tokens-tbac)
 - [Cedarling Unsigned quickstart](../cedarling-quick-start.md#step-1-create-the-cedar-policy-and-schema)
 

--- a/docs/cedarling/getting-started/javascript.md
+++ b/docs/cedarling/getting-started/javascript.md
@@ -465,6 +465,6 @@ export class PolicyEvaluationError {
 
 ## See Also
 
-- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-tbac-using-cedarling)
+- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-rbac-using-signed-tokens-tbac)
 - [Cedarling Unsigned quickstart](../cedarling-quick-start.md#step-1-create-the-cedar-policy-and-schema)
 - [Cedarling Sidecar Tutorial](../cedarling-sidecar-tutorial.md)

--- a/docs/cedarling/getting-started/python.md
+++ b/docs/cedarling/getting-started/python.md
@@ -280,6 +280,6 @@ print(logs)
 
 ## See Also
 
-- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-tbac-using-cedarling)
+- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-rbac-using-signed-tokens-tbac)
 - [Cedarling Unsigned quickstart](../cedarling-quick-start.md#step-1-create-the-cedar-policy-and-schema)
 - [Cedarling Sidecar Tutorial](../cedarling-sidecar-tutorial.md)

--- a/docs/cedarling/getting-started/rust.md
+++ b/docs/cedarling/getting-started/rust.md
@@ -305,6 +305,6 @@ Please refer to [Cedarling Rust Developer Guide](../cedarling-rust.md#api-refere
 ## See Also
 
 - [Cedarling Rust Developer Guide](../cedarling-rust.md)
-- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-tbac-using-cedarling)
+- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-rbac-using-signed-tokens-tbac)
 - [Cedarling Unsigned quickstart](../cedarling-quick-start.md#authorization-using-the-cedarling)
 - [Cedarling Sidecar Tutorial](../cedarling-sidecar-tutorial.md)


### PR DESCRIPTION
Description

Target issue #12498 

Closes #12498

Implementation Details

This PR fixes broken documentation links in multiple Cedarling “Getting Started” pages that were pointing to an outdated anchor #implement-tbac-using-cedarling.

The links have been updated to the correct section reference #implement-rbac-using-signed-tokens-tbac in the Cedarling quickstart guide.

Updated files:
	•	docs/cedarling/cedarling-quick-start.md
	•	docs/cedarling/cedarling-rust.md
	•	docs/cedarling/getting-started/java.md
	•	docs/cedarling/getting-started/javascript.md
	•	docs/cedarling/getting-started/python.md
	•	docs/cedarling/getting-started/rust.md

This resolves the 404 errors reported in the “Getting Started with Cedarling Python” page and ensures consistency across all language guides.
<img width="1249" height="714" alt="Screenshot 2025-10-29 at 2 55 43 AM" src="https://github.com/user-attachments/assets/48211f38-59aa-4acd-8d92-6aa7e697fffe" />




