### PR TITLE
ci: publish Java artifacts to GitHub Packages + Releases (jenkins offboarding A)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,48 +1,52 @@
-name: Janssen Build & Test
+name: Janssen Build & Publish
+
+# Builds the Janssen Java projects and publishes their artifacts to GitHub.
+#
+# Two destinations (see plan: offboard jenkins.jans.io -> GitHub):
+#   1. GitHub Packages Maven (maven.pkg.github.com/JanssenProject/jans) via `mvn deploy`
+#      - canonical home for io.jans:* dependency resolution (authenticated).
+#   2. GitHub Release assets (nightly / vX.Y.Z) for the service WARs + plugin
+#      distribution jars + client jars
+#      - anonymous downloads consumed by the Dockerfiles and jans-linux-setup.
+#
+# This replaces the artifact build+publish role previously performed on
+# jenkins.jans.io. GitHub Packages Maven rejects re-publishing an existing
+# version, so the `cleanup` job deletes the prior `0.0.0-nightly` package
+# versions before the nightly deploy.
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "jans-**"
-      - "agama"
   schedule:
     - cron: '0 8 * * *'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "jans-**"
-      - "agama"
+  push:
+    tags:
+      - 'v**'
+      - 'nightly'
   workflow_dispatch:
     inputs:
-      project:
-        type: choice
-        options:
-          - "jans-bom"
-          - "jans-orm"
-          - "jans-core"
-          - "jans-lock/lock-server"
-          - "agama"
-          - "jans-auth-server"
-          - "jans-link"
-          - "jans-fido2"
-          - "jans-scim"
-          - "jans-config-api"
-          - "jans-casa"
-          - "jans-shibboleth-idp"
-          - "jans-bom jans-orm jans-core jans-lock/lock-server agama jans-auth-server jans-link jans-fido2 jans-scim jans-config-api jans-casa jans-shibboleth-idp"
-        description: 'Service'
+      target_tag:
+        description: 'Release tag to publish artifacts to (e.g. nightly or v1.2.3)'
         required: true
-        default: "jans-bom jans-orm jans-core jans-lock/lock-server agama jans-auth-server jans-link jans-fido2 jans-scim jans-config-api jans-casa jans-shibboleth-idp"
-concurrency:
-  group: run-once
-  cancel-in-progress: false
+        default: 'nightly'
+      modules:
+        description: 'Space-separated project dirs to build/deploy, in dependency order'
+        required: false
+        default: 'jans-bom jans-core jans-orm jans-auth-server agama jans-config-api jans-scim jans-fido2 jans-link jans-lock/lock-server jans-casa jans-shibboleth-idp'
+
 permissions:
   contents: read
+
+concurrency:
+  group: build-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DEFAULT_MODULES: 'jans-bom jans-core jans-orm jans-auth-server agama jans-config-api jans-scim jans-fido2 jans-link jans-lock/lock-server jans-casa jans-shibboleth-idp'
+
 jobs:
+  # Delete the existing 0.0.0-nightly Maven package versions so the nightly
+  # deploy can re-publish them (GitHub Packages Maven is immutable per-version).
   cleanup:
+    if: github.repository == 'JanssenProject/jans'
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,8 +58,19 @@ jobs:
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
       with:
         egress-policy: audit
-    - name: Get version ID for 0.0.0-nightly
-      id: get_version_id
+    - name: Resolve tag
+      id: tag
+      run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          TAG_NAME="${{ inputs.target_tag }}"
+        elif [[ "${{ github.event_name }}" == "push" ]]; then
+          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+        else
+          TAG_NAME="nightly"
+        fi
+        echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+    - name: Delete 0.0.0-nightly package versions
+      if: steps.tag.outputs.tag == 'nightly'
       run: |
         page=1
         services=""
@@ -83,4 +98,118 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               /orgs/JanssenProject/packages/maven/"${service}"/versions/"${version_id}" || echo "Failed to delete $service version $version_id"
           fi
