### PR TITLE
fix(jans-cedarling): remove outdated fields in Cedarling docs

### DIFF
--- a/docs/cedarling/integrations/terraform-authz-jwt.md
+++ b/docs/cedarling/integrations/terraform-authz-jwt.md
@@ -267,7 +267,6 @@ The `mapping` field tells Cedarling which Cedar entity type to instantiate from 
         "CEDARLING_LOG_LEVEL": "INFO",
         "CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED": ["RS256"],
         "CEDARLING_JWT_SIG_VALIDATION": "enabled",
-        "CEDARLING_ID_TOKEN_TRUST_MODE": "never",
         "CEDARLING_POLICY_STORE_LOCAL_FN": "/app/demo/terraform-jwt/policy-store"
       }
     }

--- a/docs/cedarling/integrations/terraform-authz.md
+++ b/docs/cedarling/integrations/terraform-authz.md
@@ -194,11 +194,8 @@ The `cedarling.opa.authorize_unsigned` built-in is the right choice here because
       "stderr": false,
       "bootstrap_config": {
         "CEDARLING_APPLICATION_NAME": "TerraformAuthz",
-        "CEDARLING_USER_AUTHZ": "enabled",
-        "CEDARLING_WORKLOAD_AUTHZ": "disabled",
         "CEDARLING_JWT_SIG_VALIDATION": "disabled",
         "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
-        "CEDARLING_ID_TOKEN_TRUST_MODE": "never",
         "CEDARLING_LOG_TYPE": "std_out",
         "CEDARLING_LOG_TTL": 60,
         "CEDARLING_LOG_LEVEL": "INFO",
@@ -217,7 +214,6 @@ The `cedarling.opa.authorize_unsigned` built-in is the right choice here because
 The JWT-based demo ([`terraform-authz-jwt.md`](./terraform-authz-jwt.md)) requires a `policy-store/trusted-issuers/` directory so Cedarling can fetch and validate the signing keys for the incoming OIDC token. This unsigned demo does not need that directory because:
 
 - `CEDARLING_JWT_SIG_VALIDATION: "disabled"` — no signature is checked.
-- `CEDARLING_ID_TOKEN_TRUST_MODE: "never"` — Cedarling never tries to resolve an issuer from an ID token.
 - Identity is asserted directly in the `authorize_unsigned` payload (via the `principal` object in the OPA `input`) rather than carried inside a signed JWT.
 
 The policy-store directory for this demo therefore contains only `metadata.json`, `schema.cedarschema`, and `policies/`. If you later switch to signed tokens, add a `trusted-issuers/` subdirectory with one JSON file per issuer — see the [trusted issuer file format](./terraform-authz-jwt.md#trusted-issuer-file-format) in the JWT guide for the exact schema and field reference.

--- a/docs/cedarling/quick-start/cedarling-quick-start.md
+++ b/docs/cedarling/quick-start/cedarling-quick-start.md
@@ -180,14 +180,11 @@ We will now add the policy store details in the Janssen Tarp that is installed i
      "CEDARLING_POLICY_STORE_URI": "<Policy Store URI>",
      "CEDARLING_LOG_TYPE": "std_out",
      "CEDARLING_LOG_LEVEL": "INFO",
-     "CEDARLING_USER_AUTHZ": "enabled",
-     "CEDARLING_WORKLOAD_AUTHZ": "disabled",
      "CEDARLING_JWT_SIG_VALIDATION": "enabled",
      "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
      "CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED": [
        "HS256", "RS256"
-     ],
-     "CEDARLING_POLICY_STORE_VALIDATE_CHECKSUM": false
+     ]
    }
    ```
 
@@ -360,14 +357,11 @@ use the policy stored in the store (from [Step-1](#step-1-create-the-cedar-polic
        "CEDARLING_POLICY_STORE_URI": "<Policy Store URI>",
        "CEDARLING_LOG_TYPE": "std_out",
        "CEDARLING_LOG_LEVEL": "INFO",
-       "CEDARLING_USER_AUTHZ": "enabled",
-       "CEDARLING_WORKLOAD_AUTHZ": "disabled",
        "CEDARLING_JWT_SIG_VALIDATION": "disabled",
        "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
        "CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED": [
          "HS256", "RS256"
-       ],
-       "CEDARLING_POLICY_STORE_VALIDATE_CHECKSUM": false
+       ]
    }
    ```
 

--- a/docs/cedarling/reference/cedarling-policy-store.md
+++ b/docs/cedarling/reference/cedarling-policy-store.md
@@ -367,10 +367,7 @@ The `policies` field describes the Cedar policies that will be used in Cedarling
 ```json
   "policies": {
     "unique_policy_id": {
-      "cedar_version" : "v4.0.0",
-      "name": "Policy for Unique Id",
       "description": "simple policy example",
-      "creation_date": "2024-09-20T17:22:39.996050",
       "policy_content": { ... },
     },
     ...
@@ -378,9 +375,7 @@ The `policies` field describes the Cedar policies that will be used in Cedarling
 ```
 
 - **unique_policy_id**: (_String_) A unique policy ID used to for tracking and auditing purposes.
-- **name** : (_String_) A name for the policy
 - **description** : (_String_) A brief description of cedar policy
-- **creation_date** : (_String_) Policy creating date in `YYYY-MM-DDTHH:MM:SS.ssssss`
 - **policy_content** : (_String_ | _Object_) The Cedar Policy. See [policy_content](#policy_content) below.
 
 ### `policy_content`
@@ -410,24 +405,15 @@ Here is a non-normative example of the `policies` field:
 ```json
   "policies": {
     "840da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
-      "cedar_version": "v2.7.4",
-      "name": "Policy-the-first",
       "description": "simple policy example for principal workload",
-      "creation_date": "2024-09-20T17:22:39.996050",
       "policy_content": "cGVybWl0KAogICAgc..."
     },
     "0fo1kl928Afa0sc9123scma0123891asklajsh1233ab": {
-      "cedar_version": "v2.7.4",
-      "name": "Policy-the-second",
       "description": "another policy example",
-      "creation_date": "2024-09-20T18:22:39.192051",
       "policy_content": "kJW1bWl0KA0g3CAxa..."
     },
     "1fo1kl928Afa0sc9123scma0123891asklajsh1233ac": {
-      "cedar_version": "v2.7.4",
-      "name": "Policy-the-third",
       "description": "another policy example",
-      "creation_date": "2024-09-20T18:22:39.192051",
       "policy_content": {
         "encoding": "none",
         "content_type" : "cedar",
@@ -435,10 +421,7 @@ Here is a non-normative example of the `policies` field:
       }
     },
     "2fo1kl928Afa0sc9123scma0123891asklajsh1233ad": {
-      "cedar_version": "v2.7.4",
-      "name": "Policy-the-fourth",
       "description": "another policy example",
-      "creation_date": "2024-09-20T18:22:39.192051",
       "policy_content": {
         "encoding": "base64",
         "content_type" : "cedar",
@@ -493,7 +476,6 @@ The Token Entity Metadata Schema defines how tokens are mapped and validated wit
   "trusted": true,
   "entity_type_name": "Acme::Access_token",
   "token_id": "jti",
-  "principal_mapping": ["Acme::Workload"],
   "required_claims": ["iss", "exp", "some_custom_claim"]
 }
 ```
@@ -501,8 +483,6 @@ The Token Entity Metadata Schema defines how tokens are mapped and validated wit
 - `"trusted"` (bool, Default: true): Allows toggling configuration without deleting the object. When set to `false`, tokens of this type will be ignored.
 - `"entity_type_name"` (string, required): The type name of the Cedar Entity that will be created from the token; for example: `"Acme::Access_token"`.
 - `"token_id"` (string, Default: `"jti"`): The JWT claim that will be used as the ID for the Token Entity.
-
-- `"principal_mapping"` (array[string], Default: `[]`): Describes where references of the created token entity should be included.
 - `"required_claims"` (array[string], Default: `[]`): A list of claims that must be present within the JWT to be considered valid. Additionally, if a required claim is a registered claim name under [RFC 7519 Section 4.1](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1) (e.g., `exp`, `nbf`), the claim will also be validated according to the standard.
 
 ## Example Policy store
@@ -515,7 +495,6 @@ Here is a non-normative example of a `cedarling_store.json` file:
   "policies": {
     "840da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
       "description": "simple policy example",
-      "creation_date": "2024-09-20T17:22:39.996050",
       "policy_content": "cedar_policy_encoded_in_base64"
     }
   },

