### PR TITLE
fix(jans-auth-server): don't fail with NPE if there is no token exchange custom script or it failed to load

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalTokenExchangeService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/external/ExternalTokenExchangeService.java
@@ -39,7 +39,7 @@ public class ExternalTokenExchangeService extends ExternalScriptService {
             }
         }
 
-        return null;
+        return ScriptTokenExchangeControl.ok();
     }
 
     public ScriptTokenExchangeControl externalValidate(CustomScriptConfiguration script, ExecutionContext context) {
@@ -47,7 +47,7 @@ public class ExternalTokenExchangeService extends ExternalScriptService {
         log.trace("Executing external 'validate' method, script name: {}, clientId: {}",
                 script.getName(), client.getClientId());
 
-        ScriptTokenExchangeControl result = null;
+        ScriptTokenExchangeControl result = ScriptTokenExchangeControl.ok();
         try {
             final ExternalScriptContext scriptContext = new ExternalScriptContext(context);
             TokenExchangeType tokenExchangeType = (TokenExchangeType) script.getExternalType();


### PR DESCRIPTION
### Description

fix(jans-auth-server): don't fail with NPE if there is no token exchange custom script or it failed to load

#### Target issue
  
closes #13113


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token exchange validation now defaults to successful completion when no scripts explicitly fail, ensuring improved default behavior in the validation flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->