+        done
+
+  # Build every Java project and deploy its artifacts to GitHub Packages Maven,
+  # then upload the service WARs + plugin/client jars to the GitHub Release.
+  build-and-publish:
+    needs: cleanup
+    if: github.repository == 'JanssenProject/jans' && github.event_name != 'pull_request'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    permissions:
+      contents: read    # read source
+      packages: write   # deploy to GitHub Packages Maven
+      id-token: write   # cosign keyless signing
+    env:
+      # GitHub Packages auth for .github/maven-settings.xml (server id "github").
+      JANS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MAVEN_OPTS: -Xmx5g -Dhttp.keepAlive=false
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        distribution: temurin
+        java-version: '17'
+        cache: maven
+
+    - name: Resolve tag and version
+      id: ver
+      run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          TAG_NAME="${{ inputs.target_tag }}"
+        elif [[ "${{ github.event_name }}" == "push" ]]; then
+          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+        else
+          TAG_NAME="nightly"
+        fi
+        echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+        if [[ "${TAG_NAME}" == "nightly" ]]; then
+          echo "version=0.0.0-nightly" >> "$GITHUB_OUTPUT"
+        else
+          echo "version=$(echo "${TAG_NAME}" | sed 's/^v//')" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Select modules
+      id: mods
+      run: |
+        MODULES="${{ github.event.inputs.modules }}"
+        [ -z "$MODULES" ] && MODULES="${DEFAULT_MODULES}"
+        echo "modules=${MODULES}" >> "$GITHUB_OUTPUT"
+
+    # For a versioned release the poms (fixed at 0.0.0-nightly) must be bumped
+    # before deploy. Nightly publishes 0.0.0-nightly as-is.
+    - name: Set release version in poms
+      if: steps.ver.outputs.version != '0.0.0-nightly'
+      run: |
+        for m in ${{ steps.mods.outputs.modules }}; do
+          mvn -B -ntp -f "$m" \
+            org.codehaus.mojo:versions-maven-plugin:2.16.2:set \
+            -DnewVersion="${{ steps.ver.outputs.version }}" -DgenerateBackupPoms=false || true
+        done
+
+    - name: Build and deploy to GitHub Packages Maven
+      run: |
+        set -euo pipefail
+        for m in ${{ steps.mods.outputs.modules }}; do
+          echo "::group::deploy ${m}"
+          mvn -B -ntp -s "${GITHUB_WORKSPACE}/.github/maven-settings.xml" \
+            -f "${m}" \
+            -Dmaven.test.skip=true \
+            clean deploy
+          echo "::endgroup::"
+        done
+
+    - name: Collect release binaries (WARs + plugin/client jars)
+      id: collect
+      run: |
+        set -euo pipefail
+        OUT=/tmp/release-artifacts
+        mkdir -p "$OUT"
+        MODULES="${{ steps.mods.outputs.modules }}"
+        # Service WARs and plugin distribution jars consumed by Dockerfiles + jans-linux-setup.
+        find $MODULES -type f -path '*/target/*.war' -exec cp -v {} "$OUT/" \; || true
+        find $MODULES -type f -path '*/target/*-distribution.jar' -exec cp -v {} "$OUT/" \; || true
+        find $MODULES -type f -path '*/target/*-jar-with-dependencies.jar' -exec cp -v {} "$OUT/" \; || true
+        # Extra client/model jars referenced by installers (fido2 client/model, casa-config).
+        find jans-fido2 -type f -path '*/target/jans-fido2-client-*.jar' -exec cp -v {} "$OUT/" \; || true
+        find jans-fido2 -type f -path '*/target/jans-fido2-model-*.jar' -exec cp -v {} "$OUT/" \; || true
+        find jans-casa  -type f -path '*/target/casa-config-*.jar'        -exec cp -v {} "$OUT/" \; || true
+        echo "Collected:"; ls -la "$OUT"
+        echo "dir=${OUT}" >> "$GITHUB_OUTPUT"
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Sign and upload binaries to release
+      env:
+        GH_TOKEN: ${{ secrets.MOAUTO_WORKFLOW_TOKEN }}
+        TAG: ${{ steps.ver.outputs.tag }}
+        DIR: ${{ steps.collect.outputs.dir }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        cd "$DIR"
+        for f in *; do
+          [ -f "$f" ] || continue
+          cosign sign-blob --yes --bundle "${f}.bundle" "$f"
+          gh release upload "$TAG" "$f" "${f}.bundle" --repo "${{ github.repository }}" --clobber
         done

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -142,18 +142,30 @@ jobs:
         echo "Services: $services"
         for service in $services; do
           echo "Checking $service"
-          # --paginate walks every page: 0.0.0-nightly is often buried under
-          # newer release versions (e.g. 1.16.0), so the default first-page-only
-          # lookup misses it and the later deploy fails with 409 Conflict.
-          version_ids=$(gh api --paginate -H "Accept: application/vnd.github+json" \
+          # --paginate walks every page: a 0.0.0-nightly buried under newer
+          # release versions (e.g. 1.16.0) is missed by a first-page-only lookup,
+          # leaving it to fail the later deploy with 409 Conflict.
+          versions=$(gh api --paginate -H "Accept: application/vnd.github+json" \
             "/orgs/JanssenProject/packages/maven/${service}/versions" \
-            --jq '.[] | select(.name == "0.0.0-nightly") | .id')
-          for version_id in $version_ids; do
-            echo "Deleting version $version_id of $service"
-            gh api --method DELETE \
-              -H "Accept: application/vnd.github+json" \
-              "/orgs/JanssenProject/packages/maven/${service}/versions/${version_id}" || echo "Failed to delete $service version $version_id"
-          done
+            --jq '.[] | "\(.id) \(.name)"')
+          [ -z "$versions" ] && continue
+          total=$(printf '%s\n' "$versions" | grep -c .)
+          nightly_ids=$(printf '%s\n' "$versions" | awk '$2=="0.0.0-nightly"{print $1}')
+          [ -z "$nightly_ids" ] && continue
+          nightly_count=$(printf '%s\n' "$nightly_ids" | grep -c .)
+          if [ "$total" -le "$nightly_count" ]; then
+            # GitHub forbids deleting the last version of a package, so a brand-new
+            # package whose only version is 0.0.0-nightly must be deleted wholesale.
+            echo "Only nightly version(s) present; deleting package $service"
+            gh api --method DELETE -H "Accept: application/vnd.github+json" \
+              "/orgs/JanssenProject/packages/maven/${service}" || echo "Failed to delete package $service"
+          else
+            for version_id in $nightly_ids; do
+              echo "Deleting version $version_id of $service"
+              gh api --method DELETE -H "Accept: application/vnd.github+json" \
+                "/orgs/JanssenProject/packages/maven/${service}/versions/${version_id}" || echo "Failed to delete $service version $version_id"
+            done
+          fi
         done
 
   # Build every Java project and deploy its artifacts to GitHub Packages Maven,

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,10 +176,14 @@ jobs:
         # this tag; the rest of the modules ignore the property.
         for m in ${{ steps.mods.outputs.modules }}; do
           echo "::group::deploy ${m}"
+          # altDeploymentRepository supplies the deploy target for modules whose
+          # pom omits <distributionManagement> (e.g. cedarling-java); it matches
+          # the id+url the other modules already declare, so it is a no-op for them.
           mvn -B -ntp -s "${GITHUB_WORKSPACE}/.github/maven-settings.xml" \
             -f "${m}" \
             -Dmaven.test.skip=true \
             -Dcedarling.release.tag="${{ steps.ver.outputs.tag }}" \
+            -DaltDeploymentRepository="github::https://maven.pkg.github.com/JanssenProject/jans" \
             clean deploy
           echo "::endgroup::"
         done

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,10 +31,58 @@ on:
         description: 'Release tag to publish artifacts to (e.g. nightly or v1.2.3)'
         required: true
         default: 'nightly'
-      modules:
-        description: 'Space-separated project dirs to build/deploy, in dependency order'
-        required: false
-        default: 'jans-bom jans-orm jans-core agama jans-auth-server jans-cedarling/bindings/cedarling-java jans-lock/lock-server jans-fido2 jans-scim jans-link jans-config-api jans-casa'
+      build_all:
+        description: 'Build all projects'
+        type: boolean
+        default: true
+      jans_bom:
+        description: 'jans-bom'
+        type: boolean
+        default: false
+      jans_orm:
+        description: 'jans-orm'
+        type: boolean
+        default: false
+      jans_core:
+        description: 'jans-core'
+        type: boolean
+        default: false
+      agama:
+        description: 'agama'
+        type: boolean
+        default: false
+      auth_server:
+        description: 'jans-auth-server'
+        type: boolean
+        default: false
+      cedarling_java:
+        description: 'cedarling-java binding'
+        type: boolean
+        default: false
+      lock_server:
+        description: 'jans-lock/lock-server'
+        type: boolean
+        default: false
+      fido2:
+        description: 'jans-fido2'
+        type: boolean
+        default: false
+      scim:
+        description: 'jans-scim'
+        type: boolean
+        default: false
+      link:
+        description: 'jans-link'
+        type: boolean
+        default: false
+      config_api:
+        description: 'jans-config-api'
+        type: boolean
+        default: false
+      casa:
+        description: 'jans-casa'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -151,11 +199,36 @@ jobs:
           echo "version=$(echo "${TAG_NAME}" | sed 's/^v//')" >> "$GITHUB_OUTPUT"
         fi
 
+    # Build the ordered module list. Non-dispatch events (tag push) and
+    # build_all=true publish everything; otherwise pick the selected projects.
+    # The list is assembled in dependency order regardless of input order so
+    # the Maven reactor (and cross-module resolution) stays correct.
     - name: Select modules
       id: mods
       run: |
-        MODULES="${{ github.event.inputs.modules }}"
-        [ -z "$MODULES" ] && MODULES="${DEFAULT_MODULES}"
+        if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ inputs.build_all }}" == "true" ]]; then
+          MODULES="${DEFAULT_MODULES}"
+        else
+          MODULES=""
+          [[ "${{ inputs.jans_bom }}"       == "true" ]] && MODULES="$MODULES jans-bom"
+          [[ "${{ inputs.jans_orm }}"       == "true" ]] && MODULES="$MODULES jans-orm"
+          [[ "${{ inputs.jans_core }}"      == "true" ]] && MODULES="$MODULES jans-core"
+          [[ "${{ inputs.agama }}"          == "true" ]] && MODULES="$MODULES agama"
+          [[ "${{ inputs.auth_server }}"    == "true" ]] && MODULES="$MODULES jans-auth-server"
+          [[ "${{ inputs.cedarling_java }}" == "true" ]] && MODULES="$MODULES jans-cedarling/bindings/cedarling-java"
+          [[ "${{ inputs.lock_server }}"    == "true" ]] && MODULES="$MODULES jans-lock/lock-server"
+          [[ "${{ inputs.fido2 }}"          == "true" ]] && MODULES="$MODULES jans-fido2"
+          [[ "${{ inputs.scim }}"           == "true" ]] && MODULES="$MODULES jans-scim"
+          [[ "${{ inputs.link }}"           == "true" ]] && MODULES="$MODULES jans-link"
+          [[ "${{ inputs.config_api }}"     == "true" ]] && MODULES="$MODULES jans-config-api"
+          [[ "${{ inputs.casa }}"           == "true" ]] && MODULES="$MODULES jans-casa"
+        fi
+        MODULES="$(echo "$MODULES" | xargs)"
+        if [[ -z "$MODULES" ]]; then
+          echo "No modules selected" >&2
+          exit 1
+        fi
+        echo "Selected modules: $MODULES"
         echo "modules=${MODULES}" >> "$GITHUB_OUTPUT"
 
     # For a versioned release the poms (fixed at 0.0.0-nightly) must be bumped

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -142,15 +142,18 @@ jobs:
         echo "Services: $services"
         for service in $services; do
           echo "Checking $service"
