### PR TITLE
feat(jans-linux-setup): update the renamed scopes in role-to-scope mapping

### DIFF
--- a/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
@@ -785,21 +785,21 @@
       "tag": "lock-config"
     },
     {
-      "permission": "https://jans.io/oauth/config/jans_asset-read",
+      "permission": "https://jans.io/oauth/config/asset.readonly",
       "description": "",
       "defaultPermissionInToken": false,
       "essentialPermissionInAdminUI": false,
       "tag": "jans_asset"
     },
     {
-      "permission": "https://jans.io/oauth/config/jans_asset-write",
+      "permission": "https://jans.io/oauth/config/asset.write",
       "description": "",
       "defaultPermissionInToken": false,
       "essentialPermissionInAdminUI": false,
       "tag": "jans_asset"
     },
     {
-      "permission": "https://jans.io/oauth/config/jans_asset-delete",
+      "permission": "https://jans.io/oauth/config/asset.admin",
       "description": "",
       "defaultPermissionInToken": false,
       "essentialPermissionInAdminUI": false,
@@ -1065,9 +1065,9 @@
         "https://jans.io/oauth/kc-link-config.write",
         "https://jans.io/oauth/lock-config.readonly",
         "https://jans.io/oauth/lock-config.write",
-        "https://jans.io/oauth/config/jans_asset-read",
-        "https://jans.io/oauth/config/jans_asset-write",
-        "https://jans.io/oauth/config/jans_asset-delete",
+        "https://jans.io/oauth/config/asset.readonly",
+        "https://jans.io/oauth/config/asset.write",
+        "https://jans.io/oauth/config/asset.admin",
         "https://jans.io/oauth/lock/audit.readonly",
         "https://jans.io/oauth/lock/audit.write",
         "https://jans.io/oauth/lock/health.readonly",


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #12898

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated asset-related permission identifiers across authorization configuration files to reflect revised naming conventions for read, write, and admin access levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->