--- a/docs/cedarling/reference/cedarling-properties.md
+++ b/docs/cedarling/reference/cedarling-properties.md
@@ -76,7 +76,7 @@ the Cedarling will use the default value as specified in the property definition
 
 **HTTP client:**
 
-- **`CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS`** : Per-request timeout in seconds. Only applicable for native targets (not WASM). Default is `10` (10 seconds).
+- **`CEDARLING_HTTP_REQUEST_TIMEOUT`** : Per-request timeout in seconds. Only applicable for native targets (not WASM). Default is `10` (10 seconds).
 - **`CEDARLING_HTTP_REQUEST_MAX_RETRIES`** : Maximum number of retry attempts per request. Only applicable for native targets (not WASM). Default is `3`.
 - **`CEDARLING_HTTP_REQUEST_RETRY_DELAY`** : Base delay between retries in seconds. Only applicable for native targets (not WASM). Default is `3` (3 seconds).
 

--- a/docs/cedarling/tutorials/c.md
+++ b/docs/cedarling/tutorials/c.md
@@ -79,7 +79,6 @@ Before performing authorization, you need to configure a Cedarling instance. Con
 ```c
 const char* config = "{"
     "\"CEDARLING_APPLICATION_NAME\": \"MyApp\","
-    "\"CEDARLING_POLICY_STORE_ID\": \"your-policy-store-id\","
     "\"CEDARLING_LOG_LEVEL\": \"INFO\","
     "\"CEDARLING_LOG_TYPE\": \"std_out\","
     "\"CEDARLING_POLICY_STORE_LOCAL_FN\": \"/path/to/policy-store.yaml\""
@@ -91,7 +90,6 @@ const char* config = "{"
 | Property | Description |
 |----------|-------------|
 | `CEDARLING_APPLICATION_NAME` | Name of your application |
-| `CEDARLING_POLICY_STORE_ID` | ID of the policy store |
 | `CEDARLING_LOG_LEVEL` | Logging level (DEBUG, INFO, WARN, ERROR) |
 | `CEDARLING_LOG_TYPE` | Log output type (std_out, memory, off) |
 | `CEDARLING_POLICY_STORE_LOCAL_FN` | Path to local policy store file |
@@ -120,7 +118,6 @@ int main() {
     // Configuration JSON
     const char* config = "{"
         "\"CEDARLING_APPLICATION_NAME\": \"MyApp\","
-        "\"CEDARLING_POLICY_STORE_ID\": \"example-policy-store\","
         "\"CEDARLING_LOG_LEVEL\": \"INFO\","
         "\"CEDARLING_LOG_TYPE\": \"std_out\","
         "\"CEDARLING_POLICY_STORE_LOCAL_FN\": \"./policy-store.yaml\""
@@ -462,7 +459,6 @@ int main() {
     // Configuration
     const char* config = "{"
         "\"CEDARLING_APPLICATION_NAME\": \"ExampleApp\","
-        "\"CEDARLING_POLICY_STORE_ID\": \"example-store\","
         "\"CEDARLING_LOG_LEVEL\": \"DEBUG\","
         "\"CEDARLING_LOG_TYPE\": \"memory\","
         "\"CEDARLING_POLICY_STORE_LOCAL_FN\": \"./policy-store.yaml\""

--- a/docs/cedarling/uniffi/cedarling-sample-inputs.md
+++ b/docs/cedarling/uniffi/cedarling-sample-inputs.md
@@ -5,10 +5,7 @@
 "CEDARLING_APPLICATION_NAME": "Cedarling-Test-In-Custom-Script",
 "CEDARLING_POLICY_STORE_LOCAL_FN": "./custom/static/update_token_script.cjar",
 "CEDARLING_LOG_LEVEL": "DEBUG",
-"CEDARLING_LOG_TYPE": "std_out",
-"CEDARLING_PRINCIPAL_BOOLEAN_OPERATION": {
-"===": [{"var": "Jans::Workload"}, "ALLOW"]
-}
+"CEDARLING_LOG_TYPE": "std_out"
 }
 ```
 

--- a/jans-cedarling/bindings/cedarling-java/docs/policy-store.json
+++ b/jans-cedarling/bindings/cedarling-java/docs/policy-store.json
@@ -12,25 +12,13 @@
           "openid_configuration_endpoint": "https://account.gluu.org/.well-known/openid-configuration",
           "token_metadata": {
             "access_token": {
-              "entity_type_name": "Jans::Access_token",
-              "workload_id": "client_id",
-              "principal_mapping": [
-                "Jans::Workload"
-              ]
+              "entity_type_name": "Jans::Access_token"
             },
             "id_token": {
-              "entity_type_name": "Jans::Id_token",
-              "user_id": "sub",
-              "principal_mapping": [
-                "Jans::User"
-              ]
+              "entity_type_name": "Jans::Id_token"
             },
             "userinfo_token": {
-              "entity_type_name": "Jans::Userinfo_token",
-              "user_id": "sub",
-              "principal_mapping": [
-                "Jans::User"
-              ]
+              "entity_type_name": "Jans::Userinfo_token"
             }
           }
         }
@@ -46,7 +34,6 @@
           }
         },
         "444da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for principal user",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {
@@ -56,7 +43,6 @@
           }
         },
         "TestPrincipal1": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for TestPrincipal1",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {
@@ -66,7 +52,6 @@
           }
         },
         "TestPrincipal2": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for TestPrincipal2",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {

--- a/jans-cedarling/bindings/cedarling-java/src/test/resources/config/policy-store.json
+++ b/jans-cedarling/bindings/cedarling-java/src/test/resources/config/policy-store.json
@@ -12,25 +12,13 @@
           "openid_configuration_endpoint": "https://account.gluu.org/.well-known/openid-configuration",
           "token_metadata": {
             "access_token": {
-              "entity_type_name": "Jans::Access_token",
-              "workload_id": "client_id",
-              "principal_mapping": [
-                "Jans::Workload"
-              ]
+              "entity_type_name": "Jans::Access_token"
             },
             "id_token": {
-              "entity_type_name": "Jans::Id_token",
-              "user_id": "sub",
-              "principal_mapping": [
-                "Jans::User"
-              ]
+              "entity_type_name": "Jans::Id_token"
             },
             "userinfo_token": {
-              "entity_type_name": "Jans::Userinfo_token",
-              "user_id": "sub",
-              "principal_mapping": [
-                "Jans::User"
-              ]
+              "entity_type_name": "Jans::Userinfo_token"
             }
           }
         }
