### PR TITLE
docs: fix broken links in getting Started with Cerdarling Java

### DIFF
--- a/docs/cedarling/getting-started/java.md
+++ b/docs/cedarling/getting-started/java.md
@@ -15,7 +15,7 @@ tags:
 
 - Java Development Kit (JDK): version 11 or higher
 
-To use Cedarling Java bindings in Java Maven Project add following 
+To use Cedarling Java bindings in Java Maven Project add following
 `repository` and `dependency` in pom.xml of the project.
 
 ```declarative
@@ -39,7 +39,6 @@ To use Cedarling Java bindings in Java Maven Project add following
 ### Building from Source
 
 Refer to the following [guide](../uniffi/cedarling-kotlin.md#building-from-source) for steps to build the Java binding from source.
-
 
 ## Usage
 
@@ -86,8 +85,7 @@ We need to initialize Cedarling first.
 Cedarling provides two main interfaces for performing authorization checks: **Token-Based Authorization** and **Unsigned Authorization**. Both methods involve evaluating access requests based on various factors, including principals (entities), actions, resources, and context. The difference lies in how the Principals are provided.
 
 - [**Token-Based Authorization**](#token-based-authorization) is the standard method where principals are extracted from JSON Web Tokens (JWTs), typically used in scenarios where you have existing user authentication and authorization data encapsulated in tokens.
-- [**Unsigned Authorization**](#unsigned-authorization) allows you to pass principals directly, bypassing tokens entirely. This is useful when you need to authorize based on internal application data, or when tokens are not available.
-
+- [**Unsigned Authorization**](#custom-principal-authorization-unsigned) allows you to pass principals directly, bypassing tokens entirely. This is useful when you need to authorize based on internal application data, or when tokens are not available.
 
 #### Token-Based Authorization
 
@@ -226,6 +224,5 @@ Defined APIs are listed [here](https://janssenproject.github.io/developer-docs/j
 
 ## See Also
 
-- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-tbac-using-cedarling)
+- [Cedarling TBAC quickstart](../cedarling-quick-start.md#implement-rbac-using-signed-tokens-tbac)
 - [Cedarling Unsigned quickstart](../cedarling-quick-start.md#step-1-create-the-cedar-policy-and-schema)
-


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Fixes broken links in Getting Started with Cedarling Java documentation.

#### Target issue
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #12496 

### Implementation Details
- Updated incorrect anchor link for Unsigned Authorization
   - from `#unsigned-authorization` to `#custom-principal-authorization-unsigned`
- Updated incorrect anchor link for Cedarling TBAC quickstart
   - from `#implement-tbac-using-cedarling`  to `#implement-rbac-using-signed-tokens-tbac`
-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Java Getting Started guide with a revised navigation structure and improved internal linking between sections.
* Enhanced the "See Also" section with additional quickstart references, including TBAC documentation materials.
* Applied minor formatting refinements throughout the guide for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->