### PR TITLE
fix(jans-config-api): save usageType field for /api/v1/attributes

### DIFF
--- a/docs/janssen-server/config-guide/auth-server-config/attribute-configuration.md
+++ b/docs/janssen-server/config-guide/auth-server-config/attribute-configuration.md
@@ -389,7 +389,7 @@ jans cli --operation-id post-attributes --data /tmp/custom-claim.json
     "user"
   ],
   "usageType": [
-    null
+    "openid"
   ],
   "claimName": "string",
   "seeAlso": "string",

--- a/docs/janssen-server/reference/database/mysql-schema.md
+++ b/docs/janssen-server/reference/database/mysql-schema.md
@@ -142,7 +142,7 @@ tags:
 | jansAttrSystemEditTyp | varchar(64)  | YES  |     | None    | TODO - still required?                                                                                                       |
 | jansAttrTyp           | varchar(64)  | YES  |     | None    | Data type of attribute. Values can be string, photo, numeric, date                                                           |
 | jansClaimName         | varchar(64)  | YES  |     | None    | Used by jans in conjunction with jansttributeName to map claims to attributes in datastore.                                       |
-| jansAttrUsgTyp        | varchar(64)  | YES  |     | None    | TODO - Usg? Value can be OpenID                                                                                              |
+| jansAttrUsgTyp        | json         | YES  |     | None    | TODO - Usg? Value can be OpenID                                                                                              |
 | jansAttrViewTyp       | json         | YES  |     | None    | Specify in exclude who can view an attribute, admin or user                                                                  |
 | jansSAML1URI          | varchar(64)  | YES  |     | None    | SAML 1 uri of attribute                                                                                                      |
 | jansSAML2URI          | varchar(64)  | YES  |     | None    | SAML 2 uri of attribute                                                                                                      |

--- a/docs/janssen-server/reference/database/pgsql-schema.md
+++ b/docs/janssen-server/reference/database/pgsql-schema.md
@@ -343,7 +343,7 @@ tags:
 | jansAttrSystemEditTyp | character varying | 64                       | YES  | None    | TODO - still required?                                                                                                       |
 | jansAttrTyp           | character varying | 64                       | YES  | None    | Data type of attribute. Values can be string, photo, numeric, date                                                           |
 | jansClaimName         | character varying | 64                       | YES  | None    | Used by jans in conjunction with jansttributeName to map claims to attributes in LDAP.                                       |
-| jansAttrUsgTyp        | character varying | 64                       | YES  | None    | TODO - Usg? Value can be OpenID                                                                                              |
+| jansAttrUsgTyp        | jsonb             | None                     | YES  | None    | TODO - Usg? Value can be OpenID                                                                                              |
 | jansAttrViewTyp       | jsonb             | None                     | YES  | None    | Specify in exclude who can view an attribute, admin or user                                                                  |
 | jansSAML1URI          | character varying | 64                       | YES  | None    | SAML 1 uri of attribute                                                                                                      |
 | jansSAML2URI          | character varying | 64                       | YES  | None    | SAML 2 uri of attribute                                                                                                      |

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -1492,6 +1492,9 @@ paths:
                       "origin": "jansPerson",
                       "jansMultivaluedAttr": false,
                       "status": "active",
+                      "usageType": [
+                          "openid"
+                      ],
                       "urn": "urn:mace:dir:attribute-def:qaattribute",
                       "userCanAccess": true,
                       "userCanEdit": true,
@@ -1529,6 +1532,9 @@ paths:
                         "origin": "jansPerson",
                         "jansMultivaluedAttr": false,
                         "status": "active",
+                        "usageType": [
+                            "openid"
+                        ],
                         "urn": "urn:mace:dir:attribute-def:qaattribute",
                         "userCanAccess": true,
                         "userCanEdit": true,
@@ -1584,6 +1590,9 @@ paths:
                       "origin": "jansPerson",
                       "jansMultivaluedAttr": false,
                       "status": "active",
+                      "usageType": [
+                          "openid"
+                      ],
                       "urn": "urn:mace:dir:attribute-def:qaattribute",
                       "userCanAccess": true,
                       "userCanEdit": true,
@@ -1621,6 +1630,9 @@ paths:
                         "origin": "jansPerson",
                         "jansMultivaluedAttr": false,
                         "status": "active",
