### PR TITLE
fix(docs): EOL docs to align dates

### DIFF
--- a/docs/EOL.md
+++ b/docs/EOL.md
@@ -9,7 +9,7 @@ tags:
 
 ## 1. Lifecycle Overview
 
-Our End of Life (EOL) policy is designed to provide a predictable schedule for support and upgrades. The lifecycle of any major version is calculated based on its original **General Availability (GA)** date. This is applicable for version 2.0.0 and later releases.
+Our End of Life (EOL) policy is designed to provide a predictable schedule for support and upgrades. The lifecycle of any major version is calculated based on its original **General Availability (GA)** date. This applies to version 2.0.0 and later releases.
 
 ### Key Milestones
 


### PR DESCRIPTION
closes #13568 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated version lifecycle and support timelines in End of Life documentation
  * Extended v1.x end-of-life (support) date to 2026-11-14 (projected) while keeping it Active
  * Removed the v2.x row from the lifecycle table
  * Clarified that GA-based lifecycle calculations apply to versions 2.0.0 and later
  * Renamed header to "Version Status" and refined milestone wording to distinguish full vs. maintenance support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->