### PR TITLE
refactor(cloud-native): change key to check before marking secret is ready

### DIFF
--- a/jans-pycloudlib/jans/pycloudlib/wait.py
+++ b/jans-pycloudlib/jans/pycloudlib/wait.py
@@ -161,19 +161,10 @@ def wait_for_secret(manager: Manager, **kwargs: _t.Any) -> None:
             If set to `False` or omitted, this function will check secret entry.
     """
     conn_only = as_boolean(kwargs.get("conn_only", False))
+    auth_keys = manager.secret.get("auth_jks_base64")
 
-    # check following entries (shouldn't be empty) to mark whether secrets are ready
-    entries_ready = all([
-        # required for secure connection
-        manager.secret.get("ssl_cert"),
-        # required for obfuscating plain text
-        manager.secret.get("encoded_salt"),
-        # required for signing keys
-        manager.secret.get("auth_jks_base64"),
-    ])
-
-    if not conn_only and not entries_ready:
-        raise WaitError("Secret 'ssl_cert', 'encoded_salt', and 'auth_jks_base64' are not available")
+    if not conn_only and not auth_keys:
+        raise WaitError("Secret 'auth_jks_base64' is not available")
 
 
 #: DN of admin group

--- a/jans-pycloudlib/jans/pycloudlib/wait.py
+++ b/jans-pycloudlib/jans/pycloudlib/wait.py
@@ -161,10 +161,19 @@ def wait_for_secret(manager: Manager, **kwargs: _t.Any) -> None:
             If set to `False` or omitted, this function will check secret entry.
     """
     conn_only = as_boolean(kwargs.get("conn_only", False))
-    ssl_cert = manager.secret.get("ssl_cert")
 
-    if not conn_only and not ssl_cert:
-        raise WaitError("Secret 'ssl_cert' is not available")
+    # check following entries (shouldn't be empty) to mark whether secrets are ready
+    entries_ready = all([
+        # required for secure connection
+        manager.secret.get("ssl_cert"),
+        # required for obfuscating plain text
+        manager.secret.get("encoded_salt"),
+        # required for signing keys
+        manager.secret.get("auth_jks_base64"),
+    ])
+
+    if not conn_only and not entries_ready:
+        raise WaitError("Secret 'ssl_cert', 'encoded_salt', and 'auth_jks_base64' are not available")
 
 
 #: DN of admin group


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #13780 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret handling during initialization and tightened validation of authentication materials; users will now receive a clearer error if required authentication keys are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->