### PR TITLE
feat: send 403 - Forbidden error code in response if Admin UI requests Config API with expired session. This will indicate to Admin UI to logout.

### DIFF
--- a/jans-config-api/server/src/main/java/io/jans/configapi/filters/AdminUICookieFilter.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/filters/AdminUICookieFilter.java
@@ -70,18 +70,18 @@ public class AdminUICookieFilter implements ContainerRequestFilter {
     @Override
     public void filter(ContainerRequestContext requestContext) {
         try {
-            log.debug("Inside AdminUICookieFilter filter...");
+            log.info("Inside AdminUICookieFilter filter...");
             Map<String, Cookie> cookies = requestContext.getCookies();
             initializeCaches();
             removeExpiredSessionsIfNeeded();
             Optional<String> ujwtOptional = fetchUJWTFromAdminUISession(cookies);
-            //return 406 error if Admin UI session is not present on server
+            //For request from Admin UI, return 403 error if Admin UI session is not present on server
             if (cookies.containsKey(ADMIN_UI_SESSION_ID)
                     && requestContext.getHeaders().get(HttpHeaders.AUTHORIZATION) == null
                     && ujwtOptional.isEmpty()) {
-                abortWithException(requestContext, Response.Status.NOT_ACCEPTABLE, "Admin UI session is not present on server");
+                abortWithException(requestContext, Response.Status.FORBIDDEN, "Admin UI session is not present on server.");
             }
-            //return if session record is not present in the database
+            //Return this if the session record is not present in the database, covering non–Admin UI requests.
             if (ujwtOptional.isEmpty()) {
                 return;
             }


### PR DESCRIPTION
…

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #13019

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Short-circuited Admin UI requests that present an Admin UI session cookie but lack an Authorization header and server-side session token — these now return 403 instead of proceeding.
  * Preserved existing behavior for non-Admin UI cases and for empty session tokens.
  * Adjusted related logging to a higher-visibility level to aid operational visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->