### PR TITLE
feat(jans-fido2): add Fido2MetricType enum coverage in model module

### DIFF
--- a/jans-fido2/model/src/test/java/io/jans/fido2/model/metric/Fido2MetricTypeTest.java
+++ b/jans-fido2/model/src/test/java/io/jans/fido2/model/metric/Fido2MetricTypeTest.java
@@ -1,0 +1,94 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2024, Janssen Project
+ */
+
+package io.jans.fido2.model.metric;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test class for FIDO2 Fido2MetricType enum
+ *
+ * @author Janssen Project
+ * @version 1.0
+ */
+class Fido2MetricTypeTest {
+
+    /**
+     * Authoritative mapping of enum constant to expected persisted metric name.
+     * Driving the test from this map guarantees every enum value is asserted —
+     * a new enum constant added without an entry here will fail the size check.
+     */
+    private static final Map<Fido2MetricType, String> EXPECTED_METRIC_NAMES;
+    static {
+        EnumMap<Fido2MetricType, String> map = new EnumMap<>(Fido2MetricType.class);
+        map.put(Fido2MetricType.FIDO2_REGISTRATION_ATTEMPT, "fido2_registration_attempt");
+        map.put(Fido2MetricType.FIDO2_REGISTRATION_SUCCESS, "fido2_registration_success");
+        map.put(Fido2MetricType.FIDO2_REGISTRATION_FAILURE, "fido2_registration_failure");
+        map.put(Fido2MetricType.FIDO2_REGISTRATION_DURATION, "fido2_registration_duration");
+        map.put(Fido2MetricType.FIDO2_AUTHENTICATION_ATTEMPT, "fido2_authentication_attempt");
+        map.put(Fido2MetricType.FIDO2_AUTHENTICATION_SUCCESS, "fido2_authentication_success");
+        map.put(Fido2MetricType.FIDO2_AUTHENTICATION_FAILURE, "fido2_authentication_failure");
+        map.put(Fido2MetricType.FIDO2_AUTHENTICATION_DURATION, "fido2_authentication_duration");
+        map.put(Fido2MetricType.FIDO2_FALLBACK_EVENT, "fido2_fallback_event");
+        map.put(Fido2MetricType.FIDO2_DEVICE_TYPE_USAGE, "fido2_device_type_usage");
+        EXPECTED_METRIC_NAMES = map;
+    }
+
+    @Test
+    void testGetMetricNameReturnsExpectedValueForEveryEnum() {
+        assertEquals(Fido2MetricType.values().length, EXPECTED_METRIC_NAMES.size(),
+                "Every enum constant must have an expected metric name entry");
+        for (Fido2MetricType type : Fido2MetricType.values()) {
+            assertTrue(EXPECTED_METRIC_NAMES.containsKey(type),
+                    "Missing expected metric name for " + type.name());
+            assertEquals(EXPECTED_METRIC_NAMES.get(type), type.getMetricName(),
+                    "Unexpected metricName for " + type.name());
+        }
+    }
+
+    @Test
+    void testGetMetricNameIsUniqueAcrossAllEnumValues() {
+        Set<String> uniqueNames = Arrays.stream(Fido2MetricType.values())
+                .map(Fido2MetricType::getMetricName)
+                .collect(Collectors.toSet());
+        assertEquals(Fido2MetricType.values().length, uniqueNames.size(),
+                "Metric names must be unique; duplicates would silently merge in DB aggregation");
+    }
+
+    @Test
+    void testGetDescriptionIsNonNullAndNonEmptyForEveryEnum() {
+        for (Fido2MetricType type : Fido2MetricType.values()) {
+            String description = type.getDescription();
+            assertNotNull(description, "Description must not be null for " + type.name());
+            assertFalse(description.isEmpty(), "Description must not be empty for " + type.name());
+        }
+    }
+
+    @Test
+    void testToStringReturnsMetricName() {
+        for (Fido2MetricType type : Fido2MetricType.values()) {
+            assertEquals(type.getMetricName(), type.toString(),
+                    "toString() must return metricName for " + type.name());
+        }
+    }
+
+    @Test
+    void testValuesLengthIsTen() {
+        assertEquals(10, Fido2MetricType.values().length,
+                "Fido2MetricType is expected to have exactly 10 values; consumers rely on this fixed set");
+    }
+}


### PR DESCRIPTION
### Description

Adds the first unit test under jans-fido2/model, covering Fido2MetricType enum: per-constant metric name mapping, non-null/non-empty descriptions, the toString() override, the 10-value count guard, and uniqueness of metric names. Bootstraps src/test for the model module so subsequent metrics-coverage issues can build on it. No production code changes

#### Target issue

First in a planned series to add comprehensive test coverage for the FIDO2 metrics feature, starting from the smallest dependency-free piece. Follow-ups will cover Fido2MetricsConstants, the DTOs, Fido2UserMetrics.calculateUserRiskScore(), and progressively the services/scheduler/controller.
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14058

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for FIDO2 metric type validation, ensuring enum consistency, uniqueness, and proper configuration across all metric types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JanssenProject/jans/pull/14100)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->