### PR TITLE
fix(jans-fido2): align AppleAttestationProcessorTest mocks with getAp…

### DIFF
--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/AppleAttestationProcessorTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/AppleAttestationProcessorTest.java
@@ -124,7 +124,7 @@ class AppleAttestationProcessorTest {
         when(x5cNode.elements()).thenReturn(Collections.singletonList((JsonNode) new TextNode("x5c item")).iterator());
         X509Certificate credCert = mock(X509Certificate.class);
         when(certificateService.getCertificate(anyString())).thenReturn(credCert);
-        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenThrow(new Fido2RuntimeException("test exception"));
+        when(attestationCertificateService.getAppleRootCertificates()).thenThrow(new Fido2RuntimeException("test exception"));
         when(credCert.getIssuerDN()).thenReturn(new BasicUserPrincipal("test issuer dn"));
         when(errorResponseFactory.badRequestException(any(), anyString())).thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
 
@@ -136,7 +136,7 @@ class AppleAttestationProcessorTest {
 
         verify(log).info(eq("AttStmt: test_att_stmt"));
         verify(certificateService).getCertificate(eq("x5c item"));
-        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(attestationCertificateService).getAppleRootCertificates();
         verify(log).warn(eq("Failed to find attestation validation signature public certificate with DN: '{}'"), eq("test issuer dn"));
         verify(errorResponseFactory).badRequestException(any(), eq("Failed to find attestation validation signature public certificate with DN: test issuer dn"));
         verifyNoMoreInteractions(log, errorResponseFactory);
@@ -159,7 +159,7 @@ class AppleAttestationProcessorTest {
         X509Certificate credCert = mock(X509Certificate.class);
         when(certificateService.getCertificate(anyString())).thenReturn(credCert);
         List<X509Certificate> rootCertificates = Collections.singletonList(mock(X509Certificate.class));
-        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenReturn(rootCertificates);
+        when(attestationCertificateService.getAppleRootCertificates()).thenReturn(rootCertificates);
         when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(mock(X509Certificate.class));
         when(authData.getAuthDataDecoded()).thenReturn("test decoded".getBytes());
         when(commonUtilService.writeOutputStreamByteList(anyList())).thenThrow(new IOException("test ioexception"));
@@ -173,7 +173,7 @@ class AppleAttestationProcessorTest {
 
         verify(log).info(eq("AttStmt: test_att_stmt"));
         verify(certificateService).getCertificate(eq("x5c item"));
-        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(attestationCertificateService).getAppleRootCertificates();
         verify(log).debug(eq("APPLE_WEBAUTHN_ROOT_CA root certificate: 1"));
         verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
         verify(log).info(eq("Step 1 completed"));
@@ -199,7 +199,7 @@ class AppleAttestationProcessorTest {
         X509Certificate credCert = mock(X509Certificate.class);
         when(certificateService.getCertificate(anyString())).thenReturn(credCert);
         List<X509Certificate> rootCertificates = Collections.singletonList(mock(X509Certificate.class));
-        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenReturn(rootCertificates);
+        when(attestationCertificateService.getAppleRootCertificates()).thenReturn(rootCertificates);
         when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(mock(X509Certificate.class));
         when(authData.getAuthDataDecoded()).thenReturn("test decoded".getBytes());
         ByteArrayOutputStream baos = mock(ByteArrayOutputStream.class);
@@ -216,7 +216,7 @@ class AppleAttestationProcessorTest {
 
         verify(log).info(eq("AttStmt: test_att_stmt"));
         verify(certificateService).getCertificate(eq("x5c item"));
-        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(attestationCertificateService).getAppleRootCertificates();
         verify(log).debug(eq("APPLE_WEBAUTHN_ROOT_CA root certificate: 1"));
         verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
         verify(log).info(eq("Step 1 completed"));
@@ -245,7 +245,7 @@ class AppleAttestationProcessorTest {
         X509Certificate credCert = mock(X509Certificate.class);
         when(certificateService.getCertificate(anyString())).thenReturn(credCert);
         List<X509Certificate> rootCertificates = Collections.singletonList(mock(X509Certificate.class));
-        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenReturn(rootCertificates);
+        when(attestationCertificateService.getAppleRootCertificates()).thenReturn(rootCertificates);
         when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(mock(X509Certificate.class));
         when(authData.getAuthDataDecoded()).thenReturn("test decoded".getBytes());
         ByteArrayOutputStream baos = mock(ByteArrayOutputStream.class);
@@ -264,7 +264,7 @@ class AppleAttestationProcessorTest {
 
         verify(log).info(eq("AttStmt: test_att_stmt"));
         verify(certificateService).getCertificate(eq("x5c item"));
-        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(attestationCertificateService).getAppleRootCertificates();
         verify(log).debug(eq("APPLE_WEBAUTHN_ROOT_CA root certificate: 1"));
         verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
         verify(log).info(eq("Step 1 completed"));
@@ -295,7 +295,7 @@ class AppleAttestationProcessorTest {
         X509Certificate credCert = mock(X509Certificate.class);
         when(certificateService.getCertificate(anyString())).thenReturn(credCert);
         List<X509Certificate> rootCertificates = Collections.singletonList(mock(X509Certificate.class));
-        when(attestationCertificateService.getRootCertificatesBySubjectDN(anyString())).thenReturn(rootCertificates);
+        when(attestationCertificateService.getAppleRootCertificates()).thenReturn(rootCertificates);
         when(certificateVerifier.verifyAttestationCertificates(anyList(), anyList())).thenReturn(mock(X509Certificate.class));
         when(authData.getAuthDataDecoded()).thenReturn("test decoded".getBytes());
         ByteArrayOutputStream baos = mock(ByteArrayOutputStream.class);
@@ -317,7 +317,7 @@ class AppleAttestationProcessorTest {
 
         verify(log).info(eq("AttStmt: test_att_stmt"));
         verify(certificateService).getCertificate(eq("x5c item"));
-        verify(attestationCertificateService).getRootCertificatesBySubjectDN(anyString());
+        verify(attestationCertificateService).getAppleRootCertificates();
         verify(log).debug(eq("APPLE_WEBAUTHN_ROOT_CA root certificate: 1"));
         verify(certificateVerifier).verifyAttestationCertificates(anyList(), anyList());
         verify(log).info(eq("Step 1 completed"));


### PR DESCRIPTION
### Description

Updated all 10 stubs/verifications in AppleAttestationProcessorTest to target getAppleRootCertificates(), matching the method the production code now calls. This realigns the test with AppleAttestationProcessor and turns the suite green. No production code changed — test-only fix.

#### Target issue

AppleAttestationProcessorTest fails 5/7 in CI. The test still mocks the removed getRootCertificatesBySubjectDN(...) instead of getAppleRootCertificates() (changed in PR #13737), so the unstubbed call returns null and Step 1 throws an NPE
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14197

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Apple attestation processor test cases to use improved certificate validation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->