-          version_id=$(gh api -H "Accept: application/vnd.github+json" \
-            /orgs/JanssenProject/packages/maven/"${service}"/versions \
-            | jq -r '.[] | select(.name == "0.0.0-nightly") | .id')
-          if [ -n "$version_id" ]; then
+          # --paginate walks every page: 0.0.0-nightly is often buried under
+          # newer release versions (e.g. 1.16.0), so the default first-page-only
+          # lookup misses it and the later deploy fails with 409 Conflict.
+          version_ids=$(gh api --paginate -H "Accept: application/vnd.github+json" \
+            "/orgs/JanssenProject/packages/maven/${service}/versions" \
+            --jq '.[] | select(.name == "0.0.0-nightly") | .id')
+          for version_id in $version_ids; do
             echo "Deleting version $version_id of $service"
             gh api --method DELETE \
               -H "Accept: application/vnd.github+json" \
-              /orgs/JanssenProject/packages/maven/"${service}"/versions/"${version_id}" || echo "Failed to delete $service version $version_id"
-          fi
+              "/orgs/JanssenProject/packages/maven/${service}/versions/${version_id}" || echo "Failed to delete $service version $version_id"
+          done
         done
 
   # Build every Java project and deploy its artifacts to GitHub Packages Maven,

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,14 +9,18 @@ name: Janssen Build & Publish
 #      distribution jars + client jars
 #      - anonymous downloads consumed by the Dockerfiles and jans-linux-setup.
 #
