### PR TITLE
Fix broken link in Client Registration Endpoint documentation

### DIFF
--- a/docs/janssen-server/auth-server/endpoints/client-registration.md
+++ b/docs/janssen-server/auth-server/endpoints/client-registration.md
@@ -559,7 +559,8 @@ SSA is validated based on `softwareStatementValidationType` which is enum.
 ### Customizing the behavior of the AS using Interception script
 Janssen's allows developers to register a client with the Authorization Server (AS) without any intervention by the administrator. By default, all clients are given the same default scopes and attributes. Through the use of an interception script, this behavior can be modified. These scripts can be used to analyze the registration request and apply customizations to the registered client. For example, a client can be given specific scopes by analyzing the [Software Statement](https://www.rfc-editor.org/rfc/rfc7591.html#section-2.3) that is sent with the registration request.
 
-Further reading [here](../../developer/scripts/client-registration.md)
+Further reading [here](../../../script-catalog/client_registration/client-registration.md)
+
 
 ### The Use of Attestation in Dynamic Client Registration
 


### PR DESCRIPTION
This PR fixes a broken link in the Client Registration Endpoint documentation.

Old link: ../../developer/scripts/client-registration.md (404)

New link: ../../../script-catalog/client_registration/client-registration.md

Verified the fix by testing locally using poetry run mkdocs serve -f ../mkdocs.yml

Attached screenshot/video evidence as proof of successful local test.

Fixes: #12244
<img width="1911" height="985" alt="before" src="https://github.com/user-attachments/assets/2bc213c4-e9bd-42e1-be18-42c9f819ac0f" />

https://github.com/user-attachments/assets/e67e2f19-d2ba-4eb5-9159-7f9b6e9ff9cc
in this video u can see result after fixing! thank you


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation references to point to correct locations within the documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->