### PR TITLE
fix(docs): clarify pgsql setup for Docker Compose install (#12518)

### DIFF
--- a/docs/janssen-server/install/docker-install/compose.md
+++ b/docs/janssen-server/install/docker-install/compose.md
@@ -107,12 +107,9 @@ persistence.
     ./up.sh pgsql
    > Note: When using the PostgreSQL option (./up.sh pgsql), make sure that the PostgreSQL service or initialization files are available.  
 > The setup script looks for the pgsql directory or Docker service when CN_INSTALL_PGSQL=true is set in your environment.  
->
 > - If you want to run PostgreSQL in Docker, ensure that your docker-compose.yml defines a pgsql service (for example, using the postgres image).  
 > - If you plan to use an external PostgreSQL database instead, set CN_INSTALL_PGSQL=false and provide connection details (RDBMS_HOST, RDBMS_USER, RDBMS_PASSWORD, RDBMS_DATABASE) in your .env file.
 
-  
->
 > Running ./up.sh pgsql without an available PostgreSQL service or initialization files will result in a “file not found” error during setup.
     ```
 


### PR DESCRIPTION
hello maintainers!
This PR improves the Docker compose installation documentation.
I added detailed note under postgreSQL section
i updated documentation
I think and hope this clarification helps users avoid common setup errors and completes a smoothier and easier friendly installation.
RESOLVES #12518  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed PostgreSQL installation guidance: prerequisites and required files, how to configure for Docker (including defining a DB service in Docker Compose) or for an external database, which environment variables to set for host/user/password/database, how to enable/disable the bundled DB installer, and a clear warning that setup will fail if no PostgreSQL service or init files are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->