### PR TITLE
feat(jans-auth-server): harden allowed schemes for redirects #13423

### DIFF
--- a/docs/janssen-server/auth-server/client-management/client-configuration.md
+++ b/docs/janssen-server/auth-server/client-management/client-configuration.md
@@ -35,7 +35,7 @@ The client can register a list of URIs as a value for redirect URI parameter. Re
 - Janssen Server supports all [methods of redirection](https://datatracker.ietf.org/doc/html/rfc8252#section-7) used by
   **native apps**. Use of Private-Use URI (or custom URL) is
   supported by allowing redirect URI to take the form of reverse DNS name, for example, ` com.example.app`. URLs for
-  loopback interface redirection are also supported.
+  loopback interface redirection are also supported. Any schema in URI is allowed for `native` client.
 - When the client registers **multiple redirect URIs** (Janssen Server accepts a list of URIs separated by space), be aware
   that Janssen Server will use these, one by one for validation purposes and the validation stops at the first match.
 - If there are multiple registered redirect_uris, and the client is using `pairwise` subject

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/registration/RegisterParamsValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/registration/RegisterParamsValidator.java
@@ -329,7 +329,7 @@ public class RegisterParamsValidator {
                 log.debug("Invalid schema for redirect_uri. Only HTTP (localhost) and HTTPS are supported, redirect_uri: '{}'", uri);
                 return false;
             case NATIVE:
-                // Custom schemes are allowed for native apps per RFC 8252 (OAuth 2.0 for Native Apps).
+                // Any schemes (including custom) are allowed for native apps per RFC 8252 (OAuth 2.0 for Native Apps).
                 return true;
         }
         log.debug("redirect_uri is not valid, redirect_uri: '{}'", uri);

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/model/registration/RegisterParamsValidatorTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/model/registration/RegisterParamsValidatorTest.java
@@ -59,6 +59,18 @@ public class RegisterParamsValidatorTest {
     }
 
     @Test
+    public void validateRedirectUris_webApp_javascriptCamelCase_shouldReturnFalse() {
+        boolean result = registerParamsValidator.validateRedirectUris(
+                Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+                Collections.singletonList(ResponseType.CODE),
+                ApplicationType.WEB,
+                SubjectType.PUBLIC,
+                Collections.singletonList("JaVaScRiPt://example.com/callback"),
+                null);
+        assertFalse(result);
+    }
+
+    @Test
     public void validateRedirectUris_webApp_file_shouldReturnFalse() {
         boolean result = registerParamsValidator.validateRedirectUris(
                 Collections.singletonList(GrantType.AUTHORIZATION_CODE),
@@ -202,6 +214,21 @@ public class RegisterParamsValidatorTest {
                 ApplicationType.NATIVE,
                 SubjectType.PUBLIC,
                 Collections.singletonList("myapp://callback"),
+                null);
+        assertTrue(result);
+    }
+
+    @Test
+    public void validateRedirectUris_nativeApp_javascript_shouldReturnTrue() {
+        when(appConfiguration.getClientWhiteList()).thenReturn(Collections.singletonList("*"));
+        when(appConfiguration.getClientBlackList()).thenReturn(Collections.emptyList());
+
+        boolean result = registerParamsValidator.validateRedirectUris(
+                Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+                Collections.singletonList(ResponseType.CODE),
+                ApplicationType.NATIVE,
+                SubjectType.PUBLIC,
+                Collections.singletonList("javascript://example.com/callback"),
                 null);
         assertTrue(result);
     }


### PR DESCRIPTION
### Description

feat(jans-auth-server): harden allowed schemes for redirects #13423

#### Target issue
  
closes #13423

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened redirect URI validation with clearer handling of web and native client cases to improve security and correctness.

* **Refactor**
  * Centralized redirect URI validation logic for more consistent behavior.

* **Tests**
  * Added extensive tests covering many redirect URI scenarios, grant types, and sector identifier rules.

* **Documentation**
  * Clarified that native clients may use any URI scheme (loopback behavior retained).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->