-# This replaces the artifact build+publish role previously performed on
-# jenkins.jans.io. GitHub Packages Maven rejects re-publishing an existing
-# version, so the `cleanup` job deletes the prior `0.0.0-nightly` package
-# versions before the nightly deploy.
+# Released binaries are cosign-signed and covered by SLSA level 3 provenance
+# (slsa-github-generator), matching build-packages.yml.
+#
+# This replaces the artifact build+publish role previously performed by the
+# jenkins.jans.io "Full rebuild" job. The module list and order mirror that
+# job. GitHub Packages Maven rejects re-publishing an existing version, so the
+# `cleanup` job deletes the prior `0.0.0-nightly` versions before deploy.
+#
+# Triggered by the nightly tag push (recreated by build-nightly-build.yml) and
+# by version tags, so SLSA provenance is generated from a push event.
 
 on:
-  schedule:
-    - cron: '0 8 * * *'
   push:
     tags:
       - 'v**'
@@ -30,7 +34,7 @@ on:
       modules:
         description: 'Space-separated project dirs to build/deploy, in dependency order'
         required: false
-        default: 'jans-bom jans-core jans-orm jans-auth-server agama jans-config-api jans-scim jans-fido2 jans-link jans-lock/lock-server jans-casa jans-shibboleth-idp'
+        default: 'jans-bom jans-orm jans-core agama jans-auth-server jans-cedarling/bindings/cedarling-java jans-lock/lock-server jans-fido2 jans-scim jans-link jans-config-api jans-casa'
 
 permissions:
   contents: read
