### PR TITLE
fix(jans-pycloudlib): check if combined multi-parts secret already a valid JSON string

### DIFF
--- a/jans-pycloudlib/jans/pycloudlib/secret/aws_secret.py
+++ b/jans-pycloudlib/jans/pycloudlib/secret/aws_secret.py
@@ -112,11 +112,26 @@ class AwsSecret(BaseSecret):
         Returns:
             A mapping of secrets (if any).
         """
+        def _get_part_number(name: str) -> int:
+            # Extract part number from secret name like "jans_secrets", "jans_secrets_1", and so on
+            if name == self.basepath:
+                return 0
+
+            # Extract the numeric suffix
+            try:
+                return int(name.split("_")[-1])
+            except (ValueError, IndexError):
+                return 0
+
         # get all existing multipart secrets
         resp = self.client.list_secrets(
             Filters=[{"Key": "name", "Values": [self.basepath]}],
         )
         names = [secret["Name"] for secret in resp["SecretList"]]
+
+        # Sort secrets by part number to ensure correct payload assembly
+        # Part 0 is "jans_secrets", part N is "jans_secret_N"
+        names.sort(key=_get_part_number)
 
         if not names:
             return {}

--- a/jans-pycloudlib/jans/pycloudlib/secret/aws_secret.py
+++ b/jans-pycloudlib/jans/pycloudlib/secret/aws_secret.py
@@ -121,10 +121,23 @@ class AwsSecret(BaseSecret):
         if not names:
             return {}
 
-        payload = b"".join([
-            self.client.get_secret_value(SecretId=name)["SecretBinary"]
-            for name in names
-        ])
+        data = {}
+        payload = b""
+
+        for name in names:
+            fragment = self.client.get_secret_value(SecretId=name)
+            payload = payload + fragment["SecretBinary"]
+
+            try:
+                # validate if combined payload and fragment produces a valid JSON
+                json.loads(payload)
+                break
+            except json.JSONDecodeError:
+                # combined payload is not a valid JSON, proceed to merge with next secret part
+                continue
+
+        if not payload:
+            return {}
 
         try:
             # previously data is compressed using lzma

--- a/jans-pycloudlib/jans/pycloudlib/secret/google_secret.py
+++ b/jans-pycloudlib/jans/pycloudlib/secret/google_secret.py
@@ -146,6 +146,18 @@ class GoogleSecret(BaseSecret):
         Returns:
             A mapping of secrets (if any)
         """
+        def _get_part_number(name: str) -> int:
+            # Extract part number from secret name like "projects/.../secrets/jans-secret-2/versions/latest"
+            secret_name = name.split("/secrets/")[1].split("/versions/")[0]
+            if secret_name == self.google_secret_name:
+                return 0
+
+            # Extract the numeric suffix
+            try:
+                return int(secret_name.split("-")[-1])
+            except (ValueError, IndexError):
+                return 0
+
         # get a list of secrets with prefixed name
         resp = self.client.list_secrets(
             request={
@@ -157,6 +169,10 @@ class GoogleSecret(BaseSecret):
         # collect all secret names (if any) for further request
         names = [f"{scr.name}/versions/{self.version_id}" for scr in resp]
 
+        # Sort secrets by part number to ensure correct payload assembly
+        # Part 0 is "jans-secret", part N is "jans-secret-N"
+        names.sort(key=_get_part_number)
+
         if not names:
             return {}
 
@@ -164,8 +180,6 @@ class GoogleSecret(BaseSecret):
         payload = b""
 
         for name in names:
-            fragment = b""
-
             # the secret with given name may not exist or have any versions created yet
             with suppress(NotFound):
                 fragment = self.client.access_secret_version(request={"name": name})

--- a/jans-pycloudlib/jans/pycloudlib/secret/google_secret.py
+++ b/jans-pycloudlib/jans/pycloudlib/secret/google_secret.py
@@ -164,10 +164,23 @@ class GoogleSecret(BaseSecret):
         payload = b""
 
         for name in names:
+            fragment = b""
+
             # the secret with given name may not exist or have any versions created yet
             with suppress(NotFound):
-                fragment = self.client.access_secret_version(request={"name": name})
-                payload = payload + fragment.payload.data
+                fragment = self.client.access_secret_version(request={"name": name}).payload.data
+                # payload = payload + fragment.payload.data
+
+            try:
+                # validate if combined payload and fragment produces a valid JSON
+                json.loads(payload + fragment)
+            except json.JSONDecodeError:
+                # combined payload is not a valid JSON, proceed to merge with next secret part
+                continue
+            else:
+                # combined payload is probably a valid JSON
+                payload = payload + fragment
+                break
 
         if not payload:
             return {}

--- a/jans-pycloudlib/jans/pycloudlib/secret/google_secret.py
+++ b/jans-pycloudlib/jans/pycloudlib/secret/google_secret.py
@@ -168,19 +168,16 @@ class GoogleSecret(BaseSecret):
 
             # the secret with given name may not exist or have any versions created yet
             with suppress(NotFound):
-                fragment = self.client.access_secret_version(request={"name": name}).payload.data
-                # payload = payload + fragment.payload.data
+                fragment = self.client.access_secret_version(request={"name": name})
+                payload = payload + fragment.payload.data
 
             try:
                 # validate if combined payload and fragment produces a valid JSON
-                json.loads(payload + fragment)
+                json.loads(payload)
+                break
             except json.JSONDecodeError:
                 # combined payload is not a valid JSON, proceed to merge with next secret part
                 continue
-            else:
-                # combined payload is probably a valid JSON
-                payload = payload + fragment
-                break
 
         if not payload:
             return {}


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14179

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart secret retrieval: parts are ordered and concatenated incrementally, validating the combined payload as JSON and stopping once a complete valid secret is assembled.
  * Preserved existing decoding/decompression fallbacks and return an empty object when no payload is produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->