### PR TITLE
fix(cloud-native): audit log filter returns entries beyond the specified end date

### DIFF
--- a/docker-jans-all-in-one/Dockerfile
+++ b/docker-jans-all-in-one/Dockerfile
@@ -59,7 +59,7 @@ RUN apk update \
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=c0ae216653f1a615ad053ac1f88f54dfbffd0842
+ENV JANS_SOURCE_VERSION=ee1efbfcb8e14d59d5eed0456f76e9e54f906628
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the assets

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -44,7 +44,7 @@ RUN wget -q https://maven.jans.io/maven/io/jans/jython-installer/${JYTHON_VERSIO
 # ==========
 
 ENV CN_VERSION=0.0.0-nightly
-ENV CN_BUILD_DATE='2026-02-22 08:12'
+ENV CN_BUILD_DATE='2026-05-04 10:08'
 
 ENV CN_SOURCE_URL=https://jenkins.jans.io/maven/io/jans/jans-config-api-server/${CN_VERSION}/jans-config-api-server-${CN_VERSION}.war
 
@@ -75,7 +75,7 @@ RUN mkdir -p /etc/jans/conf \
     /usr/share/java \
     /opt/jans/bin
 
-ENV JANS_SOURCE_VERSION=c0ae216653f1a615ad053ac1f88f54dfbffd0842
+ENV JANS_SOURCE_VERSION=ee1efbfcb8e14d59d5eed0456f76e9e54f906628
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 ARG JANS_CONFIG_API_RESOURCES=jans-config-api/server/src/main/resources
 

--- a/docker-jans-config-api/scripts/upgrade.py
+++ b/docker-jans-config-api/scripts/upgrade.py
@@ -139,11 +139,12 @@ def _transform_api_dynamic_config(conf):
         conf["auditLogConf"]["ignoreHttpMethod"].append("GET")
         should_update = True
 
+    audit_log_date_fmt = "dd-MM-yyyy HH:mm:ss.SSS"
     for k, v in [
         ("logData", True),
         ("auditLogFilePath", "/opt/jans/jetty/jans-config-api/logs/"),
         ("auditLogFileName", "configapi-audit.log"),
-        ("auditLogDateFormat", "dd-MM-YYYY"),
+        ("auditLogDateFormat", audit_log_date_fmt),
         ("ignoreAnnotation", ["ignoreAudit"]),
         ("ignoreObjectMapping", [
             {"name": "loggingRequest", "text": ["action=FETCH"]},
@@ -153,6 +154,11 @@ def _transform_api_dynamic_config(conf):
         if k not in conf["auditLogConf"]:
             conf["auditLogConf"][k] = v
             should_update = True
+
+    # address issue https://github.com/JanssenProject/jans/issues/13894
+    if conf["auditLogConf"]["auditLogDateFormat"] != audit_log_date_fmt:
+        conf["auditLogConf"]["auditLogDateFormat"] = audit_log_date_fmt
+        should_update = True
 
     # finalized conf and flag to determine update process
     return conf, should_update


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14005

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker container images with new source revisions and build timestamps to align with latest monorepo changes
  * Adjusted default audit log date format configuration to improve consistency during system upgrade processes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->