### PR TITLE
fix(jans-fido2): remove stale TODO and commented-out /options/generat…

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/AssertionController.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/AssertionController.java
@@ -68,21 +68,6 @@ public class AssertionController {
         });
     }
 
-    //TODO: delete this when checking issue related to isAssertionOptionsGenerateEndpointEnabled
-    /*@POST
-    @Consumes({"application/json"})
-    @Produces({"application/json"})
-    @Path("/options/generate")
-    public Response generateAuthenticate(@NotNull AssertionOptionsGenerate assertionOptionsGenerate) {
-        return processRequest(() -> {
-            if (appConfiguration.getFido2Configuration() == null || !appConfiguration.getFido2Configuration().isAssertionOptionsGenerateEndpointEnabled()) {
-                throw errorResponseFactory.forbiddenException();
-            }
-            AsserOptGenerateResponse result = assertionService.generateOptions(assertionOptionsGenerate);
-            return Response.ok().entity(result).build();
-        });
-    }*/
-
     @POST
     @Consumes({"application/json"})
     @Produces({"application/json"})


### PR DESCRIPTION
### Description

This PR removes a stale //TODO: delete this when checking issue related to isAssertionOptionsGenerateEndpointEnabled marker and the accompanying commented-out generateAuthenticate method (originally lines 71–84) from [AssertionController.java](vscode-webview://1reblc1tfr3jcmu4ndk5asfc7846nlmid2deapa06l6m3h4j0s0o/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/AssertionController.java). The block had been carried in source control as dead code, added noise to the controller's public API surface, and misled readers into believing the /options/generate endpoint was still part of the controller.

This is a pure dead-code cleanup — no behavioral change, no API change, no dependency change. The diff is limited to a single file. Verified before deletion that every symbol referenced inside the commented block (AssertionOptionsGenerate, AsserOptGenerateResponse, assertionService.generateOptions, isAssertionOptionsGenerateEndpointEnabled, the /options/generate path string) remains in active use by the server AssertionService, the client AssertionService, ConfigurationController, and the model classes — none of which were touched. In [AssertionControllerTest.java](vscode-webview://1reblc1tfr3jcmu4ndk5asfc7846nlmid2deapa06l6m3h4j0s0o/jans-fido2/server/src/test/java/io/jans/fido2/ws/rs/controller/AssertionControllerTest.java), all real tests for the dormant endpoint were already commented out (lines 123–209); the only active test with a generateAuthenticate*-style name (line 212) actually calls assertionController.authenticate(...) against the still-present /options endpoint, so it is unaffected.


#### Target issue

Resolves the stale //TODO: delete this when checking issue related to isAssertionOptionsGenerateEndpointEnabled left in [AssertionController.java:71](vscode-webview://1reblc1tfr3jcmu4ndk5asfc7846nlmid2deapa06l6m3h4j0s0o/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/AssertionController.java#L71). Replace this line with the corresponding GitHub issue link once the issue is filed
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14042

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete code comments to improve codebase maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->