### PR TITLE
fix(jans-cedarling): problem with normalizing token iss 

### DIFF
--- a/jans-cedarling/cedarling/src/common/policy_store.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store.rs
@@ -8,7 +8,7 @@ mod archive_security_tests;
 pub(crate) mod log_entry;
 #[cfg(test)]
 pub(crate) mod test_utils;
-mod token_entity_metadata;
+pub(crate) mod token_entity_metadata;
 
 use crate::common::{
     default_entities::DefaultEntitiesWithWarns,

--- a/jans-cedarling/cedarling/src/common/policy_store/token_entity_metadata.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/token_entity_metadata.rs
@@ -41,8 +41,9 @@ fn default_trusted() -> bool {
     true
 }
 
+pub(crate) const DEFAULT_TKN_ID: &str = "jti";
+
 fn default_token_id() -> String {
-    const DEFAULT_TKN_ID: &str = "jti";
     DEFAULT_TKN_ID.to_string()
 }
 

--- a/jans-cedarling/cedarling/src/entity_builder/build_multi_issuer_entity.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/build_multi_issuer_entity.rs
@@ -353,8 +353,7 @@ impl EntityBuilder {
             .iss
             .as_deref()
             .and_then(|iss| iss.token_metadata.get(&token.name))
-            .map(|m| m.token_id.as_str())
-            .unwrap_or(DEFAULT_TKN_ID);
+            .map_or(DEFAULT_TKN_ID, |m| m.token_id.as_str());
 
         let entity_id_srcs = vec![EntityIdSrc::Token {
             token,

--- a/jans-cedarling/cedarling/src/entity_builder/build_multi_issuer_entity.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/build_multi_issuer_entity.rs
@@ -346,11 +346,22 @@ impl EntityBuilder {
         // Determine entity type name using the same logic as regular entity builder
         let entity_type = determine_token_entity_type(token);
 
-        // Generate entity ID using the same logic as the regular entity builder
-        // This ensures consistent behavior between regular and multi-issuer entity builders
+        // Resolve token_id from the trusted issuer's token_metadata config,
+        // falling back to "jti" when the issuer or metadata entry is not found.
+        let token_id_claim: &str = token
+            .iss
+            .as_deref()
+            .and_then(|iss| {
+                iss.token_metadata
+                    .values()
+                    .find(|m| m.entity_type_name == entity_type)
+                    .map(|m| m.token_id.as_str())
+            })
+            .unwrap_or("jti");
+
         let entity_id_srcs = vec![EntityIdSrc::Token {
             token,
-            claim: "jti",
+            claim: token_id_claim,
         }];
         let entity_id = get_first_valid_entity_id(&entity_id_srcs)
             .map_err(|e| MultiIssuerEntityError::InvalidEntityUid(e.to_string()))?
@@ -414,33 +425,33 @@ impl EntityBuilder {
         token: &Token,
     ) -> Result<String, MultiIssuerEntityError> {
         let issuer = token
-            .get_claim_val("iss")
-            .and_then(|iss| iss.as_str())
+            .extract_normalized_issuer()
             .ok_or(MultiIssuerEntityError::MissingIssuer)?;
 
-        let issuer_simplified = self.resolve_issuer_name(issuer);
+        let issuer_simplified = self.resolve_issuer_name(&issuer);
         let token_type_simplified = simplify_token_type(token_name);
 
         Ok(format!("{issuer_simplified}_{token_type_simplified}"))
     }
 
     /// Resolve issuer name using trusted issuer metadata or fallback to hostname
-    fn resolve_issuer_name(&self, issuer: &str) -> String {
+    fn resolve_issuer_name(&self, issuer: &IssClaim) -> String {
         // First, try to find the issuer in trusted issuer metadata
         if let Some(trusted_issuer) = self.issuers_index.find(issuer) {
             return sanitize_issuer_name(&trusted_issuer.name);
         }
 
         // Fallback to hostname from JWT iss claim
-        let hostname = issuer
+        let issuer_str = issuer.as_str();
+        let hostname = issuer_str
             .replace("https://", "")
             .replace("http://", "")
             .split('/')
             .next()
-            .unwrap_or(issuer)
+            .unwrap_or(issuer_str)
             .split(':')
             .next()
-            .unwrap_or(issuer)
+            .unwrap_or(issuer_str)
             .to_string();
 
         sanitize_issuer_name(&hostname)
@@ -543,13 +554,14 @@ mod tests {
         let builder = create_test_entity_builder();
 
         // Test with trusted issuer metadata
-        let result = builder.resolve_issuer_name("https://idp.acme.com/auth");
+        let result = builder.resolve_issuer_name(&IssClaim::new("https://idp.acme.com/auth"));
         assert_eq!(result, "acme");
 
-        let result = builder.resolve_issuer_name("https://idp.dolphin.sea/auth");
+        let result = builder.resolve_issuer_name(&IssClaim::new("https://idp.dolphin.sea/auth"));
         assert_eq!(result, "dolphin");
 
-        let result = builder.resolve_issuer_name("https://login.microsoftonline.com/tenant");
+        let result =
+            builder.resolve_issuer_name(&IssClaim::new("https://login.microsoftonline.com/tenant"));
         assert_eq!(result, "microsoft");
     }
 
@@ -558,7 +570,8 @@ mod tests {
         let builder = create_test_entity_builder();
 
         // Test fallback to hostname for unknown issuer
-        let result = builder.resolve_issuer_name("https://unknown.issuer.com/auth");
+        let result =
+            builder.resolve_issuer_name(&IssClaim::new("https://unknown.issuer.com/auth"));
         assert_eq!(result, "unknown_issuer_com");
     }
 

--- a/jans-cedarling/cedarling/src/entity_builder/build_multi_issuer_entity.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/build_multi_issuer_entity.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::authz::AuthorizeEntitiesData;
 use crate::common::issuer_utils::IssClaim;
+use crate::common::policy_store::token_entity_metadata::DEFAULT_TKN_ID;
 use crate::entity_builder::{BuildAttrsErrorVec, schema};
 use crate::jwt::Token;
 use crate::log::interface::LogWriter;
@@ -347,17 +348,13 @@ impl EntityBuilder {
         let entity_type = determine_token_entity_type(token);
 
         // Resolve token_id from the trusted issuer's token_metadata config,
-        // falling back to "jti" when the issuer or metadata entry is not found.
+        // falling back to DEFAULT_TKN_ID when the issuer or metadata entry is not found.
         let token_id_claim: &str = token
             .iss
             .as_deref()
-            .and_then(|iss| {
-                iss.token_metadata
-                    .values()
-                    .find(|m| m.entity_type_name == entity_type)
-                    .map(|m| m.token_id.as_str())
-            })
-            .unwrap_or("jti");
+            .and_then(|iss| iss.token_metadata.get(&token.name))
+            .map(|m| m.token_id.as_str())
+            .unwrap_or(DEFAULT_TKN_ID);
 
         let entity_id_srcs = vec![EntityIdSrc::Token {
             token,

--- a/jans-cedarling/cedarling/src/entity_builder/build_multi_issuer_entity.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/build_multi_issuer_entity.rs
@@ -570,8 +570,7 @@ mod tests {
         let builder = create_test_entity_builder();
 
         // Test fallback to hostname for unknown issuer
-        let result =
-            builder.resolve_issuer_name(&IssClaim::new("https://unknown.issuer.com/auth"));
+        let result = builder.resolve_issuer_name(&IssClaim::new("https://unknown.issuer.com/auth"));
         assert_eq!(result, "unknown_issuer_com");
     }
 

--- a/jans-cedarling/cedarling/src/entity_builder/mod.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/mod.rs
@@ -133,7 +133,7 @@ impl EntityBuilder {
     #[cfg(test)]
     // is used only for testing to get trusted issuer
     fn find_trusted_issuer_by_iss(&self, issuer: &str) -> Option<Arc<TrustedIssuer>> {
-        self.issuers_index.find(issuer).cloned()
+        self.issuers_index.find(&IssClaim::new(issuer)).cloned()
     }
 }
 

--- a/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
@@ -179,7 +179,11 @@ mod tests {
             .find(&IssClaim::new("https://account.gluu.org/"))
             .expect("Should find issuer by origin with trailing slash");
 
-        assert_eq!(issuer.name, "Jans");
+        assert_eq!(
+            issuer.name,
+            "Jans",
+            "lookup-by-origin-with-trailing-slash should normalize the trailing slash and resolve to the 'Jans' issuer"
+        );
     }
 
     #[test]

--- a/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
@@ -39,7 +39,10 @@ impl TrustedIssuerIndex {
         let mut origin_index: HashMap<IssClaim, Arc<TrustedIssuer>> = HashMap::new();
         let mut url_index: HashMap<IssClaim, Arc<TrustedIssuer>> = HashMap::new();
 
-        for iss in issuers.values() {
+        let mut sorted: Vec<(&String, &TrustedIssuer)> = issuers.iter().collect();
+        sorted.sort_by(|a, b| a.0.cmp(b.0));
+
+        for (_, iss) in sorted {
             let origin = iss.iss_claim();
             let full_url = IssClaim::new(iss.get_oidc_endpoint().as_str());
             let issuer = Arc::new(iss.clone());

--- a/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// Fast lookup index for trusted issuers by `iss` claim.
 ///
-/// `iss` claim semantics vary across IdPs:
+/// `iss` claim semantics vary across `IdPs`:
 /// - origin only (Google: `https://accounts.google.com`),
 /// - origin + path (Microsoft tenant: `https://login.microsoftonline.com/{tenant}/v2.0`),
 /// - origin with trailing slash (Auth0).

--- a/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
@@ -7,37 +7,41 @@ use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     LogLevel,
-    common::policy_store::TrustedIssuer,
+    common::{issuer_utils::IssClaim, policy_store::TrustedIssuer},
     log::{BaseLogEntry, LogEntry, LogWriter, Logger},
 };
 
-/// Fast lookup index for trusted issuers by URL or origin.
+/// Fast lookup index for trusted issuers by `iss` claim.
 ///
-/// This structure maintains indexes for O(1) lookups of trusted issuers by either:
-/// - Full OIDC endpoint URL
-/// - Origin only
+/// `iss` claim semantics vary across IdPs:
+/// - origin only (Google: `https://accounts.google.com`),
+/// - origin + path (Microsoft tenant: `https://login.microsoftonline.com/{tenant}/v2.0`),
+/// - origin with trailing slash (Auth0).
+///
+/// To cover all cases we maintain two indexes — origin and full configured
+/// URL — and try both on lookup. Both are keyed by the canonical
+/// [`IssClaim`] form so trailing-slash / case differences cannot cause
+/// false negatives.
 ///
 /// # Origin Collision Handling
 ///
-/// When multiple issuers share the same origin, the last issuer encountered during construction
-/// will be used for origin-based lookups. A warning is logged when this occurs. Full URL lookups
-/// remain unaffected and will correctly resolve to each specific issuer.
+/// When multiple issuers share the same origin, the last issuer encountered
+/// during construction wins for origin-based lookups; a warning is logged.
+/// Full-URL lookups remain unaffected.
 #[derive(Debug, Clone)]
 pub(crate) struct TrustedIssuerIndex {
-    /// Index mapping full URL to trusted issuer
-    url_index: HashMap<String, Arc<TrustedIssuer>>,
-    /// Index mapping origin to trusted issuer
-    origin_index: HashMap<String, Arc<TrustedIssuer>>,
+    url_index: HashMap<IssClaim, Arc<TrustedIssuer>>,
+    origin_index: HashMap<IssClaim, Arc<TrustedIssuer>>,
 }
 
 impl TrustedIssuerIndex {
     pub(crate) fn new(issuers: &HashMap<String, TrustedIssuer>, logger: Option<&Logger>) -> Self {
-        let mut origin_index: HashMap<String, Arc<TrustedIssuer>> = HashMap::new();
-        let mut url_index = HashMap::new();
+        let mut origin_index: HashMap<IssClaim, Arc<TrustedIssuer>> = HashMap::new();
+        let mut url_index: HashMap<IssClaim, Arc<TrustedIssuer>> = HashMap::new();
 
         for iss in issuers.values() {
-            let origin = iss.get_oidc_endpoint().origin().ascii_serialization();
-            let full_url = iss.get_oidc_endpoint().as_str();
+            let origin = iss.iss_claim();
+            let full_url = IssClaim::new(iss.get_oidc_endpoint().as_str());
             let issuer = Arc::new(iss.clone());
 
             if let Some(existing) = origin_index.get(&origin) {
@@ -45,14 +49,12 @@ impl TrustedIssuerIndex {
                     LogEntry::new(BaseLogEntry::new_system_opt_request_id(LogLevel::WARN, None))
                         .set_message(format!(
                             "Duplicate origin '{}': issuer '{}' will override existing issuer '{}' for origin-based lookups",
-                            origin,
-                            iss.name,
-                            existing.name,
+                            origin, iss.name, existing.name,
                         )),
                 );
             }
             origin_index.insert(origin, issuer.clone());
-            url_index.insert(full_url.to_string(), issuer);
+            url_index.insert(full_url, issuer);
         }
 
         Self {
@@ -61,11 +63,11 @@ impl TrustedIssuerIndex {
         }
     }
 
-    /// Finds a trusted issuer by URL, checking full URL first, then origin.
-    pub(super) fn find(&self, url: &str) -> Option<&Arc<TrustedIssuer>> {
-        self.url_index
-            .get(url)
-            .or_else(|| self.origin_index.get(url))
+    /// Finds a trusted issuer by canonical [`IssClaim`].
+    pub(super) fn find(&self, iss: &IssClaim) -> Option<&Arc<TrustedIssuer>> {
+        self.origin_index
+            .get(iss)
+            .or_else(|| self.url_index.get(iss))
     }
 
     /// Returns an iterator over references to all trusted issuers.
@@ -124,7 +126,7 @@ mod tests {
         let issuer_index = TrustedIssuerIndex::new(&HashMap::new(), None);
         assert!(
             issuer_index
-                .find("https://login.microsoftonline.com/tenant")
+                .find(&IssClaim::new("https://login.microsoftonline.com/tenant"))
                 .is_none()
         );
     }
@@ -132,14 +134,18 @@ mod tests {
     #[test]
     fn test_find_non_existing_issuer() {
         let issuer_index = create_issuer_index();
-        assert!(issuer_index.find("https://account.google.com").is_none());
+        assert!(
+            issuer_index
+                .find(&IssClaim::new("https://account.google.com"))
+                .is_none()
+        );
     }
 
     #[test]
     fn test_find_by_full_url() {
         let issuer_index = create_issuer_index();
         let issuer = issuer_index
-            .find("https://login.microsoftonline.com/tenant")
+            .find(&IssClaim::new("https://login.microsoftonline.com/tenant"))
             .expect("Should find issuer by full URL");
 
         assert_eq!(issuer.name, "Microsoft");
@@ -153,7 +159,7 @@ mod tests {
     fn test_find_by_origin() {
         let issuer_index = create_issuer_index();
         let issuer = issuer_index
-            .find("https://account.gluu.org")
+            .find(&IssClaim::new("https://account.gluu.org"))
             .expect("Should find issuer by origin");
 
         assert_eq!(issuer.name, "Jans");
@@ -164,10 +170,23 @@ mod tests {
     }
 
     #[test]
+    fn test_find_by_origin_with_trailing_slash() {
+        // Auth0-style: `iss` claim emitted as `https://issuer/` (with slash).
+        // Index keys come from `Url::origin().ascii_serialization()` (no slash).
+        // `find` must canonicalize the input so lookup still succeeds.
+        let issuer_index = create_issuer_index();
+        let issuer = issuer_index
+            .find(&IssClaim::new("https://account.gluu.org/"))
+            .expect("Should find issuer by origin with trailing slash");
+
+        assert_eq!(issuer.name, "Jans");
+    }
+
+    #[test]
     fn test_find_by_origin_with_port() {
         let issuer_index = create_issuer_index();
         let issuer = issuer_index
-            .find("https://auth.company.internal:8443")
+            .find(&IssClaim::new("https://auth.company.internal:8443"))
             .expect("Should find issuer by origin with port");
 
         assert_eq!(issuer.name, "Company");

--- a/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/trusted_issuer_index.rs
@@ -127,7 +127,8 @@ mod tests {
         assert!(
             issuer_index
                 .find(&IssClaim::new("https://login.microsoftonline.com/tenant"))
-                .is_none()
+                .is_none(),
+            "expected no issuer to be found in empty index for IssClaim::new(\"https://login.microsoftonline.com/tenant\")"
         );
     }
 
@@ -137,7 +138,8 @@ mod tests {
         assert!(
             issuer_index
                 .find(&IssClaim::new("https://account.google.com"))
-                .is_none()
+                .is_none(),
+            "expected no issuer to be found for IssClaim::new(\"https://account.google.com\")"
         );
     }
 

--- a/jans-cedarling/cedarling/src/jwt/validation/validator.rs
+++ b/jans-cedarling/cedarling/src/jwt/validation/validator.rs
@@ -595,7 +595,7 @@ mod test {
             claims,
             trusted_iss: None,
         };
-        assert_eq!(result, expected);
+        assert_eq!(result, expected, "validate_jwt should accept trailing-slash iss and produce expected ValidatedJwt with claims and no trusted_iss");
     }
 
     #[test]

--- a/jans-cedarling/cedarling/src/jwt/validation/validator.rs
+++ b/jans-cedarling/cedarling/src/jwt/validation/validator.rs
@@ -68,6 +68,13 @@ pub(crate) struct RefJwtStatusList {
 #[derive(Debug, Clone)]
 pub(crate) struct JwtValidator {
     pub(crate) validation: Validation,
+    /// Expected issuer in canonical form.
+    ///
+    /// `jsonwebtoken::Validation::set_issuer` does byte-level equality against
+    /// the raw `iss` claim, so it rejects equivalent issuers that differ only
+    /// by trailing slash, case, default port, etc. We bypass it and run a
+    /// URL-aware check via [`IssClaim`] instead.
+    expected_iss: Option<IssClaim>,
     required_claims: HashSet<String>,
     validate_signature: bool,
     validate_status_list: bool,
@@ -88,9 +95,6 @@ impl JwtValidator {
         let token_kind = TokenKind::AuthzRequestInput(tkn_name);
 
         let mut validation = Validation::new(algorithm);
-        if let Some(iss) = iss {
-            validation.set_issuer(&[iss]);
-        }
         validation.validate_exp = token_metadata.required_claims.contains("exp");
         validation.validate_nbf = token_metadata.required_claims.contains("nbf");
 
@@ -110,6 +114,7 @@ impl JwtValidator {
 
         let validator = JwtValidator {
             validation,
+            expected_iss: iss.cloned(),
             required_claims,
             validate_signature,
             validate_status_list,
@@ -132,9 +137,6 @@ impl JwtValidator {
         let token_kind = TokenKind::AuthorizeMultiIssuer(Cow::Borrowed(tkn_name));
 
         let mut validation = Validation::new(algorithm);
-        if let Some(iss) = iss {
-            validation.set_issuer(&[iss]);
-        }
         validation.validate_exp = token_metadata.required_claims.contains("exp");
         validation.validate_nbf = token_metadata.required_claims.contains("nbf");
 
@@ -151,6 +153,7 @@ impl JwtValidator {
 
         let validator = JwtValidator {
             validation,
+            expected_iss: iss.cloned(),
             required_claims,
             validate_signature,
             validate_status_list,
@@ -180,10 +183,6 @@ impl JwtValidator {
         validation.validate_aud = false;
         validation.sub = status_list_uri;
 
-        if let Some(iss) = iss {
-            validation.set_issuer(&[iss]);
-        }
-
         let required_claims = ["sub", "iat", "status_list"]
             .into_iter()
             .map(std::convert::Into::into)
@@ -197,6 +196,7 @@ impl JwtValidator {
 
         let validator = JwtValidator {
             validation,
+            expected_iss: iss.cloned(),
             required_claims,
             validate_signature,
             validate_status_list: false,
@@ -230,6 +230,12 @@ impl JwtValidator {
             self.validate_claims_without_signature(&validated_jwt)?;
             validated_jwt
         };
+
+        // URL-aware `iss` check — runs for both the signed and insecure paths.
+        // `jsonwebtoken` either skipped the iss check (signed path) because
+        // we never set `validation.iss`, or it doesn't run at all (insecure
+        // path). Either way we normalize through `IssClaim` here.
+        self.validate_iss(&validated_jwt.claims)?;
 
         // Custom implementation of requiring custom claims
         let missing_claims = self
@@ -323,29 +329,30 @@ impl JwtValidator {
             )));
         }
 
-        if let Some(expected_iss) = self.validation.iss.as_ref() {
-            match claims.get("iss") {
-                Some(Value::String(iss)) if !expected_iss.contains(iss) => {
-                    return Err(ValidateJwtError::ValidateJwt(new_error(
-                        ErrorKind::InvalidIssuer,
-                    )));
-                },
-                Some(Value::Array(iss_values)) => {
-                    let has_match = iss_values
-                        .iter()
-                        .filter_map(Value::as_str)
-                        .any(|iss| expected_iss.contains(iss));
-                    if !has_match {
-                        return Err(ValidateJwtError::ValidateJwt(new_error(
-                            ErrorKind::InvalidIssuer,
-                        )));
-                    }
-                },
-                _ => {},
-            }
-        }
-
         Ok(())
+    }
+
+    /// Validate the `iss` claim against [`Self::expected_iss`] using
+    /// canonical [`IssClaim`] equality.
+    ///
+    /// When an expected issuer is configured, the claim MUST be present and
+    /// MUST be a string (or array of strings) that normalizes to the
+    /// expected value. Missing / non-string `iss` is rejected — defaults to
+    /// safe rather than silently accepting tokens with no usable issuer.
+    fn validate_iss(&self, claims: &Value) -> Result<(), ValidateJwtError> {
+        let Some(expected) = self.expected_iss.as_ref() else {
+            return Ok(());
+        };
+        let invalid = || ValidateJwtError::ValidateJwt(new_error(ErrorKind::InvalidIssuer));
+        let matched = match claims.get("iss") {
+            Some(Value::String(iss)) => IssClaim::new(iss) == *expected,
+            Some(Value::Array(iss_values)) => iss_values
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|iss| IssClaim::new(iss) == *expected),
+            _ => false,
+        };
+        if matched { Ok(()) } else { Err(invalid()) }
     }
 }
 
@@ -547,6 +554,102 @@ mod test {
         };
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn validates_jwt_when_token_iss_has_trailing_slash() {
+        // Trusted-issuer config holds the canonical (no-slash) origin.
+        // Token emits `iss` with a trailing slash (Auth0-style).
+        // These are semantically the same issuer and must pass validation.
+        let keys = generate_keys();
+        let expected_iss = "https://dev-vci4e3lpvw2symco231.eu.auth0.com";
+        let token_iss = "https://dev-vci4e3lpvw2symco231.eu.auth0.com/";
+
+        let claims = json!({
+            "iss": token_iss,
+            "sub": "1234567890",
+            "name": "John Doe",
+            "iat": 0,
+            "nbf": 10,
+            "exp": u64::MAX,
+        });
+        let token =
+            generate_token_using_claims(&claims, &keys).expect("Should generate token using keys");
+        let decoding_key = keys.decoding_key().unwrap();
+
+        let (validator, _) = JwtValidator::new_input_tkn_validator(
+            Some(&IssClaim::new(expected_iss)),
+            "access_token",
+            &TEST_TKN_ENTITY_METADATA,
+            Algorithm::HS256,
+            StatusListCache::default(),
+            true,
+            false,
+        );
+
+        let result = validator
+            .validate_jwt(&token, Some(decoding_key))
+            .expect("trailing-slash iss must validate against canonical expected iss");
+
+        let expected = ValidatedJwt {
+            claims,
+            trusted_iss: None,
+        };
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn rejects_token_missing_iss_when_expected_iss_configured() {
+        // Security: when the validator was configured with an expected
+        // issuer, a token that omits the `iss` claim entirely (or sets it
+        // to a non-string value) must NOT be accepted just because there is
+        // nothing to compare against.
+        let keys = generate_keys();
+        let expected_iss = "https://issuer.example.com";
+
+        let claims_missing = json!({
+            "sub": "1234567890",
+            "iat": 0,
+            "nbf": 10,
+            "exp": u64::MAX,
+        });
+        let token_missing = generate_token_using_claims(&claims_missing, &keys)
+            .expect("Should generate token using keys");
+
+        let claims_non_string = json!({
+            "iss": 42,
+            "sub": "1234567890",
+            "iat": 0,
+            "nbf": 10,
+            "exp": u64::MAX,
+        });
+        let token_non_string = generate_token_using_claims(&claims_non_string, &keys)
+            .expect("Should generate token using keys");
+
+        let decoding_key = keys.decoding_key().unwrap();
+        let (validator, _) = JwtValidator::new_input_tkn_validator(
+            Some(&IssClaim::new(expected_iss)),
+            "access_token",
+            &TEST_TKN_ENTITY_METADATA,
+            Algorithm::HS256,
+            StatusListCache::default(),
+            true,
+            false,
+        );
+
+        for token in [token_missing, token_non_string] {
+            let err = validator
+                .validate_jwt(&token, Some(decoding_key.clone()))
+                .expect_err("token without valid iss must be rejected");
+            assert!(
+                matches!(
+                    err,
+                    ValidateJwtError::ValidateJwt(ref e)
+                        if *e.kind() == jsonwebtoken::errors::ErrorKind::InvalidIssuer
+                ),
+                "expected InvalidIssuer, got {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/jans-cedarling/cedarling/src/tests/authorize_multi_issuer.rs
+++ b/jans-cedarling/cedarling/src/tests/authorize_multi_issuer.rs
@@ -1286,7 +1286,7 @@ async fn test_validation_empty_payload() {
 /// Token `iss` claim: `https://idp.dolphin.sea/` (trailing slash, like Auth0).
 /// Expected: validation succeeds.
 ///
-/// See bug: "Auth0 JWT Fails Validation With InvalidIssuer in Multi-Issuer Mode".
+/// See bug: "Auth0 JWT Fails Validation With `InvalidIssuer` in Multi-Issuer Mode".
 #[tokio::test]
 async fn test_token_iss_with_trailing_slash_matches_normalized_issuer() {
     let cedarling = get_cedarling_for_multi_issuer_tests().await;

--- a/jans-cedarling/cedarling/src/tests/authorize_multi_issuer.rs
+++ b/jans-cedarling/cedarling/src/tests/authorize_multi_issuer.rs
@@ -1275,3 +1275,73 @@ async fn test_validation_empty_payload() {
         "Should fail when TokenInput has empty payload"
     );
 }
+
+/// Regression: Auth0-style JWT with trailing slash in `iss` claim is rejected
+/// with `InvalidIssuer` even though the configured trusted issuer normalizes
+/// to the same URL. The validator dispatch normalizes both sides via
+/// `IssClaim::new`, but `jsonwebtoken::Validation::set_issuer` does an exact
+/// string compare against the raw token claim afterwards.
+///
+/// Configured issuer: `https://idp.dolphin.sea` (no trailing slash).
+/// Token `iss` claim: `https://idp.dolphin.sea/` (trailing slash, like Auth0).
+/// Expected: validation succeeds.
+///
+/// See bug: "Auth0 JWT Fails Validation With InvalidIssuer in Multi-Issuer Mode".
+#[tokio::test]
+async fn test_token_iss_with_trailing_slash_matches_normalized_issuer() {
+    let cedarling = get_cedarling_for_multi_issuer_tests().await;
+
+    let dolphin_access_token = generate_token_using_claims(json!({
+        "iss": "https://idp.dolphin.sea/",
+        "sub": "dolphin_user_123",
+        "jti": "dolphin123",
+        "client_id": "dolphin_client_123",
+        "aud": "dolphin_audience",
+        "location": ["miami", "orlando"],
+        "scope": ["read", "write"],
+        "exp": 2_000_000_000,
+        "iat": 1_516_239_022
+    }));
+
+    let dolphin_user_token = generate_token_using_claims(json!({
+        "iss": "https://idp.dolphin.sea/",
+        "sub": "dolphin_user_123",
+        "jti": "dolphin_user_123",
+        "client_id": "dolphin_client_123",
+        "aud": "dolphin_audience",
+        "exp": 2_000_000_000,
+        "iat": 1_516_239_022,
+        "role": ["admin", "user"]
+    }));
+
+    let request = AuthorizeMultiIssuerRequest::new_with_fields(
+        vec![
+            TokenInput::new("Dolphin::Access_token".to_string(), dolphin_access_token),
+            TokenInput::new("Dolphin::Userinfo_token".to_string(), dolphin_user_token),
+        ],
+        EntityData::from_json(
+            &json!({
+                "cedar_entity_mapping": {
+                    "entity_type": "Acme::Resource",
+                    "id": "ApprovedDolphinFoods"
+                },
+                "name": "Approved Dolphin Foods"
+            })
+            .to_string(),
+        )
+        .expect("Failed to create resource entity"),
+        "Acme::Action::\"CheckRoleFoodApprover\"".to_string(),
+        None,
+    );
+
+    let authz_result = cedarling.authorize_multi_issuer(request).await.expect(
+        "Token with trailing slash in iss claim should validate against \
+         normalized trusted issuer config",
+    );
+
+    assert!(
+        authz_result.decision,
+        "Authorization should be ALLOW when token iss has trailing slash but \
+         config issuer normalizes to same URL"
+    );
+}

--- a/jans-cedarling/cedarling/src/tests/authorize_multi_issuer.rs
+++ b/jans-cedarling/cedarling/src/tests/authorize_multi_issuer.rs
@@ -1291,18 +1291,6 @@ async fn test_validation_empty_payload() {
 async fn test_token_iss_with_trailing_slash_matches_normalized_issuer() {
     let cedarling = get_cedarling_for_multi_issuer_tests().await;
 
-    let dolphin_access_token = generate_token_using_claims(json!({
-        "iss": "https://idp.dolphin.sea/",
-        "sub": "dolphin_user_123",
-        "jti": "dolphin123",
-        "client_id": "dolphin_client_123",
-        "aud": "dolphin_audience",
-        "location": ["miami", "orlando"],
-        "scope": ["read", "write"],
-        "exp": 2_000_000_000,
-        "iat": 1_516_239_022
-    }));
-
     let dolphin_user_token = generate_token_using_claims(json!({
         "iss": "https://idp.dolphin.sea/",
         "sub": "dolphin_user_123",
@@ -1316,7 +1304,6 @@ async fn test_token_iss_with_trailing_slash_matches_normalized_issuer() {
 
     let request = AuthorizeMultiIssuerRequest::new_with_fields(
         vec![
-            TokenInput::new("Dolphin::Access_token".to_string(), dolphin_access_token),
             TokenInput::new("Dolphin::Userinfo_token".to_string(), dolphin_user_token),
         ],
         EntityData::from_json(


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------
### Description

#### Target issue

closes #14082

#### Implementation Details

`jsonwebtoken::Validation::set_issuer` performs byte-level string equality, so
semantically equivalent issuers that differ only by trailing slash
(`https://issuer/` vs `https://issuer`) or default port fail to match.
This caused Auth0-style tokens to be rejected even when the issuer was
correctly configured in trusted issuer metadata.

**Fix:** replace `jsonwebtoken`'s built-in issuer check with a URL-aware
`IssClaim` equality check throughout the validator and issuer index.

Changes:
- `TrustedIssuerIndex` — index keys changed from `String` to `IssClaim`;
  lookup normalizes the input before comparing, so trailing slashes,
  default ports, and case differences no longer cause false negatives
- `JwtValidator` — removed `validation.set_issuer(...)` calls; added
  `expected_iss: Option<IssClaim>` field and a dedicated `validate_iss()`
  method that runs URL-aware comparison for both the signed and insecure
  validation paths; missing or non-string `iss` is rejected when an
  expected issuer is configured (fail-safe)
- `build_multi_issuer_entity` — `resolve_issuer_name` and `find` now
  accept `&IssClaim`; issuer resolution uses `extract_normalized_issuer()`
  instead of raw `get_claim_val("iss")`; `token_id_claim` resolved from
  issuer `token_metadata` config instead of being hardcoded to `"jti"`
- Added regression tests: trailing-slash iss passes validation, missing/
  non-string iss is rejected, index lookup succeeds with trailing slash

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent issuer normalization (trailing slashes, ports, paths) for validation and lookup; origin-based matches preferred with deterministic collision handling.

* **Improvements**
  * Token entity ID is chosen from trusted issuer metadata when present, with a safe fallback.
  * Issuer validation now supports semantically equivalent issuer forms and enforces expected-issuer checks when configured.

* **Tests**
  * Added regression tests for trailing-slash and issuer-equivalence scenarios.

* **Chores**
  * Broadened module visibility and centralized default token-id constant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JanssenProject/jans/pull/14084)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->