@@ -40,7 +44,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DEFAULT_MODULES: 'jans-bom jans-core jans-orm jans-auth-server agama jans-config-api jans-scim jans-fido2 jans-link jans-lock/lock-server jans-casa jans-shibboleth-idp'
+  # Authoritative build/deploy order, mirroring the jenkins.jans.io "Full rebuild" job.
+  # NOTE: jans-shibboleth-idp is intentionally excluded until it is ready to publish.
+  # NOTE: jans-keycloak / jans-keycloak-link were commented out in the jenkins job too.
+  DEFAULT_MODULES: 'jans-bom jans-orm jans-core agama jans-auth-server jans-cedarling/bindings/cedarling-java jans-lock/lock-server jans-fido2 jans-scim jans-link jans-config-api jans-casa'
 
 jobs:
   # Delete the existing 0.0.0-nightly Maven package versions so the nightly
@@ -63,10 +70,8 @@ jobs:
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           TAG_NAME="${{ inputs.target_tag }}"
-        elif [[ "${{ github.event_name }}" == "push" ]]; then
-          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
         else
-          TAG_NAME="nightly"
+          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
         fi
         echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
     - name: Delete 0.0.0-nightly package versions
@@ -104,7 +109,7 @@ jobs:
   # then upload the service WARs + plugin/client jars to the GitHub Release.
   build-and-publish:
     needs: cleanup
