### PR TITLE
fix(docs): update broken link in Getting Started with Cedarling Python — fixes #12498

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -345,9 +345,9 @@ nav:
       - SSA Modify Response: script-catalog/ssa/ssa-modify-response.md
   - Reference Guide:
     - janssen-server/reference/README.md
-    - Cedarling Development Docs:
-        - Rust : https://janssenproject.github.io/developer-docs/cedarling/cedarling/index.html
-        - Python:  https://janssenproject.github.io/developer-docs/cedarling-python/cedarling_python.html
+  - Cedarling Development Docs:
+    - Rust : https://janssenproject.github.io/developer-docs/cedarling/cedarling/index.html
+    - Python: 'cedarling/getting-started/python.md'
     - Javadocs / OpenAPI:
       - janssen-server/reference/openapi.md
       - agama: https://janssenproject.github.io/developer-docs/agama/transpiler/index.html


### PR DESCRIPTION
Hi maintainers 👋

Fixed the broken link in the “Getting Started with Cedarling Python” section.

Replaced old link with:
https://jans.io/docs/v1.7.0/cedarling/getting-started/python/

Fixes #12498


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python documentation reference in the Reference Guide to use a local path instead of an external link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->