### PR TITLE
Fix typo in trusted issuers reference

### DIFF
--- a/docs/cedarling/cedarling-jwt-validation.md
+++ b/docs/cedarling/cedarling-jwt-validation.md
@@ -43,7 +43,7 @@ On initialization, Cedarling will fetch the latest public keys from the issuers 
 
 ### Example Policy Store
 
-Cedarling only validates tokens issued by [trusted issuers](./cedarling-policy-store.md#trusted-issuer-schema) listed in the policy store. Tokens from issuers not listed in the policy store will be **ignored** and will not be used for [entity creation](./cedarling-entities.md).
+Cedarling only validates tokens issued by [trusted issuers](./cedarling-policy-store.md#trusted-issuers-schema) listed in the policy store. Tokens from issuers not listed in the policy store will be **ignored** and will not be used for [entity creation](./cedarling-entities.md).
 
 To allow an Access token like the one below to be used for authorization:
 


### PR DESCRIPTION
fix(docs): broken link in the Cedarling JWT Validation

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here
#12493

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a reference link in the JWT validation documentation to point to the correct policy store schema section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->