### PR TITLE
fix(jans-auth-server): added request_uri validation in AuthorizeAction.getRequestedClaims

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -74,6 +74,7 @@ import java.net.URLEncoder;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static io.jans.as.server.service.AcrService.isAgama;
 import static io.jans.as.server.service.DeviceAuthorizationService.SESSION_USER_CODE;
@@ -89,6 +90,14 @@ import static org.apache.commons.lang3.BooleanUtils.isTrue;
 public class AuthorizeAction {
 
     public static final String UNKNOWN = "Unknown";
+
+    private static final class RequestUriHttpClientHolder {
+        private static final jakarta.ws.rs.client.Client INSTANCE = ClientBuilder.newBuilder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
+    }
+
     @Inject
     private Logger log;
 
@@ -624,17 +633,34 @@ public class AuthorizeAction {
 
             return fetchRequestUriContent(reqUriWithoutFragment, reqUriHash);
         } catch (WebApplicationException e) {
-            log.error("request_uri is forbidden by client allowlist or block list: " + requestUri, e);
+            log.warn("request_uri is forbidden by client allowlist or block list, clientId = {}, host = {}",
+                    clientId, safeHost(requestUri));
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }
         return null;
     }
 
-    protected String fetchRequestUriContent(String reqUriWithoutFragment, String reqUriHash) throws NoSuchAlgorithmException, NoSuchProviderException {
-        jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newClient();
+    private static String safeHost(String uri) {
+        if (StringUtils.isBlank(uri)) {
+            return "";
+        }
         try {
-            Response clientResponse = clientRequest.target(reqUriWithoutFragment).request().buildGet().invoke();
+            URI parsed = new URI(uri);
+            String scheme = parsed.getScheme();
+            String host = parsed.getHost();
+            int port = parsed.getPort();
+            if (scheme == null || host == null) {
+                return "[unparseable]";
+            }
+            return scheme + "://" + host + (port > 0 ? ":" + port : "");
+        } catch (Exception e) {
+            return "[unparseable]";
+        }
+    }
+
+    protected String fetchRequestUriContent(String reqUriWithoutFragment, String reqUriHash) throws NoSuchAlgorithmException, NoSuchProviderException {
+        try (Response clientResponse = RequestUriHttpClientHolder.INSTANCE.target(reqUriWithoutFragment).request().buildGet().invoke()) {
             if (clientResponse.getStatus() != 200) {
                 return null;
             }
@@ -644,8 +670,6 @@ public class AuthorizeAction {
             }
             String hash = Base64Util.base64urlencode(JwtUtil.getMessageDigestSHA256(entity));
             return StringUtils.equals(reqUriHash, hash) ? entity : null;
-        } finally {
-            clientRequest.close();
         }
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -6,13 +6,13 @@
 
 package io.jans.as.server.authorize.ws.rs;
 
-import io.jans.as.model.authzdetails.AuthzDetail;
-import io.jans.as.model.authzdetails.AuthzDetails;
 import io.jans.as.common.model.common.User;
 import io.jans.as.common.model.registration.Client;
 import io.jans.as.common.model.session.SessionId;
 import io.jans.as.common.model.session.SessionIdState;
 import io.jans.as.model.authorize.AuthorizeErrorResponseType;
+import io.jans.as.model.authzdetails.AuthzDetail;
+import io.jans.as.model.authzdetails.AuthzDetails;
 import io.jans.as.model.common.Prompt;
 import io.jans.as.model.common.SubjectType;
 import io.jans.as.model.configuration.AppConfiguration;
@@ -71,6 +71,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.util.*;
 
 import static io.jans.as.server.service.AcrService.isAgama;
@@ -564,66 +566,87 @@ public class AuthorizeAction {
     }
 
     public List<String> getRequestedClaims() {
-        Set<String> result = new HashSet<String>();
-        String requestJwt = request;
-
-        if (StringUtils.isBlank(requestJwt) && StringUtils.isNotBlank(requestUri)) {
-            try {
-                URI reqUri = new URI(requestUri);
-                String reqUriHash = reqUri.getFragment();
-                String reqUriWithoutFragment = reqUri.getScheme() + ":" + reqUri.getSchemeSpecificPart();
-
-                jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newClient();
-                try {
-                    Response clientResponse = clientRequest.target(reqUriWithoutFragment).request().buildGet().invoke();
-                    clientRequest.close();
-
-                    int status = clientResponse.getStatus();
-                    if (status == 200) {
-                        String entity = clientResponse.readEntity(String.class);
-
-                        if (StringUtils.isBlank(reqUriHash)) {
-                            requestJwt = entity;
-                        } else {
-                            String hash = Base64Util.base64urlencode(JwtUtil.getMessageDigestSHA256(entity));
-                            if (StringUtils.equals(reqUriHash, hash)) {
-                                requestJwt = entity;
-                            }
-                        }
-                    }
-                } finally {
-                    clientRequest.close();
-                }
-            } catch (Exception e) {
-                log.error(e.getMessage(), e);
-            }
+        Set<String> result = new HashSet<>();
+        Client client = loadClient();
+        if (client == null) {
+            return new ArrayList<>(result);
         }
 
-        if (StringUtils.isNotBlank(requestJwt)) {
-            try {
-                Client client = clientService.getClient(clientId);
+        String requestJwt = request;
+        if (StringUtils.isBlank(requestJwt) && StringUtils.isNotBlank(requestUri)) {
+            requestJwt = fetchRequestJwt(client);
+        }
 
-                if (client != null) {
-                    JwtAuthorizationRequest jwtAuthorizationRequest = new JwtAuthorizationRequest(appConfiguration, cryptoProvider, request, client);
+        if (StringUtils.isBlank(requestJwt)) {
+            return new ArrayList<>(result);
+        }
 
-                    if (jwtAuthorizationRequest.getUserInfoMember() != null) {
-                        for (Claim claim : jwtAuthorizationRequest.getUserInfoMember().getClaims()) {
-                            result.add(claim.getName());
-                        }
-                    }
+        try {
+            JwtAuthorizationRequest jwtAuthorizationRequest = new JwtAuthorizationRequest(appConfiguration, cryptoProvider, requestJwt, client);
 
-                    if (jwtAuthorizationRequest.getIdTokenMember() != null) {
-                        for (Claim claim : jwtAuthorizationRequest.getIdTokenMember().getClaims()) {
-                            result.add(claim.getName());
-                        }
-                    }
+            if (jwtAuthorizationRequest.getUserInfoMember() != null) {
+                for (Claim claim : jwtAuthorizationRequest.getUserInfoMember().getClaims()) {
+                    result.add(claim.getName());
                 }
-            } catch (EntryPersistenceException | InvalidJwtException e) {
-                log.error(e.getMessage(), e);
             }
+
+            if (jwtAuthorizationRequest.getIdTokenMember() != null) {
+                for (Claim claim : jwtAuthorizationRequest.getIdTokenMember().getClaims()) {
+                    result.add(claim.getName());
+                }
+            }
+        } catch (InvalidJwtException e) {
+            log.error(e.getMessage(), e);
         }
 
         return new ArrayList<>(result);
+    }
+
+    private Client loadClient() {
+        if (StringUtils.isBlank(clientId)) {
+            return null;
+        }
+        try {
+            return clientService.getClient(clientId);
+        } catch (EntryPersistenceException e) {
+            log.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private String fetchRequestJwt(Client client) {
+        try {
+            JwtAuthorizationRequest.validateRequestUri(requestUri, client, appConfiguration, state, errorResponseFactory);
+
+            URI reqUri = new URI(requestUri);
+            String reqUriHash = reqUri.getFragment();
+            String reqUriWithoutFragment = reqUri.getScheme() + ":" + reqUri.getSchemeSpecificPart();
+
+            return fetchRequestUriContent(reqUriWithoutFragment, reqUriHash);
+        } catch (WebApplicationException e) {
+            log.error("request_uri is forbidden by client allowlist or block list: " + requestUri, e);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+        return null;
+    }
+
+    protected String fetchRequestUriContent(String reqUriWithoutFragment, String reqUriHash) throws NoSuchAlgorithmException, NoSuchProviderException {
+        jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newClient();
+        try {
+            Response clientResponse = clientRequest.target(reqUriWithoutFragment).request().buildGet().invoke();
+            if (clientResponse.getStatus() != 200) {
+                return null;
+            }
+            String entity = clientResponse.readEntity(String.class);
+            if (StringUtils.isBlank(reqUriHash)) {
+                return entity;
+            }
+            String hash = Base64Util.base64urlencode(JwtUtil.getMessageDigestSHA256(entity));
+            return StringUtils.equals(reqUriHash, hash) ? entity : null;
+        } finally {
+            clientRequest.close();
+        }
     }
 
     /**

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -691,16 +691,23 @@ public class AuthorizeAction {
     }
 
     protected String fetchRequestUriContent(String reqUriWithoutFragment, String reqUriHash) throws NoSuchAlgorithmException, NoSuchProviderException {
-        try (Response clientResponse = RequestUriHttpClientHolder.INSTANCE.target(reqUriWithoutFragment).request().buildGet().invoke()) {
+        String entity = httpGet(reqUriWithoutFragment);
+        if (entity == null) {
+            return null;
+        }
+        if (StringUtils.isBlank(reqUriHash)) {
+            return entity;
+        }
+        String hash = Base64Util.base64urlencode(JwtUtil.getMessageDigestSHA256(entity));
+        return StringUtils.equals(reqUriHash, hash) ? entity : null;
+    }
+
+    String httpGet(String url) {
+        try (Response clientResponse = RequestUriHttpClientHolder.INSTANCE.target(url).request().buildGet().invoke()) {
             if (clientResponse.getStatus() != 200) {
                 return null;
             }
-            String entity = clientResponse.readEntity(String.class);
-            if (StringUtils.isBlank(reqUriHash)) {
-                return entity;
-            }
-            String hash = Base64Util.base64urlencode(JwtUtil.getMessageDigestSHA256(entity));
-            return StringUtils.equals(reqUriHash, hash) ? entity : null;
+            return clientResponse.readEntity(String.class);
         }
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -94,7 +94,7 @@ public class AuthorizeAction {
     private static final class RequestUriHttpClientHolder {
         private static final jakarta.ws.rs.client.Client INSTANCE = ClientBuilder.newBuilder()
                 .connectTimeout(5, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
                 .build();
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -28,9 +28,7 @@ import io.jans.as.persistence.model.Scope;
 import io.jans.as.server.auth.Authenticator;
 import io.jans.as.server.i18n.LanguageBean;
 import io.jans.as.server.model.auth.AuthenticationMode;
-import io.jans.as.server.model.authorize.Claim;
-import io.jans.as.server.model.authorize.JwtAuthorizationRequest;
-import io.jans.as.server.model.authorize.ScopeChecker;
+import io.jans.as.server.model.authorize.*;
 import io.jans.as.server.model.common.CibaRequestCacheControl;
 import io.jans.as.server.model.common.DefaultScope;
 import io.jans.as.server.model.common.ExecutionContext;
@@ -65,6 +63,8 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.util.Strings;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -587,6 +587,8 @@ public class AuthorizeAction {
             return requestedClaims;
         }
 
+        populateFromStandaloneClaims(result);
+
         String requestJwt = request;
         if (StringUtils.isBlank(requestJwt) && StringUtils.isNotBlank(requestUri)) {
             requestJwt = fetchRequestJwt(client);
@@ -628,6 +630,27 @@ public class AuthorizeAction {
         } catch (EntryPersistenceException e) {
             log.error(e.getMessage(), e);
             return null;
+        }
+    }
+
+    private void populateFromStandaloneClaims(Set<String> result) {
+        if (StringUtils.isBlank(claims)) {
+            return;
+        }
+        try {
+            JSONObject claimsJson = new JSONObject(claims);
+            if (claimsJson.has("userinfo")) {
+                for (Claim claim : new UserInfoMember(claimsJson.getJSONObject("userinfo")).getClaims()) {
+                    result.add(claim.getName());
+                }
+            }
+            if (claimsJson.has("id_token")) {
+                for (Claim claim : new IdTokenMember(claimsJson.getJSONObject("id_token")).getClaims()) {
+                    result.add(claim.getName());
+                }
+            }
+        } catch (JSONException e) {
+            log.error(e.getMessage(), e);
         }
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -223,6 +223,7 @@ public class AuthorizeAction {
     private String sessionId;
 
     private String allowedScope;
+    private List<String> requestedClaims;
     private AuthzDetails authzDetails;
 
     public void checkUiLocales() {
@@ -467,7 +468,7 @@ public class AuthorizeAction {
                     && grantedScopes.size() == 1
                     && grantedScopes.contains(DefaultScope.OPEN_ID.toString())
                     && scope.equals(DefaultScope.OPEN_ID.toString())
-                    && claims == null && request == null;
+                    && claims == null && request == null && requestUri == null;
             if (isTrusted || canGrantAccess || isPairwiseWithOnlyOpenIdScope) {
                 permissionGranted(session);
                 return;
@@ -575,10 +576,15 @@ public class AuthorizeAction {
     }
 
     public List<String> getRequestedClaims() {
-        Set<String> result = new HashSet<>();
+        if (requestedClaims != null) {
+            return requestedClaims;
+        }
+
+        Set<String> result = new LinkedHashSet<>();
         Client client = loadClient();
         if (client == null) {
-            return new ArrayList<>(result);
+            requestedClaims = new ArrayList<>(result);
+            return requestedClaims;
         }
 
         String requestJwt = request;
@@ -587,7 +593,8 @@ public class AuthorizeAction {
         }
 
         if (StringUtils.isBlank(requestJwt)) {
-            return new ArrayList<>(result);
+            requestedClaims = new ArrayList<>(result);
+            return requestedClaims;
         }
 
         try {
@@ -608,7 +615,8 @@ public class AuthorizeAction {
             log.error(e.getMessage(), e);
         }
 
-        return new ArrayList<>(result);
+        requestedClaims = new ArrayList<>(result);
+        return requestedClaims;
     }
 
     private Client loadClient() {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeAction.java
@@ -68,9 +68,11 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.util.*;
@@ -699,15 +701,44 @@ public class AuthorizeAction {
             return entity;
         }
         String hash = Base64Util.base64urlencode(JwtUtil.getMessageDigestSHA256(entity));
-        return StringUtils.equals(reqUriHash, hash) ? entity : null;
+        if (StringUtils.equals(reqUriHash, hash)) {
+            return entity;
+        }
+        log.warn("request_uri content integrity check failed, url = {}, expected hash = {}, computed hash = {}",
+                reqUriWithoutFragment, reqUriHash, hash);
+        return null;
     }
+
+    static final int REQUEST_URI_MAX_BYTES = 256 * 1024;
 
     String httpGet(String url) {
         try (Response clientResponse = RequestUriHttpClientHolder.INSTANCE.target(url).request().buildGet().invoke()) {
             if (clientResponse.getStatus() != 200) {
                 return null;
             }
-            return clientResponse.readEntity(String.class);
+            String contentLength = clientResponse.getHeaderString("Content-Length");
+            if (contentLength != null) {
+                try {
+                    if (Long.parseLong(contentLength) > REQUEST_URI_MAX_BYTES) {
+                        log.warn("request_uri response exceeds max size ({} bytes), url = {}, Content-Length = {}",
+                                REQUEST_URI_MAX_BYTES, url, contentLength);
+                        return null;
+                    }
+                } catch (NumberFormatException e) {
+                    // malformed Content-Length — fall through to bounded read
+                }
+            }
+            try (InputStream in = clientResponse.readEntity(InputStream.class)) {
+                byte[] bytes = in.readNBytes(REQUEST_URI_MAX_BYTES + 1);
+                if (bytes.length > REQUEST_URI_MAX_BYTES) {
+                    log.warn("request_uri response body exceeds max size ({} bytes), url = {}", REQUEST_URI_MAX_BYTES, url);
+                    return null;
+                }
+                return new String(bytes, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                log.warn("Failed to read request_uri response, url = {}: {}", url, e.getMessage());
+                return null;
+            }
         }
     }
 

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
@@ -5,6 +5,8 @@ import io.jans.as.common.model.registration.Client;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.crypto.AbstractCryptoProvider;
 import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.util.Base64Util;
+import io.jans.as.model.util.JwtUtil;
 import io.jans.as.server.auth.Authenticator;
 import io.jans.as.server.i18n.LanguageBean;
 import io.jans.as.server.model.auth.AuthenticationMode;
@@ -19,6 +21,7 @@ import io.jans.jsf2.message.FacesMessages;
 import io.jans.jsf2.service.FacesService;
 import io.jans.service.net.NetworkService;
 import io.jans.util.OxConstants;
+import io.jans.util.security.SecurityProviderUtility;
 import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 import org.mockito.InjectMocks;
@@ -26,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.Logger;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -33,8 +37,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * @author Yuriy Z
@@ -132,6 +135,11 @@ public class AuthorizeActionTest {
 
     @Mock
     private AuthorizeRestWebServiceValidator authorizeRestWebServiceValidator;
+
+    @BeforeClass
+    public void installBcProvider() {
+        SecurityProviderUtility.installBCProvider();
+    }
 
     @Test
     public void checkPermissionGranted_whenExceptionThrown_shouldDeny() {
@@ -262,5 +270,29 @@ public class AuthorizeActionTest {
         assertTrue(result.contains("email"));
         assertTrue(result.contains("given_name"));
         assertTrue(result.contains("auth_time"));
+    }
+
+    @Test
+    public void fetchRequestUriContent_whenHashMatchesBody_shouldReturnBody() throws Exception {
+        String body = "fake-request-jwt-body";
+        String matchingHash = Base64Util.base64urlencode(JwtUtil.getMessageDigestSHA256(body));
+        doReturn(body).when(authorizeAction).httpGet("https://allowed.example/jwt");
+
+        String result = authorizeAction.fetchRequestUriContent("https://allowed.example/jwt", matchingHash);
+
+        assertEquals(result, body);
+        verify(authorizeAction).httpGet("https://allowed.example/jwt");
+    }
+
+    @Test
+    public void fetchRequestUriContent_whenHashDoesNotMatchBody_shouldReturnNull() throws Exception {
+        String body = "fake-request-jwt-body";
+        String wrongHash = "this-is-not-the-real-hash";
+        doReturn(body).when(authorizeAction).httpGet("https://allowed.example/jwt");
+
+        String result = authorizeAction.fetchRequestUriContent("https://allowed.example/jwt", wrongHash);
+
+        assertNull(result, "tampered content with wrong fragment hash must be rejected");
+        verify(authorizeAction).httpGet("https://allowed.example/jwt");
     }
 }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
@@ -246,6 +246,21 @@ public class AuthorizeActionTest {
         authorizeAction.getRequestedClaims();
         authorizeAction.getRequestedClaims();
 
-        verify(clientService, org.mockito.Mockito.times(1)).getClient("c1");
+        verify(clientService, times(1)).getClient("c1");
+    }
+
+    @Test
+    public void getRequestedClaims_whenStandaloneClaimsSetAndNoRequestJwt_shouldReturnClaimNames() {
+        authorizeAction.setClientId("c1");
+        authorizeAction.setClaims("{\"userinfo\":{\"email\":null,\"given_name\":null},\"id_token\":{\"auth_time\":{\"essential\":true}}}");
+
+        Client client = new Client();
+        when(clientService.getClient("c1")).thenReturn(client);
+
+        List<String> result = authorizeAction.getRequestedClaims();
+
+        assertTrue(result.contains("email"));
+        assertTrue(result.contains("given_name"));
+        assertTrue(result.contains("auth_time"));
     }
 }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
@@ -1,6 +1,7 @@
 package io.jans.as.server.authorize.ws.rs;
 
 import com.google.common.collect.Lists;
+import io.jans.as.common.model.registration.Client;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.crypto.AbstractCryptoProvider;
 import io.jans.as.model.error.ErrorResponseFactory;
@@ -28,9 +29,10 @@ import org.slf4j.Logger;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -172,5 +174,67 @@ public class AuthorizeActionTest {
         when(defaultAuthenticationMode.getName()).thenReturn("some_acr");
         final boolean skip = authorizeAction.shouldSkipScript(Lists.newArrayList());
         assertFalse(skip);
+    }
+
+    @Test
+    public void getRequestedClaims_whenClientIdMissing_shouldReturnEmptyAndSkipFetch() throws Exception {
+        authorizeAction.setClientId(null);
+        authorizeAction.setRequestUri("https://evil.example/jwt");
+
+        List<String> result = authorizeAction.getRequestedClaims();
+
+        assertTrue(result.isEmpty());
+        verify(authorizeAction, never()).fetchRequestUriContent(anyString(), any());
+        verify(clientService, never()).getClient(anyString());
+    }
+
+    @Test
+    public void getRequestedClaims_whenRequestUriNotInClientAllowlist_shouldReturnEmptyAndSkipFetch() throws Exception {
+        authorizeAction.setClientId("c1");
+        authorizeAction.setRequestUri("https://evil.example/jwt");
+        authorizeAction.setState("st1");
+
+        Client client = new Client();
+        client.setRequestUris(new String[]{"https://allowed.example/jwt"});
+        when(clientService.getClient("c1")).thenReturn(client);
+
+        List<String> result = authorizeAction.getRequestedClaims();
+
+        assertTrue(result.isEmpty());
+        verify(authorizeAction, never()).fetchRequestUriContent(anyString(), any());
+    }
+
+    @Test
+    public void getRequestedClaims_whenRequestUriIsBlocklisted_shouldReturnEmptyAndSkipFetch() throws Exception {
+        authorizeAction.setClientId("c1");
+        authorizeAction.setRequestUri("http://169.254.169.254/latest/meta-data/");
+        authorizeAction.setState("st1");
+
+        Client client = new Client();
+        client.setRequestUris(new String[0]);
+        when(clientService.getClient("c1")).thenReturn(client);
+        when(appConfiguration.getRequestUriBlockList()).thenReturn(Lists.newArrayList("http://169.254.169.254/*"));
+
+        List<String> result = authorizeAction.getRequestedClaims();
+
+        assertTrue(result.isEmpty());
+        verify(authorizeAction, never()).fetchRequestUriContent(anyString(), any());
+    }
+
+    @Test
+    public void getRequestedClaims_whenRequestUriIsAllowed_shouldInvokeFetch() throws Exception {
+        authorizeAction.setClientId("c1");
+        authorizeAction.setRequestUri("https://allowed.example/jwt");
+        authorizeAction.setState("st1");
+
+        Client client = new Client();
+        client.setRequestUris(new String[]{"https://allowed.example/jwt"});
+        when(clientService.getClient("c1")).thenReturn(client);
+        doReturn(null).when(authorizeAction).fetchRequestUriContent(anyString(), any());
+
+        List<String> result = authorizeAction.getRequestedClaims();
+
+        assertTrue(result.isEmpty());
+        verify(authorizeAction).fetchRequestUriContent(eq("https://allowed.example/jwt"), eq(null));
     }
 }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/authorize/ws/rs/AuthorizeActionTest.java
@@ -237,4 +237,15 @@ public class AuthorizeActionTest {
         assertTrue(result.isEmpty());
         verify(authorizeAction).fetchRequestUriContent(eq("https://allowed.example/jwt"), eq(null));
     }
+
+    @Test
+    public void getRequestedClaims_whenCalledMultipleTimes_shouldCacheAndNotRepeatClientLookup() {
+        authorizeAction.setClientId("c1");
+
+        authorizeAction.getRequestedClaims();
+        authorizeAction.getRequestedClaims();
+        authorizeAction.getRequestedClaims();
+
+        verify(clientService, org.mockito.Mockito.times(1)).getClient("c1");
+    }
 }


### PR DESCRIPTION
### Description

fix(jans-auth-server): added request_uri validation in AuthorizeAction.getRequestedClaims


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14087, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetch and validate Request-URI content with optional fragment-hash integrity check; centralized HTTP retrieval and timeouts.
  * Aggregate and deduplicate requested claim names and cache the computed list to avoid repeated lookups.

* **Bug Fixes**
  * Tightened skip-authorization fast-path to require absence of a Request-URI.
  * JWT parse errors are logged without aborting claim accumulation.

* **Tests**
  * Added unit tests for allowlist/blocklist, fetch behavior, hash verification, caching, and missing-client cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JanssenProject/jans/pull/14086)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->