### PR TITLE
feat(jans-cedarling): implement sending health checks to the lock server

### DIFF
--- a/jans-cedarling/cedarling/examples/authorize_unsigned.rs
+++ b/jans-cedarling/cedarling/examples/authorize_unsigned.rs
@@ -3,9 +3,9 @@
 //
 // Copyright (c) 2024, Gluu, Inc.
 
-use cedarling::{HttpClientConfig,
+use cedarling::{
     AuthorizationConfig, BootstrapConfig, CedarEntityMapping, Cedarling, DataStoreConfig,
-    EntityData, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig,
+    EntityData, HttpClientConfig, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig,
     PolicyStoreSource, RequestUnsigned, log_config::StdOutLoggerMode,
 };
 use serde_json::json;

--- a/jans-cedarling/cedarling/examples/bulk_authorization_benchmark.rs
+++ b/jans-cedarling/cedarling/examples/bulk_authorization_benchmark.rs
@@ -5,9 +5,9 @@
 
 #![allow(clippy::cast_precision_loss)]
 
-use cedarling::{HttpClientConfig,
+use cedarling::{
     AuthorizationConfig, BootstrapConfig, CedarEntityMapping, Cedarling, DataStoreConfig,
-    EntityData, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig,
+    EntityData, HttpClientConfig, JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig,
     PolicyStoreSource, RequestUnsigned,
 };
 use serde_json::json;

--- a/jans-cedarling/cedarling/examples/lock_integration.rs
+++ b/jans-cedarling/cedarling/examples/lock_integration.rs
@@ -6,10 +6,10 @@
 // run this example using `cargo run --example lock_integration`
 
 use cedarling::log_config::StdOutLoggerMode;
-use cedarling::{HttpClientConfig,
+use cedarling::{
     AuthorizationConfig, BootstrapConfig, CedarEntityMapping, Cedarling, DataStoreConfig,
-    EntityData, JwtConfig, LockServiceConfig, LockTransport, LogConfig, LogLevel, LogTypeConfig,
-    PolicyStoreConfig, PolicyStoreSource, RequestUnsigned,
+    EntityData, HttpClientConfig, JwtConfig, LockServiceConfig, LockTransport, LogConfig, LogLevel,
+    LogTypeConfig, PolicyStoreConfig, PolicyStoreSource, RequestUnsigned,
 };
 use serde_json::json;
 use std::collections::{HashMap, HashSet};

--- a/jans-cedarling/cedarling/examples/log_init.rs
+++ b/jans-cedarling/cedarling/examples/log_init.rs
@@ -9,10 +9,10 @@
 // and `use std::env` prevents that compilation.
 #![cfg(not(target_family = "wasm"))]
 
-use cedarling::{HttpClientConfig,
-    AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, JwtConfig, LogConfig,
-    LogLevel, LogStorage, LogTypeConfig, MemoryLogConfig, PolicyStoreConfig, PolicyStoreSource,
-    log_config::StdOutLoggerMode,
+use cedarling::{
+    AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, HttpClientConfig, JwtConfig,
+    LogConfig, LogLevel, LogStorage, LogTypeConfig, MemoryLogConfig, PolicyStoreConfig,
+    PolicyStoreSource, log_config::StdOutLoggerMode,
 };
 use std::env;
 

--- a/jans-cedarling/cedarling/examples/profiling_multi_issuer.rs
+++ b/jans-cedarling/cedarling/examples/profiling_multi_issuer.rs
@@ -6,10 +6,10 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 
-use cedarling::{HttpClientConfig,
+use cedarling::{
     AuthorizationConfig, AuthorizeMultiIssuerRequest, BootstrapConfig, Cedarling, DataStoreConfig,
-    EntityData, InitCedarlingError, JwtConfig, LogConfig, LogLevel, LogTypeConfig,
-    PolicyStoreConfig, TokenInput,
+    EntityData, HttpClientConfig, InitCedarlingError, JwtConfig, LogConfig, LogLevel,
+    LogTypeConfig, PolicyStoreConfig, TokenInput,
 };
 use serde_json::json;
 use std::collections::HashSet;

--- a/jans-cedarling/cedarling/examples/profiling_unsigned.rs
+++ b/jans-cedarling/cedarling/examples/profiling_unsigned.rs
@@ -6,9 +6,10 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 
-use cedarling::{HttpClientConfig,
-    AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, EntityData, JwtConfig,
-    LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig, PolicyStoreSource, RequestUnsigned,
+use cedarling::{
+    AuthorizationConfig, BootstrapConfig, Cedarling, DataStoreConfig, EntityData, HttpClientConfig,
+    JwtConfig, LogConfig, LogLevel, LogTypeConfig, PolicyStoreConfig, PolicyStoreSource,
+    RequestUnsigned,
 };
 use serde::Deserialize;
 use serde_json::json;

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -224,7 +224,7 @@ mod test {
     use tokio::join;
     const HTTP_CONF: HttpClientConfig = HttpClientConfig {
         max_retries: 3,
-        request_timeout: Duration::from_millis(1),
+        request_timeout: Duration::from_millis(500),
         retry_delay: Duration::from_secs(5),
     };
 

--- a/jans-cedarling/cedarling/src/http/mod.rs
+++ b/jans-cedarling/cedarling/src/http/mod.rs
@@ -173,7 +173,10 @@ impl HttpClient {
     /// response headers and lets them decide how to consume the body. Use it when you
     /// need to inspect headers (e.g. `Cache-Control`, `Content-Type`) before reading
     /// the payload.
-    pub(crate) async fn get_with_retry(&self, uri: &str) -> Result<reqwest::Response, HttpClientError> {
+    pub(crate) async fn get_with_retry(
+        &self,
+        uri: &str,
+    ) -> Result<reqwest::Response, HttpClientError> {
         let mut sender = self.create_sender();
         sender.send_with_retry(|| self.raw_client.get(uri)).await
     }

--- a/jans-cedarling/cedarling/src/jwt/key_service.rs
+++ b/jans-cedarling/cedarling/src/jwt/key_service.rs
@@ -191,9 +191,10 @@ impl KeyService {
         logger: Option<&Logger>,
         http_client: &HttpClient,
     ) -> Result<Option<u64>, KeyServiceError> {
-        let (jwks, max_age) = JwkSet::get_from_url_with_max_age(&openid_config.jwks_uri, http_client)
-            .await
-            .map_err(KeyServiceError::GetJwks)?;
+        let (jwks, max_age) =
+            JwkSet::get_from_url_with_max_age(&openid_config.jwks_uri, http_client)
+                .await
+                .map_err(KeyServiceError::GetJwks)?;
 
         self.insert_jwk_set(openid_config, logger, jwks)?;
 

--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -58,6 +58,7 @@ use init::ServiceFactory;
 use init::service_config::{ServiceConfig, ServiceConfigError};
 use init::service_factory::ServiceInitError;
 use lock::InitLockServiceError;
+use lock::health_registry::HealthStatus;
 use log::interface::LogWriter;
 use log::{BaseLogEntry, LogEntry};
 pub use log::{LogLevel, LogStorage};
@@ -151,10 +152,6 @@ impl Cedarling {
         )
         .await?;
 
-        if let Some(registry) = log.health_registry() {
-            registry.register("core", || "success".to_string());
-        }
-
         let service_config = ServiceConfig::new(config)
             .await
             .inspect(|_| {
@@ -201,6 +198,17 @@ impl Cedarling {
         // Log policy store metadata if available (new format only)
         if let Some(metadata) = service_factory.policy_store_metadata() {
             log_policy_store_metadata(&log, metadata);
+        }
+
+        if let Some(registry) = log.health_registry() {
+            registry.register("core", || HealthStatus::Success);
+            registry.register("policy_load", move || {
+                if policy_count > 0 {
+                    HealthStatus::Success
+                } else {
+                    HealthStatus::Failure
+                }
+            });
         }
 
         Ok(Cedarling {

--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -150,6 +150,10 @@ impl Cedarling {
         )
         .await?;
 
+        if let Some(registry) = log.health_registry() {
+            registry.register("core", || "success".to_string());
+        }
+
         let service_config = ServiceConfig::new(config)
             .await
             .inspect(|_| {

--- a/jans-cedarling/cedarling/src/lock/health_registry.rs
+++ b/jans-cedarling/cedarling/src/lock/health_registry.rs
@@ -1,0 +1,75 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+//! Shared health check registry for cedarling subsystems.
+//!
+//! Subsystems register health check callbacks when they are initialized.
+//! The `HealthTicker` collects statuses from all registered checks on each tick.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+type HealthCheckFn = Arc<dyn Fn() -> String + Send + Sync>;
+
+/// A registered health check with a name and callback.
+struct RegisteredCheck {
+    name: String,
+    check: HealthCheckFn,
+}
+
+/// Thread-safe registry of health check callbacks.
+///
+/// Created during `LockService` initialization, shared with cedarling subsystems
+/// so they can register their health status callbacks.
+#[derive(Clone, Default)]
+pub(crate) struct HealthRegistry {
+    checks: Arc<RwLock<Vec<RegisteredCheck>>>,
+}
+
+impl std::fmt::Debug for HealthRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HealthRegistry").finish_non_exhaustive()
+    }
+}
+
+impl HealthRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            checks: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Register a health check callback.
+    ///
+    /// The callback should return `"success"` if the subsystem is healthy,
+    /// or `"failure"` (or another descriptive error string) if not.
+    pub(crate) fn register<F>(&self, name: &str, check: F)
+    where
+        F: Fn() -> String + Send + Sync + 'static,
+    {
+        let mut checks = self
+            .checks
+            .write()
+            .expect("health registry write lock poisoned");
+        checks.push(RegisteredCheck {
+            name: name.to_string(),
+            check: Arc::new(check),
+        });
+    }
+
+    /// Collect health statuses from all registered checks.
+    ///
+    /// Returns a map of component name to status string.
+    pub(crate) fn collect(&self) -> HashMap<String, String> {
+        let checks = self
+            .checks
+            .read()
+            .expect("health registry read lock poisoned");
+        checks
+            .iter()
+            .map(|c| (c.name.clone(), (c.check)()))
+            .collect()
+    }
+}

--- a/jans-cedarling/cedarling/src/lock/health_registry.rs
+++ b/jans-cedarling/cedarling/src/lock/health_registry.rs
@@ -77,6 +77,7 @@ impl HealthRegistry {
             .checks
             .write()
             .expect("health registry write lock poisoned");
+        checks.retain(|c| c.name != name);
         checks.push(RegisteredCheck {
             name: name.to_string(),
             check: Arc::new(check),

--- a/jans-cedarling/cedarling/src/lock/health_registry.rs
+++ b/jans-cedarling/cedarling/src/lock/health_registry.rs
@@ -11,7 +11,25 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-type HealthCheckFn = Arc<dyn Fn() -> String + Send + Sync>;
+use serde::{Deserialize, Serialize};
+
+type HealthCheckFn = Arc<dyn Fn() -> HealthStatus + Send + Sync>;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum HealthStatus {
+    Success,
+    Failure,
+}
+
+impl std::fmt::Display for HealthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HealthStatus::Success => write!(f, "success"),
+            HealthStatus::Failure => write!(f, "failure"),
+        }
+    }
+}
 
 /// A registered health check with a name and callback.
 struct RegisteredCheck {
@@ -23,9 +41,15 @@ struct RegisteredCheck {
 ///
 /// Created during `LockService` initialization, shared with cedarling subsystems
 /// so they can register their health status callbacks.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct HealthRegistry {
     checks: Arc<RwLock<Vec<RegisteredCheck>>>,
+}
+
+impl Default for HealthRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl std::fmt::Debug for HealthRegistry {
@@ -43,11 +67,11 @@ impl HealthRegistry {
 
     /// Register a health check callback.
     ///
-    /// The callback should return `"success"` if the subsystem is healthy,
-    /// or `"failure"` (or another descriptive error string) if not.
+    /// The callback should return [`HealthStatus::Success`] if the subsystem is healthy,
+    /// or [`HealthStatus::Failure`] if not.
     pub(crate) fn register<F>(&self, name: &str, check: F)
     where
-        F: Fn() -> String + Send + Sync + 'static,
+        F: Fn() -> HealthStatus + Send + Sync + 'static,
     {
         let mut checks = self
             .checks
@@ -61,8 +85,8 @@ impl HealthRegistry {
 
     /// Collect health statuses from all registered checks.
     ///
-    /// Returns a map of component name to status string.
-    pub(crate) fn collect(&self) -> HashMap<String, String> {
+    /// Returns a map of component name to status.
+    pub(crate) fn collect(&self) -> HashMap<String, HealthStatus> {
         let checks = self
             .checks
             .read()
@@ -71,5 +95,71 @@ impl HealthRegistry {
             .iter()
             .map(|c| (c.name.clone(), (c.check)()))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_collect_empty() {
+        let registry = HealthRegistry::new();
+        let result = registry.collect();
+        assert!(result.is_empty(), "expected empty map for empty registry");
+    }
+
+    #[test]
+    fn test_register_and_collect() {
+        let registry = HealthRegistry::new();
+        registry.register("core", || HealthStatus::Success);
+        let result = registry.collect();
+        assert_eq!(result.len(), 1, "expected one entry");
+        assert_eq!(
+            result.get("core"),
+            Some(&HealthStatus::Success),
+            "expected Success status for core"
+        );
+    }
+
+    #[test]
+    fn test_register_multiple_distinct() {
+        let registry = HealthRegistry::new();
+        registry.register("core", || HealthStatus::Success);
+        registry.register("data", || HealthStatus::Success);
+        registry.register("policy_store", || HealthStatus::Failure);
+        let result = registry.collect();
+        assert_eq!(result.len(), 3, "expected three distinct entries");
+        assert_eq!(result.get("core"), Some(&HealthStatus::Success));
+        assert_eq!(result.get("data"), Some(&HealthStatus::Success));
+        assert_eq!(result.get("policy_store"), Some(&HealthStatus::Failure));
+    }
+
+    #[test]
+    fn test_register_same_name_twice() {
+        let registry = HealthRegistry::new();
+        registry.register("core", || HealthStatus::Success);
+        registry.register("core", || HealthStatus::Failure);
+        let result = registry.collect();
+        // the last insertion wins
+        assert_eq!(result.len(), 1, "expected only one entry after dedup");
+        assert_eq!(
+            result.get("core"),
+            Some(&HealthStatus::Failure),
+            "expected the second registration to take precedence"
+        );
+    }
+
+    #[test]
+    fn test_register_same_name_mixed_statuses() {
+        let registry = HealthRegistry::new();
+        registry.register("core", || HealthStatus::Failure);
+        registry.register("data", || HealthStatus::Success);
+        registry.register("core", || HealthStatus::Success);
+        let result = registry.collect();
+
+        assert_eq!(result.len(), 2, "expected two deduplicated entries");
+        assert_eq!(result.get("core"), Some(&HealthStatus::Success));
+        assert_eq!(result.get("data"), Some(&HealthStatus::Success));
     }
 }

--- a/jans-cedarling/cedarling/src/lock/health_ticker.rs
+++ b/jans-cedarling/cedarling/src/lock/health_ticker.rs
@@ -28,7 +28,7 @@ pub(super) struct HealthTickerParams {
     pub(super) registry: HealthRegistry,
 }
 
-pub(crate) struct HealthTicker<T: AuditTransport> {
+pub(super) struct HealthTicker<T: AuditTransport> {
     transport: Arc<T>,
     health_url: Url,
     pdp_id: String,
@@ -39,7 +39,7 @@ pub(crate) struct HealthTicker<T: AuditTransport> {
 }
 
 impl<T: AuditTransport + 'static> HealthTicker<T> {
-    pub(crate) fn spawn(
+    pub(super) fn spawn(
         transport: Arc<T>,
         params: HealthTickerParams,
     ) -> (CancellationToken, JoinHandle<()>) {

--- a/jans-cedarling/cedarling/src/lock/health_ticker.rs
+++ b/jans-cedarling/cedarling/src/lock/health_ticker.rs
@@ -57,7 +57,7 @@ impl<T: AuditTransport + 'static> HealthTicker<T> {
         (cancel_tkn, handle)
     }
 
-    pub(crate) async fn run(self, cancel_tkn: CancellationToken) {
+    async fn run(self, cancel_tkn: CancellationToken) {
         let mut ticker = interval(self.interval);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
         ticker.tick().await;
@@ -120,5 +120,119 @@ impl<T: AuditTransport + 'static> HealthTicker<T> {
             status: overall_status,
             engine_status,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::lock::transport::{SerializedAuditEntry, TransportResult};
+    use std::sync::Arc;
+    use url::Url;
+
+    /// No-op transport that does nothing on send.
+    struct NoopTransport;
+
+    #[async_trait::async_trait]
+    impl AuditTransport for NoopTransport {
+        async fn send(
+            &self,
+            _entries: &[SerializedAuditEntry],
+            _audit_kind: &AuditKind,
+        ) -> TransportResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Build a minimal [`HealthTicker`] with the given registry and a noop transport.
+    /// The other fields use dummy values since `build_health_entry` ignores them.
+    fn ticker_with_registry(registry: HealthRegistry) -> HealthTicker<NoopTransport> {
+        HealthTicker {
+            transport: Arc::new(NoopTransport),
+            health_url: Url::parse("http://localhost/health").unwrap(),
+            pdp_id: PdpID::new().to_string(),
+            app_name: String::new(),
+            interval: Duration::from_secs(10),
+            logger: None,
+            registry,
+        }
+    }
+
+    #[test]
+    fn test_build_health_entry_empty() {
+        let registry = HealthRegistry::new();
+        let ticker = ticker_with_registry(registry);
+        let entry = ticker.build_health_entry();
+        assert_eq!(
+            entry.status, "unknown",
+            "empty registry should report 'unknown'"
+        );
+        assert!(
+            entry.engine_status.is_empty(),
+            "empty registry should have empty engine_status"
+        );
+    }
+
+    #[test]
+    fn test_build_health_entry_all_success() {
+        let registry = HealthRegistry::new();
+        registry.register("core", || HealthStatus::Success);
+        registry.register("data", || HealthStatus::Success);
+        let ticker = ticker_with_registry(registry);
+        let entry = ticker.build_health_entry();
+        assert_eq!(
+            entry.status, "running",
+            "all success should report 'running'"
+        );
+        assert_eq!(entry.engine_status.len(), 2);
+    }
+
+    #[test]
+    fn test_build_health_entry_any_failure() {
+        let registry = HealthRegistry::new();
+        registry.register("core", || HealthStatus::Success);
+        registry.register("data", || HealthStatus::Failure);
+        let ticker = ticker_with_registry(registry);
+        let entry = ticker.build_health_entry();
+        assert_eq!(
+            entry.status, "degraded",
+            "any failure should report 'degraded'"
+        );
+    }
+
+    #[test]
+    fn test_build_health_entry_all_failure() {
+        let registry = HealthRegistry::new();
+        registry.register("core", || HealthStatus::Failure);
+        registry.register("data", || HealthStatus::Failure);
+        let ticker = ticker_with_registry(registry);
+        let entry = ticker.build_health_entry();
+        assert_eq!(
+            entry.status, "degraded",
+            "all failure should report 'degraded'"
+        );
+    }
+
+    #[test]
+    fn test_build_health_entry_mixed() {
+        let registry = HealthRegistry::new();
+        registry.register("core", || HealthStatus::Success);
+        registry.register("policy_store", || HealthStatus::Success);
+        registry.register("trusted_issuers", || HealthStatus::Failure);
+        let ticker = ticker_with_registry(registry);
+        let entry = ticker.build_health_entry();
+        assert_eq!(
+            entry.status, "degraded",
+            "mixed status with any failure should report 'degraded'"
+        );
+        assert_eq!(entry.engine_status.len(), 4);
+        assert_eq!(
+            entry.engine_status.get("core"),
+            Some(&HealthStatus::Success)
+        );
+        assert_eq!(
+            entry.engine_status.get("trusted_issuers"),
+            Some(&HealthStatus::Failure)
+        );
     }
 }

--- a/jans-cedarling/cedarling/src/lock/health_ticker.rs
+++ b/jans-cedarling/cedarling/src/lock/health_ticker.rs
@@ -11,13 +11,22 @@ use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
-use super::health_registry::HealthRegistry;
+use super::health_registry::{HealthRegistry, HealthStatus};
 use super::transport::mapping::LockServerHealthEntry;
 use super::transport::{AuditKind, AuditTransport};
 use crate::app_types::{ApplicationName, PdpID};
 use crate::http::{JoinHandle, spawn_task};
 use crate::lock::LockLogEntry;
 use crate::log::{LogWriter, LoggerWeak};
+
+pub(super) struct HealthTickerParams {
+    pub(super) health_url: url::Url,
+    pub(super) pdp_id: PdpID,
+    pub(super) app_name: Option<ApplicationName>,
+    pub(super) health_interval: Duration,
+    pub(super) logger: Option<LoggerWeak>,
+    pub(super) registry: HealthRegistry,
+}
 
 pub(crate) struct HealthTicker<T: AuditTransport> {
     transport: Arc<T>,
@@ -32,22 +41,17 @@ pub(crate) struct HealthTicker<T: AuditTransport> {
 impl<T: AuditTransport + 'static> HealthTicker<T> {
     pub(crate) fn spawn(
         transport: Arc<T>,
-        health_url: Url,
-        pdp_id: PdpID,
-        app_name: Option<ApplicationName>,
-        interval: Duration,
-        logger: Option<LoggerWeak>,
-        registry: HealthRegistry,
+        params: HealthTickerParams,
     ) -> (CancellationToken, JoinHandle<()>) {
         let cancel_tkn = CancellationToken::new();
         let ticker = Self {
             transport,
-            health_url,
-            pdp_id: pdp_id.to_string(),
-            app_name: app_name.map_or_else(String::new, |n| n.0),
-            interval,
-            logger,
-            registry,
+            health_url: params.health_url,
+            pdp_id: params.pdp_id.to_string(),
+            app_name: params.app_name.map_or_else(String::new, |n| n.0),
+            interval: params.health_interval,
+            logger: params.logger,
+            registry: params.registry,
         };
         let handle = spawn_task(ticker.run(cancel_tkn.clone()));
         (cancel_tkn, handle)
@@ -101,7 +105,7 @@ impl<T: AuditTransport + 'static> HealthTicker<T> {
 
         let overall_status = if engine_status.is_empty() {
             "unknown"
-        } else if engine_status.values().all(|s| s == "success") {
+        } else if engine_status.values().all(|s| *s == HealthStatus::Success) {
             "running"
         } else {
             "degraded"

--- a/jans-cedarling/cedarling/src/lock/health_ticker.rs
+++ b/jans-cedarling/cedarling/src/lock/health_ticker.rs
@@ -219,6 +219,7 @@ mod test {
         registry.register("core", || HealthStatus::Success);
         registry.register("policy_store", || HealthStatus::Success);
         registry.register("trusted_issuers", || HealthStatus::Failure);
+        registry.register("data", || HealthStatus::Success);
         let ticker = ticker_with_registry(registry);
         let entry = ticker.build_health_entry();
         assert_eq!(

--- a/jans-cedarling/cedarling/src/lock/health_ticker.rs
+++ b/jans-cedarling/cedarling/src/lock/health_ticker.rs
@@ -1,0 +1,120 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use tokio::time::{MissedTickBehavior, interval};
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+use super::health_registry::HealthRegistry;
+use super::transport::mapping::LockServerHealthEntry;
+use super::transport::{AuditKind, AuditTransport};
+use crate::app_types::{ApplicationName, PdpID};
+use crate::http::{JoinHandle, spawn_task};
+use crate::lock::LockLogEntry;
+use crate::log::{LogWriter, LoggerWeak};
+
+pub(crate) struct HealthTicker<T: AuditTransport> {
+    transport: Arc<T>,
+    health_url: Url,
+    pdp_id: String,
+    app_name: String,
+    interval: Duration,
+    logger: Option<LoggerWeak>,
+    registry: HealthRegistry,
+}
+
+impl<T: AuditTransport + 'static> HealthTicker<T> {
+    pub(crate) fn spawn(
+        transport: Arc<T>,
+        health_url: Url,
+        pdp_id: PdpID,
+        app_name: Option<ApplicationName>,
+        interval: Duration,
+        logger: Option<LoggerWeak>,
+        registry: HealthRegistry,
+    ) -> (CancellationToken, JoinHandle<()>) {
+        let cancel_tkn = CancellationToken::new();
+        let ticker = Self {
+            transport,
+            health_url,
+            pdp_id: pdp_id.to_string(),
+            app_name: app_name.map_or_else(String::new, |n| n.0),
+            interval,
+            logger,
+            registry,
+        };
+        let handle = spawn_task(ticker.run(cancel_tkn.clone()));
+        (cancel_tkn, handle)
+    }
+
+    pub(crate) async fn run(self, cancel_tkn: CancellationToken) {
+        let mut ticker = interval(self.interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        ticker.tick().await;
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    self.send_health().await;
+                }
+                () = cancel_tkn.cancelled() => {
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn send_health(&self) {
+        let entry = self.build_health_entry();
+        let logger = self.logger.as_ref().and_then(std::sync::Weak::upgrade);
+
+        let serialized = match serde_json::to_string(&entry) {
+            Ok(s) => s.into_boxed_str(),
+            Err(e) => {
+                logger.log_any(LockLogEntry::error(format!(
+                    "failed to serialize health entry: {e}"
+                )));
+                return;
+            },
+        };
+
+        let result = self
+            .transport
+            .send(&[serialized], &AuditKind::Health(self.health_url.clone()))
+            .await;
+
+        if let Err(e) = result {
+            logger.log_any(LockLogEntry::error(format!(
+                "failed to send health check to lock server: {e}"
+            )));
+        }
+    }
+
+    fn build_health_entry(&self) -> LockServerHealthEntry {
+        let now = Utc::now().to_rfc3339();
+        let engine_status = self.registry.collect();
+
+        let overall_status = if engine_status.is_empty() {
+            "unknown"
+        } else if engine_status.values().all(|s| s == "success") {
+            "running"
+        } else {
+            "degraded"
+        }
+        .to_string();
+
+        LockServerHealthEntry {
+            creation_date: now.clone(),
+            event_time: now,
+            service: self.app_name.clone(),
+            node_name: self.pdp_id.clone(),
+            status: overall_status,
+            engine_status,
+        }
+    }
+}

--- a/jans-cedarling/cedarling/src/lock/mod.rs
+++ b/jans-cedarling/cedarling/src/lock/mod.rs
@@ -103,6 +103,8 @@
 //! - Issue access tokens for Lock Server communication
 //! - Provide JWKS endpoint for key validation
 
+pub(crate) mod health_registry;
+mod health_ticker;
 mod lock_config;
 mod log_entry;
 mod log_worker;
@@ -119,9 +121,11 @@ mod proto {
     tonic::include_proto!("io.jans.lock.audit");
 }
 
-use crate::app_types::PdpID;
+use crate::app_types::{ApplicationName, PdpID};
 use crate::authz::metrics::MetricsCollector;
 use crate::common::issuer_utils::IssClaim;
+use crate::lock::health_registry::HealthRegistry;
+use crate::lock::health_ticker::HealthTicker;
 use crate::lock::telemetry_ticker::TelemetryTicker;
 use crate::log::interface::Loggable;
 use crate::log::{LogType, LoggerWeak};
@@ -154,8 +158,17 @@ pub(crate) struct LockService {
     log_worker: Option<WorkerSenderAndHandle>,
     telemetry_worker: Option<WorkerSenderAndHandle>,
     telemetry_ticker: Option<(CancellationToken, crate::http::JoinHandle<()>)>,
+    health_ticker: Option<(CancellationToken, crate::http::JoinHandle<()>)>,
+    health_registry: Option<HealthRegistry>,
     logger: Option<LoggerWeak>,
     cancel_tkn: CancellationToken,
+}
+
+impl LockService {
+    /// Returns the shared health registry for registering subsystem health checks.
+    pub(crate) fn health_registry(&self) -> Option<&HealthRegistry> {
+        self.health_registry.as_ref()
+    }
 }
 
 pub(crate) fn init_http_client(
@@ -189,6 +202,7 @@ impl LockService {
         bootstrap_conf: &LockServiceConfig,
         logger: Option<LoggerWeak>,
         metrics: Arc<MetricsCollector>,
+        app_name: Option<ApplicationName>,
     ) -> Result<Self, InitLockServiceError> {
         // Get lock config from the config uri endpoint first
         let lock_config = LockConfig::get(
@@ -263,10 +277,35 @@ impl LockService {
             TelemetryTicker::spawn(metrics, logger.clone(), telemetry_interval)
         });
 
+        let (health_ticker, health_registry) = match (
+            bootstrap_conf.health_interval,
+            lock_config.audit_endpoints.health,
+        ) {
+            (Some(health_interval), Some(health_endpoint)) => {
+                let registry = HealthRegistry::new();
+
+                let ticker = create_health_ticker(HealthTickerParams {
+                    bootstrap_conf,
+                    health_url: health_endpoint.0,
+                    access_token: &client_creds.access_token,
+                    pdp_id,
+                    app_name,
+                    health_interval,
+                    logger: logger.clone(),
+                    registry: registry.clone(),
+                });
+
+                (Some(ticker), Some(registry))
+            },
+            _ => (None, None),
+        };
+
         Ok(Self {
             log_worker,
             telemetry_worker,
             telemetry_ticker,
+            health_ticker,
+            health_registry,
             logger,
             cancel_tkn,
         })
@@ -275,6 +314,10 @@ impl LockService {
     pub(crate) async fn shut_down(&mut self) {
         self.cancel_tkn.cancel();
         if let Some((cancel_tkn, handle)) = self.telemetry_ticker.take() {
+            cancel_tkn.cancel();
+            () = handle.await_result().await;
+        }
+        if let Some((cancel_tkn, handle)) = self.health_ticker.take() {
             cancel_tkn.cancel();
             () = handle.await_result().await;
         }
@@ -391,6 +434,74 @@ fn create_worker(
     }
 }
 
+struct HealthTickerParams<'a> {
+    bootstrap_conf: &'a LockServiceConfig,
+    health_url: url::Url,
+    access_token: &'a str,
+    pdp_id: PdpID,
+    app_name: Option<ApplicationName>,
+    health_interval: Duration,
+    logger: Option<LoggerWeak>,
+    registry: HealthRegistry,
+}
+
+fn create_health_ticker(
+    params: HealthTickerParams<'_>,
+) -> (CancellationToken, crate::http::JoinHandle<()>) {
+    match params.bootstrap_conf.transport {
+        LockTransport::Rest => {
+            let mut headers = HeaderMap::new();
+            let mut auth_header = HeaderValue::from_str(&format!("Bearer {}", params.access_token))
+                .expect("valid authorization header value");
+            auth_header.set_sensitive(true);
+            headers.insert("Authorization", auth_header);
+
+            let http_client = Arc::new(
+                init_http_client(Some(headers), params.bootstrap_conf.accept_invalid_certs)
+                    .expect("health ticker HTTP client initialization"),
+            );
+
+            let transport = Arc::new(RestTransport::new(
+                http_client,
+                params.logger.as_ref().and_then(std::sync::Weak::upgrade),
+            ));
+
+            HealthTicker::spawn(
+                transport,
+                params.health_url,
+                params.pdp_id,
+                params.app_name,
+                params.health_interval,
+                params.logger,
+                params.registry,
+            )
+        },
+        #[cfg(feature = "grpc")]
+        LockTransport::Grpc => {
+            use transport::grpc::GrpcTransport;
+
+            let transport = Arc::new(
+                GrpcTransport::new(
+                    params.health_url.origin().ascii_serialization(),
+                    params.access_token,
+                    params.logger.as_ref().and_then(std::sync::Weak::upgrade),
+                )
+                .expect("health ticker gRPC transport initialization"),
+            );
+
+            HealthTicker::spawn(
+                transport,
+                params.health_url,
+                params.pdp_id,
+                params.app_name,
+                params.health_interval,
+                params.logger,
+                params.registry,
+            )
+        },
+    }
+}
+
 impl LogWriter for LockService {
     fn log_any<T: Loggable>(&self, entry: T) {
         match entry.get_log_kind() {
@@ -491,7 +602,7 @@ mod test {
 
         // Test startup
         let metrics = Arc::new(MetricsCollector::new(0));
-        let logger = LockService::new(pdp_id, &config, None, metrics)
+        let logger = LockService::new(pdp_id, &config, None, metrics, None)
             .await
             .expect("build lock logger");
         lock_config_endpoint.assert();
@@ -551,7 +662,7 @@ mod test {
 
         // Test startup without SSA
         let metrics = Arc::new(MetricsCollector::new(0));
-        let logger = LockService::new(pdp_id, &config, None, metrics)
+        let logger = LockService::new(pdp_id, &config, None, metrics, None)
             .await
             .expect("build lock logger");
         lock_config_endpoint.assert();
@@ -607,7 +718,7 @@ mod test {
 
         // Test startup with invalid SSA should fail
         let metrics = Arc::new(MetricsCollector::new(0));
-        let result = LockService::new(pdp_id, &config, None, metrics).await;
+        let result = LockService::new(pdp_id, &config, None, metrics, None).await;
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -834,5 +945,57 @@ mod test {
         fn get_tags(&self) -> Vec<&str> {
             Vec::new()
         }
+    }
+
+    fn mock_health_endpoint(server: &mut ServerGuard) -> Mock {
+        server
+            .mock("POST", "/jans-auth/v1/audit/health/bulk")
+            .match_body(mockito::Matcher::Any)
+            .with_status(200)
+            .expect_at_least(2)
+            .create()
+    }
+
+    #[tokio::test]
+    async fn test_lock_service_health_checks() {
+        let pdp_id = PdpID::new();
+
+        let mut mock_idp_server = Server::new_async().await;
+        let mut mock_lock_server = Server::new_async().await;
+
+        let (lock_config_uri, lock_config_endpoint) =
+            mock_lock_config_endpoint(&mut mock_lock_server, &mock_idp_server);
+        let oidc_endpoint = mock_oidc_endpoint(&mut mock_idp_server);
+        let dcr_endpoint = mock_dcr_endpoint_without_ssa(&mut mock_idp_server, pdp_id);
+        let token_endpoint = mock_token_endpoint(&mut mock_idp_server);
+        let health_endpoint = mock_health_endpoint(&mut mock_lock_server);
+
+        let config = LockServiceConfig {
+            config_uri: lock_config_uri,
+            dynamic_config: false,
+            ssa_jwt: None,
+            log_interval: None,
+            health_interval: Some(Duration::from_millis(100)),
+            telemetry_interval: None,
+            listen_sse: false,
+            log_level: LogLevel::TRACE,
+            accept_invalid_certs: false,
+            transport: LockTransport::Rest,
+            ..Default::default()
+        };
+
+        let metrics = Arc::new(MetricsCollector::new(0));
+        let _ = LockService::new(pdp_id, &config, None, metrics, None)
+            .await
+            .expect("build lock logger");
+        lock_config_endpoint.assert();
+        oidc_endpoint.assert();
+        dcr_endpoint.assert();
+        token_endpoint.assert();
+
+        // Wait for health checks to be sent
+        sleep(Duration::from_secs(1)).await;
+
+        health_endpoint.assert();
     }
 }

--- a/jans-cedarling/cedarling/src/lock/mod.rs
+++ b/jans-cedarling/cedarling/src/lock/mod.rs
@@ -126,7 +126,7 @@ use crate::authz::metrics::MetricsCollector;
 use crate::common::issuer_utils::IssClaim;
 use crate::http::{HttpClient, InitializeHttpClientError};
 use crate::lock::health_registry::HealthRegistry;
-use crate::lock::health_ticker::HealthTicker;
+use crate::lock::health_ticker::{HealthTicker, HealthTickerParams};
 use crate::lock::lock_config::GetLockConfigError;
 use crate::lock::telemetry_ticker::TelemetryTicker;
 use crate::log::interface::Loggable;
@@ -293,17 +293,17 @@ impl LockService {
 
                 let ticker = create_health_ticker(
                     HealthTickerParams {
-                        bootstrap_conf,
                         health_url: health_endpoint.0,
-                        access_token: &client_creds.access_token,
                         pdp_id,
                         app_name,
                         health_interval,
                         logger: logger.clone(),
                         registry: registry.clone(),
                     },
+                    bootstrap_conf,
+                    &client_creds.access_token,
                     http_conf,
-                );
+                )?;
 
                 (Some(ticker), Some(registry))
             },
@@ -446,73 +446,44 @@ fn create_worker(
     }
 }
 
-struct HealthTickerParams<'a> {
-    bootstrap_conf: &'a LockServiceConfig,
-    health_url: url::Url,
-    access_token: &'a str,
-    pdp_id: PdpID,
-    app_name: Option<ApplicationName>,
-    health_interval: Duration,
-    logger: Option<LoggerWeak>,
-    registry: HealthRegistry,
-}
-
 fn create_health_ticker(
-    params: HealthTickerParams<'_>,
+    params: HealthTickerParams,
+    bootstrap_conf: &LockServiceConfig,
+    access_token: &str,
     http_conf: HttpClientConfig,
-) -> (CancellationToken, crate::http::JoinHandle<()>) {
-    match params.bootstrap_conf.transport {
+) -> Result<(CancellationToken, crate::http::JoinHandle<()>), InitLockServiceError> {
+    match bootstrap_conf.transport {
         LockTransport::Rest => {
             let mut headers = HeaderMap::new();
-            let mut auth_header = HeaderValue::from_str(&format!("Bearer {}", params.access_token))
-                .expect("valid authorization header value");
+            let mut auth_header = HeaderValue::from_str(&format!("Bearer {access_token}"))
+                .map_err(|e| InitLockServiceError::InvalidAccessToken(e.to_string()))?;
             auth_header.set_sensitive(true);
             headers.insert("Authorization", auth_header);
 
             let http_client = init_http_client(
                 Some(headers),
-                params.bootstrap_conf.accept_invalid_certs,
+                bootstrap_conf.accept_invalid_certs,
                 http_conf,
-            )
-            .expect("health ticker HTTP client initialization");
+            )?;
 
             let transport = Arc::new(RestTransport::new(
                 http_client,
                 params.logger.as_ref().and_then(std::sync::Weak::upgrade),
             ));
 
-            HealthTicker::spawn(
-                transport,
-                params.health_url,
-                params.pdp_id,
-                params.app_name,
-                params.health_interval,
-                params.logger,
-                params.registry,
-            )
+            Ok(HealthTicker::spawn(transport, params))
         },
         #[cfg(feature = "grpc")]
         LockTransport::Grpc => {
             use transport::grpc::GrpcTransport;
 
-            let transport = Arc::new(
-                GrpcTransport::new(
-                    params.health_url.origin().ascii_serialization(),
-                    params.access_token,
-                    params.logger.as_ref().and_then(std::sync::Weak::upgrade),
-                )
-                .expect("health ticker gRPC transport initialization"),
-            );
+            let transport = Arc::new(GrpcTransport::new(
+                params.health_url.origin().ascii_serialization(),
+                access_token,
+                params.logger.as_ref().and_then(std::sync::Weak::upgrade),
+            )?);
 
-            HealthTicker::spawn(
-                transport,
-                params.health_url,
-                params.pdp_id,
-                params.app_name,
-                params.health_interval,
-                params.logger,
-                params.registry,
-            )
+            Ok(HealthTicker::spawn(transport, params))
         },
     }
 }
@@ -1022,7 +993,7 @@ mod test {
         };
 
         let metrics = Arc::new(MetricsCollector::new(0));
-        let _ = LockService::new(
+        let _lock = LockService::new(
             pdp_id,
             &config,
             None,

--- a/jans-cedarling/cedarling/src/lock/transport/grpc.rs
+++ b/jans-cedarling/cedarling/src/lock/transport/grpc.rs
@@ -216,7 +216,11 @@ fn health_json_to_proto(entry: LockServerHealthEntry) -> HealthEntry {
         service: entry.service,
         node_name: entry.node_name,
         status: entry.status,
-        engine_status: entry.engine_status,
+        engine_status: entry
+            .engine_status
+            .into_iter()
+            .map(|(k, v)| (k, v.to_string()))
+            .collect(),
     }
 }
 
@@ -240,9 +244,12 @@ mod test {
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::{Response, Status, transport::Server};
 
-    use crate::lock::proto::{
-        self, AuditResponse,
-        audit_service_server::{AuditService, AuditServiceServer},
+    use crate::lock::{
+        health_registry::HealthStatus,
+        proto::{
+            self, AuditResponse,
+            audit_service_server::{AuditService, AuditServiceServer},
+        },
     };
 
     // Mock gRPC server for testing
@@ -1065,7 +1072,7 @@ mod test {
             service: "test_app".to_string(),
             node_name: "test-pdp".to_string(),
             status: "running".to_string(),
-            engine_status: [("core".to_string(), "success".to_string())]
+            engine_status: [("core".to_string(), HealthStatus::Success)]
                 .into_iter()
                 .collect(),
         };

--- a/jans-cedarling/cedarling/src/lock/transport/grpc.rs
+++ b/jans-cedarling/cedarling/src/lock/transport/grpc.rs
@@ -20,14 +20,14 @@ use crate::{
     lock::{
         LockLogEntry,
         proto::{
-            BulkLogRequest, BulkTelemetryRequest, LogEntry, TelemetryEntry,
-            audit_service_client::AuditServiceClient,
+            BulkHealthRequest, BulkLogRequest, BulkTelemetryRequest, HealthEntry, LogEntry,
+            TelemetryEntry, audit_service_client::AuditServiceClient,
         },
         transport::{
             self, AuditKind, AuditTransport, SerializedAuditEntry, TransportError, TransportResult,
             mapping::{
-                CedarlingLogEntry, CedarlingMetricsEntry, LockServerLogEntry,
-                LockServerMetricsEntry,
+                CedarlingLogEntry, CedarlingMetricsEntry, LockServerHealthEntry,
+                LockServerLogEntry, LockServerMetricsEntry,
             },
         },
     },
@@ -118,9 +118,42 @@ impl AuditTransport for GrpcTransport {
                 .collect();
 
                 let mut request = Request::new(BulkTelemetryRequest { entries });
-                request.metadata_mut().insert("authorization", token);
+                request
+                    .metadata_mut()
+                    .insert("authorization", token.clone());
 
                 client.process_bulk_telemetry(request).await?
+            },
+            AuditKind::Health(_) => {
+                let entries: Vec<LockServerHealthEntry> = entries
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, v)| match serde_json::from_str(v) {
+                        Ok(e) => Some(e),
+                        Err(e) => {
+                            self.logger.log_any(LockLogEntry::warn(format!(
+                                "failed to parse health entry[{idx}]: {e}"
+                            )));
+                            None
+                        },
+                    })
+                    .collect();
+
+                if entries.is_empty() {
+                    return Err(TransportError::Serialization(
+                        "all health entries were malformed, nothing to send".to_string(),
+                    ));
+                }
+
+                let proto_entries: Vec<HealthEntry> =
+                    entries.into_iter().map(health_json_to_proto).collect();
+
+                let mut request = Request::new(BulkHealthRequest {
+                    entries: proto_entries,
+                });
+                request.metadata_mut().insert("authorization", token);
+
+                client.process_bulk_health(request).await?
             },
         };
 
@@ -175,6 +208,18 @@ fn telemetry_json_to_proto(entry: LockServerMetricsEntry) -> TelemetryEntry {
     }
 }
 
+/// Converts a [`LockServerHealthEntry`] into a [`HealthEntry`]
+fn health_json_to_proto(entry: LockServerHealthEntry) -> HealthEntry {
+    HealthEntry {
+        creation_date: parse_timestamp(&entry.creation_date),
+        event_time: parse_timestamp(&entry.event_time),
+        service: entry.service,
+        node_name: entry.node_name,
+        status: entry.status,
+        engine_status: entry.engine_status,
+    }
+}
+
 // Parse a RFC3339 timestamp string into a protobuf Timestamp
 fn parse_timestamp(s: &str) -> Option<Timestamp> {
     chrono::DateTime::parse_from_rfc3339(s)
@@ -205,6 +250,7 @@ mod test {
     struct MockAuditService {
         log_sender: mpsc::UnboundedSender<Vec<LogEntry>>,
         telemetry_sender: mpsc::UnboundedSender<Vec<TelemetryEntry>>,
+        health_sender: mpsc::UnboundedSender<Vec<HealthEntry>>,
         should_fail: bool,
     }
 
@@ -219,9 +265,32 @@ mod test {
 
         async fn process_bulk_health(
             &self,
-            _: Request<proto::BulkHealthRequest>,
+            request: Request<proto::BulkHealthRequest>,
         ) -> Result<Response<AuditResponse>, Status> {
-            unimplemented!()
+            if self.should_fail {
+                return Ok(Response::new(AuditResponse {
+                    success: false,
+                    message: "Server error".to_string(),
+                }));
+            }
+
+            let auth = request
+                .metadata()
+                .get("authorization")
+                .and_then(|v| v.to_str().ok());
+
+            assert!(
+                matches!(auth, Some(token) if token.starts_with("Bearer ")),
+                "expected Bearer token in authorization header, got {auth:?}"
+            );
+
+            let entries = request.into_inner().entries;
+            self.health_sender.send(entries).unwrap();
+
+            Ok(Response::new(AuditResponse {
+                success: true,
+                message: "OK".to_string(),
+            }))
         }
 
         async fn process_log(
@@ -305,12 +374,15 @@ mod test {
         SocketAddr,
         mpsc::UnboundedReceiver<Vec<LogEntry>>,
         mpsc::UnboundedReceiver<Vec<TelemetryEntry>>,
+        mpsc::UnboundedReceiver<Vec<HealthEntry>>,
     ) {
         let (tx, rx) = mpsc::unbounded_channel();
         let (telemetry_tx, telemetry_rx) = mpsc::unbounded_channel();
+        let (health_tx, health_rx) = mpsc::unbounded_channel();
         let service = MockAuditService {
             log_sender: tx,
             telemetry_sender: telemetry_tx,
+            health_sender: health_tx,
             should_fail,
         };
 
@@ -325,7 +397,7 @@ mod test {
                 .unwrap();
         });
 
-        (addr, rx, telemetry_rx)
+        (addr, rx, telemetry_rx, health_rx)
     }
 
     #[test]
@@ -402,7 +474,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_success() {
-        let (addr, mut rx, _) = start_mock_server(false).await;
+        let (addr, mut rx, _, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries = vec![
@@ -441,7 +513,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_empty() {
-        let (addr, mut rx, _) = start_mock_server(false).await;
+        let (addr, mut rx, _, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         transport
@@ -458,7 +530,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_malformed_json() {
-        let (addr, _, _) = start_mock_server(false).await;
+        let (addr, _, _, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries = vec!["not valid json".to_string().into_boxed_str()];
@@ -478,7 +550,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_server_error() {
-        let (addr, _, _) = start_mock_server(true).await;
+        let (addr, _, _, _) = start_mock_server(true).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries = vec![
@@ -511,7 +583,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_partial_malformed() {
-        let (addr, mut rx, _) = start_mock_server(false).await;
+        let (addr, mut rx, _, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries = vec![
@@ -556,7 +628,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_multiple_entries() {
-        let (addr, mut rx, _) = start_mock_server(false).await;
+        let (addr, mut rx, _, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries = vec![
@@ -612,7 +684,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_with_all_fields() {
-        let (addr, mut rx, _) = start_mock_server(false).await;
+        let (addr, mut rx, _, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries = vec![
@@ -659,7 +731,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_with_missing_optional_fields() {
-        let (addr, mut rx, _) = start_mock_server(false).await;
+        let (addr, mut rx, _, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries = vec![
@@ -692,7 +764,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_logs_large_batch() {
-        let (addr, mut rx, _) = start_mock_server(false).await;
+        let (addr, mut rx, _, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries: Vec<_> = (0..100)
@@ -727,7 +799,7 @@ mod test {
 
     #[tokio::test]
     async fn test_send_telemetry_success() {
-        let (addr, _, mut telemetry_rx) = start_mock_server(false).await;
+        let (addr, _, mut telemetry_rx, _) = start_mock_server(false).await;
         let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
 
         let entries = vec![
@@ -841,5 +913,182 @@ mod test {
             proto_entry.event_time.as_ref().unwrap().seconds,
             -2_208_988_800
         );
+    }
+
+    #[tokio::test]
+    async fn test_send_health_success() {
+        let (addr, _, _, mut health_rx) = start_mock_server(false).await;
+        let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
+
+        let entries = vec![
+            json!({
+                "creation_date": "2026-03-23T11:50:37.504Z",
+                "event_time": "2026-03-23T11:50:37.504Z",
+                "service": "test_app",
+                "node_name": "test-pdp",
+                "status": "running",
+                "engine_status": {
+                    "core": "success"
+                }
+            })
+            .to_string()
+            .into_boxed_str(),
+        ];
+
+        transport
+            .send(
+                &entries,
+                &AuditKind::Health(format!("http://{addr}").parse().unwrap()),
+            )
+            .await
+            .expect("health check should be sent successfully");
+
+        let received = health_rx.try_recv().unwrap();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].service, "test_app");
+        assert_eq!(received[0].node_name, "test-pdp");
+        assert_eq!(received[0].status, "running");
+        assert_eq!(received[0].engine_status.get("core").unwrap(), "success");
+    }
+
+    #[tokio::test]
+    async fn test_send_health_empty() {
+        let (addr, _, _, mut health_rx) = start_mock_server(false).await;
+        let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
+
+        transport
+            .send(
+                &[],
+                &AuditKind::Health(format!("http://{addr}").parse().unwrap()),
+            )
+            .await
+            .expect("empty health check should succeed");
+
+        assert!(health_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_send_health_malformed_json() {
+        let (addr, _, _, _) = start_mock_server(false).await;
+        let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
+
+        let entries = vec!["not valid json".to_string().into_boxed_str()];
+
+        let error = transport
+            .send(
+                &entries,
+                &AuditKind::Health(format!("http://{addr}").parse().unwrap()),
+            )
+            .await
+            .expect_err("this should cause a serialization error");
+        assert!(
+            matches!(error, TransportError::Serialization(_)),
+            "expected serialization error, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_health_server_error() {
+        let (addr, _, _, _) = start_mock_server(true).await;
+        let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
+
+        let entries = vec![
+            json!({
+                "creation_date": "2026-03-23T11:50:37.504Z",
+                "event_time": "2026-03-23T11:50:37.504Z",
+                "service": "test_app",
+                "node_name": "test-pdp",
+                "status": "running",
+                "engine_status": {
+                    "core": "success"
+                }
+            })
+            .to_string()
+            .into_boxed_str(),
+        ];
+
+        let error = transport
+            .send(
+                &entries,
+                &AuditKind::Health(format!("http://{addr}").parse().unwrap()),
+            )
+            .await
+            .expect_err("this should cause a server error");
+
+        assert!(
+            matches!(error, TransportError::GrpcServer(_)),
+            "expected server error, got {error:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_health_large_batch() {
+        let (addr, _, _, mut health_rx) = start_mock_server(false).await;
+        let transport = GrpcTransport::new(format!("http://{addr}"), "test-token", None).unwrap();
+
+        let entries: Vec<_> = (0..100)
+            .map(|i| {
+                json!({
+                    "creation_date": "2026-03-23T11:50:37.504Z",
+                    "event_time": "2026-03-23T11:50:37.504Z",
+                    "service": format!("service-{i}"),
+                    "node_name": "node-1",
+                    "status": "running",
+                    "engine_status": {
+                        "core": "success"
+                    }
+                })
+                .to_string()
+                .into_boxed_str()
+            })
+            .collect();
+
+        transport
+            .send(
+                &entries,
+                &AuditKind::Health(format!("http://{addr}").parse().unwrap()),
+            )
+            .await
+            .expect("health checks should be sent successfully");
+
+        let received = health_rx.try_recv().unwrap();
+        assert_eq!(received.len(), 100);
+        assert_eq!(received[0].service, "service-0");
+        assert_eq!(received[99].service, "service-99");
+    }
+
+    #[test]
+    fn test_health_json_to_proto_conversion() {
+        let entry = LockServerHealthEntry {
+            creation_date: "2026-03-23T11:50:37.504Z".to_string(),
+            event_time: "2026-03-23T11:50:37.504Z".to_string(),
+            service: "test_app".to_string(),
+            node_name: "test-pdp".to_string(),
+            status: "running".to_string(),
+            engine_status: [("core".to_string(), "success".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let proto = health_json_to_proto(entry);
+
+        assert_eq!(
+            proto.creation_date,
+            Some(Timestamp {
+                seconds: 1_774_266_637,
+                nanos: 504_000_000
+            })
+        );
+        assert_eq!(
+            proto.event_time,
+            Some(Timestamp {
+                seconds: 1_774_266_637,
+                nanos: 504_000_000,
+            })
+        );
+        assert_eq!(proto.service, "test_app");
+        assert_eq!(proto.node_name, "test-pdp");
+        assert_eq!(proto.status, "running");
+        assert_eq!(proto.engine_status.get("core").unwrap(), "success");
     }
 }

--- a/jans-cedarling/cedarling/src/lock/transport/mapping.rs
+++ b/jans-cedarling/cedarling/src/lock/transport/mapping.rs
@@ -66,6 +66,18 @@ pub(super) struct LockServerLogEntry {
     pub context_information: Option<Value>,
 }
 
+/// Serializes into the lock server's expected health format.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct LockServerHealthEntry {
+    pub creation_date: String,
+    pub event_time: String,
+    pub service: String,
+    pub node_name: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub engine_status: HashMap<String, String>,
+}
+
 /// Serializes into the lock server's expected telemetry format (3-map model).
 #[derive(Debug, Serialize)]
 pub(super) struct LockServerMetricsEntry {

--- a/jans-cedarling/cedarling/src/lock/transport/mapping.rs
+++ b/jans-cedarling/cedarling/src/lock/transport/mapping.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::lock::health_registry::HealthStatus;
 use crate::log::MetricsLogEntry;
 
 #[derive(Debug, thiserror::Error)]
@@ -75,7 +76,7 @@ pub(crate) struct LockServerHealthEntry {
     pub node_name: String,
     pub status: String,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub engine_status: HashMap<String, String>,
+    pub engine_status: HashMap<String, HealthStatus>,
 }
 
 /// Serializes into the lock server's expected telemetry format (3-map model).

--- a/jans-cedarling/cedarling/src/lock/transport/mod.rs
+++ b/jans-cedarling/cedarling/src/lock/transport/mod.rs
@@ -31,12 +31,13 @@ pub(super) type TransportResult<T> = Result<T, TransportError>;
 pub(super) enum AuditKind {
     Log(Url),
     Telemetry(Url),
+    Health(Url),
 }
 
 impl AuditKind {
     pub(super) fn url(&self) -> &Url {
         match self {
-            AuditKind::Log(url) | AuditKind::Telemetry(url) => url,
+            AuditKind::Log(url) | AuditKind::Telemetry(url) | AuditKind::Health(url) => url,
         }
     }
 }
@@ -46,6 +47,7 @@ impl Display for AuditKind {
         match self {
             AuditKind::Log(_) => write!(f, "log"),
             AuditKind::Telemetry(_) => write!(f, "telemetry"),
+            AuditKind::Health(_) => write!(f, "health"),
         }
     }
 }

--- a/jans-cedarling/cedarling/src/lock/transport/rest.rs
+++ b/jans-cedarling/cedarling/src/lock/transport/rest.rs
@@ -98,6 +98,7 @@ impl AuditTransport for RestTransport {
                 }
 
                 self.client
+                    .raw_client
                     .post(url.as_str())
                     .json(&entries)
                     .send()

--- a/jans-cedarling/cedarling/src/lock/transport/rest.rs
+++ b/jans-cedarling/cedarling/src/lock/transport/rest.rs
@@ -14,10 +14,10 @@ use crate::{
     lock::{
         LockLogEntry,
         transport::{
-            self, AuditKind, AuditTransport, SerializedAuditEntry, TransportResult,
+            self, AuditKind, AuditTransport, SerializedAuditEntry, TransportError, TransportResult,
             mapping::{
-                CedarlingLogEntry, CedarlingMetricsEntry, LockServerLogEntry,
-                LockServerMetricsEntry,
+                CedarlingLogEntry, CedarlingMetricsEntry, LockServerHealthEntry,
+                LockServerLogEntry, LockServerMetricsEntry,
             },
         },
     },
@@ -68,6 +68,34 @@ impl AuditTransport for RestTransport {
                     LockServerMetricsEntry,
                     CedarlingMetricsEntry,
                 >(entries, "telemetry", warn)?;
+
+                self.client
+                    .post(url.as_str())
+                    .json(&entries)
+                    .send()
+                    .await?
+                    .error_for_status()?;
+            },
+            AuditKind::Health(url) => {
+                let entries: Vec<LockServerHealthEntry> = entries
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, v)| match serde_json::from_str(v) {
+                        Ok(e) => Some(e),
+                        Err(e) => {
+                            self.logger.log_any(LockLogEntry::warn(format!(
+                                "failed to parse health entry[{idx}]: {e}"
+                            )));
+                            None
+                        },
+                    })
+                    .collect();
+
+                if entries.is_empty() {
+                    return Err(TransportError::Serialization(
+                        "all health entries were malformed, nothing to send".to_string(),
+                    ));
+                }
 
                 self.client
                     .post(url.as_str())
@@ -357,6 +385,222 @@ mod test {
             .await
             .expect("telemetry should be sent successfully");
 
+        mock.assert();
+    }
+
+    fn mock_health_endpoint(server: &mut ServerGuard) -> mockito::Mock {
+        server
+            .mock("POST", "/audit/health/bulk")
+            .match_header("content-type", "application/json")
+            .with_status(200)
+            .create()
+    }
+
+    #[tokio::test]
+    async fn test_send_health_success() {
+        let mut server = Server::new_async().await;
+        let mock = mock_health_endpoint(&mut server);
+
+        let endpoint: Url = format!("{}/audit/health/bulk", server.url())
+            .parse()
+            .expect("valid health endpoint URL");
+        let transport = RestTransport::new(create_test_client(), None);
+
+        let entries = vec![
+            json!({
+                "creation_date": "2026-03-23T11:50:37.504Z",
+                "event_time": "2026-03-23T11:50:37.504Z",
+                "service": "test_app",
+                "node_name": "test-pdp",
+                "status": "running",
+                "engine_status": {
+                    "core": "success"
+                }
+            })
+            .to_string()
+            .into_boxed_str(),
+        ];
+
+        transport
+            .send(&entries, &AuditKind::Health(endpoint))
+            .await
+            .expect("health check should be sent successfully");
+
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_send_health_empty() {
+        let server = Server::new_async().await;
+        let endpoint: Url = format!("{}/audit/health/bulk", server.url())
+            .parse()
+            .unwrap();
+        let transport = RestTransport::new(create_test_client(), None);
+
+        transport
+            .send(&[], &AuditKind::Health(endpoint))
+            .await
+            .expect("health check should be sent successfully");
+    }
+
+    #[tokio::test]
+    async fn test_send_health_server_error_500() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/audit/health/bulk")
+            .with_status(500)
+            .with_body("Internal Server Error")
+            .create();
+
+        let endpoint: Url = format!("{}/audit/health/bulk", server.url())
+            .parse()
+            .unwrap();
+        let transport = RestTransport::new(create_test_client(), None);
+
+        let entries = vec![
+            json!({
+                "creation_date": "2026-03-23T11:50:37.504Z",
+                "event_time": "2026-03-23T11:50:37.504Z",
+                "service": "test_app",
+                "node_name": "test-pdp",
+                "status": "running",
+                "engine_status": {
+                    "core": "success"
+                }
+            })
+            .to_string()
+            .into_boxed_str(),
+        ];
+
+        let error = transport
+            .send(&entries, &AuditKind::Health(endpoint))
+            .await
+            .expect_err("this should cause a server error");
+        assert!(
+            matches!(error, TransportError::Rest(_)),
+            "expected reqwest error, got {error:?}"
+        );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_send_health_client_error_400() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/audit/health/bulk")
+            .with_status(400)
+            .with_body("Bad Request")
+            .create();
+
+        let endpoint: Url = format!("{}/audit/health/bulk", server.url())
+            .parse()
+            .unwrap();
+        let transport = RestTransport::new(create_test_client(), None);
+
+        let entries = vec![
+            json!({
+                "creation_date": "2026-03-23T11:50:37.504Z",
+                "event_time": "2026-03-23T11:50:37.504Z",
+                "service": "test_app",
+                "node_name": "test-pdp",
+                "status": "running",
+                "engine_status": {
+                    "core": "success"
+                }
+            })
+            .to_string()
+            .into_boxed_str(),
+        ];
+
+        let error = transport
+            .send(&entries, &AuditKind::Health(endpoint))
+            .await
+            .expect_err("this should cause a client error");
+        assert!(
+            matches!(error, TransportError::Rest(_)),
+            "expected reqwest error, got {error:?}"
+        );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_send_health_network_failure() {
+        let endpoint: Url = "http://localhost:1/invalid".parse().unwrap();
+        let transport = RestTransport::new(create_test_client(), None);
+
+        let entries = vec![
+            json!({
+                "creation_date": "2026-03-23T11:50:37.504Z",
+                "event_time": "2026-03-23T11:50:37.504Z",
+                "service": "test_app",
+                "node_name": "test-pdp",
+                "status": "running",
+                "engine_status": {
+                    "core": "success"
+                }
+            })
+            .to_string()
+            .into_boxed_str(),
+        ];
+
+        let error = transport
+            .send(&entries, &AuditKind::Health(endpoint))
+            .await
+            .expect_err("this should cause a network error");
+        assert!(
+            matches!(error, TransportError::Rest(_)),
+            "expected reqwest error, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_health_malformed_json() {
+        let endpoint: Url = "http://localhost:8080/audit/health/bulk".parse().unwrap();
+        let transport = RestTransport::new(create_test_client(), None);
+
+        let entries = vec![
+            "not valid json".to_string().into_boxed_str(),
+            "{ invalid json }".to_string().into_boxed_str(),
+        ];
+
+        let result = transport.send(&entries, &AuditKind::Health(endpoint)).await;
+        assert!(
+            matches!(result, Err(TransportError::Serialization(_))),
+            "expected serialization error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_health_large_batch() {
+        let mut server = Server::new_async().await;
+        let mock = mock_health_endpoint(&mut server);
+
+        let endpoint: Url = format!("{}/audit/health/bulk", server.url())
+            .parse()
+            .unwrap();
+        let transport = RestTransport::new(create_test_client(), None);
+
+        let entries: Vec<_> = (0..1000)
+            .map(|_| {
+                json!({
+                    "creation_date": "2026-03-23T11:50:37.504Z",
+                    "event_time": "2026-03-23T11:50:37.504Z",
+                    "service": "test_app",
+                    "node_name": "test-pdp",
+                    "status": "running",
+                    "engine_status": {
+                        "core": "success"
+                    }
+                })
+                .to_string()
+                .into_boxed_str()
+            })
+            .collect();
+
+        transport
+            .send(&entries, &AuditKind::Health(endpoint))
+            .await
+            .expect("health checks should be sent successfully");
         mock.assert();
     }
 }

--- a/jans-cedarling/cedarling/src/log/log_strategy.rs
+++ b/jans-cedarling/cedarling/src/log/log_strategy.rs
@@ -13,6 +13,7 @@ use super::stdout_logger::StdOutLogger;
 use crate::app_types::{ApplicationName, PdpID};
 use crate::bootstrap_config::log_config::{LogConfig, LogTypeConfig};
 use crate::lock::LockService;
+use crate::lock::health_registry::HealthRegistry;
 use crate::log::BaseLogEntry;
 use crate::log::loggable_fn::LoggableFn;
 use serde::Serialize;
@@ -121,6 +122,15 @@ impl LogStrategy {
             .lock_service
             .write()
             .expect("obtain lock_service write lock") = Some(lock_service);
+    }
+
+    pub(crate) fn health_registry(&self) -> Option<HealthRegistry> {
+        self.lock_service
+            .read()
+            .expect("obtain lock_service read lock")
+            .as_ref()
+            .and_then(|ls| ls.health_registry())
+            .cloned()
     }
 
     pub(crate) async fn shut_down(&self) {

--- a/jans-cedarling/cedarling/src/log/mod.rs
+++ b/jans-cedarling/cedarling/src/log/mod.rs
@@ -101,11 +101,11 @@ pub(crate) async fn init_logger(
     lock_config: Option<&LockServiceConfig>,
     metrics: Arc<MetricsCollector>,
 ) -> Result<Logger, InitLockServiceError> {
-    let logger = Arc::new(LogStrategy::new(config, pdp_id, app_name));
+    let logger = Arc::new(LogStrategy::new(config, pdp_id, app_name.clone()));
     let logger_weak = Arc::downgrade(&logger);
     if let Some(lock_config) = lock_config {
         let lock_service =
-            LockService::new(pdp_id, lock_config, Some(logger_weak), metrics).await?;
+            LockService::new(pdp_id, lock_config, Some(logger_weak), metrics, app_name).await?;
         logger.set_lock_service(lock_service);
     }
     Ok(logger)

--- a/jans-cedarling/http_utils/src/lib.rs
+++ b/jans-cedarling/http_utils/src/lib.rs
@@ -165,12 +165,9 @@ impl Sender {
                         .unwrap_or("unknown error")
                         .to_string();
                     backoff.snooze().await.map_err(|_| {
-                        HttpRequestError::new(
-                            HttpRequestReasonError::MaxRetriesExceeded,
-                            status,
-                        )
-                        .with_retry_count(attempt)
-                        .with_last_error(err_msg)
+                        HttpRequestError::new(HttpRequestReasonError::MaxRetriesExceeded, status)
+                            .with_retry_count(attempt)
+                            .with_last_error(err_msg)
                     })?;
                     continue;
                 },


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #10850

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a health registry and exposes component health status.
  * Periodic health reporting to configured health endpoints (REST & gRPC), with resilience to partial/malformed entries.
  * Logger publishes initial health entries reflecting core and policy-load status.

* **Refactor**
  * Lock-server integration enhanced for health monitoring, background reporting, and graceful shutdown.
  * Examples and internal HTTP/JWT/key-refresh code reorganized with no behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->