### PR TITLE
fix(jans-cedarling): add request timeouts to outbound HTTP clients

### DIFF
--- a/docs/cedarling/reference/cedarling-properties.md
+++ b/docs/cedarling/reference/cedarling-properties.md
@@ -76,9 +76,9 @@ the Cedarling will use the default value as specified in the property definition
 
 **HTTP client:**
 
-- **`CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS`** : Per-request timeout in milliseconds. Only applicable for native targets (not WASM). Default is `10000` (10 seconds).
+- **`CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS`** : Per-request timeout in seconds. Only applicable for native targets (not WASM). Default is `10` (10 seconds).
 - **`CEDARLING_HTTP_REQUEST_MAX_RETRIES`** : Maximum number of retry attempts per request. Only applicable for native targets (not WASM). Default is `3`.
-- **`CEDARLING_HTTP_REQUEST_RETRY_DELAY`** : Base delay between retries in milliseconds. Only applicable for native targets (not WASM). Default is `3000` (3 seconds).
+- **`CEDARLING_HTTP_REQUEST_RETRY_DELAY`** : Base delay between retries in seconds. Only applicable for native targets (not WASM). Default is `3` (3 seconds).
 
 **Advanced configuration:**
 

--- a/docs/cedarling/reference/cedarling-properties.md
+++ b/docs/cedarling/reference/cedarling-properties.md
@@ -74,6 +74,12 @@ the Cedarling will use the default value as specified in the property definition
 
 - **`CEDARLING_DATA_STORE_MEMORY_ALERT_THRESHOLD`** : Memory usage threshold percentage (0.0-100.0) for triggering alerts. Default value is `80.0`. When capacity usage exceeds this threshold, `memory_alert_triggered` will be `true` in statistics.
 
+**HTTP client:**
+
+- **`CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS`** : Per-request timeout in milliseconds. Only applicable for native targets (not WASM). Default is `10000` (10 seconds).
+- **`CEDARLING_HTTP_REQUEST_MAX_RETRIES`** : Maximum number of retry attempts per request. Only applicable for native targets (not WASM). Default is `3`.
+- **`CEDARLING_HTTP_REQUEST_RETRY_DELAY`** : Base delay between retries in milliseconds. Default is `3000` (3 seconds).
+
 **Advanced configuration:**
 
 - **`CEDARLING_MAX_BASE64_SIZE`** : Maximum size in bytes for Base64-encoded content (policies, schema, etc.)

--- a/docs/cedarling/reference/cedarling-properties.md
+++ b/docs/cedarling/reference/cedarling-properties.md
@@ -78,7 +78,7 @@ the Cedarling will use the default value as specified in the property definition
 
 - **`CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS`** : Per-request timeout in milliseconds. Only applicable for native targets (not WASM). Default is `10000` (10 seconds).
 - **`CEDARLING_HTTP_REQUEST_MAX_RETRIES`** : Maximum number of retry attempts per request. Only applicable for native targets (not WASM). Default is `3`.
-- **`CEDARLING_HTTP_REQUEST_RETRY_DELAY`** : Base delay between retries in milliseconds. Default is `3000` (3 seconds).
+- **`CEDARLING_HTTP_REQUEST_RETRY_DELAY`** : Base delay between retries in milliseconds. Only applicable for native targets (not WASM). Default is `3000` (3 seconds).
 
 **Advanced configuration:**
 

