### PR TITLE
fix: correct urls in Chart.yaml and README

### DIFF
--- a/charts/janssen-all-in-one/Chart.yaml
+++ b/charts/janssen-all-in-one/Chart.yaml
@@ -16,7 +16,8 @@ icon: >-
 home: https://jans.io
 sources:
   - https://jans.io
-  - https://github.com/JanssenProject/jans/charts/janssen
+  - https://github.com/JanssenProject/jans/tree/main/charts/janssen
+  - https://github.com/JanssenProject/jans/tree/main/charts/janssen-all-in-one
 maintainers:
   - name: moabu
     email: support@jans.io

--- a/charts/janssen-all-in-one/README.md
+++ b/charts/janssen-all-in-one/README.md
@@ -15,7 +15,8 @@ Janssen Access and Identity Management All-in-One Chart. This chart deploys the 
 ## Source Code
 
 * <https://jans.io>
-* <https://github.com/JanssenProject/jans/charts/janssen>
+* <https://github.com/JanssenProject/jans/tree/main/charts/janssen>
+* <https://github.com/JanssenProject/jans/tree/main/charts/janssen-all-in-one>
 
 ## Requirements
 

--- a/charts/janssen/Chart.yaml
+++ b/charts/janssen/Chart.yaml
@@ -34,7 +34,7 @@ icon: >-
 home: https://jans.io
 sources:
   - https://jans.io
-  - https://github.com/JanssenProject/jans/charts/janssen
+  - https://github.com/JanssenProject/jans/tree/main/charts/janssen
 maintainers:
   - name: moabu
     email: support@jans.io

--- a/charts/janssen/README.md
+++ b/charts/janssen/README.md
@@ -15,7 +15,7 @@ Janssen Access and Identity Management Microservices Chart. This chart deploys e
 ## Source Code
 
 * <https://jans.io>
-* <https://github.com/JanssenProject/jans/charts/janssen>
+* <https://github.com/JanssenProject/jans/tree/main/charts/janssen>
 
 ## Requirements
 

--- a/charts/janssen/charts/auth-server-key-rotation/Chart.yaml
+++ b/charts/janssen/charts/auth-server-key-rotation/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - Auth keys Rotation
 home: https://jans.io
 sources:
-  - https://github.com/JanssenProject/docker-jans-cloudtools
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-cloudtools
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/auth-server-key-rotation/README.md
+++ b/charts/janssen/charts/auth-server-key-rotation/README.md
@@ -14,7 +14,7 @@ Responsible for regenerating auth-keys per x hours
 
 ## Source Code
 
-* <https://github.com/JanssenProject/docker-jans-cloudtools>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-cloudtools>
 
 ## Requirements
 

--- a/charts/janssen/charts/auth-server/Chart.yaml
+++ b/charts/janssen/charts/auth-server/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - OpenID
 home: https://jans.io
 sources:
-  - https://github.com/JanssenProject/jans-auth-server
-  - https://github.com/JanssenProject/docker-jans-auth-server
+  - https://github.com/JanssenProject/jans/tree/main/jans-auth-server
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-auth-server
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/auth-server/README.md
+++ b/charts/janssen/charts/auth-server/README.md
@@ -14,8 +14,8 @@ OAuth Authorization Server, the OpenID Connect Provider, the UMA Authorization S
 
 ## Source Code
 
-* <https://github.com/JanssenProject/jans-auth-server>
-* <https://github.com/JanssenProject/docker-jans-auth-server>
+* <https://github.com/JanssenProject/jans/tree/main/jans-auth-server>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-auth-server>
 
 ## Requirements
 

--- a/charts/janssen/charts/casa/Chart.yaml
+++ b/charts/janssen/charts/casa/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
 home: https://gluu.org/docs/casa/
 sources:
   - https://gluu.org/casa/
-  - https://github.com/JanssenProject/jans/docker-jans-casa
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-casa
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/casa/README.md
+++ b/charts/janssen/charts/casa/README.md
@@ -15,7 +15,7 @@ Jans Casa ("Casa") is a self-service web portal for end-users to manage authenti
 ## Source Code
 
 * <https://gluu.org/casa/>
-* <https://github.com/JanssenProject/jans/docker-jans-casa>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-casa>
 
 ## Requirements
 

--- a/charts/janssen/charts/cleanup/Chart.yaml
+++ b/charts/janssen/charts/cleanup/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - Persistence
 home: https://jans.io
 sources:
-  - https://github.com/JanssenProject/jans/docker-jans-cloudtools
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-cloudtools
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/cleanup/README.md
+++ b/charts/janssen/charts/cleanup/README.md
@@ -14,7 +14,7 @@ Cleanup expired entries in persistence
 
 ## Source Code
 
-* <https://github.com/JanssenProject/jans/docker-jans-cloudtools>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-cloudtools>
 
 ## Requirements
 

--- a/charts/janssen/charts/config-api/Chart.yaml
+++ b/charts/janssen/charts/config-api/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - API
 home: https://jans.io
 sources:
-  - https://github.com/JanssenProject/jans/jans-config-api
-  - https://github.com/JanssenProject/jans/docker-jans-config-api
+  - https://github.com/JanssenProject/jans/tree/main/jans-config-api
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-config-api
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/config-api/README.md
+++ b/charts/janssen/charts/config-api/README.md
@@ -14,8 +14,8 @@ Jans Config Api endpoints can be used to configure jans-auth-server, which is an
 
 ## Source Code
 
