### PR TITLE
feat(jans-pycloudlib): add backoff retries when authenticating to vault

### DIFF
--- a/jans-pycloudlib/jans/pycloudlib/secret/vault_secret.py
+++ b/jans-pycloudlib/jans/pycloudlib/secret/vault_secret.py
@@ -4,7 +4,9 @@ import contextlib
 import typing as _t
 import logging
 import os
+import sys
 
+import backoff
 import hvac
 
 from jans.pycloudlib.secret.base_secret import BaseSecret
@@ -15,6 +17,28 @@ logger = logging.getLogger(__name__)
 
 MaybeCert = _t.Union[tuple[str, str], None]
 MaybeCacert = _t.Union[bool, str]
+
+
+def on_backoff(details):
+    error = sys.exc_info()[1]
+    logger.warning("Vault is not ready; reason=%s; retrying in %0.1f seconds", error, details["wait"])
+
+
+def on_giveup(details):
+    error = sys.exc_info()[1]
+    logger.error("Vault is not ready after %0.1f seconds; reason=%s", details["elapsed"], error)
+
+
+retry_on_exception = backoff.on_exception(
+    backoff.constant,
+    Exception,
+    max_time=300,
+    on_backoff=on_backoff,
+    on_success=None,
+    on_giveup=on_giveup,
+    jitter=None,
+    interval=10,
+)
 
 
 class VaultSecret(BaseSecret):
@@ -139,8 +163,12 @@ class VaultSecret(BaseSecret):
         with open(self.settings["CN_SECRET_VAULT_SECRET_ID_FILE"]) as f:
             return f.read().strip()
 
+    @retry_on_exception
     def _authenticate(self) -> None:
-        """Authenticate client."""
+        """Authenticate client.
+
+        Backoff retries are applied to address Vault readiness.
+        """
         if self.client.is_authenticated():
             return
 

--- a/jans-pycloudlib/jans/pycloudlib/secret/vault_secret.py
+++ b/jans-pycloudlib/jans/pycloudlib/secret/vault_secret.py
@@ -4,7 +4,6 @@ import contextlib
 import typing as _t
 import logging
 import os
-import sys
 
 import backoff
 import hvac
@@ -20,13 +19,24 @@ MaybeCacert = _t.Union[bool, str]
 
 
 def on_backoff(details):
-    error = sys.exc_info()[1]
+    error = details.get("exception")
     logger.warning("Vault is not ready; reason=%s; retrying in %0.1f seconds", error, details["wait"])
 
 
 def on_giveup(details):
-    error = sys.exc_info()[1]
+    error = details.get("exception")
     logger.error("Vault is not ready after %0.1f seconds; reason=%s", details["elapsed"], error)
+
+
+def should_giveup(exc: Exception) -> bool:
+    non_retries_exc = (
+        FileNotFoundError,
+        PermissionError,
+        KeyError,
+        ValueError,
+        TypeError,
+    )
+    return isinstance(exc, non_retries_exc)
 
 
 retry_on_exception = backoff.on_exception(
@@ -35,6 +45,7 @@ retry_on_exception = backoff.on_exception(
     max_time=300,
     on_backoff=on_backoff,
     on_success=None,
+    giveup=should_giveup,
     on_giveup=on_giveup,
     jitter=None,
     interval=10,

--- a/jans-pycloudlib/tests/test_cli.py
+++ b/jans-pycloudlib/tests/test_cli.py
@@ -66,7 +66,7 @@ def test_encoding_decode_file_no_salt(monkeypatch, gmanager):
 
     monkeypatch.setattr(
         "hvac.Client.is_authenticated",
-        lambda cls: True,
+        lambda _: True,
     )
 
     runner = CliRunner()
@@ -153,7 +153,7 @@ def test_encoding_decode_string_no_salt(monkeypatch, gmanager):
 
     monkeypatch.setattr(
         "hvac.Client.is_authenticated",
-        lambda cls: True,
+        lambda _: True,
     )
 
     runner = CliRunner()

--- a/jans-pycloudlib/tests/test_cli.py
+++ b/jans-pycloudlib/tests/test_cli.py
@@ -64,6 +64,11 @@ def test_encoding_decode_file_no_salt(monkeypatch, gmanager):
         lambda: gmanager,
     )
 
+    monkeypatch.setattr(
+        "hvac.Client.is_authenticated",
+        lambda cls: True,
+    )
+
     runner = CliRunner()
     with runner.isolated_filesystem():
         with open("password.txt", "w") as f:
@@ -144,6 +149,11 @@ def test_encoding_decode_string_no_salt(monkeypatch, gmanager):
     monkeypatch.setattr(
         "jans.pycloudlib.manager.get_manager",
         lambda: gmanager,
+    )
+
+    monkeypatch.setattr(
+        "hvac.Client.is_authenticated",
+        lambda cls: True,
     )
 
     runner = CliRunner()


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #13738 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vault authentication reliability with automatic retry/backoff and clearer failure logging to surface retry attempts and final errors.

* **Tests**
  * Updated authentication-related tests to simulate successful auth state for specific no-salt scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->