+                        "usageType": [
+                            "openid"
+                        ],
                         "urn": "urn:mace:dir:attribute-def:qaattribute",
                         "userCanAccess": true,
                         "userCanEdit": true,
@@ -1800,6 +1812,9 @@ paths:
                         "origin": "jansPerson",
                         "jansMultivaluedAttr": false,
                         "status": "active",
+                        "usageType": [
+                            "openid"
+                        ],
                         "urn": "urn:mace:dir:attribute-def:qaattribute",
                         "userCanAccess": true,
                         "userCanEdit": true,
@@ -6989,8 +7004,8 @@ paths:
                             "jansattrusgtyp": {
                                 "name": "jansattrusgtyp",
                                 "defName": "jansAttrUsgTyp",
-                                "type": "varchar",
-                                "multiValued": false
+                                "type": "jsonb",
+                                "multiValued": true
                             },
                             "janssaml2uri": {
                                 "name": "janssaml2uri",

--- a/jans-config-api/server/src/main/resources/example/attribute/attribute.json
+++ b/jans-config-api/server/src/main/resources/example/attribute/attribute.json
@@ -14,6 +14,9 @@
     "origin": "jansPerson",
     "jansMultivaluedAttr": false,
     "status": "active",
+    "usageType": [
+        "openid"
+    ],
     "urn": "urn:mace:dir:attribute-def:qaattribute",
     "userCanAccess": true,
     "userCanEdit": true,

--- a/jans-config-api/server/src/main/resources/example/database/tableInfo.json
+++ b/jans-config-api/server/src/main/resources/example/database/tableInfo.json
@@ -1547,8 +1547,8 @@
         "jansattrusgtyp": {
             "name": "jansattrusgtyp",
             "defName": "jansAttrUsgTyp",
-            "type": "varchar",
-            "multiValued": false
+            "type": "jsonb",
+            "multiValued": true
         },
         "janssaml2uri": {
             "name": "janssaml2uri",

--- a/jans-config-api/server/src/test/java/io/jans/configapi/test/auth/AttributesResourceTest.java
+++ b/jans-config-api/server/src/test/java/io/jans/configapi/test/auth/AttributesResourceTest.java
@@ -1,0 +1,158 @@
+/*
+ * This software is available under the Apache-2.0 license.
+ * See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+ *
+ * Copyright (c) 2025, Gluu, Inc.
+ */
+
+package io.jans.configapi.test.auth;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jans.configapi.ConfigServerBaseTest;
+import io.jans.configapi.core.configuration.ObjectMapperContextResolver;
+import io.jans.configapi.core.test.listener.SkipTest;
+import io.jans.model.GluuAttributeUsageType;
+import io.jans.model.JansAttribute;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation.Builder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+@SkipTest(databases = { "LDAP", "COUCHBASE", "SPANNER" })
+public class AttributesResourceTest extends ConfigServerBaseTest {
+
+    private static final String ATTRIBUTE_NAME = "departmentNumber";
+    private static final String USAGE_TYPE_PATCH = "[{\"op\":\"add\",\"path\":\"/usageType\",\"value\":[\"openid\"]}]";
+
+    @Parameters({ "test.issuer", "attributesUrl" })
+    @Test
+    public void putAndPatchUsageTypeRoundTrip(final String issuer, final String attributesUrl) throws Exception {
+        ObjectMapper objectMapper = ObjectMapperContextResolver.createDefaultMapper();
+        JansAttribute originalAttribute = getAttributeByName(issuer, attributesUrl, ATTRIBUTE_NAME, objectMapper);
+        JansAttribute restoreAttribute = copyAttribute(objectMapper, originalAttribute);
+
+        try {
+            JansAttribute putRequest = copyAttribute(objectMapper, originalAttribute);
+            putRequest.setUsageType(new GluuAttributeUsageType[] { GluuAttributeUsageType.OPENID });
+
+            JansAttribute updatedAfterPut = putAttribute(issuer, attributesUrl, putRequest, objectMapper);
+            assertUsageType(updatedAfterPut);
+
+            JansAttribute patchedAttribute = patchAttribute(
+                    issuer,
+                    attributesUrl,
+                    originalAttribute.getInum(),
+                    USAGE_TYPE_PATCH,
+                    objectMapper);
+            assertUsageType(patchedAttribute);
+
+            JansAttribute fetchedAfterPatch = getAttributeByInum(
+                    issuer,
+                    attributesUrl,
+                    originalAttribute.getInum(),
+                    objectMapper);
+            assertUsageType(fetchedAfterPatch);
+        } finally {
+            putAttribute(issuer, attributesUrl, restoreAttribute, objectMapper);
+        }
+    }
+
+    private JansAttribute getAttributeByName(
+            String issuer,
+            String attributesUrl,
+            String attributeName,
+            ObjectMapper objectMapper) throws IOException {
+        String url = issuer
+                + attributesUrl
+                + "?pattern="
+                + URLEncoder.encode(attributeName, StandardCharsets.UTF_8)
+                + "&limit=10";
+
+        Builder request = authorizedJsonRequest(url);
+        try (Response response = request.get()) {
+            String responseBody = response.readEntity(String.class);
+            assertEquals(response.getStatus(), Status.OK.getStatusCode(), responseBody);
+
+            JsonNode rootNode = objectMapper.readTree(responseBody);
+            for (JsonNode entryNode : rootNode.path("entries")) {
+                if (attributeName.equals(entryNode.path("name").asText())) {
+                    return objectMapper.treeToValue(entryNode, JansAttribute.class);
+                }
+            }
+            throw new IllegalStateException("Failed to find attribute '" + attributeName + "' in response: " + responseBody);
+        }
+    }
+
+    private JansAttribute getAttributeByInum(
+            String issuer,
+            String attributesUrl,
+            String inum,
+            ObjectMapper objectMapper) throws IOException {
+        Builder request = authorizedJsonRequest(issuer + attributesUrl + "/" + inum);
+        try (Response response = request.get()) {
+            String responseBody = response.readEntity(String.class);
+            assertEquals(response.getStatus(), Status.OK.getStatusCode(), responseBody);
+            return objectMapper.readValue(responseBody, JansAttribute.class);
+        }
+    }
+
+    private JansAttribute putAttribute(
+            String issuer,
+            String attributesUrl,
+            JansAttribute attribute,
+            ObjectMapper objectMapper) throws IOException {
+        Builder request = authorizedJsonRequest(issuer + attributesUrl);
+        String payload = objectMapper.writeValueAsString(attribute);
+        try (Response response = request.put(Entity.entity(payload, MediaType.APPLICATION_JSON))) {
+            String responseBody = response.readEntity(String.class);
+            assertEquals(response.getStatus(), Status.OK.getStatusCode(), responseBody);
+            return objectMapper.readValue(responseBody, JansAttribute.class);
+        }
+    }
+
+    private JansAttribute patchAttribute(
+            String issuer,
+            String attributesUrl,
+            String inum,
+            String payload,
+            ObjectMapper objectMapper) throws IOException {
+        Builder request = authorizedJsonRequest(issuer + attributesUrl + "/" + inum);
+        request.header(CONTENT_TYPE, MediaType.APPLICATION_JSON_PATCH_JSON);
+        try (Response response = request.method(HttpMethod.PATCH, Entity.entity(payload, MediaType.APPLICATION_JSON_PATCH_JSON))) {
+            String responseBody = response.readEntity(String.class);
+            assertEquals(response.getStatus(), Status.OK.getStatusCode(), responseBody);
+            return objectMapper.readValue(responseBody, JansAttribute.class);
+        }
+    }
+
+    private Builder authorizedJsonRequest(String url) {
+        Builder request = getResteasyService().getClientBuilder(url);
+        request.header(AUTHORIZATION, AUTHORIZATION_TYPE + " " + accessToken);
+        request.header(CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        return request;
+    }
+
+    private JansAttribute copyAttribute(ObjectMapper objectMapper, JansAttribute attribute) throws IOException {
+        return objectMapper.readValue(objectMapper.writeValueAsBytes(attribute), JansAttribute.class);
+    }
+
+    private void assertUsageType(JansAttribute attribute) {
+        assertNotNull(attribute.getUsageType(), "usageType must be present");
+        assertEquals(attribute.getUsageType().length, 1, "usageType must contain one value");
+        assertEquals(attribute.getUsageType()[0], GluuAttributeUsageType.OPENID);
+    }
+}

--- a/jans-config-api/server/src/test/java/io/jans/configapi/test/util/JacksonPatchTest.java
+++ b/jans-config-api/server/src/test/java/io/jans/configapi/test/util/JacksonPatchTest.java
@@ -1,0 +1,45 @@
+/*
+ * This software is available under the Apache-2.0 license.
+ * See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+ *
+ * Copyright (c) 2025, Gluu, Inc.
+ */
+
+package io.jans.configapi.test.util;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+import com.github.fge.jsonpatch.JsonPatchException;
+
+import io.jans.configapi.core.util.Jackson;
+import io.jans.model.GluuAttributeUsageType;
+import io.jans.model.GluuUserRole;
+import io.jans.model.JansAttribute;
+import io.jans.model.attribute.AttributeDataType;
+
+public class JacksonPatchTest {
+
+    private static final String USAGE_TYPE_PATCH = "[{\"op\":\"add\",\"path\":\"/usageType\",\"value\":[\"openid\"]}]";
+
+    @Test
+    public void patchUsageTypeUsesApiEnumValues() throws JsonPatchException, IOException {
+        JansAttribute attribute = new JansAttribute();
+        attribute.setName("departmentNumber");
+        attribute.setDisplayName("Department");
+        attribute.setDescription("Department");
+        attribute.setDataType(AttributeDataType.STRING);
+        attribute.setEditType(new GluuUserRole[] { GluuUserRole.ADMIN });
+        attribute.setViewType(new GluuUserRole[] { GluuUserRole.ADMIN });
+
+        JansAttribute patchedAttribute = Jackson.applyPatch(USAGE_TYPE_PATCH, attribute);
+
+        assertNotNull(patchedAttribute.getUsageType(), "usageType must be set");
+        assertEquals(patchedAttribute.getUsageType().length, 1, "usageType must contain one value");
+        assertEquals(patchedAttribute.getUsageType()[0], GluuAttributeUsageType.OPENID);
+    }
+}

--- a/jans-config-api/server/src/test/resources/json/attribute/attribute.json
+++ b/jans-config-api/server/src/test/resources/json/attribute/attribute.json
@@ -14,6 +14,9 @@
     "origin": "jansPerson",
     "jansMultivaluedAttr": false,
     "status": "active",
+    "usageType": [
+        "openid"
+    ],
     "urn": "urn:mace:dir:attribute-def:qaattribute",
     "userCanAccess": true,
     "userCanEdit": true,

--- a/jans-config-api/server/src/test/resources/json/attribute/attributes.feature
+++ b/jans-config-api/server/src/test/resources/json/attribute/attributes.feature
@@ -124,6 +124,7 @@ Scenario: Delete a non-existion attribute by inum
 	Then status 404 
 	
 
+
 Scenario: Get an attribute by inum(unexisting attribute) 
 	Given url mainUrl + '/53553532727272772'
 	And header Authorization = 'Bearer ' + accessToken 
@@ -194,5 +195,3 @@ Scenario: Patch jansHideOnDiscovery configuration for Country attribute
     When method PATCH
     Then status 200
     And print response
-  
-	

--- a/jans-config-api/server/src/test/resources/testng.xml
+++ b/jans-config-api/server/src/test/resources/testng.xml
@@ -22,20 +22,32 @@
     </test>
 
 	<test name="Auth Server Config" enabled="true">
-        <classes>
-            <class name="io.jans.configapi.test.auth.AuthConfigResourceTest" />
-        </classes>
-    </test>
+	    <classes>
+	        <class name="io.jans.configapi.test.auth.AuthConfigResourceTest" />
+	    </classes>
+	</test>
 
-    <test name="Openid Client" enabled="true">
-        <classes>
-             <class name="io.jans.configapi.test.auth.ClientResourceTest" />
-        </classes>
-    </test>
+	<test name="Attributes" enabled="true">
+	    <classes>
+	        <class name="io.jans.configapi.test.auth.AttributesResourceTest" />
+	    </classes>
+	</test>
 
-	<test name="Config" enabled="true">
-        <classes>
-            <class name="io.jans.configapi.test.auth.ConfigResourceTest" />
+	    <test name="Openid Client" enabled="true">
+	        <classes>
+	             <class name="io.jans.configapi.test.auth.ClientResourceTest" />
+	        </classes>
+	    </test>
+
+	<test name="Jackson Patch" enabled="true">
+	    <classes>
+	        <class name="io.jans.configapi.test.util.JacksonPatchTest" />
+	    </classes>
+	</test>
+
+	    <test name="Config" enabled="true">
+	        <classes>
+	            <class name="io.jans.configapi.test.auth.ConfigResourceTest" />
         </classes>
     </test>
 

--- a/jans-config-api/shared/src/main/java/io/jans/configapi/core/util/Jackson.java
+++ b/jans-config-api/shared/src/main/java/io/jans/configapi/core/util/Jackson.java
@@ -28,6 +28,8 @@ import java.util.*;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import io.jans.configapi.core.configuration.ObjectMapperContextResolver;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,9 +104,10 @@ public class Jackson {
     public static <T> T applyPatch(JsonPatch jsonPatch, T obj) throws JsonPatchException, JsonProcessingException {
         Preconditions.checkNotNull(jsonPatch);
         Preconditions.checkNotNull(obj);
-        ObjectMapper objectMapper = JacksonUtils.newMapper()
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        JsonNode patched = jsonPatch.apply(objectMapper.convertValue(obj, JsonNode.class));
+        ObjectMapper objectMapper = ObjectMapperContextResolver.createDefaultMapper();
+        ObjectMapper patchTreeMapper = objectMapper.copy();
+        patchTreeMapper.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS);
+        JsonNode patched = jsonPatch.apply(patchTreeMapper.convertValue(obj, JsonNode.class));
         return (T) objectMapper.treeToValue(patched, obj.getClass());
     }
 

--- a/jans-linux-setup/jans_setup/schema/jans_schema.json
+++ b/jans-linux-setup/jans_setup/schema/jans_schema.json
@@ -107,6 +107,7 @@
       "names": [
         "jansAttrUsgTyp"
       ],
+      "multivalued": true,
       "oid": "jansAttr",
       "substr": "caseIgnoreSubstringsMatch",
       "syntax": "1.3.6.1.4.1.1466.115.121.1.15",

--- a/jans-linux-setup/jans_setup/setup_app/installers/rdbm.py
+++ b/jans-linux-setup/jans_setup/setup_app/installers/rdbm.py
@@ -319,6 +319,120 @@ class RDBMInstaller(BaseInstaller, SetupUtils):
 
         return col_def
 
+    def get_column_data_type(self, table_name, column_name):
+        if Config.rdbm_type == 'pgsql':
+            query = (
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_schema = current_schema() "
+                "AND table_name = '{}' AND column_name = '{}';"
+            ).format(table_name, column_name)
+        else:
+            query = (
+                "SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
+                "WHERE TABLE_SCHEMA = '{}' AND TABLE_NAME = '{}' AND COLUMN_NAME = '{}';"
+            ).format(Config.rdbm_db, table_name, column_name)
+
+        result = self.dbUtils.exec_rdbm_query(query, getresult=1)
+        return result[0].upper() if result and result[0] else None
+
+    def column_exists(self, table_name, column_name):
+        return self.get_column_data_type(table_name, column_name) is not None
+
+    def is_existing_json_column(self, table_name, column_name):
+        data_type = self.get_column_data_type(table_name, column_name)
+        if data_type in ('JSON', 'JSONB'):
+            return True
+
+        if Config.rdbm_type == 'mysql' and self.dbUtils.mariadb:
+            query = (
+                "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS "
+                "WHERE CONSTRAINT_SCHEMA = '{}' AND TABLE_NAME = '{}' "
+                "AND CONSTRAINT_NAME = '{}' AND LOWER(CHECK_CLAUSE) LIKE '%json_valid%';"
+            ).format(Config.rdbm_db, table_name, column_name)
+            result = self.dbUtils.exec_rdbm_query(query, getresult=1)
+            return result is not None
+
+        return False
+
+    def run_sql_commands(self, sql_cmds, tables):
+        for sql_cmd in sql_cmds:
+            self.dbUtils.exec_rdbm_query(sql_cmd)
+            tables.append(sql_cmd)
+
+    def migrate_multivalued_column(self, table_name, attrname, tables):
+        data_type = self.get_sql_col_type(attrname, table_name)
+        if data_type not in ('JSON', 'JSONB'):
+            return
+
+        if not self.column_exists(table_name, attrname) or self.is_existing_json_column(table_name, attrname):
+            return
+
+        self.logIt("Migrating multivalued column {}.{} to {}".format(table_name, attrname, data_type))
+        sql_cmds = []
+        if Config.rdbm_type == 'pgsql':
+            sql_cmds.append(
+                'ALTER TABLE "{0}" ALTER COLUMN "{1}" TYPE JSONB USING CASE '
+                'WHEN "{1}" IS NULL THEN NULL '
+                'WHEN "{1}" = \'\' THEN \'[]\'::jsonb '
+                'ELSE jsonb_build_array("{1}") END;'.format(table_name, attrname)
+            )
+            desc = self.get_attr_description(attrname)
+            if desc:
+                sql_cmds.append(
+                    '''COMMENT ON COLUMN "{}"."{}" IS '{}';'''.format(
+                        table_name,
+                        attrname,
+                        desc.replace("'", "''"),
+                    )
+                )
+        else:
+            temp_column = '{}_tmp_json'.format(attrname)
+            if self.column_exists(table_name, temp_column):
+                sql_cmds.append('ALTER TABLE `{}` DROP COLUMN `{}`;'.format(table_name, temp_column))
+
+            sql_cmds.extend(
+                [
+                    'ALTER TABLE `{}` ADD COLUMN `{}` JSON;'.format(table_name, temp_column),
+                    (
+                        "UPDATE `{0}` SET `{1}` = CASE "
+                        "WHEN `{2}` IS NULL THEN NULL "
+                        "WHEN `{2}` = '' THEN JSON_ARRAY() "
+                        "ELSE JSON_ARRAY(`{2}`) END;"
+                    ).format(table_name, temp_column, attrname),
+                    'ALTER TABLE `{}` DROP COLUMN `{}`;'.format(table_name, attrname),
+                ]
+            )
+
+            desc = self.get_attr_description(attrname)
+            if desc:
+                escaped_desc = desc.replace('\\', '\\\\').replace('"', '\\"')
+                sql_cmds.append(
+                    'ALTER TABLE `{0}` CHANGE COLUMN `{1}` `{2}` JSON COMMENT "{3}";'.format(
+                        table_name,
+                        temp_column,
+                        attrname,
+                        escaped_desc,
+                    )
+                )
+            else:
+                sql_cmds.append(
+                    'ALTER TABLE `{0}` CHANGE COLUMN `{1}` `{2}` JSON;'.format(
+                        table_name,
+                        temp_column,
+                        attrname,
+                    )
+                )
+
+            if self.dbUtils.mariadb:
+                sql_cmds.append(
+                    'ALTER TABLE `{0}` ADD CONSTRAINT `{1}` CHECK (JSON_VALID(`{1}`));'.format(
+                        table_name,
+                        attrname,
+                    )
+                )
+
+        self.run_sql_commands(sql_cmds, tables)
+
     def create_tables(self, jans_schema_files):
         self.logIt("Creating tables for {}".format(jans_schema_files))
         tables = []
@@ -383,6 +497,10 @@ class RDBMInstaller(BaseInstaller, SetupUtils):
                     tables.append(comment_sql)
 
                 tables.append(sql_cmd)
+            else:
+                for attrname in cols_:
+                    if all_attribs.get(attrname, {}).get('multivalued'):
+                        self.migrate_multivalued_column(sql_tbl_name, attrname, tables)
 
         for attrname in all_attribs:
             attr = all_attribs[attrname]
@@ -566,4 +684,3 @@ class RDBMInstaller(BaseInstaller, SetupUtils):
     def installed(self):
         # to be implemented
         return True
-


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #13517 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->
  The `usageType` field was not persisting on `POST`/`PUT`/`PATCH` `/api/v1/attributes` because the `jansAttrUsgTyp` database column was `varchar(64)` while the Java model declares it as a multi-valued array (`GluuAttributeUsageType[]`).
                                                                                                                                                                             
  - Mark `jansAttrUsgTyp` as `multivalued` in `jans_schema.json`                                                                                                             
  - Add RDBM migration to convert existing `varchar` columns to `json`/`jsonb` for both MySQL and PostgreSQL
  - Fix `Jackson.applyPatch` to use the API `ObjectMapper` so enums deserialize correctly on PATCH                                                                           
  - Update swagger examples, schema docs, and test fixtures

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attributes now include a usageType field (e.g., ["openid"]) and support multivalued usageType.

* **Documentation**
  * API docs and database schema docs updated to reflect usageType and its JSON/jsonb representation.

* **Tests**
  * Added tests to verify putting, patching, and JSON-patch behavior for usageType.

* **Chores**
  * Database migration helpers added to convert existing columns to JSON/jsonb for multivalued attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->