### PR TITLE
fix(cloud-native): set restrictive file permissions on SQL property files containing credentials

### DIFF
--- a/jans-pycloudlib/jans/pycloudlib/persistence/sql.py
+++ b/jans-pycloudlib/jans/pycloudlib/persistence/sql.py
@@ -1116,6 +1116,9 @@ def render_sql_properties(manager: Manager, src: str, dest: str) -> None:
         }
         f.write(rendered_txt)
 
+    # Set restrictive permissions to protect embedded credentials (if any)
+    os.chmod(dest, 0o600)
+
 
 def set_mysql_strict_mode(dbapi_connection, connection_record):
     cursor = dbapi_connection.cursor()

--- a/jans-pycloudlib/tests/test_persistence.py
+++ b/jans-pycloudlib/tests/test_persistence.py
@@ -113,6 +113,8 @@ def test_get_sql_password_from_file(monkeypatch, tmpdir, gmanager):
     ("pgsql", 5432, "public", "postgresql"),
 ])
 def test_render_sql_properties(monkeypatch, tmpdir, gmanager, dialect, port, schema, jdbc_driver):
+    import os
+    import stat
     from jans.pycloudlib.persistence.sql import render_sql_properties
 
     passwd = tmpdir.join("sql_password")
@@ -144,6 +146,10 @@ auth.userPassword=fHL54sT5qHk=
 
     render_sql_properties(gmanager, str(src), str(dest))
     assert dest.read() == expected
+
+    # check file permission (should writable only by owner)
+    perms = stat.S_IMODE(os.stat(dest).st_mode)
+    assert oct(perms) == '0o600'
 
 
 class PGException(Exception):


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #12895 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied restrictive file permissions (owner read/write only) to SQL configuration files, limiting access to the file owner.

* **Tests**
  * Added test assertions to verify file permission restrictions are properly enforced on generated SQL configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->