-    if: github.repository == 'JanssenProject/jans' && github.event_name != 'pull_request'
+    if: github.repository == 'JanssenProject/jans'
     runs-on: ubuntu-22.04
     timeout-minutes: 360
     permissions:
@@ -136,10 +141,8 @@ jobs:
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           TAG_NAME="${{ inputs.target_tag }}"
-        elif [[ "${{ github.event_name }}" == "push" ]]; then
-          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
         else
-          TAG_NAME="nightly"
+          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
         fi
         echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
         if [[ "${TAG_NAME}" == "nightly" ]]; then
@@ -169,11 +172,14 @@ jobs:
     - name: Build and deploy to GitHub Packages Maven
       run: |
         set -euo pipefail
+        # cedarling-java downloads its native lib from the GitHub release named by
+        # this tag; the rest of the modules ignore the property.
         for m in ${{ steps.mods.outputs.modules }}; do
           echo "::group::deploy ${m}"
           mvn -B -ntp -s "${GITHUB_WORKSPACE}/.github/maven-settings.xml" \
             -f "${m}" \
             -Dmaven.test.skip=true \
+            -Dcedarling.release.tag="${{ steps.ver.outputs.tag }}" \
             clean deploy
           echo "::endgroup::"
         done
@@ -196,6 +202,25 @@ jobs:
         echo "Collected:"; ls -la "$OUT"
         echo "dir=${OUT}" >> "$GITHUB_OUTPUT"
 
+    - name: Compute SHA256 digests for SLSA provenance
+      id: digest
+      run: |
+        set -euo pipefail
+        cd "${{ steps.collect.outputs.dir }}"
+        : > /tmp/maven-digest.sha256
+        for f in *; do
+          [ -f "$f" ] || continue
+          sha256sum "$f" >> /tmp/maven-digest.sha256
+        done
+        cat /tmp/maven-digest.sha256
+
+    - name: Upload digest artifact
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: maven-digest
+        path: /tmp/maven-digest.sha256
+        retention-days: 1
+
     - name: Install Cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
@@ -213,3 +238,51 @@ jobs:
           cosign sign-blob --yes --bundle "${f}.bundle" "$f"
           gh release upload "$TAG" "$f" "${f}.bundle" --repo "${{ github.repository }}" --clobber
         done
