### PR TITLE
fix(jans-cli-tui): omit missing properties for asset mappings

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/140_config_api/main.py
+++ b/jans-cli-tui/cli_tui/plugins/140_config_api/main.py
@@ -466,9 +466,9 @@ class Plugin(DialogUtils):
         asset_dir_mapping_data = []
         for mapping in asset_dir_mappings:
             asset_dir_mapping_data.append((
-                        mapping['directory'],
-                        ' '.join(mapping['type']),
-                        ' '.join(mapping['jansServiceModule'])
+                        mapping.get('directory') or '',
+                        ' '.join(mapping.get('type') or []),
+                        ' '.join(mapping.get('jansServiceModule') or [])
                         ))
 
         self.asset_dir_mappings_container = JansVerticalNav(

--- a/jans-cli-tui/cli_tui/plugins/140_config_api/main.py
+++ b/jans-cli-tui/cli_tui/plugins/140_config_api/main.py
@@ -381,10 +381,10 @@ class Plugin(DialogUtils):
             if kwargs:
                 title = _("Edit Mapping Properties")
                 mapping_data = (
-                    kwargs['data']['directory'],
-                    ' '.join(kwargs['data']['type']),
-                    kwargs['data']['description'],
-                    kwargs['data']['jansServiceModule']
+                    kwargs['data'].get('directory') or '',
+                    ' '.join(kwargs['data'].get('type') or []),
+                    kwargs['data'].get('description') or '',
+                    kwargs['data'].get('jansServiceModule') or []
                     )
                 services = []
             else:


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #13933

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the Directory Mappings UI by making list construction and edit/delete flows tolerant of missing or incomplete mapping fields. Missing directory, description, type, or module values now render safely as empty or joined placeholders, preventing errors and ensuring consistent display after add, edit, or delete operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->