### PR TITLE
chore(jans-cedarling): improve wasm optimization build flags

### DIFF
--- a/jans-cedarling/Cargo.toml
+++ b/jans-cedarling/Cargo.toml
@@ -33,8 +33,11 @@ pedantic = "warn"
 duration-suboptimal-units = { level = "allow", priority = 1 }
 
 
+# Native release builds (java/python/go/uniffi) are speed-oriented.
+# The WASM target is size-oriented instead: it overrides these keys via the
+# config-based profile in bindings/cedarling_wasm/.cargo/config.toml, which Cargo
+# only picks up when building from that directory (i.e. under wasm-pack). Native
+# builds run from this workspace root and never see it.
 [profile.release]
 debug-assertions = false
-opt-level = "z"
-codegen-units = 1
 overflow-checks = false

--- a/jans-cedarling/bindings/cedarling_wasm/.cargo/config.toml
+++ b/jans-cedarling/bindings/cedarling_wasm/.cargo/config.toml
@@ -1,19 +1,20 @@
 # Size-optimized release profile for the WASM build only.
 #
-# Cargo discovers .cargo/config.toml from the current directory upward, so this
-# file applies ONLY when cargo runs inside this crate directory — which is what
-# wasm-pack does. Native binding builds run from the workspace root and never see
-# it, so they keep the speed-oriented [profile.release] (opt-level = 3) defined in
-# jans-cedarling/Cargo.toml.
+# Cargo overlays .cargo/config.toml onto the workspace [profile.release].
+# This file sets opt-level = "z" (size) for the release profile, while
+# debug-assertions and overflow-checks are inherited from the workspace
+# Cargo.toml (both set to false).
 #
-# This is a config-based profile, NOT a [profile.*] in a member Cargo.toml — the
-# latter is silently ignored by Cargo ("profiles for the non root package will be
-# ignored"). Config-based profiles are honored and merge over the workspace root
-# profile key-by-key (debug-assertions/overflow-checks are inherited from root).
+# Cargo discovers .cargo/config.toml from the current directory upward, so
+# this file applies ONLY when cargo runs from this crate directory — which
+# is what wasm-pack does. Native binding builds run from the workspace root
+# and never see it, so they keep the default speed-oriented opt-level = 3.
+# wasm-pack build --release uses Cargo's standard profile handling, so the
+# local .cargo/config.toml will be honored when building from this directory.
 #
 # Why not a custom cargo profile + `wasm-pack --profile`: wasm-pack 0.14 ignores
-# the wasm-opt metadata for custom profile names, dropping our wasm-opt feature
-# flags. Why not [env] here: a config [env] block does not override a profile.
+# the wasm-opt metadata for custom profile names, dropping our wasm-opt flags.
+# Why not [env] here: a config [env] block does not override a profile.
 #
 # wasm-opt flags live in Cargo.toml; fat-LTO output uses bulk-memory and
 # nontrapping float-to-int, which wasm-opt must be told to allow or it fails.

--- a/jans-cedarling/bindings/cedarling_wasm/.cargo/config.toml
+++ b/jans-cedarling/bindings/cedarling_wasm/.cargo/config.toml
@@ -1,0 +1,24 @@
+# Size-optimized release profile for the WASM build only.
+#
+# Cargo discovers .cargo/config.toml from the current directory upward, so this
+# file applies ONLY when cargo runs inside this crate directory — which is what
+# wasm-pack does. Native binding builds run from the workspace root and never see
+# it, so they keep the speed-oriented [profile.release] (opt-level = 3) defined in
+# jans-cedarling/Cargo.toml.
+#
+# This is a config-based profile, NOT a [profile.*] in a member Cargo.toml — the
+# latter is silently ignored by Cargo ("profiles for the non root package will be
+# ignored"). Config-based profiles are honored and merge over the workspace root
+# profile key-by-key (debug-assertions/overflow-checks are inherited from root).
+#
+# Why not a custom cargo profile + `wasm-pack --profile`: wasm-pack 0.14 ignores
+# the wasm-opt metadata for custom profile names, dropping our wasm-opt feature
+# flags. Why not [env] here: a config [env] block does not override a profile.
+#
+# wasm-opt flags live in Cargo.toml; fat-LTO output uses bulk-memory and
+# nontrapping float-to-int, which wasm-opt must be told to allow or it fails.
+[profile.release]
+opt-level = "z"
+lto = "fat"
+codegen-units = 1
+strip = true

--- a/jans-cedarling/bindings/cedarling_wasm/Cargo.toml
+++ b/jans-cedarling/bindings/cedarling_wasm/Cargo.toml
@@ -26,11 +26,22 @@ serde_json = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 wasm-bindgen-test = "0.3.49"
 
-[profile.release]
-lto = true
-strip = "symbols"
+# NOTE: profile settings (lto/opt-level/strip/codegen-units) for the WASM build
+# are NOT set here — Cargo ignores [profile.*] in non-root workspace members.
+# They live in ./.cargo/config.toml (a config-based profile Cargo honors only when
+# building from this directory, i.e. under wasm-pack).
+# wasm-opt runs AFTER LTO; fat-LTO output uses bulk-memory + nontrapping
+# float-to-int, so those features must be enabled here or wasm-opt fails validation.
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-O4', '--enable-reference-types']
+wasm-opt = [
+    '-Oz',
+    '--enable-reference-types',
+    '--enable-bulk-memory',
+    '--enable-nontrapping-float-to-int',
+    '--enable-sign-ext',
+    '--enable-mutable-globals',
+    '--enable-multivalue',
+]
 
 [dev-dependencies]
 # is used in testing


### PR DESCRIPTION
Move size-oriented release settings (opt-level = "z", lto = "fat", etc.) from workspace [profile.release] into a per-directory config-based profile under bindings/cedarling_wasm/.cargo/config.toml, so WASM builds stay size-optimized while native builds get speed optimization (opt-level = 3).

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14200

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->
##### Problem
The workspace [profile.release] in jans-cedarling/Cargo.toml used opt-level = "z", codegen-units = 1, and no LTO — all size-oriented settings. This applied to all release builds regardless of target, meaning native binding builds (Java, Python, Go, Uniffi) were unintentionally size-optimized instead of speed-optimized.
##### Solution
Split release profiles:
- jans-cedarling/Cargo.toml: restored default opt-level = 3 for native speed. Removed codegen-units = 1.
- bindings/cedarling_wasm/.cargo/config.toml (new): config-based [profile.release] overriding opt-level = "z", lto = "fat", codegen-units = 1, strip = true. Cargo applies this only when building from the cedarling_wasm directory (i.e. under wasm-pack).
- bindings/cedarling_wasm/Cargo.toml: moved wasm-opt flags to -Oz (aggressive size) and added required feature flags (bulk-memory, nontrapping-float-to-int, sign-ext, mutable-globals, multivalue) so fat-LTO output passes wasm-opt validation.
##### Why not custom profile + wasm-pack --profile
wasm-pack 0.14 ignores wasm-opt metadata for custom profile names, breaking --enable-* features.
##### Why config-based profile instead of [profile.*] in member Cargo.toml
Cargo silently ignores [profile.*] in non-root workspace members. Config-based profiles (.cargo/config.toml) are honored and merge over workspace root settings.

-------------------
### Test and Document the changes
-  [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined build configurations to separate native speed-optimized releases from WebAssembly size-optimized releases, improving WASM package size and build outputs.
* **Documentation**
  * Added clarifying comments explaining which release profiles apply for workspace vs WASM crate builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->