### PR TITLE
fix(jans-linux-setup): install epel relase fro url for rhel9-10

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/package_utils.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/package_utils.py
@@ -26,7 +26,7 @@ class PackageUtils(SetupUtils):
                 update_command = ''
             else:
                 install_command = 'yum install -y {0}'
-                update_command = 'yum install -y epel-release'
+                update_command = f'yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{base.os_version}.noarch.rpm'
             query_command = 'rpm -q {0}'
             check_text = 'is not installed'
 


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #13746

  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPEL repository installation reliability on RPM-based systems by downloading the release package directly from Fedora's repository, ensuring the correct version-specific package is installed during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->