### PR TITLE
Fix broken link to config-api-interception script

### DIFF
--- a/docs/script-catalog/config_api/config-api.md
+++ b/docs/script-catalog/config_api/config-api.md
@@ -107,4 +107,4 @@ class ConfigApiAuthorization(ConfigApiType):
 
 
 ## Sample Scripts
-- [ConfigApiInterception](../../../script-catalog/config_api/config-api-interception/config-api-interception.py)
+- [ConfigApiInterception](../../script-catalog/config_api/config-api-interception/config-api-interception.py)


### PR DESCRIPTION
### Prepare
Fix a broken documentation link.

### Description  
This PR corrects a broken link in  
`docs/script-catalog/config_api/config-api.md`  
that pointed to a non-existent path for `ConfigApiInterception`.

**Target issue:** closes #12555  <!-- or remove this line if you didn't pick a specific issue -->

### Implementation Details  
- Updated relative link from  
  `../../../script-catalog/config_api/config-api-interception/config-api-interception.py`  
  to  
  `../../script-catalog/config_api/config-api-interception/config-api-interception.py`.

### Test and Document  
- Verified that the link now works locally using VS Code preview.  
- No code changes; only documentation updated.

[skip docstring]

