### PR TITLE
fix(jans-auth-server): added validation for sector_identifier_uri in RedirectionUriService

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectionUriService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectionUriService.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Javier Rojas Blum
@@ -121,15 +122,15 @@ public class RedirectionUriService {
     }
 
     String fetchSectorIdentifierContent(String sectorIdentiferUri) {
-        jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newClient();
-        try {
-            Response clientResponse = clientRequest.target(sectorIdentiferUri).request().buildGet().invoke();
+        try (jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newBuilder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
+             Response clientResponse = clientRequest.target(sectorIdentiferUri).request().buildGet().invoke()) {
             if (clientResponse.getStatus() != 200) {
                 return null;
             }
             return clientResponse.readEntity(String.class);
-        } finally {
-            clientRequest.close();
         }
     }
 

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectionUriService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectionUriService.java
@@ -15,6 +15,7 @@ import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
 import io.jans.as.model.session.EndSessionErrorResponseType;
 import io.jans.as.model.util.QueryStringDecoder;
+import io.jans.as.model.util.URLPatternList;
 import io.jans.as.model.util.Util;
 import io.jans.as.server.session.ws.rs.EndSessionService;
 import jakarta.ejb.Stateless;
@@ -73,24 +74,18 @@ public class RedirectionUriService {
             return result;
         }
 
+        if (!isAllowedSectorIdentifierUri(sectorIdentiferUri)) {
+            return result;
+        }
+
         final List<String> sectorRedirectUris = localResponseCache.getSectorRedirectUris(sectorIdentiferUri);
         if (sectorRedirectUris != null) {
             return sectorRedirectUris;
         }
 
-        jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newClient();
-
-        String entity = null;
-        try {
-            Response clientResponse = clientRequest.target(sectorIdentiferUri).request().buildGet().invoke();
-            int status = clientResponse.getStatus();
-            if (status != 200) {
-                return result;
-            }
-
-            entity = clientResponse.readEntity(String.class);
-        } finally {
-            clientRequest.close();
+        String entity = fetchSectorIdentifierContent(sectorIdentiferUri);
+        if (StringUtils.isBlank(entity)) {
+            return result;
         }
 
         JSONArray sectorIdentifierJsonArray = new JSONArray(entity);
@@ -100,6 +95,42 @@ public class RedirectionUriService {
         }
         localResponseCache.putSectorRedirectUris(sectorIdentiferUri, result);
         return result;
+    }
+
+    boolean isAllowedSectorIdentifierUri(String sectorIdentiferUri) {
+        try {
+            java.net.URI uri = new java.net.URI(sectorIdentiferUri);
+            if (!"https".equalsIgnoreCase(uri.getScheme())) {
+                log.warn("sector_identifier_uri must use https scheme, got: {}", sectorIdentiferUri);
+                return false;
+            }
+        } catch (java.net.URISyntaxException e) {
+            log.warn("sector_identifier_uri is not a valid URI: {}", sectorIdentiferUri);
+            return false;
+        }
+
+        final List<String> blockList = appConfiguration.getRequestUriBlockList();
+        if (blockList != null && !blockList.isEmpty()) {
+            URLPatternList urlPatternList = new URLPatternList(blockList);
+            if (urlPatternList.isUrlListed(sectorIdentiferUri)) {
+                log.warn("sector_identifier_uri is forbidden by block list: {}", sectorIdentiferUri);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    String fetchSectorIdentifierContent(String sectorIdentiferUri) {
+        jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newClient();
+        try {
+            Response clientResponse = clientRequest.target(sectorIdentiferUri).request().buildGet().invoke();
+            if (clientResponse.getStatus() != 200) {
+                return null;
+            }
+            return clientResponse.readEntity(String.class);
+        } finally {
+            clientRequest.close();
+        }
     }
 
     public String validateRedirectionUri(@NotNull Client client, String redirectionUri) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/RedirectionUriServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/RedirectionUriServiceTest.java
@@ -1,5 +1,6 @@
 package io.jans.as.server.service;
 
+import com.google.common.collect.Lists;
 import io.jans.as.common.model.registration.Client;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
@@ -17,7 +18,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @Listeners(MockitoTestNGListener.class)
 public class RedirectionUriServiceTest {
@@ -136,6 +137,49 @@ public class RedirectionUriServiceTest {
 
         final String returnValue = redirectionUriService.validateRedirectionUri(client, singleRedirectUri);
         assertEquals(singleRedirectUri, returnValue);
+    }
+
+    @Test
+    public void getSectorRedirectUris_whenHttpScheme_shouldReturnEmptyAndSkipFetch() {
+        final List<String> result = redirectionUriService.getSectorRedirectUris("http://169.254.169.254/latest/meta-data/");
+        assertTrue(result.isEmpty());
+        verify(redirectionUriService, never()).fetchSectorIdentifierContent(anyString());
+    }
+
+    @Test
+    public void getSectorRedirectUris_whenHttpsAndBlocklisted_shouldReturnEmptyAndSkipFetch() {
+        when(appConfiguration.getRequestUriBlockList()).thenReturn(Lists.newArrayList("https://internal.example/*"));
+
+        final List<String> result = redirectionUriService.getSectorRedirectUris("https://internal.example/sector.json");
+        assertTrue(result.isEmpty());
+        verify(redirectionUriService, never()).fetchSectorIdentifierContent(anyString());
+    }
+
+    @Test
+    public void getSectorRedirectUris_whenMalformedUri_shouldReturnEmptyAndSkipFetch() {
+        final List<String> result = redirectionUriService.getSectorRedirectUris("not a uri");
+        assertTrue(result.isEmpty());
+        verify(redirectionUriService, never()).fetchSectorIdentifierContent(anyString());
+    }
+
+    @Test
+    public void getSectorRedirectUris_whenHttpsAndAllowed_shouldInvokeFetch() {
+        when(localResponseCache.getSectorRedirectUris(anyString())).thenReturn(null);
+        doReturn(null).when(redirectionUriService).fetchSectorIdentifierContent(anyString());
+
+        final List<String> result = redirectionUriService.getSectorRedirectUris("https://rp.example/sector.json");
+        assertTrue(result.isEmpty());
+        verify(redirectionUriService).fetchSectorIdentifierContent("https://rp.example/sector.json");
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_httpsWithoutBlocklist_returnsTrue() {
+        assertTrue(redirectionUriService.isAllowedSectorIdentifierUri("https://rp.example/sector.json"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_httpScheme_returnsFalse() {
+        assertFalse(redirectionUriService.isAllowedSectorIdentifierUri("http://rp.example/sector.json"));
     }
 
     private Client getClientForValidateRedirectionUri_full() {


### PR DESCRIPTION
### Description

fix(jans-auth-server): added validation for sector_identifier_uri in RedirectionUriService

#### Target issue
  
closes #issue-number-here

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14112, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforce HTTPS for sector identifier URIs and apply configured blocklist rules
  * Avoid remote fetches for invalid, non-HTTPS, or blocklisted URIs
  * Fetch sector identifier content with stricter validation, handle non-200/blank responses gracefully
  * Cache parsed redirect URI lists and improve related caching behavior

* **Tests**
  * Added tests covering HTTP vs HTTPS, blocklisted and malformed URIs, and fetch vs skip behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JanssenProject/jans/pull/14111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->