### PR TITLE
feat(jans-config-api): send 406 - Not Acceptable error code in response if Admin UI re…

### DIFF
--- a/jans-config-api/server/src/main/java/io/jans/configapi/filters/AdminUICookieFilter.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/filters/AdminUICookieFilter.java
@@ -75,6 +75,12 @@ public class AdminUICookieFilter implements ContainerRequestFilter {
             initializeCaches();
             removeExpiredSessionsIfNeeded();
             Optional<String> ujwtOptional = fetchUJWTFromAdminUISession(cookies);
+            //return 406 error if Admin UI session is not present on server
+            if (cookies.containsKey(ADMIN_UI_SESSION_ID)
+                    && requestContext.getHeaders().get(HttpHeaders.AUTHORIZATION) == null
+                    && ujwtOptional.isEmpty()) {
+                abortWithException(requestContext, Response.Status.NOT_ACCEPTABLE, "Admin UI session is not present on server");
+            }
             //return if session record is not present in the database
             if (ujwtOptional.isEmpty()) {
                 return;


### PR DESCRIPTION
…quests Config API with expired session

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #13021, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Admin UI session validation to properly detect and reject requests without an active session, ensuring better security and error handling for Admin UI operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->