--- a/jans-cedarling/cedarling/benches/authz_authorize_multi_issuer_benchmark.rs
+++ b/jans-cedarling/cedarling/benches/authz_authorize_multi_issuer_benchmark.rs
@@ -5,8 +5,8 @@
 
 use cedarling::{
     AuthorizationConfig, AuthorizeMultiIssuerRequest, BootstrapConfig, Cedarling, DataStoreConfig,
-    EntityData, InitCedarlingError, JwtConfig, LogConfig, LogLevel, LogTypeConfig,
-    PolicyStoreConfig, TokenInput,
+    EntityData, HttpClientConfig, InitCedarlingError, JwtConfig, LogConfig, LogLevel,
+    LogTypeConfig, PolicyStoreConfig, TokenInput,
 };
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use jsonwebtoken::Algorithm;
@@ -83,8 +83,8 @@ async fn prepare_cedarling_with_jwt_validation(
     base_idp_url1: &str,
     base_idp_url2: &str,
 ) -> Result<Cedarling, InitCedarlingError> {
-    let mut policy_store =
-        serde_yaml_ng::from_str::<serde_yaml_ng::Value>(POLICY_STORE).expect("a valid YAML policy store");
+    let mut policy_store = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(POLICY_STORE)
+        .expect("a valid YAML policy store");
 
     policy_store["policy_stores"]["multi_issuer_basic_store"]["trusted_issuers"]["AcmeIssuer"]["openid_configuration_endpoint"] =
         format!("{base_idp_url1}/.well-known/openid-configuration").into();
@@ -116,6 +116,7 @@ async fn prepare_cedarling_with_jwt_validation(
         max_base64_size: None,
         max_default_entities: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: HttpClientConfig::default(),
     };
 
     Cedarling::new(&bootstrap_config).await

--- a/jans-cedarling/cedarling/benches/authz_authorize_unsigned_benchmark.rs
+++ b/jans-cedarling/cedarling/benches/authz_authorize_unsigned_benchmark.rs
@@ -4,7 +4,7 @@
 // Copyright (c) 2024, Gluu, Inc.
 
 use cedarling::{
-    AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, EntityData,
+    AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, EntityData, HttpClientConfig,
     InitCedarlingError, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig,
     PolicyStoreSource, RequestUnsigned,
 };
@@ -155,6 +155,7 @@ async fn prepare_cedarling() -> Result<Cedarling, InitCedarlingError> {
         max_base64_size: None,
         max_default_entities: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: HttpClientConfig::default(),
     };
 
     Cedarling::new(&bootstrap_config).await

--- a/jans-cedarling/cedarling/benches/context_data_store_benchmark.rs
+++ b/jans-cedarling/cedarling/benches/context_data_store_benchmark.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 
 use cedarling::{
     AuthorizationConfig, BootstrapConfig, Cedarling, DataApi, DataStoreConfig, EntityData,
-    JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig, PolicyStoreSource,
-    RequestUnsigned,
+    HttpClientConfig, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig,
+    PolicyStoreSource, RequestUnsigned,
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use serde::Deserialize;
@@ -101,6 +101,7 @@ static BSCONFIG: LazyLock<BootstrapConfig> = LazyLock::new(|| BootstrapConfig {
     max_base64_size: None,
     max_default_entities: None,
     data_store_config: DataStoreConfig::default(),
+    http_client_config: HttpClientConfig::default(),
 });
 
 static BSCONFIG_WITH_DATA_POLICY: LazyLock<BootstrapConfig> = LazyLock::new(|| BootstrapConfig {
@@ -118,6 +119,7 @@ static BSCONFIG_WITH_DATA_POLICY: LazyLock<BootstrapConfig> = LazyLock::new(|| B
     max_base64_size: None,
     max_default_entities: None,
     data_store_config: DataStoreConfig::default(),
+    http_client_config: HttpClientConfig::default(),
 });
 
 // =============================================================================

--- a/jans-cedarling/cedarling/benches/startup_benchmark.rs
+++ b/jans-cedarling/cedarling/benches/startup_benchmark.rs
@@ -9,8 +9,8 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use tokio::runtime::Runtime;
 
 use cedarling::{
-    AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, JwtConfig, LogConfig,
-    LogLevel, LogTypeConfig, PolicyStoreConfig, PolicyStoreSource,
+    AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, HttpClientConfig, JwtConfig,
+    LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig, PolicyStoreSource,
 };
 
 const POLICY_STORE: &str = include_str!("../../test_files/policy-store_ok.yaml");
@@ -46,4 +46,5 @@ static BSCONFIG_LOCAL: LazyLock<BootstrapConfig> = LazyLock::new(|| BootstrapCon
     max_base64_size: None,
     max_default_entities: None,
     data_store_config: DataStoreConfig::default(),
+    http_client_config: HttpClientConfig::default(),
 });

--- a/jans-cedarling/cedarling/examples/authorize_unsigned.rs
+++ b/jans-cedarling/cedarling/examples/authorize_unsigned.rs
@@ -3,7 +3,7 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
-use cedarling::{
+use cedarling::{HttpClientConfig,
     AuthorizationConfig, BootstrapConfig, CedarEntityMapping, Cedarling, DataStoreConfig,
     EntityData, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig,
     PolicyStoreSource, RequestUnsigned, log_config::StdOutLoggerMode,
@@ -39,6 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_default_entities: None,
         max_base64_size: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: HttpClientConfig::default(),
     })
     .await?;
 

--- a/jans-cedarling/cedarling/examples/bulk_authorization_benchmark.rs
+++ b/jans-cedarling/cedarling/examples/bulk_authorization_benchmark.rs
@@ -5,7 +5,7 @@
 
 #![allow(clippy::cast_precision_loss)]
 
-use cedarling::{
+use cedarling::{HttpClientConfig,
     AuthorizationConfig, BootstrapConfig, CedarEntityMapping, Cedarling, DataStoreConfig,
     EntityData, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig,
     PolicyStoreSource, RequestUnsigned,
@@ -96,6 +96,7 @@ async fn initialize_cedarling() -> Result<Cedarling, Box<dyn std::error::Error>>
         max_base64_size: None,
         max_default_entities: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: HttpClientConfig::default(),
     })
     .await?;
 

--- a/jans-cedarling/cedarling/examples/lock_integration.rs
+++ b/jans-cedarling/cedarling/examples/lock_integration.rs
@@ -6,7 +6,7 @@
 // run this example using `cargo run --example lock_integration`
 
 use cedarling::log_config::StdOutLoggerMode;
-use cedarling::{
+use cedarling::{HttpClientConfig,
     AuthorizationConfig, BootstrapConfig, CedarEntityMapping, Cedarling, DataStoreConfig,
     EntityData, JwtConfig, LockServiceConfig, LockTransport, LogConfig, LogLevel, LogTypeConfig,
     PolicyStoreConfig, PolicyStoreSource, RequestUnsigned,
@@ -64,6 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_default_entities: None,
         max_base64_size: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: HttpClientConfig::default(),
     })
     .await?;
 

--- a/jans-cedarling/cedarling/examples/log_init.rs
+++ b/jans-cedarling/cedarling/examples/log_init.rs
@@ -9,7 +9,7 @@
 // and `use std::env` prevents that compilation.
 #![cfg(not(target_family = "wasm"))]
 
-use cedarling::{
+use cedarling::{HttpClientConfig,
     AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, JwtConfig, LogConfig,
     LogLevel, LogStorage, LogTypeConfig, MemoryLogConfig, PolicyStoreConfig, PolicyStoreSource,
     log_config::StdOutLoggerMode,
@@ -61,6 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_default_entities: None,
         max_base64_size: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: HttpClientConfig::default(),
     })
     .await?;
 

--- a/jans-cedarling/cedarling/examples/profiling_multi_issuer.rs
+++ b/jans-cedarling/cedarling/examples/profiling_multi_issuer.rs
@@ -6,7 +6,7 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 
-use cedarling::{
+use cedarling::{HttpClientConfig,
     AuthorizationConfig, AuthorizeMultiIssuerRequest, BootstrapConfig, Cedarling, DataStoreConfig,
     EntityData, InitCedarlingError, JwtConfig, LogConfig, LogLevel, LogTypeConfig,
     PolicyStoreConfig, TokenInput,
@@ -112,6 +112,7 @@ async fn init_cedarling_multi_issuer(
         max_base64_size: None,
         max_default_entities: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: HttpClientConfig::default(),
     };
 
     Cedarling::new(&bootstrap_config).await

--- a/jans-cedarling/cedarling/examples/profiling_unsigned.rs
+++ b/jans-cedarling/cedarling/examples/profiling_unsigned.rs
@@ -6,7 +6,7 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 
-use cedarling::{
+use cedarling::{HttpClientConfig,
     AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, EntityData, JwtConfig,
     LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig, PolicyStoreSource, RequestUnsigned,
 };
@@ -156,6 +156,7 @@ async fn init_cedarling() -> Cedarling {
         max_default_entities: None,
         max_base64_size: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: HttpClientConfig::default(),
     })
     .await
     .expect("should initialize cedarling")

--- a/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
@@ -137,8 +137,12 @@ impl BootstrapConfig {
         let data_store_config = build_data_store_config(raw);
 
         let http_client_config = HttpClientConfig {
+            #[cfg(not(target_arch = "wasm32"))]
             max_retries: raw.http_client_request_max_retries,
+            #[cfg(target_arch = "wasm32")]
+            max_retries: HttpClientConfig::DEFAULT_MAX_RETRIES,
             retry_delay: Duration::from_millis(raw.http_client_request_retry_delay),
+            #[cfg(not(target_arch = "wasm32"))]
             request_timeout: Duration::from_millis(raw.http_client_request_timeout_millis),
         };
 

--- a/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
@@ -138,9 +138,9 @@ impl BootstrapConfig {
 
         let http_client_config = HttpClientConfig {
             max_retries: raw.http_client_request_max_retries,
-            retry_delay: Duration::from_millis(raw.http_client_request_retry_delay),
+            retry_delay: Duration::from_secs(raw.http_client_request_retry_delay),
             #[cfg(not(target_arch = "wasm32"))]
-            request_timeout: Duration::from_millis(raw.http_client_request_timeout_millis),
+            request_timeout: Duration::from_secs(raw.http_client_request_timeout),
         };
 
         Ok(Self {

--- a/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
@@ -13,6 +13,7 @@ use std::fs;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::str::FromStr;
+use std::time::Duration;
 
 use super::authorization_config::AuthorizationConfig;
 use super::raw_config::LoggerType;
@@ -21,6 +22,7 @@ use super::{
     MemoryLogConfig, PolicyStoreConfig, PolicyStoreSource,
 };
 use super::{BootstrapConfigRaw, LockServiceConfig};
+use crate::HttpClientConfig;
 use crate::context_data_api::DataStoreConfig;
 use crate::jwt_config::{TrustedIssuerLoaderConfig, TrustedIssuerLoaderTypeRaw, WorkersCount};
 use crate::log::{LogLevel, StdOutLoggerMode};
@@ -132,6 +134,12 @@ impl BootstrapConfig {
         // Build `DataStoreConfig` from raw config, using defaults if not specified
         let data_store_config = build_data_store_config(raw);
 
+        let http_client_config = HttpClientConfig {
+            max_retries: raw.http_client_request_max_retries,
+            retry_delay: Duration::from_millis(raw.http_client_request_retry_delay),
+            request_timeout: Duration::from_millis(raw.http_client_request_timeout_millis),
+        };
+
         Ok(Self {
             application_name: raw.application_name.clone(),
             log_config,
@@ -142,6 +150,7 @@ impl BootstrapConfig {
             max_default_entities: raw.max_default_entities,
             max_base64_size: raw.max_base64_size,
             data_store_config,
+            http_client_config,
         })
     }
 }

--- a/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/decode.rs
@@ -137,10 +137,7 @@ impl BootstrapConfig {
         let data_store_config = build_data_store_config(raw);
 
         let http_client_config = HttpClientConfig {
-            #[cfg(not(target_arch = "wasm32"))]
             max_retries: raw.http_client_request_max_retries,
-            #[cfg(target_arch = "wasm32")]
-            max_retries: HttpClientConfig::DEFAULT_MAX_RETRIES,
             retry_delay: Duration::from_millis(raw.http_client_request_retry_delay),
             #[cfg(not(target_arch = "wasm32"))]
             request_timeout: Duration::from_millis(raw.http_client_request_timeout_millis),

--- a/jans-cedarling/cedarling/src/bootstrap_config/mod.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/mod.rs
@@ -26,7 +26,7 @@ use config::{Config, File};
 #[cfg(not(target_arch = "wasm32"))]
 use std::{io, path::Path};
 
-use crate::context_data_api::DataStoreConfig;
+use crate::{context_data_api::DataStoreConfig, http::HttpClientConfig};
 
 // Re-export types that need to be public
 pub use authorization_config::AuthorizationConfig;
@@ -62,6 +62,8 @@ pub struct BootstrapConfig {
     pub max_base64_size: Option<usize>,
     /// Data store configuration for the pushed data API.
     pub data_store_config: DataStoreConfig,
+    /// HTTP client settings shared across all outbound requests (timeouts, retries).
+    pub http_client_config: HttpClientConfig,
 }
 
 impl Default for BootstrapConfig {
@@ -88,6 +90,7 @@ impl Default for BootstrapConfig {
             max_default_entities: None,
             max_base64_size: None,
             data_store_config: DataStoreConfig::default(),
+            http_client_config: HttpClientConfig::default(),
         }
     }
 }

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
@@ -6,12 +6,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use super::super::BootstrapConfigLoadingError;
 use super::super::log_config::StdOutMode;
-use super::default_values::{
-    default_jti, default_log_channel_capacity, default_log_max_retries,
-    default_token_cache_capacity, default_true,
-};
-#[cfg(not(target_arch = "wasm32"))]
-use super::default_values::{default_stdout_buffer_limit, default_stdout_timeout_millis};
+use super::default_values::*;
 use super::feature_types::{FeatureToggle, LoggerType};
 use super::json_util::{deserialize_or_parse_string_as_json, parse_option_string};
 use crate::JwtConfig;
@@ -335,6 +330,33 @@ pub struct BootstrapConfigRaw {
         deserialize_with = "deserialize_or_parse_string_as_json"
     )]
     pub trusted_issuer_loader_workers: WorkersCount,
+    // =========================================================================
+    // HTTP CLIENT CONFIGURATION
+    // =========================================================================
+    /// `CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS` — per-request timeout in milliseconds.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[serde(
+        rename = "CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS",
+        default = "default_http_client_request_timeout_millis",
+        deserialize_with = "deserialize_or_parse_string_as_json"
+    )]
+    pub http_client_request_timeout_millis: u64,
+    /// `CEDARLING_HTTP_REQUEST_MAX_RETRIES` — maximum number of retry attempts per request.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[serde(
+        rename = "CEDARLING_HTTP_REQUEST_MAX_RETRIES",
+        default = "default_http_client_max_retries",
+        deserialize_with = "deserialize_or_parse_string_as_json"
+    )]
+    pub http_client_request_max_retries: u32,
+
+    /// `CEDARLING_HTTP_REQUEST_RETRY_DELAY` — base delay between retries in milliseconds.
+    #[serde(
+        rename = "CEDARLING_HTTP_REQUEST_RETRY_DELAY",
+        default = "default_http_client_retry_delay",
+        deserialize_with = "deserialize_or_parse_string_as_json"
+    )]
+    pub http_client_request_retry_delay: u64,
 }
 
 impl Default for BootstrapConfigRaw {

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
@@ -333,7 +333,7 @@ pub struct BootstrapConfigRaw {
     // =========================================================================
     // HTTP CLIENT CONFIGURATION
     // =========================================================================
-    /// `CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS` — per-request timeout in milliseconds.
+    /// Per-request timeout in milliseconds.
     #[cfg(not(target_arch = "wasm32"))]
     #[serde(
         rename = "CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS",
@@ -341,7 +341,7 @@ pub struct BootstrapConfigRaw {
         deserialize_with = "deserialize_or_parse_string_as_json"
     )]
     pub http_client_request_timeout_millis: u64,
-    /// `CEDARLING_HTTP_REQUEST_MAX_RETRIES` — maximum number of retry attempts per request.
+    /// Maximum number of retry attempts per request.
     #[cfg(not(target_arch = "wasm32"))]
     #[serde(
         rename = "CEDARLING_HTTP_REQUEST_MAX_RETRIES",
@@ -350,7 +350,7 @@ pub struct BootstrapConfigRaw {
     )]
     pub http_client_request_max_retries: u32,
 
-    /// `CEDARLING_HTTP_REQUEST_RETRY_DELAY` — base delay between retries in milliseconds.
+    /// Base delay between retries in milliseconds.
     #[serde(
         rename = "CEDARLING_HTTP_REQUEST_RETRY_DELAY",
         default = "default_http_client_retry_delay",

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
@@ -7,14 +7,13 @@
 use super::super::BootstrapConfigLoadingError;
 use super::super::log_config::StdOutMode;
 use super::default_values::{
-    default_http_client_max_retries, default_http_client_retry_delay, default_jti,
+    default_http_client_max_retries, default_http_client_retry_delay_secs, default_jti,
     default_jwks_refresh_min_interval, default_log_channel_capacity, default_log_max_retries,
     default_token_cache_capacity, default_true,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use super::default_values::{
-    default_http_client_request_timeout_millis, default_stdout_buffer_limit,
-    default_stdout_timeout_millis,
+    default_http_client_request_timeout, default_stdout_buffer_limit, default_stdout_timeout_millis,
 };
 use super::feature_types::{FeatureToggle, LoggerType};
 use super::json_util::{
@@ -345,14 +344,14 @@ pub struct BootstrapConfigRaw {
     // =========================================================================
     // HTTP CLIENT CONFIGURATION
     // =========================================================================
-    /// Per-request timeout in milliseconds.
+    /// Per-request timeout in seconds.
     #[cfg(not(target_arch = "wasm32"))]
     #[serde(
-        rename = "CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS",
-        default = "default_http_client_request_timeout_millis",
+        rename = "CEDARLING_HTTP_REQUEST_TIMEOUT",
+        default = "default_http_client_request_timeout",
         deserialize_with = "deserialize_or_parse_string_as_json"
     )]
-    pub http_client_request_timeout_millis: u64,
+    pub http_client_request_timeout: u64,
     /// Maximum number of retry attempts per request.
     #[serde(
         rename = "CEDARLING_HTTP_REQUEST_MAX_RETRIES",
@@ -361,10 +360,10 @@ pub struct BootstrapConfigRaw {
     )]
     pub http_client_request_max_retries: u32,
 
-    /// Base delay between retries in milliseconds.
+    /// Base delay between retries in seconds.
     #[serde(
         rename = "CEDARLING_HTTP_REQUEST_RETRY_DELAY",
-        default = "default_http_client_retry_delay",
+        default = "default_http_client_retry_delay_secs",
         deserialize_with = "deserialize_or_parse_string_as_json"
     )]
     pub http_client_request_retry_delay: u64,

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
@@ -13,8 +13,9 @@ use super::default_values::{
 #[cfg(not(target_arch = "wasm32"))]
 use super::default_values::{
     default_http_client_max_retries, default_http_client_request_timeout_millis,
-    default_http_client_retry_delay, default_stdout_buffer_limit, default_stdout_timeout_millis,
+    default_stdout_buffer_limit, default_stdout_timeout_millis,
 };
+use super::default_values::default_http_client_retry_delay;
 use super::feature_types::{FeatureToggle, LoggerType};
 use super::json_util::{
     deserialize_jwks_refresh_interval, deserialize_jwks_refresh_min_interval,

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/config.rs
@@ -7,15 +7,15 @@
 use super::super::BootstrapConfigLoadingError;
 use super::super::log_config::StdOutMode;
 use super::default_values::{
-    default_jti, default_jwks_refresh_min_interval, default_log_channel_capacity,
-    default_log_max_retries, default_token_cache_capacity, default_true,
+    default_http_client_max_retries, default_http_client_retry_delay, default_jti,
+    default_jwks_refresh_min_interval, default_log_channel_capacity, default_log_max_retries,
+    default_token_cache_capacity, default_true,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use super::default_values::{
-    default_http_client_max_retries, default_http_client_request_timeout_millis,
-    default_stdout_buffer_limit, default_stdout_timeout_millis,
+    default_http_client_request_timeout_millis, default_stdout_buffer_limit,
+    default_stdout_timeout_millis,
 };
-use super::default_values::default_http_client_retry_delay;
 use super::feature_types::{FeatureToggle, LoggerType};
 use super::json_util::{
     deserialize_jwks_refresh_interval, deserialize_jwks_refresh_min_interval,
@@ -354,7 +354,6 @@ pub struct BootstrapConfigRaw {
     )]
     pub http_client_request_timeout_millis: u64,
     /// Maximum number of retry attempts per request.
-    #[cfg(not(target_arch = "wasm32"))]
     #[serde(
         rename = "CEDARLING_HTTP_REQUEST_MAX_RETRIES",
         default = "default_http_client_max_retries",

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/default_values.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/default_values.rs
@@ -7,7 +7,7 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::log::StdOutLoggerMode;
-use crate::{JwtConfig, lock_config::LockServiceConfig};
+use crate::{HttpClientConfig, JwtConfig, lock_config::LockServiceConfig};
 
 pub(super) fn default_jti() -> String {
     "jti".to_string()
@@ -37,4 +37,17 @@ pub(super) fn default_log_channel_capacity() -> usize {
 
 pub(super) fn default_log_max_retries() -> u32 {
     LockServiceConfig::DEFAULT_LOG_MAX_RETRIES
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) fn default_http_client_request_timeout_millis() -> u64 {
+    u64::try_from(HttpClientConfig::DEFAULT_REQUEST_TIMEOUT.as_millis()).unwrap_or(u64::MAX)
+}
+
+pub(super) fn default_http_client_max_retries() -> u32 {
+    HttpClientConfig::DEFAULT_MAX_RETRIES
+}
+
+pub(super) fn default_http_client_retry_delay() -> u64 {
+    u64::try_from(HttpClientConfig::DEFAULT_RETRY_DELAY.as_millis()).unwrap_or(u64::MAX)
 }

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/default_values.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/default_values.rs
@@ -48,7 +48,6 @@ pub(super) fn default_http_client_request_timeout_millis() -> u64 {
     u64::try_from(HttpClientConfig::DEFAULT_REQUEST_TIMEOUT.as_millis()).unwrap_or(u64::MAX)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub(super) fn default_http_client_max_retries() -> u32 {
     HttpClientConfig::DEFAULT_MAX_RETRIES
 }

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/default_values.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/default_values.rs
@@ -44,14 +44,14 @@ pub(super) fn default_log_max_retries() -> u32 {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(super) fn default_http_client_request_timeout_millis() -> u64 {
-    u64::try_from(HttpClientConfig::DEFAULT_REQUEST_TIMEOUT.as_millis()).unwrap_or(u64::MAX)
+pub(super) fn default_http_client_request_timeout() -> u64 {
+    HttpClientConfig::DEFAULT_REQUEST_TIMEOUT.as_secs()
 }
 
 pub(super) fn default_http_client_max_retries() -> u32 {
     HttpClientConfig::DEFAULT_MAX_RETRIES
 }
 
-pub(super) fn default_http_client_retry_delay() -> u64 {
-    u64::try_from(HttpClientConfig::DEFAULT_RETRY_DELAY.as_millis()).unwrap_or(u64::MAX)
+pub(super) fn default_http_client_retry_delay_secs() -> u64 {
+    HttpClientConfig::DEFAULT_RETRY_DELAY.as_secs()
 }

--- a/jans-cedarling/cedarling/src/bootstrap_config/raw_config/default_values.rs
+++ b/jans-cedarling/cedarling/src/bootstrap_config/raw_config/default_values.rs
@@ -48,6 +48,7 @@ pub(super) fn default_http_client_request_timeout_millis() -> u64 {
     u64::try_from(HttpClientConfig::DEFAULT_REQUEST_TIMEOUT.as_millis()).unwrap_or(u64::MAX)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(super) fn default_http_client_max_retries() -> u32 {
     HttpClientConfig::DEFAULT_MAX_RETRIES
 }

--- a/jans-cedarling/cedarling/src/common/policy_store.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store.rs
@@ -130,7 +130,7 @@ pub struct TrustedIssuersValidationError {
 /// When loaded from the new directory/archive format, includes optional metadata
 /// containing version, description, and other policy store information.
 #[derive(Clone, derive_more::Deref)]
-pub struct PolicyStoreWithID {
+pub(crate) struct PolicyStoreWithID {
     /// ID of policy store
     pub(crate) id: String,
     /// Policy store value

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -12,20 +12,17 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::time::Duration;
 
-/// Default per-request timeout for production callers of [`HttpClient`].
-/// Without this, a slow or unresponsive upstream can stall a Cedarling task
-/// indefinitely.
-pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// A wrapper around `reqwest::Client` providing HTTP request functionality
 /// with retry logic using exponential backoff.
 ///
 /// The `HttpClient` struct allows for sending GET requests with a retry mechanism
 /// that attempts to fetch the requested resource up to a maximum number of times
 /// if an error occurs, using the `Sender` and `Backoff` utilities from `http_utils`.
-#[derive(Debug)]
+///
+/// Structure is thread safe, feel free to clone.
+#[derive(Debug, Clone)]
 pub(crate) struct HttpClient {
-    client: Client,
+    pub(crate) raw_client: Client,
     retry_delay: Duration,
     max_retries: u32,
 }
@@ -40,13 +37,28 @@ pub(crate) struct HttpClientConfig {
     request_timeout: Duration,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl HttpClientConfig {
+    /// Default per-request timeout for production callers of [`HttpClient`].
+    /// Without this, a slow or unresponsive upstream can stall a Cedarling task
+    /// indefinitely.
+    pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Time budget for the TCP connect step alone. Most healthy issuers respond well
+    /// inside this window; a longer wait usually means the host is unreachable.
+    const DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+}
+
 impl HttpClient {
     pub(crate) fn new(conf: HttpClientConfig) -> Result<Self, HttpClientError> {
-        let builder = Client::builder();
+        let mut builder = Client::builder();
         #[cfg(not(target_arch = "wasm32"))]
-        let builder = builder.timeout(conf.request_timeout);
-        #[cfg(target_arch = "wasm32")]
-        let _ = request_timeout;
+        {
+            builder = builder
+                .timeout(conf.request_timeout)
+                .connect_timeout(HttpClientConfig::DEFAULT_HTTP_CONNECT_TIMEOUT);
+        }
+
         let client = builder
             .build()
             .map_err(HttpRequestError::InitializeHttpClient)?;

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -167,6 +167,31 @@ impl HttpClient {
         let client = &self.raw_client;
         sender.send(|| builder_fn(client)).await
     }
+
+    /// Sends a GET request with retry logic and returns the raw [`reqwest::Response`].
+    ///
+    /// Unlike `get`, `get_json`, or `get_bytes`, this method gives the caller access to
+    /// response headers and lets them decide how to consume the body. Use it when you
+    /// need to inspect headers (e.g. `Cache-Control`, `Content-Type`) before reading
+    /// the payload.
+    pub(crate) async fn get_with_retry(&self, uri: &str) -> Result<reqwest::Response, HttpClientError> {
+        let mut sender = self.create_sender();
+        sender.send_with_retry(|| self.raw_client.get(uri)).await
+    }
+
+    /// Sends a GET request with retry logic, allowing the caller to modify the
+    /// [`RequestBuilder`] before dispatch (e.g. to add custom headers).
+    pub(crate) async fn get_with_retry_with<F>(
+        &self,
+        uri: &str,
+        f: F,
+    ) -> Result<reqwest::Response, HttpClientError>
+    where
+        F: Fn(RequestBuilder) -> RequestBuilder,
+    {
+        let mut sender = self.create_sender();
+        sender.send_with_retry(|| f(self.raw_client.get(uri))).await
+    }
 }
 
 #[derive(Debug)]

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -72,6 +72,7 @@ impl Default for HttpClientConfig {
         Self {
             max_retries: 3,
             retry_delay: Self::DEFAULT_RETRY_DELAY,
+            #[cfg(not(target_arch = "wasm32"))]
             request_timeout: Self::DEFAULT_REQUEST_TIMEOUT,
         }
     }
@@ -90,13 +91,10 @@ impl HttpClient {
         builder: ClientBuilder,
         conf: HttpClientConfig,
     ) -> Result<Self, InitializeHttpClientError> {
-        let mut builder = builder;
         #[cfg(not(target_arch = "wasm32"))]
-        {
-            builder = builder
-                .timeout(conf.request_timeout)
-                .connect_timeout(HttpClientConfig::DEFAULT_HTTP_CONNECT_TIMEOUT);
-        }
+        let builder = builder
+            .timeout(conf.request_timeout)
+            .connect_timeout(HttpClientConfig::DEFAULT_HTTP_CONNECT_TIMEOUT);
 
         let raw_client = builder.build().map_err(InitializeHttpClientError)?;
 
@@ -211,7 +209,7 @@ impl Response {
 /// Error type for the [`HttpClient`] - re-export from [`http_utils`] for compatibility
 pub(crate) type HttpClientError = HttpRequestError;
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use crate::http::{HttpClient, HttpClientConfig};
 

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -26,22 +26,25 @@ pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 #[derive(Debug)]
 pub(crate) struct HttpClient {
     client: Client,
-    base_delay: Duration,
+    retry_delay: Duration,
     max_retries: u32,
 }
 
+pub(crate) struct HttpClientConfig {
+    max_retries: u32,
+    retry_delay: Duration,
+    // WASM's reqwest backend (browser fetch) doesn't expose `.timeout(...)`;
+    // request timing is handled by the browser. `request_timeout` is
+    // intentionally consumed as a no-op on that target.
+    #[cfg(not(target_arch = "wasm32"))]
+    request_timeout: Duration,
+}
+
 impl HttpClient {
-    pub(crate) fn new(
-        max_retries: u32,
-        retry_delay: Duration,
-        request_timeout: Duration,
-    ) -> Result<Self, HttpClientError> {
-        // WASM's reqwest backend (browser fetch) doesn't expose `.timeout(...)`;
-        // request timing is handled by the browser. `request_timeout` is
-        // intentionally consumed as a no-op on that target.
+    pub(crate) fn new(conf: HttpClientConfig) -> Result<Self, HttpClientError> {
         let builder = Client::builder();
         #[cfg(not(target_arch = "wasm32"))]
-        let builder = builder.timeout(request_timeout);
+        let builder = builder.timeout(conf.request_timeout);
         #[cfg(target_arch = "wasm32")]
         let _ = request_timeout;
         let client = builder
@@ -50,15 +53,15 @@ impl HttpClient {
 
         Ok(Self {
             client,
-            base_delay: retry_delay,
-            max_retries,
+            retry_delay: conf.retry_delay,
+            max_retries: conf.max_retries,
         })
     }
 
     /// Creates a new Sender with the configured backoff strategy.
     fn create_sender(&self) -> Sender {
         Sender::new(Backoff::new_exponential(
-            self.base_delay,
+            self.retry_delay,
             Some(self.max_retries),
         ))
     }
@@ -102,13 +105,18 @@ pub(crate) type HttpClientError = HttpRequestError;
 
 #[cfg(test)]
 mod test {
-    use crate::http::{HttpClient, HttpClientError};
+    use crate::http::{HttpClient, HttpClientConfig, HttpClientError};
 
     use mockito::Server;
     use serde_json::json;
     use std::time::Duration;
     use test_utils::assert_eq;
     use tokio::join;
+    const HTTP_CONF: HttpClientConfig = HttpClientConfig {
+        max_retries: 3,
+        request_timeout: Duration::from_millis(1),
+        retry_delay: Duration::from_secs(5),
+    };
 
     #[tokio::test]
     async fn can_fetch() {
@@ -127,9 +135,7 @@ mod test {
             .expect(1)
             .create_async();
 
-        let client =
-            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
-                .expect("Should create HttpClient.");
+        let client = HttpClient::new(HTTP_CONF).expect("Should create HttpClient.");
 
         let link = &format!("{}/.well-known/openid-configuration", mock_server.url());
         let req_fut = client.get(link);
@@ -150,9 +156,7 @@ mod test {
 
     #[tokio::test]
     async fn errors_when_max_http_retries_exceeded() {
-        let client =
-            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
-                .expect("Should create HttpClient");
+        let client = HttpClient::new(HTTP_CONF).expect("Should create HttpClient");
         let response = client.get("0.0.0.0").await;
 
         assert!(
@@ -173,9 +177,7 @@ mod test {
             .expect_at_least(1)
             .create_async();
 
-        let client =
-            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
-                .expect("Should create HttpClient.");
+        let client = HttpClient::new(HTTP_CONF).expect("Should create HttpClient.");
 
         let link = &format!("{}/.well-known/openid-configuration", mock_server.url());
         let client_fut = client.get(link);
@@ -202,9 +204,7 @@ mod test {
             .expect(1)
             .create_async();
 
-        let client =
-            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
-                .expect("Should create HttpClient.");
+        let client = HttpClient::new(HTTP_CONF).expect("Should create HttpClient.");
         let link = &format!("{}/binary", mock_server.url());
         let req_fut = client.get_bytes(link);
         let (req_result, mock_result) = join!(req_fut, mock_endpoint);
@@ -225,9 +225,7 @@ mod test {
             .expect_at_least(1)
             .create_async();
 
-        let client =
-            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
-                .expect("Should create HttpClient.");
+        let client = HttpClient::new(HTTP_CONF).expect("Should create HttpClient.");
         let link = &format!("{}/error-binary", mock_server.url());
         let req_fut = client.get_bytes(link);
         let (req_result, mock_result) = join!(req_fut, mock_endpoint);
@@ -241,9 +239,7 @@ mod test {
 
     #[tokio::test]
     async fn get_bytes_max_retries_exceeded() {
-        let client =
-            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
-                .expect("Should create HttpClient");
+        let client = HttpClient::new(HTTP_CONF).expect("Should create HttpClient");
         let response = client.get_bytes("0.0.0.0").await;
         assert!(
             matches!(response, Err(HttpClientError::MaxRetriesExceeded)),
@@ -273,8 +269,12 @@ mod test {
 
         // 0 retries so the timeout fires once and we don't measure backoff.
         let request_timeout = Duration::from_millis(200);
-        let client = HttpClient::new(0, Duration::from_millis(1), request_timeout)
-            .expect("Should create HttpClient");
+        let client = HttpClient::new(HttpClientConfig {
+            max_retries: 0,
+            retry_delay: Duration::from_millis(1),
+            request_timeout,
+        })
+        .expect("Should create HttpClient");
 
         let start = std::time::Instant::now();
         let response = client.get(&format!("http://{addr}/")).await;

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -8,9 +8,11 @@ mod spawn_task;
 pub use spawn_task::*;
 
 use http_utils::{Backoff, HttpRequestError, Sender};
-use reqwest::Client;
+pub(crate) use reqwest::RequestBuilder;
+use reqwest::{Client, ClientBuilder};
 use serde::Deserialize;
 use std::time::Duration;
+use thiserror::Error;
 
 /// A wrapper around `reqwest::Client` providing HTTP request functionality
 /// with retry logic using exponential backoff.
@@ -23,18 +25,26 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 pub(crate) struct HttpClient {
     pub(crate) raw_client: Client,
+    // used in non-test builds via create_sender()
+    #[allow(unused)]
     retry_delay: Duration,
+    #[allow(unused)]
     max_retries: u32,
 }
 
-pub(crate) struct HttpClientConfig {
-    max_retries: u32,
-    retry_delay: Duration,
+/// Configuration for [`HttpClient`] — controls retry behavior and per-request timeout.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HttpClientConfig {
+    /// Maximum number of times a failed request is retried before giving up.
+    pub max_retries: u32,
+    /// Base delay between retries; actual delay grows exponentially with each attempt.
+    pub retry_delay: Duration,
     // WASM's reqwest backend (browser fetch) doesn't expose `.timeout(...)`;
     // request timing is handled by the browser. `request_timeout` is
     // intentionally consumed as a no-op on that target.
+    /// Maximum time to wait for a single HTTP request to complete.
     #[cfg(not(target_arch = "wasm32"))]
-    request_timeout: Duration,
+    pub request_timeout: Duration,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -42,16 +52,45 @@ impl HttpClientConfig {
     /// Default per-request timeout for production callers of [`HttpClient`].
     /// Without this, a slow or unresponsive upstream can stall a Cedarling task
     /// indefinitely.
-    pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+    pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
     /// Time budget for the TCP connect step alone. Most healthy issuers respond well
     /// inside this window; a longer wait usually means the host is unreachable.
     const DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 }
 
+impl HttpClientConfig {
+    /// Default maximum retry count used when building an [`HttpClient`] without explicit config.
+    pub const DEFAULT_MAX_RETRIES: u32 = 3;
+
+    /// Default base retry delay used when building an [`HttpClient`] without explicit config.
+    pub const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(3);
+}
+
+impl Default for HttpClientConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            retry_delay: Self::DEFAULT_RETRY_DELAY,
+            request_timeout: Self::DEFAULT_REQUEST_TIMEOUT,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct InitializeHttpClientError(#[from] reqwest::Error);
+
 impl HttpClient {
-    pub(crate) fn new(conf: HttpClientConfig) -> Result<Self, HttpClientError> {
-        let mut builder = Client::builder();
+    pub(crate) fn new(conf: HttpClientConfig) -> Result<Self, InitializeHttpClientError> {
+        Self::new_with_builder(Client::builder(), conf)
+    }
+
+    pub(crate) fn new_with_builder(
+        builder: ClientBuilder,
+        conf: HttpClientConfig,
+    ) -> Result<Self, InitializeHttpClientError> {
+        let mut builder = builder;
         #[cfg(not(target_arch = "wasm32"))]
         {
             builder = builder
@@ -59,31 +98,51 @@ impl HttpClient {
                 .connect_timeout(HttpClientConfig::DEFAULT_HTTP_CONNECT_TIMEOUT);
         }
 
-        let client = builder
-            .build()
-            .map_err(HttpRequestError::InitializeHttpClient)?;
+        let raw_client = builder.build().map_err(InitializeHttpClientError)?;
 
         Ok(Self {
-            client,
+            raw_client,
             retry_delay: conf.retry_delay,
             max_retries: conf.max_retries,
         })
     }
 
     /// Creates a new Sender with the configured backoff strategy.
-    fn create_sender(&self) -> Sender {
-        Sender::new(Backoff::new_exponential(
-            self.retry_delay,
-            Some(self.max_retries),
-        ))
+    pub(crate) fn create_sender(&self) -> Sender {
+        #[cfg(not(test))]
+        {
+            Sender::new(Backoff::new_exponential(
+                self.retry_delay,
+                Some(self.max_retries),
+            ))
+        }
+
+        // We implement a faster retry for the tests (faster backoff, but still
+        // respects the configured max_retries count).
+        #[cfg(test)]
+        {
+            Sender::new(Backoff::new_exponential(
+                Duration::from_millis(10),
+                Some(self.max_retries),
+            ))
+        }
     }
 
     /// Sends a GET request to the specified URI with retry logic.
     pub(crate) async fn get(&self, uri: &str) -> Result<Response, HttpClientError> {
         let mut sender = self.create_sender();
-        let client = &self.client;
+        let client = &self.raw_client;
         let text = sender.send_text(|| client.get(uri)).await?;
         Ok(Response { text })
+    }
+
+    pub(crate) async fn get_json<T>(&self, uri: &str) -> Result<T, HttpClientError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut sender = self.create_sender();
+        let client = &self.raw_client;
+        sender.send(|| client.get(uri)).await
     }
 
     /// Sends a GET request to the specified URI with retry logic, returning raw bytes.
@@ -93,8 +152,20 @@ impl HttpClient {
     /// like archive files.
     pub(crate) async fn get_bytes(&self, uri: &str) -> Result<Vec<u8>, HttpClientError> {
         let mut sender = self.create_sender();
-        let client = &self.client;
+        let client = &self.raw_client;
         sender.send_bytes(|| client.get(uri)).await
+    }
+
+    // Execute POST request
+    // prepare request build in `builder_fn` and return value as parsed json
+    pub(crate) async fn post_json<T, F>(&self, builder_fn: F) -> Result<T, HttpClientError>
+    where
+        T: serde::de::DeserializeOwned,
+        F: Fn(&Client) -> RequestBuilder,
+    {
+        let mut sender = self.create_sender();
+        let client = &self.raw_client;
+        sender.send(|| builder_fn(client)).await
     }
 }
 
@@ -117,7 +188,7 @@ pub(crate) type HttpClientError = HttpRequestError;
 
 #[cfg(test)]
 mod test {
-    use crate::http::{HttpClient, HttpClientConfig, HttpClientError};
+    use crate::http::{HttpClient, HttpClientConfig};
 
     use mockito::Server;
     use serde_json::json;
@@ -172,7 +243,7 @@ mod test {
         let response = client.get("0.0.0.0").await;
 
         assert!(
-            matches!(response, Err(HttpClientError::MaxRetriesExceeded)),
+            matches!(response, Err(ref e) if e.is_max_retries_exceeded()),
             "Expected error due to MaxRetriesExceeded: {response:?}"
         );
     }
@@ -197,7 +268,7 @@ mod test {
         let (mock_endpoint, response) = join!(mock_endpoint_fut, client_fut);
 
         assert!(
-            matches!(response, Err(HttpClientError::MaxRetriesExceeded)),
+            matches!(response, Err(ref e) if e.is_max_retries_exceeded()),
             "Expected error due to MaxRetriesExceeded after retrying on HTTP errors: {response:?}"
         );
 
@@ -243,7 +314,7 @@ mod test {
         let (req_result, mock_result) = join!(req_fut, mock_endpoint);
 
         assert!(
-            matches!(req_result, Err(HttpClientError::MaxRetriesExceeded)),
+            matches!(req_result, Err(ref e) if e.is_max_retries_exceeded()),
             "Expected MaxRetriesExceeded after retrying on HTTP error status: {req_result:?}"
         );
         mock_result.assert();
@@ -254,7 +325,7 @@ mod test {
         let client = HttpClient::new(HTTP_CONF).expect("Should create HttpClient");
         let response = client.get_bytes("0.0.0.0").await;
         assert!(
-            matches!(response, Err(HttpClientError::MaxRetriesExceeded)),
+            matches!(response, Err(ref e) if e.is_max_retries_exceeded()),
             "Expected error due to MaxRetriesExceeded: {response:?}"
         );
     }

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -36,8 +36,15 @@ impl HttpClient {
         retry_delay: Duration,
         request_timeout: Duration,
     ) -> Result<Self, HttpClientError> {
-        let client = Client::builder()
-            .timeout(request_timeout)
+        // WASM's reqwest backend (browser fetch) doesn't expose `.timeout(...)`;
+        // request timing is handled by the browser. `request_timeout` is
+        // intentionally consumed as a no-op on that target.
+        let builder = Client::builder();
+        #[cfg(not(target_arch = "wasm32"))]
+        let builder = builder.timeout(request_timeout);
+        #[cfg(target_arch = "wasm32")]
+        let _ = request_timeout;
+        let client = builder
             .build()
             .map_err(HttpRequestError::InitializeHttpClient)?;
 

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -12,6 +12,11 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::time::Duration;
 
+/// Default per-request timeout for production callers of [`HttpClient`].
+/// Without this, a slow or unresponsive upstream can stall a Cedarling task
+/// indefinitely.
+pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// A wrapper around `reqwest::Client` providing HTTP request functionality
 /// with retry logic using exponential backoff.
 ///
@@ -26,8 +31,13 @@ pub(crate) struct HttpClient {
 }
 
 impl HttpClient {
-    pub(crate) fn new(max_retries: u32, retry_delay: Duration) -> Result<Self, HttpClientError> {
+    pub(crate) fn new(
+        max_retries: u32,
+        retry_delay: Duration,
+        request_timeout: Duration,
+    ) -> Result<Self, HttpClientError> {
         let client = Client::builder()
+            .timeout(request_timeout)
             .build()
             .map_err(HttpRequestError::InitializeHttpClient)?;
 
@@ -111,7 +121,8 @@ mod test {
             .create_async();
 
         let client =
-            HttpClient::new(3, Duration::from_millis(1)).expect("Should create HttpClient.");
+            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
+                .expect("Should create HttpClient.");
 
         let link = &format!("{}/.well-known/openid-configuration", mock_server.url());
         let req_fut = client.get(link);
@@ -133,7 +144,8 @@ mod test {
     #[tokio::test]
     async fn errors_when_max_http_retries_exceeded() {
         let client =
-            HttpClient::new(3, Duration::from_millis(1)).expect("Should create HttpClient");
+            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
+                .expect("Should create HttpClient");
         let response = client.get("0.0.0.0").await;
 
         assert!(
@@ -155,7 +167,8 @@ mod test {
             .create_async();
 
         let client =
-            HttpClient::new(3, Duration::from_millis(1)).expect("Should create HttpClient.");
+            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
+                .expect("Should create HttpClient.");
 
         let link = &format!("{}/.well-known/openid-configuration", mock_server.url());
         let client_fut = client.get(link);
@@ -183,7 +196,8 @@ mod test {
             .create_async();
 
         let client =
-            HttpClient::new(3, Duration::from_millis(1)).expect("Should create HttpClient.");
+            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
+                .expect("Should create HttpClient.");
         let link = &format!("{}/binary", mock_server.url());
         let req_fut = client.get_bytes(link);
         let (req_result, mock_result) = join!(req_fut, mock_endpoint);
@@ -205,7 +219,8 @@ mod test {
             .create_async();
 
         let client =
-            HttpClient::new(3, Duration::from_millis(1)).expect("Should create HttpClient.");
+            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
+                .expect("Should create HttpClient.");
         let link = &format!("{}/error-binary", mock_server.url());
         let req_fut = client.get_bytes(link);
         let (req_result, mock_result) = join!(req_fut, mock_endpoint);
@@ -220,11 +235,49 @@ mod test {
     #[tokio::test]
     async fn get_bytes_max_retries_exceeded() {
         let client =
-            HttpClient::new(3, Duration::from_millis(1)).expect("Should create HttpClient");
+            HttpClient::new(3, Duration::from_millis(1), Duration::from_secs(5))
+                .expect("Should create HttpClient");
         let response = client.get_bytes("0.0.0.0").await;
         assert!(
             matches!(response, Err(HttpClientError::MaxRetriesExceeded)),
             "Expected error due to MaxRetriesExceeded: {response:?}"
+        );
+    }
+
+    /// A server that accepts TCP connections but never sends a response would
+    /// previously stall an `HttpClient::get` call indefinitely. With a request
+    /// timeout configured the call must error promptly.
+    #[tokio::test]
+    async fn get_times_out_when_server_never_responds() {
+        use tokio::net::{TcpListener, TcpStream};
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Should bind a local TCP listener");
+        let addr = listener.local_addr().expect("Should read local addr");
+
+        // Accept connections and hold them open without writing any response.
+        let _accept_task = tokio::spawn(async move {
+            let mut held: Vec<TcpStream> = Vec::new();
+            while let Ok((sock, _)) = listener.accept().await {
+                held.push(sock);
+            }
+        });
+
+        // 0 retries so the timeout fires once and we don't measure backoff.
+        let request_timeout = Duration::from_millis(200);
+        let client = HttpClient::new(0, Duration::from_millis(1), request_timeout)
+            .expect("Should create HttpClient");
+
+        let start = std::time::Instant::now();
+        let response = client.get(&format!("http://{addr}/")).await;
+        let elapsed = start.elapsed();
+
+        assert!(response.is_err(), "Expected timeout error: {response:?}");
+        // Timeout fires at ~200ms; allow generous slack for CI variance.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "Expected to time out near {request_timeout:?}, took {elapsed:?}",
         );
     }
 }

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -156,14 +156,15 @@ impl HttpClient {
 
     // Execute POST request
     // prepare request build in `builder_fn` and return value as parsed json
+    // NOTE: no retries — POST is non-idempotent; replay can cause duplicate side effects.
     pub(crate) async fn post_json<T, F>(&self, builder_fn: F) -> Result<T, HttpClientError>
     where
         T: serde::de::DeserializeOwned,
-        F: Fn(&Client) -> RequestBuilder,
+        F: FnOnce(&Client) -> RequestBuilder,
     {
         let mut sender = self.create_sender();
         let client = &self.raw_client;
-        sender.send(|| builder_fn(client)).await
+        sender.send_once(move || builder_fn(client)).await
     }
 
     /// Sends a GET request with retry logic and returns the raw [`reqwest::Response`].

--- a/jans-cedarling/cedarling/src/init/policy_store.rs
+++ b/jans-cedarling/cedarling/src/init/policy_store.rs
@@ -11,7 +11,7 @@ use crate::bootstrap_config::policy_store_config::{PolicyStoreConfig, PolicyStor
 use crate::common::policy_store::legacy_store::LegacyAgamaPolicyStore;
 use crate::common::policy_store::manager::PolicyStoreManager;
 use crate::common::policy_store::{ConversionError, PolicyStoreWithID};
-use crate::http::{HttpClient, HttpClientError};
+use crate::http::{DEFAULT_REQUEST_TIMEOUT, HttpClient, HttpClientError};
 
 /// Errors that can occur when loading a policy store.
 #[derive(Debug, thiserror::Error)]
@@ -128,7 +128,7 @@ pub async fn load_policy_store(
 async fn load_policy_store_from_lock_master(
     uri: &str,
 ) -> Result<PolicyStoreWithID, PolicyStoreLoadError> {
-    let client = HttpClient::new(3, Duration::from_secs(3))?;
+    let client = HttpClient::new(3, Duration::from_secs(3), DEFAULT_REQUEST_TIMEOUT)?;
     let agama_policy_store = client.get(uri).await?.json::<LegacyAgamaPolicyStore>()?;
     extract_first_policy_store(&agama_policy_store)
 }
@@ -194,7 +194,7 @@ async fn load_policy_store_from_cjar_url(
     use crate::common::policy_store::loader;
 
     // Fetch the archive bytes via HTTP
-    let client = HttpClient::new(3, Duration::from_secs(3))?;
+    let client = HttpClient::new(3, Duration::from_secs(3), DEFAULT_REQUEST_TIMEOUT)?;
     let bytes = client
         .get_bytes(url)
         .await
@@ -232,7 +232,7 @@ async fn load_policy_store_from_cjar_url(
     use crate::common::policy_store::loader;
 
     // Fetch the archive bytes via HTTP
-    let client = HttpClient::new(3, Duration::from_secs(3))?;
+    let client = HttpClient::new(3, Duration::from_secs(3), DEFAULT_REQUEST_TIMEOUT)?;
     let bytes = client
         .get_bytes(url)
         .await

--- a/jans-cedarling/cedarling/src/init/policy_store.rs
+++ b/jans-cedarling/cedarling/src/init/policy_store.rs
@@ -4,14 +4,13 @@
 // Copyright (c) 2024, Gluu, Inc.
 
 use std::path::Path;
-use std::time::Duration;
 use std::{fs, io};
 
 use crate::bootstrap_config::policy_store_config::{PolicyStoreConfig, PolicyStoreSource};
 use crate::common::policy_store::legacy_store::LegacyAgamaPolicyStore;
 use crate::common::policy_store::manager::PolicyStoreManager;
 use crate::common::policy_store::{ConversionError, PolicyStoreWithID};
-use crate::http::{DEFAULT_REQUEST_TIMEOUT, HttpClient, HttpClientError};
+use crate::http::{HttpClient, HttpClientError};
 
 /// Errors that can occur when loading a policy store.
 #[derive(Debug, thiserror::Error)]
@@ -78,8 +77,9 @@ fn extract_first_policy_store(
 /// Loads the policy store based on the provided configuration.
 ///
 /// This function supports multiple sources for loading policies.
-pub async fn load_policy_store(
+pub(crate) async fn load_policy_store(
     config: &PolicyStoreConfig,
+    http_client: &HttpClient,
 ) -> Result<PolicyStoreWithID, PolicyStoreLoadError> {
     let policy_store = match &config.source {
         PolicyStoreSource::Json(policy_json) => {
@@ -93,7 +93,7 @@ pub async fn load_policy_store(
             extract_first_policy_store(&agama_policy_store)?
         },
         PolicyStoreSource::LockServer(policy_store_uri) => {
-            load_policy_store_from_lock_master(policy_store_uri).await?
+            load_policy_store_from_lock_master(policy_store_uri, http_client).await?
         },
         PolicyStoreSource::FileJson(path) => {
             let policy_json = fs::read_to_string(path)
@@ -104,14 +104,17 @@ pub async fn load_policy_store(
         PolicyStoreSource::FileYaml(path) => {
             let policy_yaml = fs::read_to_string(path)
                 .map_err(|e| PolicyStoreLoadError::ParseFile(path.clone().into(), e))?;
-            let agama_policy_store = serde_yaml_ng::from_str::<LegacyAgamaPolicyStore>(&policy_yaml)?;
+            let agama_policy_store =
+                serde_yaml_ng::from_str::<LegacyAgamaPolicyStore>(&policy_yaml)?;
             extract_first_policy_store(&agama_policy_store)?
         },
         #[cfg(not(target_arch = "wasm32"))]
         PolicyStoreSource::CjarFile(path) => load_policy_store_from_cjar_file(path).await?,
         #[cfg(target_arch = "wasm32")]
         PolicyStoreSource::CjarFile(path) => load_policy_store_from_cjar_file(path)?,
-        PolicyStoreSource::CjarUrl(url) => load_policy_store_from_cjar_url(url).await?,
+        PolicyStoreSource::CjarUrl(url) => {
+            load_policy_store_from_cjar_url(url, http_client).await?
+        },
         #[cfg(not(target_arch = "wasm32"))]
         PolicyStoreSource::Directory(path) => load_policy_store_from_directory(path).await?,
         #[cfg(target_arch = "wasm32")]
@@ -127,9 +130,12 @@ pub async fn load_policy_store(
 /// The URI is from the `CEDARLING_POLICY_STORE_URI` bootstrap property.
 async fn load_policy_store_from_lock_master(
     uri: &str,
+    http_client: &HttpClient,
 ) -> Result<PolicyStoreWithID, PolicyStoreLoadError> {
-    let client = HttpClient::new(3, Duration::from_secs(3), DEFAULT_REQUEST_TIMEOUT)?;
-    let agama_policy_store = client.get(uri).await?.json::<LegacyAgamaPolicyStore>()?;
+    let agama_policy_store = http_client
+        .get(uri)
+        .await?
+        .json::<LegacyAgamaPolicyStore>()?;
     extract_first_policy_store(&agama_policy_store)
 }
 
@@ -190,12 +196,12 @@ fn load_policy_store_from_cjar_file(
 #[cfg(not(target_arch = "wasm32"))]
 async fn load_policy_store_from_cjar_url(
     url: &str,
+    http_client: &HttpClient,
 ) -> Result<PolicyStoreWithID, PolicyStoreLoadError> {
     use crate::common::policy_store::loader;
 
     // Fetch the archive bytes via HTTP
-    let client = HttpClient::new(3, Duration::from_secs(3), DEFAULT_REQUEST_TIMEOUT)?;
-    let bytes = client
+    let bytes = http_client
         .get_bytes(url)
         .await
         .map_err(|e| PolicyStoreLoadError::Archive(format!("Failed to fetch archive: {e}")))?;
@@ -228,12 +234,12 @@ async fn load_policy_store_from_cjar_url(
 #[cfg(target_arch = "wasm32")]
 async fn load_policy_store_from_cjar_url(
     url: &str,
+    http_client: &HttpClient,
 ) -> Result<PolicyStoreWithID, PolicyStoreLoadError> {
     use crate::common::policy_store::loader;
 
     // Fetch the archive bytes via HTTP
-    let client = HttpClient::new(3, Duration::from_secs(3), DEFAULT_REQUEST_TIMEOUT)?;
-    let bytes = client
+    let bytes = http_client
         .get_bytes(url)
         .await
         .map_err(|e| PolicyStoreLoadError::Archive(format!("Failed to fetch archive: {e}")))?;
@@ -342,12 +348,24 @@ fn load_policy_store_from_archive_bytes(
 
 #[cfg(test)]
 mod test {
-    use std::path::Path;
+    use std::{path::Path, sync::LazyLock, time::Duration};
 
     use mockito::Server;
 
     use super::load_policy_store;
-    use crate::PolicyStoreConfig;
+    use crate::{
+        PolicyStoreConfig,
+        http::{HttpClient, HttpClientConfig},
+    };
+
+    static HTTP_CLIENT: LazyLock<HttpClient> = LazyLock::new(|| {
+        HttpClient::new(HttpClientConfig {
+            max_retries: 0,
+            retry_delay: Duration::from_millis(3),
+            request_timeout: Duration::from_millis(500),
+        })
+        .expect("http client should be constructed")
+    });
 
     // NOTE: we probably don't need to test if the deserialization for JSON and YAML
     // works correctly anymore here since we already have tests for those in
@@ -355,22 +373,28 @@ mod test {
 
     #[tokio::test]
     async fn can_load_from_json_file() {
-        load_policy_store(&PolicyStoreConfig {
-            source: crate::PolicyStoreSource::FileJson(
-                Path::new("../test_files/policy-store_generated.json").into(),
-            ),
-        })
+        load_policy_store(
+            &PolicyStoreConfig {
+                source: crate::PolicyStoreSource::FileJson(
+                    Path::new("../test_files/policy-store_generated.json").into(),
+                ),
+            },
+            &HTTP_CLIENT,
+        )
         .await
         .expect("Should load policy store from JSON file");
     }
 
     #[tokio::test]
     async fn can_load_from_yaml_file() {
-        load_policy_store(&PolicyStoreConfig {
-            source: crate::PolicyStoreSource::FileYaml(
-                Path::new("../test_files/policy-store_ok.yaml").into(),
-            ),
-        })
+        load_policy_store(
+            &PolicyStoreConfig {
+                source: crate::PolicyStoreSource::FileYaml(
+                    Path::new("../test_files/policy-store_ok.yaml").into(),
+                ),
+            },
+            &HTTP_CLIENT,
+        )
         .await
         .expect("Should load policy store from YAML file");
     }
@@ -392,9 +416,12 @@ mod test {
 
         let uri = format!("{}/policy-store", mock_server.url()).to_string();
 
-        load_policy_store(&PolicyStoreConfig {
-            source: crate::PolicyStoreSource::LockServer(uri),
-        })
+        load_policy_store(
+            &PolicyStoreConfig {
+                source: crate::PolicyStoreSource::LockServer(uri),
+            },
+            &HTTP_CLIENT,
+        )
         .await
         .expect("Should load policy store from Lock Master file");
 

--- a/jans-cedarling/cedarling/src/init/service_config.rs
+++ b/jans-cedarling/cedarling/src/init/service_config.rs
@@ -8,12 +8,14 @@
 use super::policy_store::{PolicyStoreLoadError, load_policy_store};
 use crate::bootstrap_config;
 use crate::common::policy_store::PolicyStoreWithID;
+use crate::http::{HttpClient, InitializeHttpClientError};
 use bootstrap_config::BootstrapConfig;
 
 /// Configuration that hold validated infomation from bootstrap config
 #[derive(Clone)]
 pub(crate) struct ServiceConfig {
     pub policy_store: PolicyStoreWithID,
+    pub http_client: HttpClient,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -21,12 +23,18 @@ pub enum ServiceConfigError {
     /// Error that may occur during loading the policy store.
     #[error("Could not load policy: {0}")]
     PolicyStore(#[from] PolicyStoreLoadError),
+    #[error(transparent)]
+    InitHttpClient(#[from] InitializeHttpClientError),
 }
 
 impl ServiceConfig {
     pub(crate) async fn new(bootstrap: &BootstrapConfig) -> Result<Self, ServiceConfigError> {
-        let policy_store = load_policy_store(&bootstrap.policy_store_config).await?;
+        let http_client = HttpClient::new(bootstrap.http_client_config)?;
+        let policy_store = load_policy_store(&bootstrap.policy_store_config, &http_client).await?;
 
-        Ok(Self { policy_store })
+        Ok(Self {
+            policy_store,
+            http_client,
+        })
     }
 }

--- a/jans-cedarling/cedarling/src/init/service_factory.rs
+++ b/jans-cedarling/cedarling/src/init/service_factory.rs
@@ -91,8 +91,14 @@ impl<'a> ServiceFactory<'a> {
             let trusted_issuers = self.policy_store()?.trusted_issuers.clone();
             let logger = self.log_service();
             let service = Arc::new(
-                JwtService::new(config, trusted_issuers, Some(logger), self.metrics.clone())
-                    .await?,
+                JwtService::new(
+                    config,
+                    trusted_issuers,
+                    Some(logger),
+                    self.metrics.clone(),
+                    self.service_config.http_client.clone(),
+                )
+                .await?,
             );
             self.container.jwt_service = Some(service.clone());
             Ok(service)

--- a/jans-cedarling/cedarling/src/jwt/http_utils.rs
+++ b/jans-cedarling/cedarling/src/jwt/http_utils.rs
@@ -122,7 +122,7 @@ impl StatusListJwtStr {
     pub(super) async fn get_from_url(url: &Url, client: &HttpClient) -> Result<Self, HttpError> {
         let response = client
             .get_with_retry_with(url.as_str(), |b| {
-                b.header("Content-Type", "application/statuslist+jwt")
+                b.header("Accept", "application/statuslist+jwt")
             })
             .await
             .map_err(HttpError::Request)?;

--- a/jans-cedarling/cedarling/src/jwt/http_utils.rs
+++ b/jans-cedarling/cedarling/src/jwt/http_utils.rs
@@ -4,6 +4,7 @@
 // Copyright (c) 2024, Gluu, Inc.
 
 use std::sync::LazyLock;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
 use crate::common::issuer_utils::IssClaim;
@@ -17,17 +18,24 @@ use url::Url;
 
 /// Total time budget for any single OIDC discovery, JWKS, or status-list fetch.
 /// Without a bound, a slow or unresponsive issuer can stall a Cedarling task
-/// forever and starve the tokio runtime.
+/// forever and starve the tokio runtime. WASM targets rely on the browser
+/// fetch backend's own timing — `reqwest::ClientBuilder` doesn't expose
+/// `timeout` there.
+#[cfg(not(target_arch = "wasm32"))]
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Time budget for the TCP connect step alone. Most healthy issuers respond well
 /// inside this window; a longer wait usually means the host is unreachable.
+#[cfg(not(target_arch = "wasm32"))]
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
-    Client::builder()
+    let builder = Client::builder();
+    #[cfg(not(target_arch = "wasm32"))]
+    let builder = builder
         .timeout(HTTP_REQUEST_TIMEOUT)
-        .connect_timeout(HTTP_CONNECT_TIMEOUT)
+        .connect_timeout(HTTP_CONNECT_TIMEOUT);
+    builder
         .build()
         .expect("default reqwest client should build")
 });

--- a/jans-cedarling/cedarling/src/jwt/http_utils.rs
+++ b/jans-cedarling/cedarling/src/jwt/http_utils.rs
@@ -3,42 +3,14 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
-use std::sync::LazyLock;
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::Duration;
-
-use crate::common::issuer_utils::IssClaim;
+use crate::{common::issuer_utils::IssClaim, http::HttpClient};
 
 use super::key_service::JwkSet;
 use super::status_list::StatusListJwtStr;
 use async_trait::async_trait;
-use reqwest::{Client, header::ToStrError};
+use reqwest::header::ToStrError;
 use serde::{Deserialize, Deserializer, de};
 use url::Url;
-
-/// Total time budget for any single OIDC discovery, JWKS, or status-list fetch.
-/// Without a bound, a slow or unresponsive issuer can stall a Cedarling task
-/// forever and starve the tokio runtime. WASM targets rely on the browser
-/// fetch backend's own timing — `reqwest::ClientBuilder` doesn't expose
-/// `timeout` there.
-#[cfg(not(target_arch = "wasm32"))]
-const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-
-/// Time budget for the TCP connect step alone. Most healthy issuers respond well
-/// inside this window; a longer wait usually means the host is unreachable.
-#[cfg(not(target_arch = "wasm32"))]
-const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-
-static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
-    let builder = Client::builder();
-    #[cfg(not(target_arch = "wasm32"))]
-    let builder = builder
-        .timeout(HTTP_REQUEST_TIMEOUT)
-        .connect_timeout(HTTP_CONNECT_TIMEOUT);
-    builder
-        .build()
-        .expect("default reqwest client should build")
-});
 
 // async_traits are Send by default but wasm-bindgen doesn't support those
 // so we opt out of it for the wasm bindings to compile.
@@ -48,7 +20,7 @@ static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
 #[cfg_attr(any(target_arch = "wasm32", target_arch = "wasm64"), async_trait(?Send))]
 pub(super) trait GetFromUrl<T> {
     /// Send a get request to receive the resource from a URL
-    async fn get_from_url(url: &Url) -> Result<T, HttpError>;
+    async fn get_from_url(url: &Url, client: &HttpClient) -> Result<T, HttpError>;
 }
 
 #[derive(Deserialize)]
@@ -88,7 +60,7 @@ where
 #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), async_trait)]
 #[cfg_attr(any(target_arch = "wasm32", target_arch = "wasm64"), async_trait(?Send))]
 impl GetFromUrl<OpenIdConfig> for OpenIdConfig {
-    async fn get_from_url(url: &Url) -> Result<Self, HttpError> {
+    async fn get_from_url(url: &Url, client: &HttpClient) -> Result<Self, HttpError> {
         // add delay to simulate network latency and test async behavior of trusted issuers loading
         // it would be great to implement delay in mock server, but mockito doesn't support it.
         #[cfg(test)]
@@ -99,7 +71,8 @@ impl GetFromUrl<OpenIdConfig> for OpenIdConfig {
             sleep(Duration::from_millis(1)).await;
         }
 
-        let openid_config = HTTP_CLIENT
+        let openid_config = client
+            .raw_client
             .get(url.as_str())
             .send()
             .await
@@ -117,8 +90,9 @@ impl GetFromUrl<OpenIdConfig> for OpenIdConfig {
 #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), async_trait)]
 #[cfg_attr(any(target_arch = "wasm32", target_arch = "wasm64"), async_trait(?Send))]
 impl GetFromUrl<JwkSet> for JwkSet {
-    async fn get_from_url(url: &Url) -> Result<Self, HttpError> {
-        let jwk_set = HTTP_CLIENT
+    async fn get_from_url(url: &Url, client: &HttpClient) -> Result<Self, HttpError> {
+        let jwk_set = client
+            .raw_client
             .get(url.as_str())
             .send()
             .await
@@ -136,8 +110,9 @@ impl GetFromUrl<JwkSet> for JwkSet {
 // NOTE: we cant use the async_trait here since this is called from another async
 // function which requires this to be Send.
 impl StatusListJwtStr {
-    pub(super) async fn get_from_url(url: &Url) -> Result<Self, HttpError> {
-        let response = HTTP_CLIENT
+    pub(super) async fn get_from_url(url: &Url, client: &HttpClient) -> Result<Self, HttpError> {
+        let response = client
+            .raw_client
             .get(url.as_str())
             .header("Content-Type", "application/statuslist+jwt")
             .send()

--- a/jans-cedarling/cedarling/src/jwt/http_utils.rs
+++ b/jans-cedarling/cedarling/src/jwt/http_utils.rs
@@ -3,7 +3,10 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
-use crate::{common::issuer_utils::IssClaim, http::HttpClient};
+use crate::{
+    common::issuer_utils::IssClaim,
+    http::{HttpClient, HttpClientError},
+};
 
 use super::key_service::JwkSet;
 use super::status_list::StatusListJwtStr;
@@ -32,16 +35,9 @@ pub(super) trait GetFromUrl<T: for<'de> serde::Deserialize<'de>> {
         }
 
         let result = client
-            .raw_client
-            .get(url.as_str())
-            .send()
+            .get_json::<T>(url.as_str())
             .await
-            .map_err(HttpError::GetRequest)?
-            .error_for_status()
-            .map_err(HttpError::ErrorCode)?
-            .json::<T>()
-            .await
-            .map_err(HttpError::JsonDeserializeResponse)?;
+            .map_err(HttpError::Request)?;
 
         Ok(result)
     }
@@ -91,13 +87,9 @@ impl JwkSet {
         client: &HttpClient,
     ) -> Result<(Self, Option<u64>), HttpError> {
         let response = client
-            .raw_client
-            .get(url.as_str())
-            .send()
+            .get_with_retry(url.as_str())
             .await
-            .map_err(HttpError::GetRequest)?
-            .error_for_status()
-            .map_err(HttpError::ErrorCode)?;
+            .map_err(HttpError::Request)?;
 
         let max_age = response
             .headers()
@@ -129,14 +121,11 @@ fn parse_max_age(cache_control: &str) -> Option<u64> {
 impl StatusListJwtStr {
     pub(super) async fn get_from_url(url: &Url, client: &HttpClient) -> Result<Self, HttpError> {
         let response = client
-            .raw_client
-            .get(url.as_str())
-            .header("Content-Type", "application/statuslist+jwt")
-            .send()
+            .get_with_retry_with(url.as_str(), |b| {
+                b.header("Content-Type", "application/statuslist+jwt")
+            })
             .await
-            .map_err(HttpError::GetRequest)?
-            .error_for_status()
-            .map_err(HttpError::ErrorCode)?;
+            .map_err(HttpError::Request)?;
 
         if let Some(content_type) = response.headers().get("Content-Type") {
             let content_type = content_type
@@ -159,13 +148,11 @@ impl StatusListJwtStr {
 
 #[derive(Debug, thiserror::Error)]
 pub enum HttpError {
-    #[error("failed to complete GET request: {0}")]
-    GetRequest(#[source] reqwest::Error),
-    #[error("received an error response: {0}")]
-    ErrorCode(#[source] reqwest::Error),
-    #[error("failed to deserialize respose from JSON: {0}")]
+    #[error("HTTP request failed: {0}")]
+    Request(#[from] HttpClientError),
+    #[error("failed to deserialize response from JSON: {0}")]
     JsonDeserializeResponse(#[source] reqwest::Error),
-    #[error("failed to read the respose text: {0}")]
+    #[error("failed to read the response text: {0}")]
     ReadTextResponse(#[source] reqwest::Error),
     #[error("the value of the '{0}' header is invalid: {1}")]
     InvalidHeader(String, ToStrError),

--- a/jans-cedarling/cedarling/src/jwt/http_utils.rs
+++ b/jans-cedarling/cedarling/src/jwt/http_utils.rs
@@ -4,6 +4,7 @@
 // Copyright (c) 2024, Gluu, Inc.
 
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use crate::common::issuer_utils::IssClaim;
 
@@ -14,7 +15,22 @@ use reqwest::{Client, header::ToStrError};
 use serde::{Deserialize, Deserializer, de};
 use url::Url;
 
-static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(Client::new);
+/// Total time budget for any single OIDC discovery, JWKS, or status-list fetch.
+/// Without a bound, a slow or unresponsive issuer can stall a Cedarling task
+/// forever and starve the tokio runtime.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Time budget for the TCP connect step alone. Most healthy issuers respond well
+/// inside this window; a longer wait usually means the host is unreachable.
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .timeout(HTTP_REQUEST_TIMEOUT)
+        .connect_timeout(HTTP_CONNECT_TIMEOUT)
+        .build()
+        .expect("default reqwest client should build")
+});
 
 // async_traits are Send by default but wasm-bindgen doesn't support those
 // so we opt out of it for the wasm bindings to compile.

--- a/jans-cedarling/cedarling/src/jwt/http_utils.rs
+++ b/jans-cedarling/cedarling/src/jwt/http_utils.rs
@@ -18,9 +18,33 @@ use url::Url;
 // see this relevant discussion: https://github.com/rustwasm/wasm-bindgen/issues/2409
 #[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), async_trait)]
 #[cfg_attr(any(target_arch = "wasm32", target_arch = "wasm64"), async_trait(?Send))]
-pub(super) trait GetFromUrl<T> {
+pub(super) trait GetFromUrl<T: for<'de> serde::Deserialize<'de>> {
     /// Send a get request to receive the resource from a URL
-    async fn get_from_url(url: &Url, client: &HttpClient) -> Result<T, HttpError>;
+    async fn get_from_url(url: &Url, client: &HttpClient) -> Result<T, HttpError> {
+        // add delay to simulate network latency and test async behavior
+        // it would be great to implement delay in mock server, but mockito doesn't support it.
+        #[cfg(test)]
+        {
+            use std::time::Duration;
+            use tokio::time::sleep;
+
+            sleep(Duration::from_millis(1)).await;
+        }
+
+        let result = client
+            .raw_client
+            .get(url.as_str())
+            .send()
+            .await
+            .map_err(HttpError::GetRequest)?
+            .error_for_status()
+            .map_err(HttpError::ErrorCode)?
+            .json::<T>()
+            .await
+            .map_err(HttpError::JsonDeserializeResponse)?;
+
+        Ok(result)
+    }
 }
 
 #[derive(Deserialize)]
@@ -57,55 +81,9 @@ where
     Ok(url)
 }
 
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), async_trait)]
-#[cfg_attr(any(target_arch = "wasm32", target_arch = "wasm64"), async_trait(?Send))]
-impl GetFromUrl<OpenIdConfig> for OpenIdConfig {
-    async fn get_from_url(url: &Url, client: &HttpClient) -> Result<Self, HttpError> {
-        // add delay to simulate network latency and test async behavior of trusted issuers loading
-        // it would be great to implement delay in mock server, but mockito doesn't support it.
-        #[cfg(test)]
-        {
-            use std::time::Duration;
-            use tokio::time::sleep;
+impl GetFromUrl<OpenIdConfig> for OpenIdConfig {}
 
-            sleep(Duration::from_millis(1)).await;
-        }
-
-        let openid_config = client
-            .raw_client
-            .get(url.as_str())
-            .send()
-            .await
-            .map_err(HttpError::GetRequest)?
-            .error_for_status()
-            .map_err(HttpError::ErrorCode)?
-            .json::<OpenIdConfig>()
-            .await
-            .map_err(HttpError::JsonDeserializeResponse)?;
-
-        Ok(openid_config)
-    }
-}
-
-#[cfg_attr(not(any(target_arch = "wasm32", target_arch = "wasm64")), async_trait)]
-#[cfg_attr(any(target_arch = "wasm32", target_arch = "wasm64"), async_trait(?Send))]
-impl GetFromUrl<JwkSet> for JwkSet {
-    async fn get_from_url(url: &Url, client: &HttpClient) -> Result<Self, HttpError> {
-        let jwk_set = client
-            .raw_client
-            .get(url.as_str())
-            .send()
-            .await
-            .map_err(HttpError::GetRequest)?
-            .error_for_status()
-            .map_err(HttpError::ErrorCode)?
-            .json::<JwkSet>()
-            .await
-            .map_err(HttpError::JsonDeserializeResponse)?;
-
-        Ok(jwk_set)
-    }
-}
+impl GetFromUrl<JwkSet> for JwkSet {}
 
 // NOTE: we cant use the async_trait here since this is called from another async
 // function which requires this to be Send.

--- a/jans-cedarling/cedarling/src/jwt/key_service.rs
+++ b/jans-cedarling/cedarling/src/jwt/key_service.rs
@@ -316,15 +316,25 @@ pub enum FetchKeysError {
 
 #[cfg(test)]
 mod test {
+    use std::sync::LazyLock;
     use std::time::Duration;
 
     use super::*;
     use crate::{
-        http::HttpClientConfig,
+        http::{HttpClient, HttpClientConfig},
         jwt::test_utils::{MockServer, generate_jwks, generate_keypair_hs256},
     };
     use jsonwebtoken::Algorithm;
     use serde_json::json;
+
+    static HTTP_CLIENT: LazyLock<HttpClient> = LazyLock::new(|| {
+        HttpClient::new(HttpClientConfig {
+            max_retries: 0,
+            retry_delay: Duration::from_millis(3),
+            request_timeout: Duration::from_millis(500),
+        })
+        .expect("http client should be constructed")
+    });
 
     #[test]
     fn can_insert_and_get_keys_from_str() {
@@ -497,7 +507,7 @@ mod test {
 
         let key_service = KeyService::default();
         let max_age = key_service
-            .refresh_keys_using_oidc(&openid_config, None)
+            .refresh_keys_using_oidc(&openid_config, None, &HTTP_CLIENT)
             .await
             .expect("refresh with cache-control header should succeed");
 
@@ -543,7 +553,7 @@ mod test {
 
         let key_service = KeyService::default();
         let max_age = key_service
-            .refresh_keys_using_oidc(&openid_config, None)
+            .refresh_keys_using_oidc(&openid_config, None, &HTTP_CLIENT)
             .await
             .expect("refresh without cache-control header should succeed");
 
@@ -573,7 +583,7 @@ mod test {
         let key_service = KeyService::default();
 
         key_service
-            .get_keys_using_oidc(&openid_config, None)
+            .get_keys_using_oidc(&openid_config, None, HTTP_CLIENT.clone())
             .await
             .expect("initial key fetch should succeed");
 
@@ -594,7 +604,7 @@ mod test {
             .expect("should rotate signing key");
 
         key_service
-            .refresh_keys_using_oidc(&server.openid_config(), None)
+            .refresh_keys_using_oidc(&server.openid_config(), None, &HTTP_CLIENT)
             .await
             .expect("refresh should succeed");
 

--- a/jans-cedarling/cedarling/src/jwt/key_service.rs
+++ b/jans-cedarling/cedarling/src/jwt/key_service.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::LogWriter;
 use crate::common::issuer_utils::IssClaim;
+use crate::http::HttpClient;
 use crate::jwt::log_entry::JwtLogEntry;
 use crate::log::Logger;
 
@@ -108,8 +109,9 @@ impl KeyService {
         &self,
         openid_config: &OpenIdConfig,
         logger: Option<&Logger>,
+        http_client: HttpClient,
     ) -> Result<(), KeyServiceError> {
-        let jwks = JwkSet::get_from_url(&openid_config.jwks_uri)
+        let jwks = JwkSet::get_from_url(&openid_config.jwks_uri, &http_client)
             .await
             .map_err(KeyServiceError::GetJwks)?;
 
@@ -281,8 +283,10 @@ pub enum FetchKeysError {
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use super::*;
-    use crate::jwt::test_utils::MockServer;
+    use crate::{http::HttpClientConfig, jwt::test_utils::MockServer};
     use jsonwebtoken::Algorithm;
     use serde_json::json;
 
@@ -371,12 +375,19 @@ mod test {
 
         let key_service = KeyService::default();
 
+        let http_client = HttpClient::new(HttpClientConfig {
+            max_retries: 0,
+            retry_delay: Duration::from_millis(3),
+            request_timeout: Duration::from_millis(500),
+        })
+        .expect("http client should be constructed");
+
         key_service
-            .get_keys_using_oidc(&server1.openid_config(), None)
+            .get_keys_using_oidc(&server1.openid_config(), None, http_client.clone())
             .await
             .expect("fetch keys for issuer 1");
         key_service
-            .get_keys_using_oidc(&server2.openid_config(), None)
+            .get_keys_using_oidc(&server2.openid_config(), None, http_client)
             .await
             .expect("fetch keys for issuer 2");
 

--- a/jans-cedarling/cedarling/src/jwt/mod.rs
+++ b/jans-cedarling/cedarling/src/jwt/mod.rs
@@ -920,6 +920,7 @@ mod test {
             Some(HashMap::from([(server.issuer().to_string(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("JwtService should initialize with trusted issuer metadata");
@@ -1000,6 +1001,7 @@ mod test {
             Some(HashMap::from([(server.issuer().to_string(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("JwtService should initialize with trusted issuer metadata");

--- a/jans-cedarling/cedarling/src/jwt/mod.rs
+++ b/jans-cedarling/cedarling/src/jwt/mod.rs
@@ -92,6 +92,7 @@ use crate::authz::request::TokenInput;
 use crate::common::issuer_utils::IssClaim;
 use crate::common::policy_store::TrustedIssuer;
 
+use crate::http::HttpClient;
 use crate::log::Logger;
 use chrono::Utc;
 use http_utils::{GetFromUrl, OpenIdConfig};
@@ -147,6 +148,7 @@ impl JwtService {
         trusted_issuers: Option<HashMap<String, TrustedIssuer>>,
         logger: Option<Logger>,
         metrics: Arc<MetricsCollector>,
+        http_client: HttpClient,
     ) -> Result<Self, JwtServiceInitError> {
         if jwt_config.jwt_sig_validation && jwt_config.signature_algorithms_supported.is_empty() {
             return Err(JwtServiceInitError::NoSupportedAlgorithms);
@@ -177,6 +179,7 @@ impl JwtService {
             token_cache: token_cache.clone(),
             logger: logger.clone(),
             loading_state: loading_state.clone(),
+            http_client,
         };
 
         loader.load_trusted_issuers(trusted_issuers.clone()).await?;
@@ -499,11 +502,24 @@ mod test {
     use crate::authz::metrics::MetricsCollector;
     use crate::authz::request::TokenInput;
     use crate::common::policy_store::TokenEntityMetadata;
+    use crate::http::HttpClient;
+    use crate::http::HttpClientConfig;
     use jsonwebtoken::Algorithm;
     use serde_json::json;
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
+    use std::sync::LazyLock;
+    use std::time::Duration;
     use tokio::test;
+
+    static HTTP_CLIENT: LazyLock<HttpClient> = LazyLock::new(|| {
+        HttpClient::new(HttpClientConfig {
+            max_retries: 0,
+            retry_delay: Duration::from_millis(3),
+            request_timeout: Duration::from_millis(500),
+        })
+        .expect("http client should be constructed")
+    });
 
     #[test]
     async fn test_validate_multi_issuer_tokens_success() {
@@ -565,6 +581,7 @@ mod test {
             Some(HashMap::from([(server.issuer().to_string(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("Should create JwtService");
@@ -602,6 +619,7 @@ mod test {
             Some(HashMap::from([(server.issuer().to_string(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("Should create JwtService");
@@ -629,6 +647,7 @@ mod test {
             Some(HashMap::from([(server.issuer().to_string(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("Should create JwtService");
@@ -697,6 +716,7 @@ mod test {
             Some(HashMap::from([(server.issuer().to_string(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("Should create JwtService");
@@ -764,6 +784,7 @@ mod test {
             Some(HashMap::from([(server.issuer().to_string(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("Should create JwtService");
@@ -807,6 +828,7 @@ mod test {
             Some(HashMap::from([(server.issuer().to_string(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("Should create JwtService");
@@ -836,6 +858,7 @@ mod test {
             Some(HashMap::from([("Jans".into(), iss)])),
             None,
             Arc::new(MetricsCollector::new(0)),
+            HTTP_CLIENT.clone(),
         )
         .await
         .expect("Should create JwtService");

--- a/jans-cedarling/cedarling/src/jwt/status_list/cache.rs
+++ b/jans-cedarling/cedarling/src/jwt/status_list/cache.rs
@@ -32,6 +32,16 @@ use super::{StatusList, StatusListJwt, StatusListJwtStr, UpdateStatusListError};
 /// The value of the `status_list_uri` claim from a JWT
 type StatusListUri = String;
 
+struct StatusListUpdateCtx {
+    ttl: u64,
+    status_list_url: Url,
+    decoding_key: Option<Arc<DecodingKey>>,
+    validator: Arc<RwLock<JwtValidator>>,
+    status_lists: Arc<RwLock<HashMap<String, StatusList>>>,
+    logger: Option<Logger>,
+    http_client: HttpClient,
+}
+
 /// Contains an `Arc<RwLock<_>>` internally so clone should be fine
 #[derive(Debug, Default, Clone)]
 pub(crate) struct StatusListCache {
@@ -97,18 +107,21 @@ impl StatusListCache {
         // spawn a background task to handle updating the statuslist if the JWT has a TTL
         // claim
         if let Some(ttl) = ttl {
-            crate::http::spawn_task(keep_status_list_updated(
+            let ctx = StatusListUpdateCtx {
                 ttl,
-                status_list_url.clone(),
+                status_list_url: status_list_url.clone(),
                 decoding_key,
                 validator,
-                self.status_lists.clone(),
+                status_lists: self.status_lists.clone(),
                 logger,
+                http_client: http_client.clone(),
+            };
+            crate::http::spawn_task(keep_status_list_updated(
                 // callback is called on updated status list
                 move || {
                     token_cache.invalidate_by_index(&IndexKey::Iss(iss.clone()));
                 },
-                http_client.clone(),
+                ctx,
             ));
         }
 
@@ -126,18 +139,20 @@ impl StatusListCache {
 
 /// Keeps the statuslist form the given URL updated based on the TTL
 /// `cb` will be called when status list updated
-async fn keep_status_list_updated<F>(
-    mut ttl: u64,
-    status_list_url: Url,
-    decoding_key: Option<Arc<DecodingKey>>,
-    validator: Arc<RwLock<JwtValidator>>,
-    status_lists: Arc<RwLock<HashMap<String, StatusList>>>,
-    logger: Option<Logger>,
-    cb: F,
-    http_client: HttpClient,
-) where
+async fn keep_status_list_updated<F>(cb: F, ctx: StatusListUpdateCtx)
+where
     F: Fn(),
 {
+    let StatusListUpdateCtx {
+        mut ttl,
+        status_list_url,
+        decoding_key,
+        validator,
+        status_lists,
+        logger,
+        http_client,
+    } = ctx;
+
     loop {
         sleep(Duration::from_secs(ttl)).await;
 

--- a/jans-cedarling/cedarling/src/jwt/status_list/cache.rs
+++ b/jans-cedarling/cedarling/src/jwt/status_list/cache.rs
@@ -15,6 +15,7 @@ use url::Url;
 use crate::{
     LogLevel, LogWriter,
     async_sleep::sleep,
+    http::HttpClient,
     jwt::{
         IssuerConfig, TokenCache,
         decode::{DecodeJwtError, decode_jwt},
@@ -46,6 +47,7 @@ impl StatusListCache {
         key_service: &KeyService,
         token_cache: TokenCache,
         logger: Option<Logger>,
+        http_client: HttpClient,
     ) -> Result<(), UpdateStatusListError> {
         let openid_config = iss_config
             .openid_config
@@ -55,7 +57,7 @@ impl StatusListCache {
             .status_list_endpoint
             .as_ref()
             .ok_or(UpdateStatusListError::MissingStatusListUri)?;
-        let status_list_jwt = StatusListJwtStr::get_from_url(status_list_url)
+        let status_list_jwt = StatusListJwtStr::get_from_url(status_list_url, &http_client)
             .await
             .map_err(UpdateStatusListError::GetStatusListJwt)?;
         let iss = iss_config.policy.iss_claim();
@@ -106,6 +108,7 @@ impl StatusListCache {
                 move || {
                     token_cache.invalidate_by_index(&IndexKey::Iss(iss.clone()));
                 },
+                http_client.clone(),
             ));
         }
 
@@ -131,26 +134,28 @@ async fn keep_status_list_updated<F>(
     status_lists: Arc<RwLock<HashMap<String, StatusList>>>,
     logger: Option<Logger>,
     cb: F,
+    http_client: HttpClient,
 ) where
     F: Fn(),
 {
     loop {
         sleep(Duration::from_secs(ttl)).await;
 
-        let status_list_jwt = match StatusListJwtStr::get_from_url(&status_list_url).await {
-            Ok(jwt) => jwt,
-            Err(e) => {
-                logger.log_any(JwtLogEntry::new(
-                    format!(
-                        "failed to fetch an updated the status list from '{0}': {1}",
-                        status_list_url.as_str(),
-                        e
-                    ),
-                    Some(LogLevel::ERROR),
-                ));
-                continue;
-            },
-        };
+        let status_list_jwt =
+            match StatusListJwtStr::get_from_url(&status_list_url, &http_client).await {
+                Ok(jwt) => jwt,
+                Err(e) => {
+                    logger.log_any(JwtLogEntry::new(
+                        format!(
+                            "failed to fetch an updated the status list from '{0}': {1}",
+                            status_list_url.as_str(),
+                            e
+                        ),
+                        Some(LogLevel::ERROR),
+                    ));
+                    continue;
+                },
+            };
 
         let result = {
             validator
@@ -242,18 +247,26 @@ mod test {
     use super::*;
     use crate::JwtConfig;
     use crate::common::policy_store::TrustedIssuer;
+    use crate::http::HttpClientConfig;
     use crate::jwt::test_utils::MockServer;
     use std::collections::HashSet;
     use std::time::Duration;
 
     #[tokio::test]
     async fn keep_status_list_updated() {
+        let http_client = HttpClient::new(HttpClientConfig {
+            max_retries: 0,
+            retry_delay: Duration::from_millis(3),
+            request_timeout: Duration::from_millis(500),
+        })
+        .expect("http client should be constructed");
+
         // Setup
         let validators = JwtValidatorCache::default();
         let key_service = KeyService::default();
         let mut mock_server = MockServer::new_with_defaults().await.unwrap();
         key_service
-            .get_keys_using_oidc(&mock_server.openid_config(), None)
+            .get_keys_using_oidc(&mock_server.openid_config(), None, http_client.clone())
             .await
             .unwrap();
         // we initialize the status list with a 1 sec ttl
@@ -291,6 +304,7 @@ mod test {
                 &key_service,
                 TokenCache::default(),
                 None,
+                http_client,
             )
             .await
             .unwrap();

--- a/jans-cedarling/cedarling/src/jwt/trusted_issuers_loader.rs
+++ b/jans-cedarling/cedarling/src/jwt/trusted_issuers_loader.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 use crate::{
     JwtConfig, LogLevel,
     common::{issuer_utils::IssClaim, policy_store::TrustedIssuer},
+    http::HttpClient,
     jwt::{
         GetFromUrl, IssuerConfig, IssuerIndex, JwtLogEntry, JwtServiceInitError, KeyService,
         OpenIdConfig, TokenCache, key_service::KeyServiceError,
@@ -51,6 +52,7 @@ pub(super) struct TrustedIssuerLoader {
     pub(super) token_cache: TokenCache,
     pub(super) logger: Option<Logger>,
     pub(super) loading_state: Arc<TrustedIssuerLoadingState>,
+    pub(super) http_client: HttpClient,
 }
 
 impl TrustedIssuerLoader {
@@ -122,8 +124,10 @@ async fn load_trusted_issuers(
         let loader_clone = loader.clone();
         let errors_clone = errors.clone();
 
+        let http_client_clone = loader.http_client.clone();
         let handle = spawn_task(async move {
-            let result = load_trusted_issuer(&loader_clone, issuer_id.clone(), iss).await;
+            let result =
+                load_trusted_issuer(&loader_clone, issuer_id.clone(), iss, http_client_clone).await;
             drop(permit); // Release the permit
 
             if let Err(error) = result {
@@ -176,6 +180,7 @@ pub(super) async fn load_trusted_issuer(
     loader: &TrustedIssuerLoader,
     issuer_id: String,
     iss: TrustedIssuer,
+    http_client: HttpClient,
 ) -> Result<(), JwtServiceInitError> {
     // this is what we expect to find in the JWT `iss` claim
     let mut iss_claim = iss.iss_claim();
@@ -187,7 +192,9 @@ pub(super) async fn load_trusted_issuer(
     };
 
     if loader.jwt_config.jwt_sig_validation || loader.jwt_config.jwt_status_validation {
-        iss_claim = update_openid_config(&mut iss_config, loader.logger.as_ref()).await?;
+        iss_claim =
+            update_openid_config(&mut iss_config, loader.logger.as_ref(), http_client.clone())
+                .await?;
     }
 
     insert_keys(
@@ -195,6 +202,7 @@ pub(super) async fn load_trusted_issuer(
         &loader.jwt_config,
         &iss_config,
         loader.logger.as_ref(),
+        http_client.clone(),
     )
     .await?;
 
@@ -214,6 +222,7 @@ pub(super) async fn load_trusted_issuer(
                 &loader.key_service,
                 loader.token_cache.clone(),
                 loader.logger.clone(),
+                http_client,
             )
             .await?;
     }
@@ -227,18 +236,20 @@ pub(super) async fn load_trusted_issuer(
 async fn update_openid_config(
     iss_config: &mut IssuerConfig,
     logger: Option<&Logger>,
+    http_client: HttpClient,
 ) -> Result<IssClaim, JwtServiceInitError> {
-    let openid_config = OpenIdConfig::get_from_url(iss_config.policy.get_oidc_endpoint())
-        .await
-        .inspect_err(|e| {
-            logger.log_any(JwtLogEntry::new(
-                format!(
-                    "failed to get openid configuration for trusted issuer: '{}': {}",
-                    iss_config.issuer_id, e
-                ),
-                Some(LogLevel::ERROR),
-            ));
-        })?;
+    let openid_config =
+        OpenIdConfig::get_from_url(iss_config.policy.get_oidc_endpoint(), &http_client)
+            .await
+            .inspect_err(|e| {
+                logger.log_any(JwtLogEntry::new(
+                    format!(
+                        "failed to get openid configuration for trusted issuer: '{}': {}",
+                        iss_config.issuer_id, e
+                    ),
+                    Some(LogLevel::ERROR),
+                ));
+            })?;
 
     let iss_claim = openid_config.issuer.clone();
     iss_config.openid_config = Some(openid_config);
@@ -252,6 +263,7 @@ async fn insert_keys(
     jwt_config: &JwtConfig,
     iss_config: &IssuerConfig,
     logger: Option<&Logger>,
+    http_client: HttpClient,
 ) -> Result<(), KeyServiceError> {
     if !jwt_config.jwt_sig_validation {
         return Ok(());
@@ -259,7 +271,7 @@ async fn insert_keys(
 
     if let Some(openid_config) = iss_config.openid_config.as_ref() {
         key_service
-            .get_keys_using_oidc(openid_config, logger)
+            .get_keys_using_oidc(openid_config, logger, http_client)
             .await?;
     }
 
@@ -281,6 +293,7 @@ fn log_load_trusted_issuers_error(logger: Option<&Logger>, error: &JwtServiceIni
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::http::HttpClientConfig;
     use crate::jwt::key_service::DecodingKeyInfo;
     use crate::jwt::test_utils::{
         MockServer, create_failing_trusted_issuer, create_unreachable_trusted_issuer,
@@ -289,9 +302,18 @@ mod test {
     use jsonwebtoken::Algorithm;
     use mockito::Server;
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, LazyLock};
     use tokio::time::{Duration, sleep};
     use url::Url;
+
+    static HTTP_CLIENT: LazyLock<HttpClient> = LazyLock::new(|| {
+        HttpClient::new(HttpClientConfig {
+            max_retries: 0,
+            retry_delay: Duration::from_millis(3),
+            request_timeout: Duration::from_millis(500),
+        })
+        .expect("http client should be constructed")
+    });
 
     /// Helper to retry an assertion for a short period, useful for async tests
     /// where operations may complete slightly after tasks are awaited.
@@ -324,6 +346,7 @@ mod test {
             token_cache: TokenCache::default(),
             logger: None,
             loading_state: Arc::new(TrustedIssuerLoadingState::new(issuer_count)),
+            http_client: HTTP_CLIENT.clone(),
         }
     }
 
@@ -536,6 +559,7 @@ mod test {
             token_cache: TokenCache::default(),
             logger: None,
             loading_state: Arc::new(TrustedIssuerLoadingState::new(0)),
+            http_client: HTTP_CLIENT.clone(),
         };
 
         loader_with_keys.check_keys_loaded();

--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -44,7 +44,6 @@ pub use crate::context_data_api::{
     DataStoreConfig, DataStoreStats, DataValidator, ExtensionValue, ValidationConfig,
     ValidationError, ValidationResult, ValueMappingError,
 };
-pub use crate::init::policy_store::{PolicyStoreLoadError, load_policy_store};
 pub use crate::jwt::TrustedIssuerLoadingInfo;
 use authz::Authz;
 pub use authz::request::{
@@ -54,6 +53,7 @@ pub use authz::{AuthorizeError, AuthorizeResult, MultiIssuerAuthorizeResult};
 pub use bootstrap_config::*;
 use common::app_types::{self, ApplicationName};
 pub use common::policy_store::{PolicyEffect, PolicyMetadata};
+pub use http::HttpClientConfig;
 use init::ServiceFactory;
 use init::service_config::{ServiceConfig, ServiceConfigError};
 use init::service_factory::ServiceInitError;
@@ -147,6 +147,7 @@ impl Cedarling {
             app_name,
             config.lock_config.as_ref(),
             metrics.clone(),
+            config.http_client_config,
         )
         .await?;
 

--- a/jans-cedarling/cedarling/src/lock/lock_config.rs
+++ b/jans-cedarling/cedarling/src/lock/lock_config.rs
@@ -8,8 +8,8 @@
 
 use std::str::FromStr;
 
-use super::init_http_client;
-use http_utils::{Backoff, HttpRequestError, Sender};
+use crate::http::{HttpClient, InitializeHttpClientError};
+use http_utils::HttpRequestError;
 use serde::{Deserialize, Deserializer, de};
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
@@ -59,18 +59,20 @@ pub(super) struct ConfigEndpoints {
     pub sse: Option<Url>,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum GetLockConfigError {
+    #[error(transparent)]
+    InitializeHttpClient(#[from] InitializeHttpClientError),
+    #[error(transparent)]
+    Request(#[from] HttpRequestError),
+}
+
 impl LockConfig {
     pub(super) async fn get(
         lock_config_url: &url::Url,
-        accept_invalid_certs: bool,
-    ) -> Result<Self, HttpRequestError> {
-        let client = init_http_client(None, accept_invalid_certs)
-            .map_err(HttpRequestError::InitializeHttpClient)?;
-
-        let mut sender = Sender::new(Backoff::default_exponential());
-
-        let config: LockConfig = sender.send(|| client.get(lock_config_url.as_ref())).await?;
-
+        http_client: &HttpClient,
+    ) -> Result<Self, GetLockConfigError> {
+        let config: LockConfig = http_client.get_json(lock_config_url.as_ref()).await?;
         Ok(config)
     }
 }

--- a/jans-cedarling/cedarling/src/lock/mod.rs
+++ b/jans-cedarling/cedarling/src/lock/mod.rs
@@ -122,10 +122,12 @@ mod proto {
 use crate::app_types::PdpID;
 use crate::authz::metrics::MetricsCollector;
 use crate::common::issuer_utils::IssClaim;
+use crate::http::{HttpClient, InitializeHttpClientError};
+use crate::lock::lock_config::GetLockConfigError;
 use crate::lock::telemetry_ticker::TelemetryTicker;
 use crate::log::interface::Loggable;
 use crate::log::{LogType, LoggerWeak};
-use crate::{LockServiceConfig, LockTransport, LogWriter};
+use crate::{HttpClientConfig, LockServiceConfig, LockTransport, LogWriter};
 use futures::channel::mpsc;
 use lock_config::LockConfig;
 use log_entry::LockLogEntry;
@@ -161,26 +163,29 @@ pub(crate) struct LockService {
 pub(crate) fn init_http_client(
     default_headers: Option<HeaderMap>,
     accept_invalid_certs: bool,
-) -> Result<Client, reqwest::Error> {
+    conf: HttpClientConfig,
+) -> Result<HttpClient, InitializeHttpClientError> {
     let headers = default_headers.unwrap_or_default();
+    let builder = Client::builder();
 
-    if accept_invalid_certs {
+    let builder = if accept_invalid_certs {
         // NOTE: WASM builds fail when calling .danger_accept_invalid_certs
         #[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
         {
-            Client::builder().default_headers(headers).build()
+            builder.default_headers(headers)
         }
 
         #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
         {
-            Client::builder()
+            builder
                 .default_headers(headers)
                 .danger_accept_invalid_certs(true)
-                .build()
         }
     } else {
-        Client::builder().default_headers(headers).build()
-    }
+        Client::builder().default_headers(headers)
+    };
+
+    HttpClient::new_with_builder(builder, conf)
 }
 
 impl LockService {
@@ -189,13 +194,12 @@ impl LockService {
         bootstrap_conf: &LockServiceConfig,
         logger: Option<LoggerWeak>,
         metrics: Arc<MetricsCollector>,
+        http_conf: HttpClientConfig,
     ) -> Result<Self, InitLockServiceError> {
+        let http_client = init_http_client(None, bootstrap_conf.accept_invalid_certs, http_conf)?;
+
         // Get lock config from the config uri endpoint first
-        let lock_config = LockConfig::get(
-            &bootstrap_conf.config_uri,
-            bootstrap_conf.accept_invalid_certs,
-        )
-        .await?;
+        let lock_config = LockConfig::get(&bootstrap_conf.config_uri, &http_client).await?;
 
         // Validate SSA JWT if provided
         if let Some(ssa_jwt) = &bootstrap_conf.ssa_jwt {
@@ -207,7 +211,7 @@ impl LockService {
             );
 
             // Validate the SSA JWT
-            validate_ssa_jwt(ssa_jwt, &jwks_uri, bootstrap_conf.accept_invalid_certs)
+            validate_ssa_jwt(ssa_jwt, &jwks_uri, &http_client)
                 .await
                 .map_err(|e| {
                     InitLockServiceError::InvalidSsaJwt(format!("SSA JWT validation failed: {e}"))
@@ -220,6 +224,7 @@ impl LockService {
             &lock_config.issuer_oidc_url,
             bootstrap_conf.ssa_jwt.as_ref(),
             bootstrap_conf.accept_invalid_certs,
+            http_conf,
         )
         .await?;
 
@@ -233,6 +238,7 @@ impl LockService {
                     log_interval,
                     logger.clone(),
                     cancel_tkn.clone(),
+                    http_conf,
                 )?;
                 Some(worker)
             },
@@ -252,6 +258,7 @@ impl LockService {
                     telemetry_interval,
                     logger.clone(),
                     cancel_tkn.clone(),
+                    http_conf,
                 )?;
 
                 Some(worker)
@@ -327,6 +334,7 @@ fn create_worker(
     audit_interval: Duration,
     logger: Option<LoggerWeak>,
     cancel_tkn: CancellationToken,
+    http_conf: HttpClientConfig,
 ) -> Result<WorkerSenderAndHandle, InitLockServiceError> {
     let (tx, rx) = mpsc::channel::<SerializedAuditEntry>(bootstrap_conf.log_channel_capacity);
 
@@ -339,10 +347,12 @@ fn create_worker(
             auth_header.set_sensitive(true);
             headers.insert("Authorization", auth_header);
 
-            let http_client = Arc::new(init_http_client(
+            let http_client = init_http_client(
                 Some(headers),
                 bootstrap_conf.accept_invalid_certs,
-            )?);
+                http_conf,
+            )
+            .map_err(GetLockConfigError::from)?;
 
             let transport = Arc::new(RestTransport::new(
                 http_client,
@@ -414,16 +424,16 @@ impl LogWriter for LockService {
 
 #[derive(Debug, thiserror::Error)]
 pub enum InitLockServiceError {
+    #[error("init http lock client: {0}")]
+    InitHttpClient(#[from] InitializeHttpClientError),
     #[error("the provided CEDARLING_LOCK_SSA_JWT is either malformed or expired: {0}")]
     InvalidSsaJwt(String),
     #[error(
         "failed to GET lock server config from the `.well-known/lock-server-configuration` endpoint: {0}"
     )]
-    GetLockConfig(#[from] http_utils::HttpRequestError),
+    GetLockConfig(#[from] GetLockConfigError),
     #[error("failed to dynamically register client for the Lock server's auth: {0}")]
     ClientRegistration(#[from] ClientRegistrationError),
-    #[error("failed to initialize the Lock logger's HttpClient: {0}")]
-    InitHttpClient(#[from] reqwest::Error),
     #[error("transport error: {0}")]
     TransportError(#[from] transport::TransportError),
     #[error("failed to parse access token: {0}")]
@@ -491,7 +501,7 @@ mod test {
 
         // Test startup
         let metrics = Arc::new(MetricsCollector::new(0));
-        let logger = LockService::new(pdp_id, &config, None, metrics)
+        let logger = LockService::new(pdp_id, &config, None, metrics, HttpClientConfig::default())
             .await
             .expect("build lock logger");
         lock_config_endpoint.assert();
@@ -551,7 +561,7 @@ mod test {
 
         // Test startup without SSA
         let metrics = Arc::new(MetricsCollector::new(0));
-        let logger = LockService::new(pdp_id, &config, None, metrics)
+        let logger = LockService::new(pdp_id, &config, None, metrics, HttpClientConfig::default())
             .await
             .expect("build lock logger");
         lock_config_endpoint.assert();
@@ -607,7 +617,8 @@ mod test {
 
         // Test startup with invalid SSA should fail
         let metrics = Arc::new(MetricsCollector::new(0));
-        let result = LockService::new(pdp_id, &config, None, metrics).await;
+        let result =
+            LockService::new(pdp_id, &config, None, metrics, HttpClientConfig::default()).await;
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),

--- a/jans-cedarling/cedarling/src/lock/mod.rs
+++ b/jans-cedarling/cedarling/src/lock/mod.rs
@@ -351,8 +351,7 @@ fn create_worker(
                 Some(headers),
                 bootstrap_conf.accept_invalid_certs,
                 http_conf,
-            )
-            .map_err(GetLockConfigError::from)?;
+            )?;
 
             let transport = Arc::new(RestTransport::new(
                 http_client,

--- a/jans-cedarling/cedarling/src/lock/register_client.rs
+++ b/jans-cedarling/cedarling/src/lock/register_client.rs
@@ -8,8 +8,7 @@
 use std::collections::HashMap;
 
 use super::{init_http_client, lock_config::Url};
-use crate::app_types::PdpID;
-use http_utils::{Backoff, Sender};
+use crate::{HttpClientConfig, app_types::PdpID, http::InitializeHttpClientError};
 use serde::Deserialize;
 use serde_json::json;
 use thiserror::Error;
@@ -22,22 +21,13 @@ pub(super) async fn register_client(
     oidc_endpoint: &Url,
     ssa_jwt: Option<&String>,
     accept_invalid_certs: bool,
+    http_conf: HttpClientConfig,
 ) -> Result<ClientCredentials, ClientRegistrationError> {
-    let client = init_http_client(None, accept_invalid_certs)?;
-
-    #[cfg(not(test))]
-    let mut sender = Sender::new(Backoff::default_exponential());
-
-    // We implement a faster retry for the tests
-    #[cfg(test)]
-    let mut sender = {
-        use std::time::Duration;
-        Sender::new(Backoff::new_exponential(Duration::from_millis(10), Some(3)))
-    };
+    let client = init_http_client(None, accept_invalid_certs, http_conf)?;
 
     // Get openid config
-    let oidc: OpenidConfig = sender
-        .send(|| client.get(oidc_endpoint.0.as_str()))
+    let oidc: OpenidConfig = client
+        .get_json(oidc_endpoint.0.as_str())
         .await
         .map_err(ClientRegistrationError::GetOpenidConfig)?;
 
@@ -58,8 +48,8 @@ pub(super) async fn register_client(
     let ClientIdAndSecret {
         client_id,
         client_secret,
-    } = sender
-        .send(|| {
+    } = client
+        .post_json(|client| {
             client
                 .post(&oidc.registration_endpoint)
                 .header("Content-Type", "application/json")
@@ -76,8 +66,8 @@ pub(super) async fn register_client(
     // this should never fail since this is a hard-coded valid JSON
     .expect("serialize form data");
 
-    let AccessToken { access_token } = sender
-        .send(|| {
+    let AccessToken { access_token } = client
+        .post_json(|client| {
             client
                 .post(&oidc.token_endpoint)
                 .basic_auth(&client_id, Some(&client_secret))
@@ -110,7 +100,7 @@ pub enum ClientRegistrationError {
     #[error("failed to get access token: {0}")]
     GetAccessToken(#[source] http_utils::HttpRequestError),
     #[error("failed to initialize HTTP client: {0}")]
-    InitializeHttpClient(#[from] reqwest::Error),
+    InitializeHttpClient(#[from] InitializeHttpClientError),
 }
 
 #[derive(Debug, Deserialize)]
@@ -157,6 +147,7 @@ mod tests {
             &super::super::lock_config::Url(oidc_url),
             Some(&ssa_jwt.to_string()),
             false,
+            crate::http::HttpClientConfig::default(),
         )
         .await;
 
@@ -185,6 +176,7 @@ mod tests {
             &super::super::lock_config::Url(oidc_url),
             None,
             false,
+            crate::http::HttpClientConfig::default(),
         )
         .await;
 

--- a/jans-cedarling/cedarling/src/lock/ssa_validation.rs
+++ b/jans-cedarling/cedarling/src/lock/ssa_validation.rs
@@ -59,9 +59,7 @@
 //! - **`InvalidExpirationTime`**: Expiration time is not a number
 //! - **`InvalidIssuedAtTime`**: Issued at time is not a number
 //! - **`HttpClientError`**: HTTP client initialization failed
-//! - **`JwksFetchError`**: Failed to fetch JWKS from IDP
-//! - **`JwksParseError`**: Failed to parse JWKS response
-//! - **`MissingKeyId`**: JWT header missing key ID
+//! - **`JwksFetchError`**: Failed to fetch JWKS from IDP//! - **`MissingKeyId`**: JWT header missing key ID
 //! - **`KeyNotFound`**: Key not found in JWKS
 //! - **`KeyDecodeError`**: Failed to decode key data
 //! - **`InvalidKeyFormat`**: Key format is invalid
@@ -74,8 +72,12 @@
 //! before performing Dynamic Client Registration. The validated SSA JWT
 //! is then included in the DCR request to the Identity Provider.
 
-use crate::jwt::{DecodeJwtError, DecodedJwt, decode_jwt};
+use crate::{
+    http::{HttpClient, InitializeHttpClientError},
+    jwt::{DecodeJwtError, DecodedJwt, decode_jwt},
+};
 use base64::Engine;
+use http_utils::HttpRequestError;
 use jsonwebtoken::{self as jwt, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -114,10 +116,6 @@ pub(crate) struct SsaValidationConfig {
     /// Default: false
     pub validate_audience: bool,
 
-    /// Whether to accept invalid SSL certificates when fetching JWKS.
-    /// Default: false
-    pub accept_invalid_certs: bool,
-
     /// Whether to validate that `grant_types` is an array.
     /// Default: true
     pub validate_grant_types_array: bool,
@@ -145,7 +143,6 @@ impl Default for SsaValidationConfig {
             validate_issued_at: true,
             validate_not_before: false,
             validate_audience: false,
-            accept_invalid_certs: false,
             validate_grant_types_array: true,
             validate_software_roles_array: true,
         }
@@ -185,13 +182,12 @@ pub(crate) struct SsaClaims {
 pub(crate) async fn validate_ssa_jwt(
     ssa_jwt: &str,
     jwks_uri: &str,
-    accept_invalid_certs: bool,
+    client: &HttpClient,
 ) -> Result<SsaClaims, SsaValidationError> {
     let config = SsaValidationConfig {
-        accept_invalid_certs,
         ..Default::default()
     };
-    validate_ssa_jwt_with_config(ssa_jwt, jwks_uri, &config).await
+    validate_ssa_jwt_with_config(ssa_jwt, jwks_uri, &config, client).await
 }
 
 /// Validates an SSA JWT with custom configuration.
@@ -202,6 +198,7 @@ pub(crate) async fn validate_ssa_jwt_with_config(
     ssa_jwt: &str,
     jwks_uri: &str,
     config: &SsaValidationConfig,
+    client: &HttpClient,
 ) -> Result<SsaClaims, SsaValidationError> {
     // First decode the JWT to get basic information (header and claims without signature validation)
     // This is needed to extract the algorithm and kid for key selection
@@ -220,7 +217,7 @@ pub(crate) async fn validate_ssa_jwt_with_config(
     }
 
     // Fetch JWKS from the issuer
-    let jwks = fetch_jwks(jwks_uri, config.accept_invalid_certs).await?;
+    let jwks = fetch_jwks(jwks_uri, client).await?;
 
     // Find the appropriate key for validation
     let decoding_key = find_decoding_key(&decoded_jwt, &jwks)?;
@@ -293,31 +290,11 @@ pub(crate) fn validate_ssa_structure_with_config(
 }
 
 /// Fetches JWKS from the specified URI
-async fn fetch_jwks(
-    jwks_uri: &str,
-    accept_invalid_certs: bool,
-) -> Result<Value, SsaValidationError> {
-    use super::init_http_client;
-
-    let client = init_http_client(None, accept_invalid_certs)
-        .map_err(SsaValidationError::HttpClientError)?;
-
-    let response = client
-        .get(jwks_uri)
-        .send()
+async fn fetch_jwks(jwks_uri: &str, client: &HttpClient) -> Result<Value, SsaValidationError> {
+    let jwks: Value = client
+        .get_json(jwks_uri)
         .await
         .map_err(SsaValidationError::JwksFetchError)?;
-
-    if !response.status().is_success() {
-        return Err(SsaValidationError::JwksFetchError(
-            response.error_for_status().unwrap_err(),
-        ));
-    }
-
-    let jwks: Value = response
-        .json()
-        .await
-        .map_err(SsaValidationError::JwksParseError)?;
 
     Ok(jwks)
 }
@@ -455,15 +432,11 @@ pub(crate) enum SsaValidationError {
 
     /// Failed to initialize HTTP client for JWKS fetching
     #[error("failed to initialize HTTP client: {0}")]
-    HttpClientError(reqwest::Error),
+    HttpClientError(#[from] InitializeHttpClientError),
 
     /// Failed to fetch JWKS due to network or HTTP errors
     #[error("failed to fetch JWKS (network/HTTP error): {0}")]
-    JwksFetchError(reqwest::Error),
-
-    /// Failed to parse JWKS JSON response
-    #[error("failed to parse JWKS (JSON parsing error): {0}")]
-    JwksParseError(reqwest::Error),
+    JwksFetchError(HttpRequestError),
 
     /// Missing key ID (kid) in JWT header
     #[error("missing key ID (kid) in JWT header")]
@@ -901,7 +874,6 @@ mod tests {
         assert!(config.validate_issued_at);
         assert!(!config.validate_not_before);
         assert!(!config.validate_audience);
-        assert!(!config.accept_invalid_certs);
         assert!(config.validate_grant_types_array);
         assert!(config.validate_software_roles_array);
         assert!(config.allowed_algorithms.is_empty()); // Empty means all allowed

--- a/jans-cedarling/cedarling/src/lock/ssa_validation.rs
+++ b/jans-cedarling/cedarling/src/lock/ssa_validation.rs
@@ -59,7 +59,8 @@
 //! - **`InvalidExpirationTime`**: Expiration time is not a number
 //! - **`InvalidIssuedAtTime`**: Issued at time is not a number
 //! - **`HttpClientError`**: HTTP client initialization failed
-//! - **`JwksFetchError`**: Failed to fetch JWKS from IDP//! - **`MissingKeyId`**: JWT header missing key ID
+//! - **`JwksFetchError`**: Failed to fetch JWKS from IDP
+//! - **`MissingKeyId`**: JWT header missing key ID
 //! - **`KeyNotFound`**: Key not found in JWKS
 //! - **`KeyDecodeError`**: Failed to decode key data
 //! - **`InvalidKeyFormat`**: Key format is invalid

--- a/jans-cedarling/cedarling/src/lock/ssa_validation.rs
+++ b/jans-cedarling/cedarling/src/lock/ssa_validation.rs
@@ -58,7 +58,6 @@
 //! - **`InvalidSoftwareRoles`**: Software roles claim is not an array
 //! - **`InvalidExpirationTime`**: Expiration time is not a number
 //! - **`InvalidIssuedAtTime`**: Issued at time is not a number
-//! - **`HttpClientError`**: HTTP client initialization failed
 //! - **`JwksFetchError`**: Failed to fetch JWKS from IDP
 //! - **`MissingKeyId`**: JWT header missing key ID
 //! - **`KeyNotFound`**: Key not found in JWKS
@@ -74,7 +73,7 @@
 //! is then included in the DCR request to the Identity Provider.
 
 use crate::{
-    http::{HttpClient, InitializeHttpClientError},
+    http::HttpClient,
     jwt::{DecodeJwtError, DecodedJwt, decode_jwt},
 };
 use base64::Engine;
@@ -430,10 +429,6 @@ pub(crate) enum SsaValidationError {
     /// Issued at time is not a valid number
     #[error("iat must be a number")]
     InvalidIssuedAtTime,
-
-    /// Failed to initialize HTTP client for JWKS fetching
-    #[error("failed to initialize HTTP client: {0}")]
-    HttpClientError(#[from] InitializeHttpClientError),
 
     /// Failed to fetch JWKS due to network or HTTP errors
     #[error("failed to fetch JWKS (network/HTTP error): {0}")]

--- a/jans-cedarling/cedarling/src/lock/transport/rest.rs
+++ b/jans-cedarling/cedarling/src/lock/transport/rest.rs
@@ -5,12 +5,10 @@
 
 //! REST transport implementation for Lock Server communication.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
-use reqwest::Client;
 
 use crate::{
+    http::HttpClient,
     lock::{
         LockLogEntry,
         transport::{
@@ -25,13 +23,13 @@ use crate::{
 };
 
 pub(crate) struct RestTransport {
-    client: Arc<Client>,
+    client: HttpClient,
     logger: Option<Logger>,
 }
 
 impl RestTransport {
     /// Construct a new [`RestTransport`]
-    pub(crate) fn new(client: Arc<Client>, logger: Option<Logger>) -> Self {
+    pub(crate) fn new(client: HttpClient, logger: Option<Logger>) -> Self {
         Self { client, logger }
     }
 }
@@ -57,6 +55,7 @@ impl AuditTransport for RestTransport {
                 >(entries, "log", warn)?;
 
                 self.client
+                    .raw_client
                     .post(url.as_str())
                     .json(&entries)
                     .send()
@@ -70,6 +69,7 @@ impl AuditTransport for RestTransport {
                 >(entries, "telemetry", warn)?;
 
                 self.client
+                    .raw_client
                     .post(url.as_str())
                     .json(&entries)
                     .send()
@@ -84,7 +84,7 @@ impl AuditTransport for RestTransport {
 
 #[cfg(test)]
 mod test {
-    use crate::lock::transport::TransportError;
+    use crate::{HttpClientConfig, lock::transport::TransportError};
 
     use super::*;
 
@@ -92,8 +92,8 @@ mod test {
     use serde_json::json;
     use url::Url;
 
-    fn create_test_client() -> Arc<Client> {
-        Arc::new(Client::builder().build().unwrap())
+    fn create_test_client() -> HttpClient {
+        HttpClient::new(HttpClientConfig::default()).expect("Http client should be initialized")
     }
 
     fn mock_log_endpoint(server: &mut ServerGuard) -> mockito::Mock {

--- a/jans-cedarling/cedarling/src/log/mod.rs
+++ b/jans-cedarling/cedarling/src/log/mod.rs
@@ -78,11 +78,11 @@ pub use interface::LogStorage;
 pub(crate) use interface::LogWriter;
 pub(crate) use log_strategy::LogStrategy;
 
-use crate::LockServiceConfig;
 use crate::app_types::{ApplicationName, PdpID};
 use crate::authz::metrics::MetricsCollector;
 use crate::bootstrap_config::log_config::LogConfig;
 use crate::lock::{InitLockServiceError, LockService};
+use crate::{HttpClientConfig, LockServiceConfig};
 
 /// Type alias for logger that is used in application
 pub(crate) type Logger = Arc<LogStrategy>;
@@ -100,12 +100,13 @@ pub(crate) async fn init_logger(
     app_name: Option<ApplicationName>,
     lock_config: Option<&LockServiceConfig>,
     metrics: Arc<MetricsCollector>,
+    http_conf: HttpClientConfig,
 ) -> Result<Logger, InitLockServiceError> {
     let logger = Arc::new(LogStrategy::new(config, pdp_id, app_name));
     let logger_weak = Arc::downgrade(&logger);
     if let Some(lock_config) = lock_config {
         let lock_service =
-            LockService::new(pdp_id, lock_config, Some(logger_weak), metrics).await?;
+            LockService::new(pdp_id, lock_config, Some(logger_weak), metrics, http_conf).await?;
         logger.set_lock_service(lock_service);
     }
     Ok(logger)

--- a/jans-cedarling/cedarling/src/tests/policy_store_loader.rs
+++ b/jans-cedarling/cedarling/src/tests/policy_store_loader.rs
@@ -247,6 +247,7 @@ fn create_jwt_cedarling_config_with_loader(
         max_default_entities: None,
         max_base64_size: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: crate::HttpClientConfig::default(),
     }
 }
 
@@ -809,9 +810,14 @@ permit(
     let archive_path = temp_dir.path().join("multi_template.cjar");
     fs::write(&archive_path, &archive).expect("Failed to write archive file");
 
-    let loaded = crate::load_policy_store(&crate::PolicyStoreConfig {
-        source: crate::PolicyStoreSource::CjarFile(archive_path),
-    })
+    let http_client = crate::http::HttpClient::new(crate::HttpClientConfig::default())
+        .expect("Should create HttpClient");
+    let loaded = crate::init::policy_store::load_policy_store(
+        &crate::PolicyStoreConfig {
+            source: crate::PolicyStoreSource::CjarFile(archive_path),
+        },
+        &http_client,
+    )
     .await
     .expect("Loading .cjar with a multi-template file should succeed");
 

--- a/jans-cedarling/cedarling/src/tests/ssa_validation_integration.rs
+++ b/jans-cedarling/cedarling/src/tests/ssa_validation_integration.rs
@@ -62,6 +62,7 @@ async fn test_cedarling_with_valid_ssa() {
         max_default_entities: None,
         max_base64_size: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: crate::HttpClientConfig::default(),
     })
     .await;
 
@@ -114,6 +115,7 @@ async fn test_cedarling_without_ssa() {
         max_default_entities: None,
         max_base64_size: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: crate::HttpClientConfig::default(),
     })
     .await;
 

--- a/jans-cedarling/cedarling/src/tests/utils/cedarling_util.rs
+++ b/jans-cedarling/cedarling/src/tests/utils/cedarling_util.rs
@@ -30,6 +30,7 @@ pub(crate) fn get_config(policy_source: PolicyStoreSource) -> BootstrapConfig {
         max_default_entities: None,
         max_base64_size: None,
         data_store_config: DataStoreConfig::default(),
+        http_client_config: crate::HttpClientConfig::default(),
     }
 }
 

--- a/jans-cedarling/http_utils/src/lib.rs
+++ b/jans-cedarling/http_utils/src/lib.rs
@@ -35,13 +35,64 @@
 
 mod backoff;
 
+use std::fmt::Display;
+
 pub use backoff::Backoff;
 
-use reqwest::RequestBuilder;
+use reqwest::{RequestBuilder, StatusCode};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum HttpRequestError {
+pub struct HttpRequestError {
+    reason: HttpRequestReasonError,
+    status_code: Option<StatusCode>,
+    retry_count: u32,
+    last_error: Option<String>,
+}
+
+impl HttpRequestError {
+    pub fn new(reason: HttpRequestReasonError, status_code: Option<StatusCode>) -> Self {
+        Self {
+            reason,
+            status_code,
+            retry_count: 0,
+            last_error: None,
+        }
+    }
+
+    pub fn is_max_retries_exceeded(&self) -> bool {
+        matches!(self.reason, HttpRequestReasonError::MaxRetriesExceeded)
+    }
+
+    pub fn with_retry_count(mut self, count: u32) -> Self {
+        self.retry_count = count;
+        self
+    }
+
+    pub fn with_last_error(mut self, error: impl Into<String>) -> Self {
+        self.last_error = Some(error.into());
+        self
+    }
+}
+
+impl Display for HttpRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.reason)?;
+        if let Some(code) = self.status_code {
+            write!(f, " (HTTP {})", code)?;
+        }
+        if self.retry_count > 0 {
+            write!(f, " (retries: {})", self.retry_count)?;
+        }
+        if let Some(err) = &self.last_error {
+            write!(f, " [last error: {}]", err)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum HttpRequestReasonError {
     #[error("max retries exceeded")]
     MaxRetriesExceeded,
     #[error("failed to deserialize response to JSON: {0}")]
@@ -50,8 +101,6 @@ pub enum HttpRequestError {
     DecodeResponseText(#[source] reqwest::Error),
     #[error("failed to read response body bytes: {0}")]
     DecodeResponseBytes(#[source] reqwest::Error),
-    #[error("failed to initialize HTTP client: {0}")]
-    InitializeHttpClient(#[source] reqwest::Error),
 }
 
 /// Sends an HTTP request with backoff retry logic.
@@ -76,32 +125,48 @@ impl Sender {
     {
         let backoff = &mut self.backoff;
         backoff.reset();
+        let mut attempt = 0u32;
 
         loop {
+            attempt += 1;
             let response = match request().send().await {
                 Ok(resp) => resp,
-                Err(_err) => {
+                Err(err) => {
                     // Retry silently - callers receive the final error if all retries fail.
                     // TODO: add optional debug-level logging hook here once a logger can be
                     //       passed in without pulling logging into this low-level crate.
-                    backoff
-                        .snooze()
-                        .await
-                        .map_err(|_| HttpRequestError::MaxRetriesExceeded)?;
+                    let err_msg = err
+                        .to_string()
+                        .lines()
+                        .next()
+                        .unwrap_or("unknown error")
+                        .to_string();
+                    backoff.snooze().await.map_err(|_| {
+                        HttpRequestError::new(HttpRequestReasonError::MaxRetriesExceeded, None)
+                            .with_retry_count(attempt)
+                            .with_last_error(err_msg)
+                    })?;
                     continue;
                 },
             };
 
             let response = match response.error_for_status() {
                 Ok(resp) => resp,
-                Err(_err) => {
+                Err(err) => {
                     // Retry silently - callers receive the final error if all retries fail.
                     // TODO: add optional debug-level logging hook here once a logger can be
                     //       passed in without pulling logging into this low-level crate.
-                    backoff
-                        .snooze()
-                        .await
-                        .map_err(|_| HttpRequestError::MaxRetriesExceeded)?;
+                    let err_msg = err
+                        .to_string()
+                        .lines()
+                        .next()
+                        .unwrap_or("unknown error")
+                        .to_string();
+                    backoff.snooze().await.map_err(|_| {
+                        HttpRequestError::new(HttpRequestReasonError::MaxRetriesExceeded, None)
+                            .with_retry_count(attempt)
+                            .with_last_error(err_msg)
+                    })?;
                     continue;
                 },
             };
@@ -128,10 +193,10 @@ impl Sender {
         T: serde::de::DeserializeOwned,
     {
         let response = self.send_with_retry(request).await?;
-        response
-            .json::<T>()
-            .await
-            .map_err(HttpRequestError::DeserializeToJson)
+        let status = response.status();
+        response.json::<T>().await.map_err(|e| {
+            HttpRequestError::new(HttpRequestReasonError::DeserializeToJson(e), Some(status))
+        })
     }
 
     /// Sends an HTTP request with retry logic and returns the response body as text.
@@ -148,10 +213,10 @@ impl Sender {
         F: FnMut() -> RequestBuilder,
     {
         let response = self.send_with_retry(request).await?;
-        response
-            .text()
-            .await
-            .map_err(HttpRequestError::DecodeResponseText)
+        let status = response.status();
+        response.text().await.map_err(|e| {
+            HttpRequestError::new(HttpRequestReasonError::DecodeResponseText(e), Some(status))
+        })
     }
 
     /// Sends an HTTP request with retry logic and returns the response body as raw bytes.
@@ -168,10 +233,9 @@ impl Sender {
         F: FnMut() -> RequestBuilder,
     {
         let response = self.send_with_retry(request).await?;
-        response
-            .bytes()
-            .await
-            .map(|b| b.to_vec())
-            .map_err(HttpRequestError::DecodeResponseBytes)
+        let status = response.status();
+        response.bytes().await.map(|b| b.to_vec()).map_err(|e| {
+            HttpRequestError::new(HttpRequestReasonError::DecodeResponseBytes(e), Some(status))
+        })
     }
 }

--- a/jans-cedarling/http_utils/src/lib.rs
+++ b/jans-cedarling/http_utils/src/lib.rs
@@ -180,6 +180,34 @@ impl Sender {
         }
     }
 
+    /// Sends an HTTP request a single time and deserializes the JSON response.
+    ///
+    /// Unlike [`send`], this method performs **no retries** — useful for non-idempotent
+    /// requests (POST, PUT, PATCH, DELETE) where replaying the request is unsafe.
+    pub async fn send_once<T, F>(&mut self, request: F) -> Result<T, HttpRequestError>
+    where
+        F: FnOnce() -> RequestBuilder,
+        T: serde::de::DeserializeOwned,
+    {
+        let response = request().send().await.map_err(|e| {
+            let err_msg = e.to_string();
+            HttpRequestError::new(HttpRequestReasonError::MaxRetriesExceeded, None)
+                .with_retry_count(1)
+                .with_last_error(err_msg)
+        })?;
+        let response = response.error_for_status().map_err(|e| {
+            let status = e.status();
+            let err_msg = e.to_string();
+            HttpRequestError::new(HttpRequestReasonError::MaxRetriesExceeded, status)
+                .with_retry_count(1)
+                .with_last_error(err_msg)
+        })?;
+        let status = response.status();
+        response.json::<T>().await.map_err(|e| {
+            HttpRequestError::new(HttpRequestReasonError::DeserializeToJson(e), Some(status))
+        })
+    }
+
     /// Sends an HTTP request with retry logic then deserializes the JSON response to a
     /// struct.
     ///

--- a/jans-cedarling/http_utils/src/lib.rs
+++ b/jans-cedarling/http_utils/src/lib.rs
@@ -116,7 +116,7 @@ impl Sender {
     /// Internal helper that sends an HTTP request with retry logic and returns the response.
     ///
     /// This is the core retry loop used by all public send methods.
-    async fn send_with_retry<F>(
+    pub async fn send_with_retry<F>(
         &mut self,
         mut request: F,
     ) -> Result<reqwest::Response, HttpRequestError>

--- a/jans-cedarling/http_utils/src/lib.rs
+++ b/jans-cedarling/http_utils/src/lib.rs
@@ -44,6 +44,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub struct HttpRequestError {
+    #[source]
     reason: HttpRequestReasonError,
     status_code: Option<StatusCode>,
     retry_count: u32,

--- a/jans-cedarling/http_utils/src/lib.rs
+++ b/jans-cedarling/http_utils/src/lib.rs
@@ -156,6 +156,7 @@ impl Sender {
                     // Retry silently - callers receive the final error if all retries fail.
                     // TODO: add optional debug-level logging hook here once a logger can be
                     //       passed in without pulling logging into this low-level crate.
+                    let status = err.status();
                     let err_msg = err
                         .to_string()
                         .lines()
@@ -163,9 +164,12 @@ impl Sender {
                         .unwrap_or("unknown error")
                         .to_string();
                     backoff.snooze().await.map_err(|_| {
-                        HttpRequestError::new(HttpRequestReasonError::MaxRetriesExceeded, None)
-                            .with_retry_count(attempt)
-                            .with_last_error(err_msg)
+                        HttpRequestError::new(
+                            HttpRequestReasonError::MaxRetriesExceeded,
+                            status,
+                        )
+                        .with_retry_count(attempt)
+                        .with_last_error(err_msg)
                     })?;
                     continue;
                 },


### PR DESCRIPTION

The two outbound HTTP clients in `jans-cedarling` are built from `reqwest::Client` defaults, which set no timeouts at all. A slow or unresponsive issuer or policy-store host can stall a Cedarling task forever and exhaust the tokio runtime. This PR puts a bound on both of them.

#### Implementation Details

- replace `LazyLock::new(Client::new)` with a builder that sets a 10s request timeout and 5s connect timeout.
- I also added a new test (`get_times_out_when_server_never_responds`) that accepts connections without ever responding and asserts `HttpClient::get` returns an error within ~200ms

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)
Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14002


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable HTTP client with JSON GET/POST helpers and injectable configuration.

* **Improvements**
  * Per-request timeouts (default 10s on native) and retry controls to fail fast and reduce hangs.
  * Shared/injected HTTP client used across policy loading, JWT, lock service, and transports to avoid redundant construction.

* **Documentation**
  * Added properties for request timeout, max retries, and retry delay (native-only).

* **Tests**
  * Added timeout test for non-responding servers; tests use shared HTTP config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->