### PR TITLE
fix(jans-auth-server): ExternalTokenExchangeService.externalValidate returns null instead of result 

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalTokenExchangeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalTokenExchangeService.java
@@ -66,7 +66,7 @@ public class ExternalTokenExchangeService extends ExternalScriptService {
 
         log.trace("Finished 'validate' method, script name: {}, clientId: {}, result: {}", script.getName(), client.getClientId(), result);
 
-        return null;
+        return result;
     }
 
     public boolean externalModifyResponse(JSONObject response, ExecutionContext context) {


### PR DESCRIPTION
### Description

fix(jans-auth-server): ExternalTokenExchangeService.externalValidate returns null instead of result 

#### Target issue

closes #12804

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token exchange validation to consistently return results in all scenarios, improving reliability when processing token exchange operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->