-* <https://github.com/JanssenProject/jans/jans-config-api>
-* <https://github.com/JanssenProject/jans/docker-jans-config-api>
+* <https://github.com/JanssenProject/jans/tree/main/jans-config-api>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-config-api>
 
 ## Requirements
 

--- a/charts/janssen/charts/config/Chart.yaml
+++ b/charts/janssen/charts/config/Chart.yaml
@@ -10,7 +10,6 @@ keywords:
   - secrets
 home: /docker-jans-configurator
 sources:
-  - /docker-jans-configurator
   - https://github.com/JanssenProject/jans/tree/main/docker-jans-configurator
 maintainers:
   - name: Mohammad Abudayyeh

--- a/charts/janssen/charts/config/Chart.yaml
+++ b/charts/janssen/charts/config/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
 home: /docker-jans-configurator
 sources:
   - /docker-jans-configurator
-  - https://github.com/JanssenProject/jans/docker-jans-configurator
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-configurator
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/config/README.md
+++ b/charts/janssen/charts/config/README.md
@@ -15,7 +15,7 @@ Configuration parameters for setup and initial configuration secret and config l
 ## Source Code
 
 * </docker-jans-configurator>
-* <https://github.com/JanssenProject/jans/docker-jans-configurator>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-configurator>
 
 ## Requirements
 

--- a/charts/janssen/charts/config/README.md
+++ b/charts/janssen/charts/config/README.md
@@ -14,7 +14,6 @@ Configuration parameters for setup and initial configuration secret and config l
 
 ## Source Code
 
-* </docker-jans-configurator>
 * <https://github.com/JanssenProject/jans/tree/main/docker-jans-configurator>
 
 ## Requirements

--- a/charts/janssen/charts/fido2/Chart.yaml
+++ b/charts/janssen/charts/fido2/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
 home: https://jans.io/
 sources:
   - https://jans.io/
-  - https://github.com/JanssenProject/jans/jans-fido2
-  - https://github.com/JanssenProject/jans/docker-jans-fido2
+  - https://github.com/JanssenProject/jans/tree/main/jans-fido2
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-fido2
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/fido2/README.md
+++ b/charts/janssen/charts/fido2/README.md
@@ -15,8 +15,8 @@ FIDO 2.0 (FIDO2) is an open authentication standard that enables leveraging comm
 ## Source Code
 
 * <https://jans.io/>
-* <https://github.com/JanssenProject/jans/jans-fido2>
-* <https://github.com/JanssenProject/jans/docker-jans-fido2>
+* <https://github.com/JanssenProject/jans/tree/main/jans-fido2>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-fido2>
 
 ## Requirements
 

--- a/charts/janssen/charts/persistence/Chart.yaml
+++ b/charts/janssen/charts/persistence/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - persistence prep
 home: https://jans.io
 sources:
-  - https://github.com/JanssenProject/jans/docker-jans-persistence-loader
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-persistence-loader
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/persistence/README.md
+++ b/charts/janssen/charts/persistence/README.md
@@ -14,7 +14,7 @@ Job to generate data and initial config for Janssen Server persistence layer.
 
 ## Source Code
 
-* <https://github.com/JanssenProject/jans/docker-jans-persistence-loader>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-persistence-loader>
 
 ## Requirements
 

--- a/charts/janssen/charts/scim/Chart.yaml
+++ b/charts/janssen/charts/scim/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - API
 home: https://jans.io
 sources:
-  - https://github.com/JanssenProject/jans/jans-scim
-  - https://github.com/JanssenProject/jans/docker-jans-scim
+  - https://github.com/JanssenProject/jans/tree/main/jans-scim
+  - https://github.com/JanssenProject/jans/tree/main/docker-jans-scim
 maintainers:
   - name: Mohammad Abudayyeh
     email: support@jans.io

--- a/charts/janssen/charts/scim/README.md
+++ b/charts/janssen/charts/scim/README.md
@@ -14,8 +14,8 @@ System for Cross-domain Identity Management (SCIM) version 2.0
 
 ## Source Code
 
-* <https://github.com/JanssenProject/jans/jans-scim>
-* <https://github.com/JanssenProject/jans/docker-jans-scim>
+* <https://github.com/JanssenProject/jans/tree/main/jans-scim>
+* <https://github.com/JanssenProject/jans/tree/main/docker-jans-scim>
 
 ## Requirements
 

--- a/charts/janssen/charts/shibboleth-idp/Chart.yaml
+++ b/charts/janssen/charts/shibboleth-idp/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 home: https://jans.io
 sources:
   - https://github.com/JanssenProject/jans
-  - https://shibboleth.net/products/identity-provider.html
+  - https://shibboleth.atlassian.net/wiki/spaces/IDP5/overview
 maintainers:
   - name: Janssen Project
     email: support@jans.io

--- a/charts/janssen/charts/shibboleth-idp/README.md
+++ b/charts/janssen/charts/shibboleth-idp/README.md
@@ -15,7 +15,7 @@ Shibboleth Identity Provider 5.1.6 for SAML SSO, integrated with Janssen Auth Se
 ## Source Code
 
 * <https://github.com/JanssenProject/jans>
-* <https://shibboleth.net/products/identity-provider.html>
+* <https://shibboleth.atlassian.net/wiki/spaces/IDP5/overview>
 
 ## Requirements
 


### PR DESCRIPTION
closes #14145 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated chart READMEs to point to correct upstream repository and documentation links.

* **Chores**
  * Standardized Helm chart source metadata across Janssen charts to use consistent repository paths and branch-aware URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JanssenProject/jans/pull/14146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->