### PR TITLE
feat(jans-linux-setup): map fido2-metrics READ scope to admin role (used in admin ui) by default 

### DIFF
--- a/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
@@ -978,14 +978,14 @@
       "description": "",
       "defaultPermissionInToken": false,
       "essentialPermissionInAdminUI": false,
-      "tag": "fido2-metrics"
+      "tag": "fido2"
     },
     {
       "permission": "https://jans.io/oauth/config/fido2.admin",
       "description": "",
       "defaultPermissionInToken": false,
       "essentialPermissionInAdminUI": false,
-      "tag": "fido2-metrics"
+      "tag": "fido2"
     }
   ],
   "rolePermissionMapping": [

--- a/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
@@ -972,6 +972,20 @@
       "description": "",
       "defaultPermissionInToken": false,
       "essentialPermissionInAdminUI": false
+    },
+    {
+      "permission": "https://jans.io/oauth/config/fido2-metrics.readonly",
+      "description": "",
+      "defaultPermissionInToken": false,
+      "essentialPermissionInAdminUI": false,
+      "tag": "fido2-metrics"
+    },
+    {
+      "permission": "https://jans.io/oauth/config/fido2.admin",
+      "description": "",
+      "defaultPermissionInToken": false,
+      "essentialPermissionInAdminUI": false,
+      "tag": "fido2-metrics"
     }
   ],
   "rolePermissionMapping": [

--- a/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
@@ -1115,7 +1115,8 @@
         "https://jans.io/oauth/config/ssa.write",
         "https://jans.io/oauth/config/uma.readonly",
         "https://jans.io/oauth/config/uma.write",
-        "https://jans.io/oauth/config/uma.admin"
+        "https://jans.io/oauth/config/uma.admin",
+        "https://jans.io/oauth/config/fido2-metrics.readonly"
       ]
     }
   ]

--- a/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/role-scope-mappings.json
@@ -1130,7 +1130,8 @@
         "https://jans.io/oauth/config/uma.readonly",
         "https://jans.io/oauth/config/uma.write",
         "https://jans.io/oauth/config/uma.admin",
-        "https://jans.io/oauth/config/fido2-metrics.readonly"
+        "https://jans.io/oauth/config/fido2-metrics.readonly",
+        "https://jans.io/oauth/config/fido2.admin"
       ]
     }
   ]


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14039

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a FIDO2 metrics read-only permission to the admin role scope mappings, placed alongside the existing UMA admin permission. Admin role now includes read-only access to FIDO2 metrics without changes to other admin mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->