### PR TITLE
feat(jans-auth-server): how to test interception scripts? - sample unit test and docs #12663

### DIFF
--- a/docs/janssen-server/developer/scripts/README.md
+++ b/docs/janssen-server/developer/scripts/README.md
@@ -226,6 +226,103 @@ class UpdateToken(UpdateTokenType):
 
 ***
 
+## Unit testing custom scripts
+
+You don't need to start the Authorization Server to verify your script logic.
+The interception interfaces (e.g. `DiscoveryType`, `UpdateTokenType`,
+`IntrospectionType`) are plain Java interfaces, so a script class can be
+instantiated and its methods called directly from a unit test.
+
+### Recommended approach
+
+The `ExecutionContext` (and other context objects passed to interception
+methods) holds references to most server-side objects at runtime. **You only
+need to populate the parts of the context your script actually reads.** This
+keeps tests focused and fast.
+
+Cover both **positive** and **negative** scenarios for each branch of script
+logic:
+
+- **Positive** — provide the inputs the script expects and assert the
+  observable outcome (response was modified, return value is `true`, etc.).
+- **Negative** — provide missing/empty inputs and assert the failure mode
+  (`NullPointerException`, `false` return, response left untouched, etc.).
+  These tests document the script's preconditions.
+
+Two mocking styles work well:
+
+1. **Plain construction** — build a real `ExecutionContext`, set what you need
+   (`context.setClient(client)`), and pass it. Easiest to read.
+2. **Mockito** — already used heavily in jans-auth-server tests. Useful when
+   the real object is heavy or pulls in too many collaborators. Stub only the
+   methods the script calls.
+
+### Example: Discovery script
+
+Given a `Discovery` script that does not touch context:
+
+```java
+public boolean modifyResponse(Object responseAsJsonObject, Object context) {
+    JSONObject response = (JSONObject) responseAsJsonObject;
+    response.accumulate("key_from_java", "value_from_script_on_java");
+    return true;
+}
+```
+
+A bare `new ExecutionContext()` is enough — there is nothing to set up:
+
+```java
+DiscoveryType script = new Discovery();
+JSONObject response = new JSONObject();
+
+assertTrue(script.modifyResponse(response, new ExecutionContext()));
+assertEquals(response.getString("key_from_java"), "value_from_script_on_java");
+```
+
+If the same script is changed to read the client from the context:
+
+```java
+public boolean modifyResponse(Object responseAsJsonObject, Object context) {
+    ExecutionContext executionContext = (ExecutionContext) context;
+    JSONObject response = (JSONObject) responseAsJsonObject;
+    response.accumulate("client_id_from_script", executionContext.getClient().getClientId());
+    return true;
+}
+```
+
+…the negative test is to pass an empty context and assert NPE; the positive
+test sets the client (either with a real `Client` or a Mockito mock):
+
+```java
+// negative — empty context, client is null
+assertThrows(NullPointerException.class,
+        () -> script.modifyResponse(new JSONObject(), new ExecutionContext()));
+
+// positive — explicit setter
+Client client = new Client();
+client.setClientId("test_id");
+ExecutionContext context = new ExecutionContext();
+context.setClient(client);
+
+JSONObject response = new JSONObject();
+assertTrue(script.modifyResponse(response, context));
+assertEquals(response.getString("client_id_from_script"), "test_id");
+```
+
+### Full sample test
+
+A complete, runnable example covering context-free, client-aware, and
+opt-out (returns `false`) scenarios — both with explicit construction and
+with Mockito — lives in the jans-auth-server test suite:
+
+[`jans-auth-server/server/src/test/java/io/jans/as/server/scripts/DiscoveryScriptTest.java`](https://github.com/JanssenProject/jans/blob/main/jans-auth-server/server/src/test/java/io/jans/as/server/scripts/DiscoveryScriptTest.java)
+
+The same pattern applies to every other script type — substitute the type's
+interface and its context object (`ExternalUpdateTokenContext`,
+`ExternalIntrospectionContext`, etc.).
+
+***
+
 ### Mandatory methods to be overridden
 This is the [base class of all custom script types](https://github.com/JanssenProject/jans/blob/main/jans-core/script/src/main/java/io/jans/model/custom/script/type/BaseExternalType.java) and all custom
 scripts should implement the following methods.

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/scripts/DiscoveryScriptTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/scripts/DiscoveryScriptTest.java
@@ -1,0 +1,182 @@
+package io.jans.as.server.scripts;
+
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.server.model.common.ExecutionContext;
+import io.jans.model.SimpleCustomProperty;
+import io.jans.model.custom.script.model.CustomScript;
+import io.jans.model.custom.script.type.discovery.DiscoveryType;
+import org.json.JSONObject;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+/**
+ * Demonstrates how to unit-test {@link DiscoveryType} interception scripts.
+ *
+ * <p>The strategy follows the recommendation in
+ * <a href="https://github.com/JanssenProject/jans/issues/12663#issuecomment-3581063779">jans#12663</a>:
+ * exercise the script's {@code modifyResponse} method directly, covering positive
+ * and negative paths that depend on what the script logic actually reads from the
+ * {@link ExecutionContext}.
+ *
+ * @author Yuriy Z
+ */
+public class DiscoveryScriptTest {
+
+    // ---------------------------------------------------------------------
+    // Scenario 1 — script does not touch ExecutionContext.
+    // A bare `new ExecutionContext()` is enough; no setup required.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void modifyResponse_contextFreeScript_withEmptyContext_addsKey() {
+        DiscoveryType script = contextFreeScript();
+        JSONObject response = new JSONObject();
+
+        boolean modified = script.modifyResponse(response, new ExecutionContext());
+
+        assertTrue(modified);
+        assertEquals(response.getString("key_from_java"), "value_from_script_on_java");
+    }
+
+    // ---------------------------------------------------------------------
+    // Scenario 2 — script reads `executionContext.getClient().getClientId()`.
+    // Negative: empty ExecutionContext means client == null, so NPE.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void modifyResponse_clientAwareScript_withEmptyContext_throwsNpe() {
+        DiscoveryType script = clientAwareScript();
+        JSONObject response = new JSONObject();
+
+        assertThrows(NullPointerException.class,
+                () -> script.modifyResponse(response, new ExecutionContext()));
+    }
+
+    // ---------------------------------------------------------------------
+    // Scenario 3 — same script, positive path with a real Client wired in.
+    // Shows the "explicit setter" mocking style from the linked comment.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void modifyResponse_clientAwareScript_withClientSet_addsClientId() {
+        Client client = new Client();
+        client.setClientId("test_id");
+
+        ExecutionContext context = new ExecutionContext();
+        context.setClient(client);
+
+        DiscoveryType script = clientAwareScript();
+        JSONObject response = new JSONObject();
+
+        boolean modified = script.modifyResponse(response, context);
+
+        assertTrue(modified);
+        assertEquals(response.getString("client_id_from_script"), "test_id");
+    }
+
+    // ---------------------------------------------------------------------
+    // Scenario 4 — same script, positive path using Mockito to stub the
+    // pieces of ExecutionContext the script actually touches. Useful when
+    // wiring a real ExecutionContext is heavy or has side effects.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void modifyResponse_clientAwareScript_withMockedContext_addsClientId() {
+        Client client = mock(Client.class);
+        when(client.getClientId()).thenReturn("mocked_id");
+
+        ExecutionContext context = mock(ExecutionContext.class);
+        when(context.getClient()).thenReturn(client);
+
+        DiscoveryType script = clientAwareScript();
+        JSONObject response = new JSONObject();
+
+        boolean modified = script.modifyResponse(response, context);
+
+        assertTrue(modified);
+        assertEquals(response.getString("client_id_from_script"), "mocked_id");
+    }
+
+    // ---------------------------------------------------------------------
+    // Scenario 5 — script signals "do not modify" by returning false.
+    // ExternalDiscoveryService propagates this back to the caller; the
+    // discovery JSON should remain untouched.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void modifyResponse_optOutScript_returnsFalseAndLeavesResponseUntouched() {
+        DiscoveryType script = optOutScript();
+        JSONObject response = new JSONObject().put("issuer", "https://as.example.org");
+
+        boolean modified = script.modifyResponse(response, new ExecutionContext());
+
+        assertEquals(modified, false);
+        assertEquals(response.length(), 1);
+        assertEquals(response.getString("issuer"), "https://as.example.org");
+    }
+
+    // ---------------------------------------------------------------------
+    // Inline DiscoveryType implementations used by the scenarios above.
+    // They mirror the snippets discussed in the linked comment and the
+    // sample script under docs/script-catalog/discovery/.
+    // ---------------------------------------------------------------------
+
+    private static DiscoveryType contextFreeScript() {
+        return new BaseDiscoveryScript() {
+            @Override
+            public boolean modifyResponse(Object responseAsJsonObject, Object context) {
+                JSONObject response = (JSONObject) responseAsJsonObject;
+                response.accumulate("key_from_java", "value_from_script_on_java");
+                return true;
+            }
+        };
+    }
+
+    private static DiscoveryType clientAwareScript() {
+        return new BaseDiscoveryScript() {
+            @Override
+            public boolean modifyResponse(Object responseAsJsonObject, Object context) {
+                ExecutionContext executionContext = (ExecutionContext) context;
+                JSONObject response = (JSONObject) responseAsJsonObject;
+                response.accumulate("client_id_from_script", executionContext.getClient().getClientId());
+                return true;
+            }
+        };
+    }
+
+    private static DiscoveryType optOutScript() {
+        return new BaseDiscoveryScript() {
+            @Override
+            public boolean modifyResponse(Object responseAsJsonObject, Object context) {
+                return false;
+            }
+        };
+    }
+
+    private static abstract class BaseDiscoveryScript implements DiscoveryType {
+        @Override
+        public boolean init(Map<String, SimpleCustomProperty> configurationAttributes) {
+            return true;
+        }
+
+        @Override
+        public boolean init(CustomScript customScript, Map<String, SimpleCustomProperty> configurationAttributes) {
+            return true;
+        }
+
+        @Override
+        public boolean destroy(Map<String, SimpleCustomProperty> configurationAttributes) {
+            return true;
+        }
+
+        @Override
+        public int getApiVersion() {
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
### Description

feat(jans-auth-server): how to test interception scripts? - sample unit test and docs 

#### Target issue
  
closes #12663

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for unit testing custom scripts, including best practices for populating execution context and example test scenarios covering positive and negative cases.

* **Tests**
  * Added complete example test suite demonstrating unit testing patterns for custom scripts with scenarios for context-free behavior, client-aware scripts, and opt-out configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JanssenProject/jans/pull/14147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->