### PR TITLE
fix(jans-auth): use default web application servlet for non GRPC requests

### DIFF
--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/grpc/servlet/GrpcAuditServlet.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/grpc/servlet/GrpcAuditServlet.java
@@ -27,6 +27,7 @@ import io.jans.lock.service.grpc.audit.GrpcAuditServiceProvider;
 import io.jans.lock.service.grpc.security.GrpcAuthorizationInterceptor;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -108,26 +109,32 @@ public class GrpcAuditServlet extends HttpServlet {
         }
     }
 
-    @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    private void handleGrpcRequest(HttpServletRequest req, HttpServletResponse resp, boolean isPost) throws IOException, ServletException {
+        if (!GrpcRequestWrapper.isGrpcRequest(req)) {
+            getServletContext().getNamedDispatcher("default").forward(req, resp);
+            return;
+        }
         ServletAdapter adapter = adapterRef.get();
-        if (adapter != null) {
-            HttpServletRequest wrappedRequest = GrpcRequestWrapper.isGrpcRequest(req) ? new GrpcRequestWrapper(req) : req;
-            adapter.doPost(wrappedRequest, resp);
-        } else {
+        if (adapter == null) {
             resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "gRPC not initialized yet");
+            return;
+        }
+        GrpcRequestWrapper wrapped = new GrpcRequestWrapper(req);
+        if (isPost) {
+            adapter.doPost(wrapped, resp);
+        } else {
+            adapter.doGet(wrapped, resp);
         }
     }
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        ServletAdapter adapter = adapterRef.get();
-        if (adapter != null) {
-            HttpServletRequest wrappedRequest = GrpcRequestWrapper.isGrpcRequest(req) ? new GrpcRequestWrapper(req) : req;
-            adapter.doGet(wrappedRequest, resp);
-        } else {
-            resp.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "gRPC not initialized yet");
-        }
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+        handleGrpcRequest(req, resp, false);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+        handleGrpcRequest(req, resp, true);
     }
 
     @Override


### PR DESCRIPTION


### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #13593

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved gRPC audit request handling with streamlined routing logic for both gRPC and non-gRPC requests.
  * Enhanced error handling for service unavailability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->