### PR TITLE
fix(jans-cli-tui): display confirmation message after saving jans-lock server config

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/120_lock/main.py
+++ b/jans-cli-tui/cli_tui/plugins/120_lock/main.py
@@ -224,7 +224,11 @@ class Plugin(DialogUtils):
             response = await common_data.app.loop.run_in_executor(common_data.app.executor, common_data.app.cli_requests, cli_args)
             common_data.app.stop_progressing()
             if response.status_code not in (200, 201):
-                common_data.app.show_message(_(common_strings.error), str(response.text), tobefocused=self.main_container)
+                common_data.app.show_message(
+                    title=_(common_strings.error),
+                    message=str(response.text),
+                    tobefocused=self.main_container
+                    )
             else:
                 self.data = response.json()
                 common_data.app.show_message(


### PR DESCRIPTION
After this commit, TUI will display a confirmation message after saving jans-lock server configuration as follows:

<img width="843" height="408" alt="jas-lock-config-saved-confirmation" src="https://github.com/user-attachments/assets/1a55f3a8-cacc-4ce2-906f-98d965b6de6c" />



### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #12910
#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a translated success notification: "Jans Lock Server configuration was saved." after configuration is saved.

* **Bug Fixes / Localization**
  * Error messages for failed lock configuration requests are now shown using localized strings for consistent user-facing messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->