### PR TITLE
fix(jans-pycloudlib): column type mismatch on DATETIME

### DIFF
--- a/jans-pycloudlib/jans/pycloudlib/persistence/sql.py
+++ b/jans-pycloudlib/jans/pycloudlib/persistence/sql.py
@@ -398,21 +398,23 @@ class SqlClient(SqlSchemaMixin):
             for column in table.c:
                 collation = getattr(column.type, "collation", None)
 
-                # temporarily truncate COLLATION string (if needed)
-                if collation:
-                    column.type.collation = None
+                try:
+                    # temporarily truncate COLLATION string (if needed)
+                    if collation:
+                        column.type.collation = None
 
-                col_type = str(column.type)
+                    col_type = str(column.type)
 
-                # extract the size of DATETIME to match the schema from file
-                if col_type.startswith("DATETIME"):
-                    col_type = f"DATETIME({column.type.fsp})"
+                    # extract the size of DATETIME to match the schema from file
+                    if col_type.startswith("DATETIME") and getattr(column.type, "fsp", None):
+                        col_type = f"DATETIME({column.type.fsp})"
 
-                table_mapping[table_name][column.name] = col_type
+                    table_mapping[table_name][column.name] = col_type
 
-                # preserve the original collation
-                if collation and column.type.collation is None:
-                    column.type.collation = collation
+                finally:
+                    # preserve the original collation
+                    if collation and column.type.collation is None:
+                        column.type.collation = collation
 
         # finalized table mapping
         return dict(table_mapping)


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #12629 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve column collation during schema inspection so original collation is retained in type mappings.
  * Accurately capture DATETIME precision (fractional seconds) in type mappings, improving schema reflection and comparisons without changing table creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->