### PR TITLE
chore(jans-cedarling): add cargo-deny CI with committed policy

### DIFF
--- a/.github/workflows/test-cedarling.yml
+++ b/.github/workflows/test-cedarling.yml
@@ -61,6 +61,19 @@ jobs:
         # decryption path is not reachable. No upstream fix available.
         ignore: RUSTSEC-2023-0071
 
+  cargo_deny:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Run cargo-deny
+      uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
+      with:
+        manifest-path: jans-cedarling/Cargo.toml
+
   custom_lints:
     runs-on: ubuntu-latest
     steps:

--- a/jans-cedarling/bindings/cedarling_c/Cargo.toml
+++ b/jans-cedarling/bindings/cedarling_c/Cargo.toml
@@ -3,6 +3,7 @@ name = "cedarling_c"
 version = "0.1.0"
 edition = "2024"
 description = "C bindings for the Jans Cedarling authorization engine"
+license = "Apache-2.0"
 
 [lib]
 name = "cedarling_c"

--- a/jans-cedarling/bindings/cedarling_go/Cargo.toml
+++ b/jans-cedarling/bindings/cedarling_go/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cedarling_go"
 version = "0.0.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/jans-cedarling/bindings/cedarling_uniffi/Cargo.toml
+++ b/jans-cedarling/bindings/cedarling_uniffi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cedarling_uniffi"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/jans-cedarling/deny.toml
+++ b/jans-cedarling/deny.toml
@@ -1,0 +1,45 @@
+# cargo-deny policy
+# Layered on top of the cargo-audit job in test-cedarling.yml: This basically
+# extends coverage to license compliance, duplicate-crate drift, source-origin
+# pinning, and advisories.
+
+[graph]
+all-features = true
+
+[advisories]
+# See rationale in jans-cedarling/.cargo/audit.toml
+ignore = ["RUSTSEC-2023-0071"]
+
+[licenses]
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.93
+
+# Per-crate exceptions
+exceptions = [{ allow = ["bzip2-1.0.6"], crate = "libbz2-rs-sys" }]
+
+[bans]
+# for now, we keep it at "warn" for duplicates and wildcards. This will be updated to "deny" in a follow-up PR after we propagate `publish = false` to the internal crates
+multiple-versions = "warn"
+wildcards = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/jans-cedarling/test_utils/Cargo.toml
+++ b/jans-cedarling/test_utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_utils"
 version = "0.0.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 pretty_assertions = "1"


### PR DESCRIPTION

`cargo audit` covers RustSec advisories only. This PR adds `cargo-deny` with a committed policy file layered on top to extend coverage to license compliance and duplicate-crate issues and source-origin pinning.

#### Implementation Details

- Add `jans-cedarling/deny.toml` which covers `[advisories]`, `[licenses]`, `[bans]`, `[sources]`
- Add `license = "Apache-2.0"` to four workspace-internal crates (`test_utils`, `cedarling_c`, `cedarling_go`, `cedarling_uniffi`) that previously had no `license` field
- I also added a CI workflow to run `cargo_deny`
- `[bans]` set to `multiple-versions = "warn"` (3 semver-compatible versions of `rand` exist today) and `wildcards = "warn"` (workspace `path = ...` deps look like wildcards

> I will probably tighten the `[bans]` rules to `deny` in a follow-up PR after this one is merged to avoid having to propagate `publish = false` across all internal crates in this PR.

---

### Test and Document the changes

- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)
      Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14001, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI job to run cargo-deny for dependency and policy checks.
  * Added a cargo-deny policy configuration enforcing license and source rules (with allowed exceptions).
  * Added explicit Apache-2.0 license declarations to several packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->