### PR TITLE
feat(jans-auth-server): added User Info JWT to Token Status List #14007

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/token/StatusListService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/token/StatusListService.java
@@ -7,6 +7,7 @@ import io.jans.as.model.crypto.signature.SignatureAlgorithm;
 import io.jans.as.model.error.ErrorResponseFactory;
 import io.jans.as.model.exception.InvalidJwtException;
 import io.jans.as.model.jwt.Jwt;
+import io.jans.as.model.jwt.JwtClaims;
 import io.jans.as.model.jwt.JwtType;
 import io.jans.as.model.token.JsonWebResponse;
 import io.jans.as.server.model.common.ExecutionContext;
@@ -140,6 +141,10 @@ public class StatusListService {
     }
 
     public void addStatusClaimWithIndex(JsonWebResponse jwr, ExecutionContext executionContext) {
+        addStatusClaimWithIndex(jwr.getClaims(), executionContext);
+    }
+
+    public void addStatusClaimWithIndex(JwtClaims jwr, ExecutionContext executionContext) {
         if (!errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)) {
             log.trace("Skipped status claim addition because {} feature flag is disabled.", FeatureFlagType.STATUS_LIST.getValue());
             return;
@@ -157,7 +162,7 @@ public class StatusListService {
         final JSONObject statusList = new JSONObject();
         statusList.put("status_list", indexAndUri);
 
-        jwr.getClaims().setClaim("status", statusList);
+        jwr.setClaim("status", statusList);
     }
 
     /**

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImpl.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImpl.java
@@ -50,6 +50,8 @@ import io.jans.as.server.service.UserService;
 import io.jans.as.server.service.date.DateFormatterService;
 import io.jans.as.server.service.external.ExternalDynamicScopeService;
 import io.jans.as.server.service.external.context.DynamicScopeExternalContext;
+import io.jans.as.server.service.token.StatusListIndexService;
+import io.jans.as.server.service.token.StatusListService;
 import io.jans.as.server.service.token.TokenService;
 import io.jans.as.server.util.ServerUtil;
 import io.jans.model.JansAttribute;
@@ -121,6 +123,12 @@ public class UserInfoRestWebServiceImpl implements UserInfoRestWebService {
 
     @Inject
     private UserInfoService userInfoService;
+
+    @Inject
+    private StatusListService statusListService;
+
+    @Inject
+    private StatusListIndexService statusListIndexService;
 
     @Override
     public Response requestUserInfoGet(String accessToken, String authorization, HttpServletRequest request, SecurityContext securityContext) {
@@ -268,6 +276,14 @@ public class UserInfoRestWebServiceImpl implements UserInfoRestWebService {
 
         claims.setIssuer(appConfiguration.getIssuer());
         Audience.setAudience(claims, authorizationGrant.getClient());
+
+        // add status claim with index
+        if (errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)) {
+            ExecutionContext executionContext = new ExecutionContext();
+            executionContext.setStatusListIndex(statusListIndexService.next());
+
+            statusListService.addStatusClaimWithIndex(claims, executionContext);
+        }
         return claims;
     }
 

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/token/StatusListServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/token/StatusListServiceTest.java
@@ -1,17 +1,25 @@
 package io.jans.as.server.service.token;
 
+import io.jans.as.model.common.FeatureFlagType;
 import io.jans.as.model.config.WebKeysConfiguration;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.jwt.JwtClaims;
+import io.jans.as.model.token.JsonWebResponse;
+import io.jans.as.server.model.common.ExecutionContext;
 import io.jans.as.server.service.DiscoveryService;
 import io.jans.as.server.service.cluster.StatusIndexPoolService;
 import jakarta.ws.rs.WebApplicationException;
+import org.json.JSONObject;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.Logger;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
 
 @Listeners(MockitoTestNGListener.class)
 public class StatusListServiceTest {
@@ -45,5 +53,97 @@ public class StatusListServiceTest {
     @Test
     public void validateTime_whenTimeIsEmpty_shouldPass() {
         statusListService.validateTime(null);
+    }
+
+    @Test
+    public void addStatusClaimWithIndex_whenFeatureFlagDisabled_shouldSkip() {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(false);
+
+        JwtClaims claims = new JwtClaims();
+        ExecutionContext executionContext = new ExecutionContext();
+        executionContext.setStatusListIndex(5);
+
+        statusListService.addStatusClaimWithIndex(claims, executionContext);
+
+        assertNull(claims.getClaim("status"));
+    }
+
+    @Test
+    public void addStatusClaimWithIndex_whenIndexIsNull_shouldSkip() {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(true);
+
+        JwtClaims claims = new JwtClaims();
+        ExecutionContext executionContext = new ExecutionContext();
+        // index is null by default
+
+        statusListService.addStatusClaimWithIndex(claims, executionContext);
+
+        assertNull(claims.getClaim("status"));
+    }
+
+    @Test
+    public void addStatusClaimWithIndex_whenIndexIsNegative_shouldSkip() {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(true);
+
+        JwtClaims claims = new JwtClaims();
+        ExecutionContext executionContext = new ExecutionContext();
+        executionContext.setStatusListIndex(-1);
+
+        statusListService.addStatusClaimWithIndex(claims, executionContext);
+
+        assertNull(claims.getClaim("status"));
+    }
+
+    @Test
+    public void addStatusClaimWithIndex_whenValidIndex_shouldSetStatusClaim() {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(true);
+        when(discoveryService.getStatusListEndpoint()).thenReturn("https://example.com/status");
+
+        JwtClaims claims = new JwtClaims();
+        ExecutionContext executionContext = new ExecutionContext();
+        executionContext.setStatusListIndex(42);
+
+        statusListService.addStatusClaimWithIndex(claims, executionContext);
+
+        JSONObject statusClaim = claims.getClaimAsJSON("status");
+        assertNotNull(statusClaim);
+        assertTrue(statusClaim.has("status_list"));
+        JSONObject statusList = statusClaim.getJSONObject("status_list");
+        assertEquals(statusList.getInt("idx"), 42);
+        assertEquals(statusList.getString("uri"), "https://example.com/status");
+    }
+
+    @Test
+    public void addStatusClaimWithIndex_viaJsonWebResponseDelegate_shouldSetStatusClaim() {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(true);
+        when(discoveryService.getStatusListEndpoint()).thenReturn("https://example.com/status");
+
+        JsonWebResponse jwr = new JsonWebResponse();
+        ExecutionContext executionContext = new ExecutionContext();
+        executionContext.setStatusListIndex(10);
+
+        statusListService.addStatusClaimWithIndex(jwr, executionContext);
+
+        JSONObject statusClaim = jwr.getClaims().getClaimAsJSON("status");
+        assertNotNull(statusClaim);
+        JSONObject statusList = statusClaim.getJSONObject("status_list");
+        assertEquals(statusList.getInt("idx"), 10);
+        assertEquals(statusList.getString("uri"), "https://example.com/status");
+    }
+
+    @Test
+    public void addStatusClaimWithIndex_whenIndexIsZero_shouldSetStatusClaim() {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(true);
+        when(discoveryService.getStatusListEndpoint()).thenReturn("https://example.com/status");
+
+        JwtClaims claims = new JwtClaims();
+        ExecutionContext executionContext = new ExecutionContext();
+        executionContext.setStatusListIndex(0);
+
+        statusListService.addStatusClaimWithIndex(claims, executionContext);
+
+        JSONObject statusClaim = claims.getClaimAsJSON("status");
+        assertNotNull(statusClaim);
+        assertEquals(statusClaim.getJSONObject("status_list").getInt("idx"), 0);
     }
 }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImplTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImplTest.java
@@ -134,7 +134,7 @@ public class UserInfoRestWebServiceImplTest {
     }
 
     @Test
-    public void createJwtClaims_whenStatusListEnabled_shouldReturnClaimsWithIssuer() throws Exception {
+    public void createJwtClaims_whenStatusListDisabled_shouldReturnClaimsWithIssuer() throws Exception {
         when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(false);
 
         JwtClaims claims = invokeCreateJwtClaims();

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImplTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/userinfo/ws/rs/UserInfoRestWebServiceImplTest.java
@@ -1,0 +1,152 @@
+package io.jans.as.server.userinfo.ws.rs;
+
+import io.jans.as.common.model.common.User;
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.service.AttributeService;
+import io.jans.as.model.common.FeatureFlagType;
+import io.jans.as.model.config.WebKeysConfiguration;
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.crypto.AbstractCryptoProvider;
+import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.model.jwt.JwtClaims;
+import io.jans.as.server.audit.ApplicationAuditLogger;
+import io.jans.as.server.model.common.AuthorizationGrant;
+import io.jans.as.server.model.common.ExecutionContext;
+import io.jans.as.server.service.ClientService;
+import io.jans.as.server.service.ScopeService;
+import io.jans.as.server.service.UserService;
+import io.jans.as.server.service.date.DateFormatterService;
+import io.jans.as.server.service.external.ExternalDynamicScopeService;
+import io.jans.as.server.service.token.StatusListIndexService;
+import io.jans.as.server.service.token.StatusListService;
+import io.jans.as.server.service.token.TokenService;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@Listeners(MockitoTestNGListener.class)
+public class UserInfoRestWebServiceImplTest {
+
+    @InjectMocks
+    private UserInfoRestWebServiceImpl userInfoRestWebServiceImpl;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private ApplicationAuditLogger applicationAuditLogger;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private WebKeysConfiguration webKeysConfiguration;
+
+    @Mock
+    private AbstractCryptoProvider cryptoProvider;
+
+    @Mock
+    private ClientService clientService;
+
+    @Mock
+    private ScopeService scopeService;
+
+    @Mock
+    private AttributeService attributeService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ExternalDynamicScopeService externalDynamicScopeService;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private DateFormatterService dateFormatterService;
+
+    @Mock
+    private UserInfoService userInfoService;
+
+    @Mock
+    private StatusListService statusListService;
+
+    @Mock
+    private StatusListIndexService statusListIndexService;
+
+    private User user;
+    private AuthorizationGrant grant;
+    private Client client;
+
+    @BeforeMethod
+    public void setUp() {
+        user = mock(User.class);
+        grant = mock(AuthorizationGrant.class);
+        client = new Client();
+        client.setClientId("test-client");
+
+        lenient().when(grant.getClaims()).thenReturn(null);
+        lenient().when(grant.getJwtAuthorizationRequest()).thenReturn(null);
+        lenient().when(grant.getSub()).thenReturn("test-sub");
+        lenient().when(grant.getClient()).thenReturn(client);
+        lenient().when(appConfiguration.getIssuer()).thenReturn("https://example.com");
+        lenient().when(externalDynamicScopeService.isEnabled()).thenReturn(false);
+    }
+
+    @Test
+    public void createJwtClaims_whenStatusListEnabled_shouldCallAddStatusClaimWithIndex() throws Exception {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(true);
+        when(statusListIndexService.next()).thenReturn(42);
+
+        invokeCreateJwtClaims();
+
+        ArgumentCaptor<ExecutionContext> contextCaptor = ArgumentCaptor.forClass(ExecutionContext.class);
+        verify(statusListService).addStatusClaimWithIndex(any(JwtClaims.class), contextCaptor.capture());
+        assertEquals(contextCaptor.getValue().getStatusListIndex(), Integer.valueOf(42));
+        verify(statusListIndexService).next();
+    }
+
+    @Test
+    public void createJwtClaims_whenStatusListDisabled_shouldNotCallAddStatusClaimWithIndex() throws Exception {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(false);
+
+        invokeCreateJwtClaims();
+
+        verify(statusListService, never()).addStatusClaimWithIndex(any(JwtClaims.class), any(ExecutionContext.class));
+        verify(statusListIndexService, never()).next();
+    }
+
+    @Test
+    public void createJwtClaims_whenStatusListEnabled_shouldReturnClaimsWithIssuer() throws Exception {
+        when(errorResponseFactory.isFeatureFlagEnabled(FeatureFlagType.STATUS_LIST)).thenReturn(false);
+
+        JwtClaims claims = invokeCreateJwtClaims();
+
+        assertNotNull(claims);
+        assertEquals(claims.getClaimAsString("iss"), "https://example.com");
+    }
+
+    private JwtClaims invokeCreateJwtClaims() throws Exception {
+        Method method = UserInfoRestWebServiceImpl.class.getDeclaredMethod(
+                "createJwtClaims", User.class, AuthorizationGrant.class, java.util.Collection.class);
+        method.setAccessible(true);
+        return (JwtClaims) method.invoke(userInfoRestWebServiceImpl, user, grant, Collections.emptyList());
+    }
+}


### PR DESCRIPTION
### Description

feat(jans-auth-server): added User Info JWT to Token Status List 

#### Target issue
  
closes #14007


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status list integration for JWT/userinfo claims with optional indexed status entries
  * Status claims included conditionally based on the STATUS_LIST feature flag

* **Tests**
  * Expanded unit tests covering status claim injection, index handling (null/negative/zero/valid), and feature-flag behavior
  * New tests verifying userinfo behavior with status-list enabled/disabled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JanssenProject/jans/pull/14163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->