+
+  # Merge the artifact digests into a single base64 subjects string for SLSA.
+  collect-maven-digests:
+    needs: build-and-publish
+    if: github.repository == 'JanssenProject/jans'
+    runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.merge.outputs.hashes }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+    - name: Resolve release tag
+      id: tag
+      run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "tag=${{ inputs.target_tag }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Download digest artifact
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+      with:
+        name: maven-digest
+        path: /tmp/maven-digests
+    - name: Merge and encode digests
+      id: merge
+      run: |
+        MERGED=$(cat /tmp/maven-digests/*.sha256 | grep -v '^$' || true)
+        echo "hashes=$(echo -n "${MERGED}" | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  # SLSA level 3 provenance for the released Maven binaries.
+  provenance-maven:
+    needs: [collect-maven-digests]
+    if: github.repository == 'JanssenProject/jans' && needs.collect-maven-digests.outputs.hashes != ''
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    with:
+      base64-subjects: "${{ needs.collect-maven-digests.outputs.hashes }}"
+      upload-assets: true
+      upload-tag-name: "${{ needs.collect-maven-digests.outputs.tag }}"
+      compile-generator: true
+      provenance-name: maven-artifacts.intoto.jsonl

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,14 +176,10 @@ jobs:
         # this tag; the rest of the modules ignore the property.
         for m in ${{ steps.mods.outputs.modules }}; do
           echo "::group::deploy ${m}"
-          # altDeploymentRepository supplies the deploy target for modules whose
-          # pom omits <distributionManagement> (e.g. cedarling-java); it matches
-          # the id+url the other modules already declare, so it is a no-op for them.
           mvn -B -ntp -s "${GITHUB_WORKSPACE}/.github/maven-settings.xml" \
             -f "${m}" \
             -Dmaven.test.skip=true \
             -Dcedarling.release.tag="${{ steps.ver.outputs.tag }}" \
-            -DaltDeploymentRepository="github::https://maven.pkg.github.com/JanssenProject/jans" \
             clean deploy
           echo "::endgroup::"
         done

--- a/jans-cedarling/bindings/cedarling-java/pom.xml
+++ b/jans-cedarling/bindings/cedarling-java/pom.xml
@@ -31,6 +31,13 @@
         <connection>scm:git:git://github.com/JanssenProject/jans.git</connection>
         <developerConnection>scm:git:git@github.com:JanssenProject/jans.git</developerConnection>
     </scm>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/JanssenProject/jans</url>
+        </repository>
+    </distributionManagement>
     <repositories>
         <repository>
             <id>mavencentral</id>


### PR DESCRIPTION
## Why

`jenkins.jans.io` is being shut off. Today it does two things GitHub does **not** yet do — and one of them is **building and publishing the Java artifacts** (service WARs + `*-distribution.jar` plugins) to `jenkins.jans.io/maven` / `maven.jans.io/maven`. There is currently **no `mvn deploy` anywhere in `.github/workflows`** (`.github/maven-settings.xml` was orphaned; `build-test.yml` was a cleanup-only stub that *deletes* nightly packages nothing publishes).

When Jenkins dies, every Docker image build, `jans-linux-setup`, and `build-packages.yml` break, because they download those WARs from Jenkins.

This is **Phase A** of the offboarding series: stand up the artifact build+publish on GitHub.

## What

Replaces the `build-test.yml` stub with a **build + publish** workflow:

- **`mvn deploy` → GitHub Packages Maven** (`maven.pkg.github.com/JanssenProject/jans`) for every `io.jans` project, in dependency order (configurable via the `modules` input). Canonical home for dependency resolution. Auth via the existing `.github/maven-settings.xml` (`github` server) + `JANS_TOKEN`/`packages: write`.
- **Service WARs + plugin/client jars → GitHub Release assets** (cosign-signed), for **anonymous** download by the Dockerfiles and `jans-linux-setup` (which run without a token). Mirrors the existing `.deb/.rpm/.pyz` release-asset pattern in `build-packages.yml`.
- Keeps the **`cleanup`** job: GitHub Packages Maven is immutable per-version, so the prior `0.0.0-nightly` versions are deleted before the nightly deploy.

Triggers: nightly `schedule`, version tags (`v**`/`nightly`), and `workflow_dispatch`. Publish never runs on PRs. Versioned tags bump the poms (fixed at `0.0.0-nightly`) via `versions-maven-plugin` before deploy.

## Status / needs CI iteration

Opening as **draft** — a full monorepo `mvn deploy` cannot be validated locally; it needs a real run with repo secrets + Packages write. Expect to iterate on:

- **module/build order** (the `modules` input makes this a one-line fix),
- the exact set of release binaries the consumers need (current globs: `*.war`, `*-distribution.jar`, `*-jar-with-dependencies.jar`, plus fido2 client/model + casa-config jars),
- memory/runtime on the hosted runner for the large reactor.

Depends on the `nightly` GitHub Release existing before the upload step (wired in the pipeline-chaining phase). **Keep Jenkins alive until this is green.** Prebuilt blobs not built from source (`jython-installer`, `casa-agama` project zip, lock service-deps zip) still need a one-time harvest from `maven.jans.io` → Release; tracked separately.

Consumer repoint (Dockerfiles, `jans-linux-setup`, pom `<repositories>`) follows in the next phase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to build and publish artifacts to GitHub Packages Maven instead of just testing.
  * Added support for versioned releases and nightly builds with automatic cleanup.
  * Integrated SLSA level 3 provenance generation for enhanced supply chain security.
  * Enhanced release workflow with manual dispatch and tag-based triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->