@@ -46,7 +34,6 @@
           }
         },
         "444da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for principal user",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {
@@ -56,7 +43,6 @@
           }
         },
         "TestPrincipal1": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for TestPrincipal1",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {
@@ -66,7 +52,6 @@
           }
         },
         "TestPrincipal2": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for TestPrincipal2",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {

--- a/jans-cedarling/bindings/cedarling_c/README.md
+++ b/jans-cedarling/bindings/cedarling_c/README.md
@@ -85,7 +85,6 @@ cedarling_init();
 // Create a new instance with configuration
 const char* config = "{"
     "\"CEDARLING_APPLICATION_NAME\": \"MyApp\","
-    "\"CEDARLING_POLICY_STORE_ID\": \"your-policy-store-id\","
     "\"CEDARLING_LOG_LEVEL\": \"INFO\","
     "\"CEDARLING_LOG_TYPE\": \"std_out\","
     "\"CEDARLING_POLICY_STORE_LOCAL_FN\": \"/path/to/policy-store.yaml\""
@@ -420,7 +419,6 @@ For complete configuration documentation, see [cedarling-properties.md](../../..
 ```json
 {
     "CEDARLING_APPLICATION_NAME": "MyApp",
-    "CEDARLING_POLICY_STORE_ID": "your-policy-store-id",
     "CEDARLING_LOG_LEVEL": "INFO",
     "CEDARLING_LOG_TYPE": "std_out",
     "CEDARLING_POLICY_STORE_LOCAL_FN": "/path/to/policy-store.yaml",

--- a/jans-cedarling/bindings/cedarling_c/benchmarks/benchmark_cedarling.c
+++ b/jans-cedarling/bindings/cedarling_c/benchmarks/benchmark_cedarling.c
@@ -58,7 +58,6 @@ static void init_benchmark_configs(const char *argv0) {
         sizeof(UNSIGNED_CONFIG),
         "{"
         "\"CEDARLING_APPLICATION_NAME\":\"BenchmarkApp\","
-        "\"CEDARLING_POLICY_STORE_ID\":\"a1bf93115de86de760ee0bea1d529b521489e5a11747\","
         "\"CEDARLING_JWT_SIG_VALIDATION\":\"disabled\","
         "\"CEDARLING_JWT_STATUS_VALIDATION\":\"disabled\","
         "\"CEDARLING_LOG_TYPE\":\"off\","
@@ -76,7 +75,6 @@ static void init_benchmark_configs(const char *argv0) {
         sizeof(MULTI_ISSUER_CONFIG),
         "{"
         "\"CEDARLING_APPLICATION_NAME\":\"BenchmarkApp\","
-        "\"CEDARLING_POLICY_STORE_ID\":\"a1bf93115de86de760ee0bea1d529b521489e5a11747\","
         "\"CEDARLING_JWT_SIG_VALIDATION\":\"disabled\","
         "\"CEDARLING_JWT_STATUS_VALIDATION\":\"disabled\","
         "\"CEDARLING_LOG_TYPE\":\"off\","

--- a/jans-cedarling/bindings/cedarling_c/examples/authorize_multi_issuer.c
+++ b/jans-cedarling/bindings/cedarling_c/examples/authorize_multi_issuer.c
@@ -28,7 +28,6 @@
 // Uses policy-store-multi-issuer-basic.yaml which has schema supporting tokens in context
 const char* BOOTSTRAP_CONFIG = "{\n"
     "    \"CEDARLING_APPLICATION_NAME\": \"MultiIssuerExample\",\n"
-    "    \"CEDARLING_POLICY_STORE_ID\": \"multi_issuer_basic_store\",\n"
     "    \"CEDARLING_JWT_SIG_VALIDATION\": \"disabled\",\n"
     "    \"CEDARLING_JWT_STATUS_VALIDATION\": \"disabled\",\n"
     "    \"CEDARLING_LOG_TYPE\": \"memory\",\n"

--- a/jans-cedarling/bindings/cedarling_c/examples/authorize_unsigned.c
+++ b/jans-cedarling/bindings/cedarling_c/examples/authorize_unsigned.c
@@ -24,7 +24,6 @@
 // Configuration JSON - uses policy-store_ok_2.yaml for unsigned authorization
 const char* BOOTSTRAP_CONFIG = "{\n"
     "    \"CEDARLING_APPLICATION_NAME\": \"UnsignedAuthExample\",\n"
-    "    \"CEDARLING_POLICY_STORE_ID\": \"a1bf93115de86de760ee0bea1d529b521489e5a11747\",\n"
     "    \"CEDARLING_LOG_TYPE\": \"std_out\",\n"
     "    \"CEDARLING_LOG_TTL\": 60,\n"
     "    \"CEDARLING_LOG_LEVEL\": \"DEBUG\",\n"

--- a/jans-cedarling/bindings/cedarling_c/examples/basic_example.c
+++ b/jans-cedarling/bindings/cedarling_c/examples/basic_example.c
@@ -26,7 +26,6 @@
 // Sample configuration JSON - uses policy-store_ok_2.yaml for unsigned authorization
 const char* BOOTSTRAP_CONFIG = "{\n"
     "    \"CEDARLING_APPLICATION_NAME\": \"TestApp\",\n"
-    "    \"CEDARLING_POLICY_STORE_ID\": \"a1bf93115de86de760ee0bea1d529b521489e5a11747\",\n"
     "    \"CEDARLING_LOG_TYPE\": \"std_out\",\n"
     "    \"CEDARLING_LOG_TTL\": 60,\n"
     "    \"CEDARLING_LOG_LEVEL\": \"DEBUG\",\n"

--- a/jans-cedarling/bindings/cedarling_c/tests/test_cedarling.c
+++ b/jans-cedarling/bindings/cedarling_c/tests/test_cedarling.c
@@ -15,7 +15,6 @@
 // Test configuration - uses policy-store_ok_2.yaml for unsigned authorization
 const char* TEST_CONFIG = "{\n"
     "    \"CEDARLING_APPLICATION_NAME\": \"TestApp\",\n"
-    "    \"CEDARLING_POLICY_STORE_ID\": \"a1bf93115de86de760ee0bea1d529b521489e5a11747\",\n"
     "    \"CEDARLING_JWT_SIG_VALIDATION\": \"disabled\",\n"
     "    \"CEDARLING_JWT_STATUS_VALIDATION\": \"disabled\",\n"
     "    \"CEDARLING_LOG_TYPE\": \"std_out\",\n"

--- a/jans-cedarling/bindings/cedarling_python/cedarling_python/cedarling_python.pyi
+++ b/jans-cedarling/bindings/cedarling_python/cedarling_python/cedarling_python.pyi
@@ -14,7 +14,6 @@ class BootstrapConfig:
     Example Usage:
         bootstrap_config = BootstrapConfig({
             "CEDARLING_APPLICATION_NAME": "MyApp",
-            "CEDARLING_POLICY_STORE_ID": "12345",
             "CEDARLING_LOG_TYPE": "memory",
             "CEDARLING_LOG_TTL": 30,
             ...

--- a/jans-cedarling/bindings/cedarling_python/example_files/policy-store-multi-issuer/trusted-issuers/jans-test-issuer.json
+++ b/jans-cedarling/bindings/cedarling_python/example_files/policy-store-multi-issuer/trusted-issuers/jans-test-issuer.json
@@ -6,20 +6,17 @@
     "access_token": {
       "trusted": true,
       "entity_type_name": "Jans::Access_Token",
-      "token_id": "jti",
-      "principal_mapping": ["Jans::Workload"]
+      "token_id": "jti"
     },
     "id_token": {
       "trusted": true,
       "entity_type_name": "Jans::Id_Token",
-      "token_id": "jti",
-      "principal_mapping": ["Jans::User"]
+      "token_id": "jti"
     },
     "userinfo_token": {
       "trusted": true,
       "entity_type_name": "Jans::Userinfo_Token",
-      "token_id": "jti",
-      "principal_mapping": ["Jans::User"]
+      "token_id": "jti"
     }
   }
 }

--- a/jans-cedarling/bindings/cedarling_python/example_files/policy-store.json
+++ b/jans-cedarling/bindings/cedarling_python/example_files/policy-store.json
@@ -39,53 +39,7 @@
                             "entity_type_name": "Jans::Id_token"
                         },
                         "userinfo_token": {
-                            "entity_type_name": "Jans::Userinfo_token",
-                            "user_id": "sub",
-                            "role_mapping": "role",
-                            "claim_mapping": {
-                                "email": {
-                                    "parser": "regex",
-                                    "type": "Jans::email_address",
-                                    "regex_expression": "^(?P<UID>[^@]+)@(?P<DOMAIN>.+)$",
-                                    "UID": {
-                                        "attr": "uid",
-                                        "type": "String"
-                                    },
-                                    "DOMAIN": {
-                                        "attr": "domain",
-                                        "type": "String"
-                                    }
-                                },
-                                "profile": {
-                                    "parser": "regex",
-                                    "type": "Jans::Url",
-                                    "regex_expression": "(?x) ^(?P<SCHEME>[a-zA-Z][a-zA-Z0-9+.-]*):\\/\\/(?P<HOST>[^\\/:\\#?]+)(?::(?<PORT>\\d+))?(?P<PATH>\\/[^?\\#]*)?(?:\\?(?P<QUERY>[^\\#]*))?(?:(?P<FRAGMENT>.*))?/gm",
-                                    "SCHEME": {
-                                        "attr": "scheme",
-                                        "type": "String"
-                                    },
-                                    "HOST": {
-                                        "attr": "host",
-                                        "type": "String"
-                                    },
-                                    "PORT": {
-                                        "attr": "port",
-                                        "type": "String"
-                                    },
-                                    "PATH": {
-                                        "attr": "path",
-                                        "type": "String"
-                                    },
-                                    "QUERY": {
-                                        "attr": "query",
-                                        "type": "String"
-                                    },
-                                    "FRAGMENT": {
-                                        "attr": "fragment",
-                                        "type": "String"
-                                    }
-                                }
-                            }
+                            "entity_type_name": "Jans::Userinfo_token"
                         }
                     }
                 }

--- a/jans-cedarling/bindings/cedarling_python/examples/multi_issuer_authz.py
+++ b/jans-cedarling/bindings/cedarling_python/examples/multi_issuer_authz.py
@@ -79,8 +79,6 @@ def main():
         "CEDARLING_POLICY_STORE_LOCAL_FN": str(
             EXAMPLE_FILES / "policy-store-multi-issuer"
         ),
-        "CEDARLING_USER_AUTHZ": "enabled",
-        "CEDARLING_WORKLOAD_AUTHZ": "enabled",
         "CEDARLING_JWT_SIG_VALIDATION": "disabled",
         "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
         "CEDARLING_LOG_TYPE": "std_out",

--- a/jans-cedarling/bindings/cedarling_python/examples/unsigned_authz.py
+++ b/jans-cedarling/bindings/cedarling_python/examples/unsigned_authz.py
@@ -52,8 +52,6 @@ def main():
         "CEDARLING_POLICY_STORE_LOCAL_FN": str(
             EXAMPLE_FILES / "policy-store-unsigned"
         ),
-        "CEDARLING_USER_AUTHZ": "enabled",
-        "CEDARLING_WORKLOAD_AUTHZ": "enabled",
         "CEDARLING_JWT_SIG_VALIDATION": "disabled",
         "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
         "CEDARLING_LOG_TYPE": "std_out",

--- a/jans-cedarling/bindings/cedarling_uniffi/javaApp/src/main/resources/config/policy-store.json
+++ b/jans-cedarling/bindings/cedarling_uniffi/javaApp/src/main/resources/config/policy-store.json
@@ -12,25 +12,13 @@
           "openid_configuration_endpoint": "https://account.gluu.org/.well-known/openid-configuration",
           "token_metadata": {
             "access_token": {
-              "entity_type_name": "Jans::Access_token",
-              "workload_id": "client_id",
-              "principal_mapping": [
-                "Jans::Workload"
-              ]
+              "entity_type_name": "Jans::Access_token"
             },
             "id_token": {
-              "entity_type_name": "Jans::Id_token",
-              "user_id": "sub",
-              "principal_mapping": [
-                "Jans::User"
-              ]
+              "entity_type_name": "Jans::Id_token"
             },
             "userinfo_token": {
-              "entity_type_name": "Jans::Userinfo_token",
-              "user_id": "sub",
-              "principal_mapping": [
-                "Jans::User"
-              ]
+              "entity_type_name": "Jans::Userinfo_token"
             }
           }
         }
@@ -46,7 +34,6 @@
           }
         },
         "444da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for principal user",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {
@@ -56,7 +43,6 @@
           }
         },
         "TestPrincipal1": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for TestPrincipal1",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {
@@ -66,7 +52,6 @@
           }
         },
         "TestPrincipal2": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for TestPrincipal2",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {

--- a/jans-cedarling/bindings/cedarling_uniffi/test_files/policy-store.json
+++ b/jans-cedarling/bindings/cedarling_uniffi/test_files/policy-store.json
@@ -12,25 +12,13 @@
           "openid_configuration_endpoint": "https://account.gluu.org/.well-known/openid-configuration",
           "token_metadata": {
             "access_token": {
-              "entity_type_name": "Jans::Access_token",
-              "workload_id": "client_id",
-              "principal_mapping": [
-                "Jans::Workload"
-              ]
+              "entity_type_name": "Jans::Access_token"
             },
             "id_token": {
-              "entity_type_name": "Jans::Id_token",
-              "user_id": "sub",
-              "principal_mapping": [
-                "Jans::User"
-              ]
+              "entity_type_name": "Jans::Id_token"
             },
             "userinfo_token": {
-              "entity_type_name": "Jans::Userinfo_token",
-              "user_id": "sub",
-              "principal_mapping": [
-                "Jans::User"
-              ]
+              "entity_type_name": "Jans::Userinfo_token"
             }
           }
         }
@@ -46,7 +34,6 @@
           }
         },
         "444da5d85403f35ea76519ed1a18a33989f855bf1cf8": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for principal user",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {
@@ -56,7 +43,6 @@
           }
         },
         "TestPrincipal1": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for TestPrincipal1",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {
@@ -66,7 +52,6 @@
           }
         },
         "TestPrincipal2": {
-          "cedar_version": "v4.0.0",
           "description": "simple policy example for TestPrincipal2",
           "creation_date": "2024-09-20T17:22:39.996050",
           "policy_content": {

--- a/jans-cedarling/cedarling/src/common/policy_store/issuer_parser.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/issuer_parser.rs
@@ -290,14 +290,11 @@ mod tests {
             "token_metadata": {
                 "access_token": {
                     "trusted": true,
-                    "entity_type_name": "Jans::access_token",
-                    "user_id": "sub",
-                    "role_mapping": "role"
+                    "entity_type_name": "Jans::access_token"
                 },
                 "id_token": {
                     "trusted": true,
-                    "entity_type_name": "Jans::id_token",
-                    "user_id": "sub"
+                    "entity_type_name": "Jans::id_token"
                 }
             }
         }"#;

--- a/jans-cedarling/cedarling/src/common/policy_store/legacy_store/mod.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/legacy_store/mod.rs
@@ -57,8 +57,6 @@ pub(crate) struct LegacyTokenEntityMetadata {
     #[serde(default = "default_trusted")]
     pub(crate) trusted: bool,
     pub(crate) entity_type_name: String,
-    #[serde(default)]
-    pub(crate) principal_mapping: HashSet<String>,
     #[serde(default = "default_token_id")]
     pub(crate) token_id: String,
     #[serde(default)]
@@ -78,7 +76,6 @@ impl From<LegacyTokenEntityMetadata> for super::TokenEntityMetadata {
         super::TokenEntityMetadata::builder()
             .trusted(v.trusted)
             .entity_type_name(v.entity_type_name)
-            .principal_mapping(v.principal_mapping)
             .token_id(v.token_id)
             .required_claims(v.required_claims)
             .build()

--- a/jans-cedarling/cedarling/src/common/policy_store/loader_tests.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/loader_tests.rs
@@ -729,14 +729,11 @@ fn test_load_and_parse_trusted_issuers_end_to_end() {
             "token_metadata": {
                 "access_token": {
                     "trusted": true,
-                    "entity_type_name": "Jans::access_token",
-                    "user_id": "sub",
-                    "role_mapping": "role"
+                    "entity_type_name": "Jans::access_token"
                 },
                 "id_token": {
                     "trusted": true,
-                    "entity_type_name": "Jans::id_token",
-                    "user_id": "sub"
+                    "entity_type_name": "Jans::id_token"
                 }
             }
         }"#,
@@ -753,8 +750,7 @@ fn test_load_and_parse_trusted_issuers_end_to_end() {
             "token_metadata": {
                 "id_token": {
                     "trusted": false,
-                    "entity_type_name": "Google::id_token",
-                    "user_id": "email"
+                    "entity_type_name": "Google::id_token"
                 }
             }
         }"#,
@@ -824,20 +820,16 @@ fn test_parse_issuer_with_token_metadata() {
                 "access_token": {
                     "trusted": true,
                     "entity_type_name": "App::access_token",
-                    "user_id": "sub",
-                    "role_mapping": "role",
                     "token_id": "jti"
                 },
                 "id_token": {
                     "trusted": true,
                     "entity_type_name": "App::id_token",
-                    "user_id": "sub",
                     "token_id": "jti"
                 },
                 "userinfo_token": {
                     "trusted": true,
-                    "entity_type_name": "App::userinfo_token",
-                    "user_id": "sub"
+                    "entity_type_name": "App::userinfo_token"
                 }
             }
         }"#,
@@ -1073,8 +1065,7 @@ fn test_complete_policy_store_with_issuers() {
             "configuration_endpoint": "https://auth.test/.well-known/openid-configuration",
             "token_metadata": {
                 "access_token": {
-                    "entity_type_name": "Jans::access_token",
-                    "user_id": "sub"
+                    "entity_type_name": "Jans::access_token"
                 }
             }
         }"#,

--- a/jans-cedarling/cedarling/src/common/policy_store/token_entity_metadata.rs
+++ b/jans-cedarling/cedarling/src/common/policy_store/token_entity_metadata.rs
@@ -22,10 +22,6 @@ pub(crate) struct TokenEntityMetadata {
     pub(crate) trusted: bool,
     /// The Cedar entity name that represents this token
     pub(crate) entity_type_name: String,
-    /// The Cedar entities that this token is an attribute of
-    #[serde(default)]
-    #[builder(default)]
-    pub(crate) principal_mapping: HashSet<String>,
     /// An optional string representing the principal identifier (e.g., `jti`).
     #[serde(default = "default_token_id")]
     #[builder(default = default_token_id())]
@@ -56,7 +52,6 @@ impl TokenEntityMetadata {
             token_id: default_token_id(),
             required_claims: HashSet::from(["iss".into(), "exp".into(), "jti".into()]),
             entity_type_name: "Jans::Access_token".into(),
-            principal_mapping: HashSet::from(["Jans::Workload".into()]),
         }
     }
 
@@ -72,7 +67,6 @@ impl TokenEntityMetadata {
                 "exp".into(),
             ]),
             entity_type_name: "Jans::Id_token".into(),
-            principal_mapping: HashSet::from(["Jans::User".into()]),
         }
     }
 
@@ -88,7 +82,6 @@ impl TokenEntityMetadata {
                 "exp".into(),
             ]),
             entity_type_name: "Jans::Userinfo_token".into(),
-            principal_mapping: HashSet::from(["Jans::User".into()]),
         }
     }
 }

--- a/jans-cedarling/cedarling/src/entity_builder/mod.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/mod.rs
@@ -180,28 +180,6 @@ fn default_tkn_entity_name(tkn_name: &str) -> Option<&'static str> {
 #[derive(Default)]
 pub(super) struct TokenPrincipalMappings(HashMap<String, Vec<(String, RestrictedExpression)>>);
 
-impl From<Vec<TokenPrincipalMapping>> for TokenPrincipalMappings {
-    fn from(value: Vec<TokenPrincipalMapping>) -> Self {
-        Self(value.into_iter().fold(HashMap::new(), |mut acc, mapping| {
-            acc.entry(mapping.principal.clone())
-                .or_default()
-                .push((mapping.attr_name.clone(), mapping.expr.clone()));
-            acc
-        }))
-    }
-}
-
-/// Represents a token and it's UID
-#[derive(Clone)]
-pub(super) struct TokenPrincipalMapping {
-    /// The principal where token will be inserted
-    principal: String,
-    /// The name of the attribute of the token
-    attr_name: String,
-    /// An `EntityUID` reference to the token
-    expr: RestrictedExpression,
-}
-
 impl TokenPrincipalMappings {
     fn get(&self, principal: &str) -> Option<&Vec<(String, RestrictedExpression)>> {
         self.0.get(principal)

--- a/jans-cedarling/cedarling/src/jwt/mod.rs
+++ b/jans-cedarling/cedarling/src/jwt/mod.rs
@@ -601,7 +601,6 @@ mod test {
             TokenEntityMetadata {
                 trusted: true,
                 entity_type_name: "Jans::Access_Token".to_string(),
-                principal_mapping: HashSet::new(),
                 token_id: "jti".to_string(),
                 required_claims: HashSet::new(),
             },
@@ -611,7 +610,6 @@ mod test {
             TokenEntityMetadata {
                 trusted: true,
                 entity_type_name: "Jans::Id_Token".to_string(),
-                principal_mapping: HashSet::new(),
                 token_id: "jti".to_string(),
                 required_claims: HashSet::new(),
             },
@@ -734,7 +732,6 @@ mod test {
             TokenEntityMetadata {
                 trusted: true,
                 entity_type_name: "Jans::Access_Token".to_string(),
-                principal_mapping: HashSet::new(),
                 token_id: "jti".to_string(),
 
                 required_claims: HashSet::new(),
@@ -745,7 +742,6 @@ mod test {
             TokenEntityMetadata {
                 trusted: true,
                 entity_type_name: "Jans::Id_Token".to_string(),
-                principal_mapping: HashSet::new(),
                 token_id: "jti".to_string(),
 
                 required_claims: HashSet::new(),
@@ -813,7 +809,6 @@ mod test {
             TokenEntityMetadata {
                 trusted: true,
                 entity_type_name: "Jans::Access_Token".to_string(),
-                principal_mapping: HashSet::new(),
                 token_id: "jti".to_string(),
 
                 required_claims: HashSet::new(),
@@ -902,7 +897,6 @@ mod test {
             TokenEntityMetadata {
                 trusted: true,
                 entity_type_name: mapping.clone(),
-                principal_mapping: HashSet::new(),
                 token_id: "jti".to_string(),
                 required_claims: HashSet::new(),
             },
@@ -983,7 +977,6 @@ mod test {
             TokenEntityMetadata {
                 trusted: true,
                 entity_type_name: mapping.clone(),
-                principal_mapping: HashSet::new(),
                 token_id: "jti".to_string(),
                 required_claims: HashSet::new(),
             },

--- a/jans-cedarling/cedarling/src/jwt/validation/validator.rs
+++ b/jans-cedarling/cedarling/src/jwt/validation/validator.rs
@@ -434,7 +434,6 @@ mod test {
         LazyLock::new(|| TokenEntityMetadata {
             trusted: true,
             entity_type_name: "Jans::AccessToken".into(),
-            principal_mapping: HashSet::new(),
             token_id: "jti".into(),
             required_claims: HashSet::from(["exp".into(), "nbf".into()]),
         });

--- a/jans-cedarling/cedarling/src/jwt/validation/validator_cache.rs
+++ b/jans-cedarling/cedarling/src/jwt/validation/validator_cache.rs
@@ -318,7 +318,6 @@ mod test {
             &TokenEntityMetadata {
                 trusted: true,
                 entity_type_name: "AccessToken".into(),
-                principal_mapping: HashSet::default(),
                 token_id: "iss".into(),
                 required_claims: HashSet::new(),
             },

--- a/jans-cedarling/cedarling/src/tests/policy_store_loader.rs
+++ b/jans-cedarling/cedarling/src/tests/policy_store_loader.rs
@@ -260,16 +260,13 @@ fn create_jwt_trusted_issuer_json(oidc_endpoint: &str) -> String {
         "configuration_endpoint": "{oidc_endpoint}",
         "token_metadata": {{
             "access_token": {{
-                "entity_type_name": "Jans::Access_token",
-                "principal_mapping": ["Jans::Workload"]
+                "entity_type_name": "Jans::Access_token"
             }},
             "id_token": {{
                 "entity_type_name": "Jans::Id_token"
             }},
             "userinfo_token": {{
-                "entity_type_name": "Jans::Userinfo_token",
-                "user_id": "sub",
-                "role_mapping": "role"
+                "entity_type_name": "Jans::Userinfo_token"
             }}
         }}
     }}"#
@@ -286,16 +283,13 @@ fn create_jwt_trusted_issuer_json_with_id(issuer_id: &str, oidc_endpoint: &str) 
         "configuration_endpoint": "{oidc_endpoint}",
         "token_metadata": {{
             "access_token": {{
-                "entity_type_name": "Jans::Access_token",
-                "principal_mapping": ["Jans::Workload"]
+                "entity_type_name": "Jans::Access_token"
             }},
             "id_token": {{
                 "entity_type_name": "Jans::Id_token"
             }},
             "userinfo_token": {{
-                "entity_type_name": "Jans::Userinfo_token",
-                "user_id": "sub",
-                "role_mapping": "role"
+                "entity_type_name": "Jans::Userinfo_token"
             }}
         }}
     }}"#

--- a/jans-cedarling/cedarling_opa/demo/opa-config.json
+++ b/jans-cedarling/cedarling_opa/demo/opa-config.json
@@ -4,11 +4,8 @@
       "stderr": false,
       "bootstrap_config": {
         "CEDARLING_APPLICATION_NAME": "TestApp",
-        "CEDARLING_USER_AUTHZ": "enabled",
-        "CEDARLING_WORKLOAD_AUTHZ": "disabled",
         "CEDARLING_JWT_SIG_VALIDATION": "disabled",
         "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
-        "CEDARLING_ID_TOKEN_TRUST_MODE": "never",
         "CEDARLING_LOG_TYPE": "std_out",
         "CEDARLING_LOG_TTL": 60,
         "CEDARLING_LOG_LEVEL": "DEBUG",

--- a/jans-cedarling/cedarling_opa/demo/terraform-jwt/opa-config-demo.json
+++ b/jans-cedarling/cedarling_opa/demo/terraform-jwt/opa-config-demo.json
@@ -13,7 +13,6 @@
         "CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED": ["HS256", "RS256"],
         "CEDARLING_JWT_SIG_VALIDATION": "disabled",
         "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
-        "CEDARLING_ID_TOKEN_TRUST_MODE": "never",
 
         "CEDARLING_POLICY_STORE_LOCAL_FN": "/app/demo/terraform-jwt/policy-store"
       }

--- a/jans-cedarling/cedarling_opa/demo/terraform-jwt/opa-config.json
+++ b/jans-cedarling/cedarling_opa/demo/terraform-jwt/opa-config.json
@@ -11,7 +11,6 @@
 
         "CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED": ["RS256"],
         "CEDARLING_JWT_SIG_VALIDATION": "enabled",
-        "CEDARLING_ID_TOKEN_TRUST_MODE": "never",
 
         "CEDARLING_POLICY_STORE_LOCAL_FN": "/app/demo/terraform-jwt/policy-store"
       }

--- a/jans-cedarling/cedarling_opa/demo/terraform/opa-config.json
+++ b/jans-cedarling/cedarling_opa/demo/terraform/opa-config.json
@@ -4,11 +4,8 @@
       "stderr": false,
       "bootstrap_config": {
         "CEDARLING_APPLICATION_NAME": "TerraformAuthz",
-        "CEDARLING_USER_AUTHZ": "enabled",
-        "CEDARLING_WORKLOAD_AUTHZ": "disabled",
         "CEDARLING_JWT_SIG_VALIDATION": "disabled",
         "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
-        "CEDARLING_ID_TOKEN_TRUST_MODE": "never",
         "CEDARLING_LOG_TYPE": "std_out",
         "CEDARLING_LOG_TTL": 60,
         "CEDARLING_LOG_LEVEL": "INFO",

--- a/jans-cedarling/schema/minimal_policy_store.json
+++ b/jans-cedarling/schema/minimal_policy_store.json
@@ -26,8 +26,7 @@
             "openid_configuration_endpoint": "https://idp.example.com/.well-known/openid-configuration",
             "token_metadata": {
                 "access_token": {
-                    "entity_type_name": "Jans::Access_token",
-                    "principal_mapping": ["Jans::Workload"]
+                    "entity_type_name": "Jans::Access_token"
                 }
             }
         }

--- a/jans-cedarling/schema/policy_store_schema.json
+++ b/jans-cedarling/schema/policy_store_schema.json
@@ -140,14 +140,6 @@
             "description": "Represents an individual Cedar policy, including metadata and content.",
             "type": "object",
             "properties": {
-                "cedar_version": {
-                    "description": "The version of the Cedar language that Cedarling should use for policy evaluation.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "A name for the policy.",
-                    "type": "string"
-                },
                 "description": {
                     "description": "A short, optional description explaining the purpose of this policy.",
                     "type": "string",
@@ -170,7 +162,7 @@
                     ]
                 }
             },
-            "required": ["creation_date", "policy_content"],
+            "required": ["policy_content"],
             "additionalProperties": true
         },
         "PolicyContent": {
@@ -242,49 +234,10 @@
                     "description": "The Cedar entity type that tokens from this issuer should be mapped to (e.g., 'Jans::AccessToken'). This is required.",
                     "type": "string"
                 },
-                "principal_mapping": {
-                    "description": "A list of Cedar principal types to which this token should be mapped (e.g., ['Jans::Workload']). Defaults to an empty list.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "uniqueItems": true
-                },
                 "token_id": {
                     "description": "The claim in the token that should be treated as the unique identifier for the token. Defaults to 'jti'.",
                     "type": "string",
                     "default": "jti"
-                },
-                "user_id": {
-                    "description": "The primary claim to extract from the token to create the Workload entity. If not specified, Cedarling will attempt to use 'sub' before failing.",
-                    "type": "string",
-                    "default": "sub"
-                },
-                "role_mapping": {
-                    "description": "The claim in the token that lists the user's roles (e.g., 'role', 'group', 'memberOf'). Defaults to 'role'.",
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    ],
-                    "default": "role"
-                },
-                "workload_id": {
-                    "description": "The primary claim to extract from the token to create the Workload entity. If not specified, Cedarling will attempt to use 'aud', followed by 'client_id', before failing.",
-                    "type": "string",
-                    "default": "aud"
-                },
-                "claim_mapping": {
-                    "description": "An object defining custom mappings from token claims to Cedar entity attributes. Defaults to an empty object.",
-                    "type": "object",
-                    "default": {}
                 },
                 "required_claims": {
                     "description": "A list of claims that must be present in the token for it to be considered valid. Defaults to an empty list.",

--- a/jans-cedarling/test_files/README.md
+++ b/jans-cedarling/test_files/README.md
@@ -4,7 +4,7 @@ This folder contains policy store files used for unit testing purposes.
 
 ## Bootstrap config fixtures
 
-- `bootstrap_props.json` / `bootstrap_props.yaml`: sample bootstrap config. `CEDARLING_POLICY_STORE_LOCAL_FN` points to `policy-store_ok.yaml` (Agama format with `policy_stores`). All keys match `BootstrapConfigRaw`; deprecated options (e.g. `CEDARLING_USER_AUTHZ`) are not present.
+- `bootstrap_props.json` / `bootstrap_props.yaml`: sample bootstrap config. `CEDARLING_POLICY_STORE_LOCAL_FN` points to `policy-store_ok.yaml` (Agama format with `policy_stores`). All keys match `BootstrapConfigRaw`.
 
 ## Descriptions of json policy store test fixtures
 

--- a/jans-cedarling/test_files/agama-store.yaml
+++ b/jans-cedarling/test_files/agama-store.yaml
@@ -31,19 +31,15 @@ policy_stores:
         access_tokens:
           trusted: true
           token_id: ''
-          role_mapping: ''
         id_tokens:
           trusted: true
           token_id: sub
-          role_mapping: ''
         userinfo_tokens:
           trusted: true
           token_id: ''
-          role_mapping: role
         tx_tokens:
           trusted: true
           token_id: ''
-          role_mapping: ''
     schema:
       encoding: none
       content_type: cedar

--- a/jans-cedarling/test_files/policy-store-multi-issuer-basic.yaml
+++ b/jans-cedarling/test_files/policy-store-multi-issuer-basic.yaml
@@ -16,13 +16,8 @@ policy_stores:
         token_metadata:
           access_token:
             entity_type_name: "Acme::Access_Token"
-            workload_id: "client_id"
-            principal_mapping:
-              - "Acme::Workload"
           id_token:
             entity_type_name: "Acme::Id_Token"
-            principal_mapping:
-              - "Acme::User"
       DolphinIssuer:
         name: "Dolphin"
         description: "Dolphin Sea Identity Provider"
@@ -30,13 +25,8 @@ policy_stores:
         token_metadata:
           access_token:
             entity_type_name: "Dolphin::Access_Token"
-            workload_id: "client_id"
-            principal_mapping:
-              - "Dolphin::Workload"
           dolphin_token:
             entity_type_name: "Dolphin::Dolphin_Token"
-            principal_mapping:
-              - "Dolphin::User"
           userinfo_token:
             entity_type_name: "Dolphin::Userinfo_token"
     policies:

--- a/jans-cedarling/test_files/policy-store-multi-issuer-test.yaml
+++ b/jans-cedarling/test_files/policy-store-multi-issuer-test.yaml
@@ -16,18 +16,10 @@ policy_stores:
         token_metadata:
           access_token:
             entity_type_name: "Jans::Access_Token"
-            workload_id: "client_id"
-            principal_mapping:
-              - "Jans::Workload"
           id_token:
             entity_type_name: "Jans::Id_Token"
-            principal_mapping:
-              - "Jans::User"
           userinfo_token:
             entity_type_name: "Jans::Userinfo_Token"
-            user_id: "sub"
-            principal_mapping:
-              - "Jans::User"
     policies:
       840da5d85403f35ea76519ed1a18a33989f855bf1cf8:
         description: Multi-issuer policy example using context tokens

--- a/jans-cedarling/test_files/policy-store_generated.json
+++ b/jans-cedarling/test_files/policy-store_generated.json
@@ -23,9 +23,7 @@
                     "openid_configuration_endpoint": "https://test-casa.gluu.info/.well-known/openid-configuration",
                     "token_metadata": {
                         "access_token": {
-                            "entity_type_name": "Jans::Access_token",
-                            "workload_id": "aud",
-                            "principal_mapping": ["Jans::Workload"]
+                            "entity_type_name": "Jans::Access_token"
                         }
                     }
                 }

--- a/jans-cedarling/test_files/policy-store_lock_master_ok.json
+++ b/jans-cedarling/test_files/policy-store_lock_master_ok.json
@@ -26,52 +26,7 @@
                         "token_id": "jti"
                     },
                     "id_tokens": {},
-                    "userinfo_tokens": {
-                        "user_id": "sub",
-                        "role_mapping": "role",
-                        "claim_mapping": {
-                            "email": {
-                                "parser": "regex",
-                                "regex_expression": "^(?P<UID>[^@]+)@(?P<DOMAIN>.+)$",
-                                "UID": {
-                                    "attr": "uid",
-                                    "type": "String"
-                                },
-                                "DOMAIN": {
-                                    "attr": "domain",
-                                    "type": "String"
-                                }
-                            },
-                            "profile": {
-                                "parser": "regex",
-                                "regex_expression": "(?x) ^(?P<SCHEME>[a-zA-Z][a-zA-Z0-9+.-]*):\\/\\/(?P<HOST>[^\\/:\\#?]+)(?::(?<PORT>\\d+))?(?P<PATH>\\/[^?\\#]*)?(?:\\?(?P<QUERY>[^\\#]*))?(?:(?P<FRAGMENT>.*))?/gm",
-                                "SCHEME": {
-                                    "attr": "scheme",
-                                    "type": "String"
-                                },
-                                "HOST": {
-                                    "attr": "host",
-                                    "type": "String"
-                                },
-                                "PORT": {
-                                    "attr": "port",
-                                    "type": "String"
-                                },
-                                "PATH": {
-                                    "attr": "path",
-                                    "type": "String"
-                                },
-                                "QUERY": {
-                                    "attr": "query",
-                                    "type": "String"
-                                },
-                                "FRAGMENT": {
-                                    "attr": "fragment",
-                                    "type": "String"
-                                }
-                            }
-                        }
-                    },
+                    "userinfo_tokens": {},
                     "tx_tokens": {}
                 }
             },

--- a/jans-cedarling/test_files/policy-store_ok.yaml
+++ b/jans-cedarling/test_files/policy-store_ok.yaml
@@ -16,18 +16,10 @@ policy_stores:
         token_metadata:
           access_token:
             entity_type_name: "Jans::Access_token"
-            workload_id: "client_id"
-            principal_mapping:
-              - "Jans::Workload"
           id_token:
             entity_type_name: "Jans::Id_token"
-            principal_mapping:
-              - "Jans::User"
           userinfo_token:
             entity_type_name: "Jans::Userinfo_token"
-            user_id: "sub"
-            principal_mapping:
-              - "Jans::User"
     policies:
       840da5d85403f35ea76519ed1a18a33989f855bf1cf8:
         description: simple policy example for principal workload
@@ -42,10 +34,9 @@ policy_stores:
                 resource is Jans::Issue
             )when{
                 principal.access_token.org_id == resource.org_id &&
-                principal.aud == "5b4487c4-8db1-409d-a653-f907b8094039" 
+                principal.aud == "5b4487c4-8db1-409d-a653-f907b8094039"
             };
       444da5d85403f35ea76519ed1a18a33989f855bf1cf8:
-        cedar_version: v4.0.0
         description: simple policy example for principal user
         creation_date: '2024-09-20T17:22:39.996050'
         policy_content:
@@ -58,10 +49,9 @@ policy_stores:
                 resource is Jans::Issue
             )when{
                 principal.country == resource.country &&
-                principal.id_token.aud.contains("5b4487c4-8db1-409d-a653-f907b8094039") 
+                principal.id_token.aud.contains("5b4487c4-8db1-409d-a653-f907b8094039")
             };
       555da5d85403f35ea76519ed1a18a33989f855bf1cf8:
-        cedar_version: v4.0.0
         description: Superuser that can do anything
         creation_date: '2024-09-20T17:22:39.996050'
         policy_content:

--- a/jans-cedarling/test_files/policy-store_with_trusted_issuers_ok.yaml
+++ b/jans-cedarling/test_files/policy-store_with_trusted_issuers_ok.yaml
@@ -43,47 +43,5 @@ trusted_issuers:
     access_tokens:
         trusted: true
         token_id: jti
-        user_id: ''
-        role_mapping: ''
-        claim_mapping: {}
-    id_tokens:
-        user_id: 'sub'
-        role_mapping: 'role'
-        claim_mapping:
-          email:
-            parser: 'regex'
-            regex_expression: r'^(?P<UID>[^@]+)@(?P<DOMAIN>.+)$'
-            UID: 
-              attr: 'uid'
-              type: 'string'
-            DOMAIN: 
-              attr: 'domain'
-              type: 'string'
-          profile:
-            parser: 'regex'
-            regex_expression: r'(?x) ^(?P<SCHEME>[a-zA-Z][a-zA-Z0-9+.-]*):\/\/ (?P<HOST>[^\/:#?]+) (?::(?P<PORT>\d+))?  (?P<PATH>\/[^?#]*)? (?:\?(?P<QUERY>[^#]*))?  (?:#(?P<FRAGMENT>.*))?$'
-            SCHEME: 
-              attr: 'scheme'
-              type: 'string'
-            HOST: 
-              attr: 'host'
-              type: 'string'
-            PORT: 
-              attr: 'port'
-              type: 'string'
-            PATH: 
-              attr: 'path'
-              type: 'string'
-            QUERY: 
-              attr: 'query'
-              type: 'string'
-            FRAGMENT: 
-              attr: 'fragment'
-              type: 'string'
-          dolphin:
-            parser: 'json'
-            type: 'Acme::Dolphin'
-    userinfo_tokens:
-        user_id: ''
-        role_mapping: ''
-        claim_mapping: {}
+    id_tokens: {}
+    userinfo_tokens: {}


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------
### Description

#### Target issue

closes #14092

#### Implementation Details

- Removed deprecated fields from the policy store schema and corresponding Rust struct definitions.
- Removed deprecated bootstrap config properties from docs and examples (`CEDARLING_POLICY_STORE_ID`, `CEDARLING_USER_AUTHZ`, `CEDARLING_WORKLOAD_AUTHZ`, `CEDARLING_ID_TOKEN_TRUST_MODE`, `CEDARLING_POLICY_STORE_VALIDATE_CHECKSUM`) across Markdown docs, C examples, Python examples, and OPA demo configs.
- Fixed property name `CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS` → `CEDARLING_HTTP_REQUEST_TIMEOUT`.
- Aligned `JwtConfig::default()` with the permissive defaults produced from an empty bootstrap config (signature/status validation off, `token_cache_max_ttl=0`). Refactored `new_without_validation()` to delegate to `default()`.
- Fixed token cache to skip caching tokens without `exp` when `max_ttl` is 0, instead of falling back to a 5-minute default TTL.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples across tutorials and integrations to reflect current best practices and simplified token metadata structure.

* **Configuration Changes**
  * Removed deprecated properties: `CEDARLING_POLICY_STORE_ID`, `CEDARLING_ID_TOKEN_TRUST_MODE`, `CEDARLING_USER_AUTHZ`, `CEDARLING_WORKLOAD_AUTHZ`.
  * Renamed `CEDARLING_HTTP_REQUEST_TIMEOUT_MILLIS` to `CEDARLING_HTTP_REQUEST_TIMEOUT` (now in seconds).
  * Simplified token metadata schema by removing principal mapping fields.

* **Policy Store Updates**
  * Removed optional fields from policy definitions: `cedar_version`, `name`, `creation_date`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JanssenProject/jans/pull/14096)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->