### PR TITLE
ci: chain nightly/release pipeline via workflow_run (offboarding C)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,11 +1,14 @@
 name: Build and Publish Releases to Hub
 
 on:
-  schedule:
-    - cron: "0 23 * * *"
+  # Chained after the publish workflow so the service WARs exist on the release
+  # before the Dockerfiles pull them. (Replaces the standalone nightly cron,
+  # which collided with build-nightly-build recreating the release.)
+  workflow_run:
+    workflows: ["Janssen Build & Publish"]
+    types:
+      - completed
   push:
-    tags:
-      - "*"
     branches:
       - main
   pull_request:
@@ -100,6 +103,12 @@ permissions:
 
 jobs:
   docker:
+    # On workflow_run, only proceed when the publish workflow succeeded for a
+    # release tag. Other events (PR, main push, manual dispatch) run as before.
+    if: |
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v')))
     permissions:
       packages: write
       id-token: write
@@ -123,6 +132,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
           sparse-checkout: |
             docker-jans-${{ matrix.docker-images }}
@@ -173,8 +183,8 @@ jobs:
             if [[ -n "$pull_number" && "$pull_number" != "null" ]]; then
               # PR: get changed files via GitHub API
               DIRECTORIES_CHANGED=$(gh pr view "$pull_number" --json files --jq '.files.[].path' | cut -d/ -f1 | sort -u | grep -E '^docker-jans|^flask-sidecar|^cedarling_opa' || echo "$ALL_SERVICES")
-            elif [[ "${{ github.event_name }}" == "schedule" || "${{ github.ref_type }}" == "tag" ]]; then
-              # Nightly schedule or tag push: build all images
+            elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+              # Chained: the nightly/release publish completed -> build all images
               DIRECTORIES_CHANGED="$ALL_SERVICES"
             else
               # Direct branch push: use git diff to find which docker dirs changed.

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
           sparse-checkout: |
             docker-jans-${{ matrix.docker-images }}

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,10 +1,13 @@
 name: Publish packages
 
 on:
-  push:
-    tags:
-    - 'v**'
-    - 'nightly'
+  # Chained after the publish workflow so the service WARs/jars exist on the
+  # release before install.py downloads them. build-nightly-build recreates the
+  # nightly tag -> "Janssen Build & Publish" publishes -> this runs.
+  workflow_run:
+    workflows: ["Janssen Build & Publish"]
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       target_tag:
@@ -59,7 +62,7 @@ jobs:
   publish_binary_packages:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_binary_packages))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_binary_packages))
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
@@ -120,6 +123,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
         path: temp-jans
 
     - name: Getting build dependencies
@@ -142,7 +146,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           TAG_NAME="${{ inputs.target_tag }}"
         else
-          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          TAG_NAME=${{ github.event.workflow_run.head_branch }}
         fi
 
         echo "tag=${TAG_NAME}" >> $GITHUB_OUTPUT
@@ -226,7 +230,7 @@ jobs:
   build_and_upload_python_packages:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_python_packages))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_python_packages))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -252,6 +256,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
     - name: Set up Python
       if: matrix.name != 'suse'
@@ -307,7 +313,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           TAG_NAME="${{ inputs.target_tag }}"
         else
-          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          TAG_NAME=${{ github.event.workflow_run.head_branch }}
         fi
 
         echo "tag=${TAG_NAME}" >> $GITHUB_OUTPUT
@@ -370,7 +376,7 @@ jobs:
   build_cedarling_wasm:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_wasm))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_wasm))
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
@@ -382,6 +388,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
     - name: Install Protoc
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
     - name: Install Cosign
@@ -417,7 +425,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           TAG_NAME="${{ inputs.target_tag }}"
         else
-          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          TAG_NAME=${{ github.event.workflow_run.head_branch }}
         fi
         
         TAG=$(echo "${TAG_NAME}" | sed 's/^v//')
@@ -482,7 +490,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ inputs.target_tag }}"
         else
-          VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VERSION=${{ github.event.workflow_run.head_branch }}
         fi
         
         TAG=$(echo "${VERSION}" | sed 's/^v//')
@@ -504,7 +512,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ inputs.target_tag }}"
         else
-          VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VERSION=${{ github.event.workflow_run.head_branch }}
         fi
         TAG=$(echo "${VERSION}" | sed 's/^v//')
         if [ "${TAG}" == "nightly" ]; then
@@ -524,7 +532,7 @@ jobs:
   build_demo_packages:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_demo_packages))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_demo_packages))
     needs: build_cedarling_wasm
     runs-on: ubuntu-latest
     steps:
@@ -535,6 +543,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
     - name: Build with Ubuntu
       continue-on-error: true
       env:
@@ -547,7 +557,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VER="${{ inputs.target_tag }}"
         else
-          VER=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VER=${{ github.event.workflow_run.head_branch }}
         fi
 
         for i in $(ls -d */); do zip -r demo-${i%/}-$VER-source.zip $i; done
@@ -595,7 +605,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VER="${{ inputs.target_tag }}"
         else
-          VER=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VER=${{ github.event.workflow_run.head_branch }}
         fi
         DIGEST_FILE="/tmp/demo-digest.sha256"
         rm -f "${DIGEST_FILE}"
@@ -617,7 +627,7 @@ jobs:
   build_cedarling_python:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_python))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_python))
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
@@ -655,6 +665,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
     - name: Install Protoc (macOS)
       if: runner.os == 'macOS'
@@ -694,7 +706,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           TAG_NAME="${{ inputs.target_tag }}"
         else
-          TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          TAG_NAME=${{ github.event.workflow_run.head_branch }}
         fi
 
         TAG=$(echo "${TAG_NAME}" | sed 's/^v//')
@@ -791,7 +803,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ inputs.target_tag }}"
         else
-          VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VERSION=${{ github.event.workflow_run.head_branch }}
         fi
 
         TAG=$(echo "${VERSION}" | sed 's/^v//')
@@ -849,7 +861,7 @@ jobs:
   build_cedarling_go:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_go))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_go))
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
@@ -872,6 +884,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Install Protoc (Native)
         shell: bash
         run: |
@@ -907,7 +921,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="${{ inputs.target_tag }}"
           else
-            VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+            VERSION=${{ github.event.workflow_run.head_branch }}
           fi
           TAG=$(echo "${VERSION}" | sed 's/^v//')
           if [ "${TAG}" == "nightly" ]; then
@@ -968,7 +982,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="${{ inputs.target_tag }}"
           else
-            VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+            VERSION=${{ github.event.workflow_run.head_branch }}
           fi
           TAG=$(echo "${VERSION}" | sed 's/^v//')
           if [ "${TAG}" == "nightly" ]; then
@@ -1028,7 +1042,7 @@ jobs:
   build_cedarling_krakend:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_krakend))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_krakend))
     needs: build_cedarling_go
     runs-on: ubuntu-22.04
     permissions:
@@ -1044,6 +1058,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
     - name: Install Cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Set environment variables
@@ -1051,7 +1067,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ inputs.target_tag }}"
         else
-          VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VERSION=${{ github.event.workflow_run.head_branch }}
         fi
         TAG=$(echo "${VERSION}" | sed 's/^v//')
         if [ "${TAG}" == "nightly" ]; then
@@ -1116,7 +1132,7 @@ jobs:
   build_cedarling_uniffi:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_uniffi))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_uniffi))
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
@@ -1128,6 +1144,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
     - name: Install Protoc
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
     - name: Install Cosign
@@ -1147,7 +1165,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ inputs.target_tag }}"
         else
-          VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VERSION=${{ github.event.workflow_run.head_branch }}
         fi
         TAG=$(echo "${VERSION}" | sed 's/^v//')
         if [ "${TAG}" == "nightly" ]; then
@@ -1190,7 +1208,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ inputs.target_tag }}"
         else
-          VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VERSION=${{ github.event.workflow_run.head_branch }}
         fi
         TAG=$(echo "${VERSION}" | sed 's/^v//')
         if [ "${TAG}" == "nightly" ]; then
@@ -1239,7 +1257,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ inputs.target_tag }}"
         else
-          VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VERSION=${{ github.event.workflow_run.head_branch }}
         fi
         TAG=$(echo "${VERSION}" | sed 's/^v//')
         if [ "${TAG}" == "nightly" ]; then
@@ -1257,7 +1275,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ inputs.target_tag }}"
         else
-          VERSION=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
+          VERSION=${{ github.event.workflow_run.head_branch }}
         fi
         TAG=$(echo "${VERSION}" | sed 's/^v//')
         if [ "${TAG}" == "nightly" ]; then
@@ -1284,7 +1302,7 @@ jobs:
     needs: [publish_binary_packages]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_binary_packages))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_binary_packages))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1296,7 +1314,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download binary digest artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -1315,7 +1333,7 @@ jobs:
     needs: [collect-binary-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_binary_packages)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_binary_packages)) &&
       needs.collect-binary-digests.outputs.hashes != ''
     permissions:
       actions: read
@@ -1334,7 +1352,7 @@ jobs:
     needs: [build_and_upload_python_packages]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_python_packages))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_python_packages))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1346,7 +1364,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download python digest artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -1365,7 +1383,7 @@ jobs:
     needs: [collect-python-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_python_packages)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_python_packages)) &&
       needs.collect-python-digests.outputs.hashes != ''
     permissions:
       actions: read
@@ -1384,7 +1402,7 @@ jobs:
     needs: [build_cedarling_wasm]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_wasm))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_wasm))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1396,7 +1414,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download WASM digest artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -1414,7 +1432,7 @@ jobs:
     needs: [collect-wasm-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_wasm)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_wasm)) &&
       needs.collect-wasm-digests.outputs.hashes != ''
     permissions:
       actions: read
@@ -1433,7 +1451,7 @@ jobs:
     needs: [build_cedarling_python]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_python))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_python))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1445,7 +1463,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download Cedarling Python digest artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -1464,7 +1482,7 @@ jobs:
     needs: [collect-cedarling-python-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_python)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_python)) &&
       needs.collect-cedarling-python-digests.outputs.hashes != ''
     permissions:
       actions: read
@@ -1483,7 +1501,7 @@ jobs:
     needs: [build_cedarling_go]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_go))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_go))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1495,7 +1513,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download Cedarling Go digest artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -1514,7 +1532,7 @@ jobs:
     needs: [collect-cedarling-go-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_go)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_go)) &&
       needs.collect-cedarling-go-digests.outputs.hashes != ''
     permissions:
       actions: read
@@ -1533,7 +1551,7 @@ jobs:
     needs: [build_cedarling_krakend]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_krakend))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_krakend))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1545,7 +1563,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download KrakenD digest artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -1564,7 +1582,7 @@ jobs:
     needs: [collect-cedarling-krakend-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_krakend)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_krakend)) &&
       needs.collect-cedarling-krakend-digests.outputs.hashes != ''
     permissions:
       actions: read
@@ -1583,7 +1601,7 @@ jobs:
     needs: [build_cedarling_uniffi]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_uniffi))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_uniffi))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1595,7 +1613,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download UniFFI digest artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -1613,7 +1631,7 @@ jobs:
     needs: [collect-cedarling-uniffi-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_uniffi)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_uniffi)) &&
       needs.collect-cedarling-uniffi-digests.outputs.hashes != ''
     permissions:
       actions: read
@@ -1632,7 +1650,7 @@ jobs:
     needs: [build_demo_packages]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_demo_packages))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_demo_packages))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1644,7 +1662,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=$(echo '${{ github.event.ref }}' | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download demo digest artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
@@ -1662,7 +1680,7 @@ jobs:
     needs: [collect-demo-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_demo_packages)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_demo_packages)) &&
       needs.collect-demo-digests.outputs.hashes != ''
     permissions:
       actions: read

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
         path: temp-jans
 
     - name: Getting build dependencies
@@ -257,7 +257,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     - name: Set up Python
       if: matrix.name != 'suse'
@@ -389,7 +389,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     - name: Install Protoc
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
     - name: Install Cosign
@@ -544,7 +544,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     - name: Build with Ubuntu
       continue-on-error: true
       env:
@@ -666,7 +666,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     - name: Install Protoc (macOS)
       if: runner.os == 'macOS'
@@ -885,7 +885,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - name: Install Protoc (Native)
         shell: bash
         run: |
@@ -1059,7 +1059,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     - name: Install Cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Set environment variables
@@ -1145,7 +1145,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     - name: Install Protoc
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
     - name: Install Cosign

--- a/docs/script-catalog/person_authentication/other/otp/OTPExternalAuthenticator.py
+++ b/docs/script-catalog/person_authentication/other/otp/OTPExternalAuthenticator.py
@@ -18,9 +18,9 @@ import jarray
 import json
 import sys
 from com.google.common.io import BaseEncoding
-from com.github.bastiaanjansen.otp import HMACAlgorithm
-from com.github.bastiaanjansen.otp import HOTPGenerator
-from com.github.bastiaanjansen.otp import TOTPGenerator
+from com.bastiaanjansen.otp import HMACAlgorithm
+from com.bastiaanjansen.otp import HOTPGenerator
+from com.bastiaanjansen.otp import TOTPGenerator
 from java.security import SecureRandom
 from java.time import Duration
 from java.util import Arrays

--- a/docs/script-catalog/person_authentication/other/otp/OTPExternalAuthenticator.py
+++ b/docs/script-catalog/person_authentication/other/otp/OTPExternalAuthenticator.py
@@ -540,7 +540,7 @@ class PersonAuthentication(PersonAuthenticationType):
 
         hotp = HOTPGenerator.Builder(secretKey).withPasswordLength(digits).withAlgorithm(HMACAlgorithm.SHA1).build()
 
-        return hotp.getURI(issuer, userDisplayName).toString()
+        return hotp.getURI(0, issuer, userDisplayName).toString()
 
     # TOTP methods
     def generateSecretTotpKey(self):

--- a/docs/script-catalog/person_authentication/otp-external-authenticator/OtpExternalAuthenticator.py
+++ b/docs/script-catalog/person_authentication/otp-external-authenticator/OtpExternalAuthenticator.py
@@ -524,7 +524,7 @@ class PersonAuthentication(PersonAuthenticationType):
 
         hotp = HOTPGenerator.Builder(secretKey).withPasswordLength(digits).withAlgorithm(HMACAlgorithm.SHA1).build()
 
-        return hotp.getURI(issuer, userDisplayName).toString()
+        return hotp.getURI(0, issuer, userDisplayName).toString()
 
     # TOTP methods
     def generateSecretTotpKey(self):

--- a/docs/script-catalog/person_authentication/otp-external-authenticator/OtpExternalAuthenticator.py
+++ b/docs/script-catalog/person_authentication/otp-external-authenticator/OtpExternalAuthenticator.py
@@ -18,9 +18,9 @@ import jarray
 import json
 import sys
 from com.google.common.io import BaseEncoding
-from com.github.bastiaanjansen.otp import HMACAlgorithm
-from com.github.bastiaanjansen.otp import HOTPGenerator
-from com.github.bastiaanjansen.otp import TOTPGenerator
+from com.bastiaanjansen.otp import HMACAlgorithm
+from com.bastiaanjansen.otp import HOTPGenerator
+from com.bastiaanjansen.otp import TOTPGenerator
 from java.security import SecureRandom
 from java.time import Duration
 from java.util import Arrays, HashMap

--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/HOTPAlgorithmService.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/HOTPAlgorithmService.java
@@ -1,7 +1,7 @@
 package io.jans.casa.plugins.authnmethod.service.otp;
 
-import com.github.bastiaanjansen.otp.HMACAlgorithm;
-import com.github.bastiaanjansen.otp.HOTPGenerator;
+import com.bastiaanjansen.otp.HMACAlgorithm;
+import com.bastiaanjansen.otp.HOTPGenerator;
 import io.jans.casa.misc.Utils;
 import io.jans.casa.plugins.authnmethod.conf.otp.HOTPConfig;
 import org.slf4j.Logger;

--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/HOTPAlgorithmService.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/HOTPAlgorithmService.java
@@ -50,7 +50,7 @@ public class HOTPAlgorithmService implements IOTPAlgorithm {
     public String generateSecretKeyUri(byte[] secretKey, String displayName) {
         logger.trace("Generating secret key URI");
         try {
-            URI uri = buildGenerator(secretKey).getURI(issuer, displayName.replace(':', ' '));
+            URI uri = buildGenerator(secretKey).getURI(0, issuer, displayName.replace(':', ' '));
             return uri.toString();
         } catch (Exception e) {
             throw new IllegalStateException("Could not build HOTP key URI", e);

--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/TOTPAlgorithmService.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/TOTPAlgorithmService.java
@@ -1,7 +1,7 @@
 package io.jans.casa.plugins.authnmethod.service.otp;
 
-import com.github.bastiaanjansen.otp.HMACAlgorithm;
-import com.github.bastiaanjansen.otp.TOTPGenerator;
+import com.bastiaanjansen.otp.HMACAlgorithm;
+import com.bastiaanjansen.otp.TOTPGenerator;
 import io.jans.casa.misc.Utils;
 import io.jans.casa.plugins.authnmethod.conf.otp.TOTPConfig;
 import org.slf4j.Logger;


### PR DESCRIPTION
## Why

After the offboarding, `build-packages` and `build-docker-image` pull the service WARs from the **GitHub `nightly` release**, which `build-test` ("Janssen Build & Publish") populates on the same `nightly` tag. They previously all fired off that one tag push (plus `build-docker-image` had its **own** `0 23 * * *` cron that collided with `build-nightly-build` deleting+recreating the release) — so consumers raced the producer and could build against missing/half-uploaded WARs.

## What — declarative `workflow_run` chaining

```
build-nightly-build  (cron 23:00, recreates the `nightly` tag via MOAUTO PAT)
        │  tag push
        ▼
"Janssen Build & Publish"  (build-test: mvn deploy → Packages, upload WARs/jars → release)
        │  workflow_run: completed (success)
        ├──────────────► build-packages      (install.py downloads WARs → .deb/.rpm)
        └──────────────► build-docker-image   (Dockerfiles pull WARs → ghcr images)
```

- **build-packages**: `on: push: tags` → `on: workflow_run` (after build-test). Every job gated on `workflow_run.conclusion == 'success'` and `head_branch` ∈ {`nightly`, `v*`}; tag derived from `workflow_run.head_branch`; checkout pinned to that ref (so `v*` builds use the tagged source, not main). `workflow_dispatch` path unchanged.
- **build-docker-image**: removed the standalone `0 23 * * *` cron and the `tags: "*"` push trigger; added `workflow_run`. Job-level `if` gates workflow_run runs to success + `nightly`/`v*`. The "build all" branch now keys off `workflow_run`. **PR-validation and `main` push image builds are unchanged.**

## Validation (needs a real nightly — opening as draft)

1. Trigger `build-nightly-build` (or wait for 23:00). Confirm: it recreates `nightly` → build-test runs → on success, build-packages + build-docker-image start (not before).
2. Confirm the `nightly` release ends up with WARs + .deb/.rpm, and ghcr images are pushed.
3. Confirm PR builds of `build-docker-image` still run on `docker-jans-**` PRs.

## Known follow-up (not blocking nightly)

For **version** releases (`v*`), `build-docker-image` doesn't yet set `CN_RELEASE_TAG`/`CN_VERSION` to the tag, so images would pull `nightly` WARs. Nightly (the automated path) is correct via defaults. Version-release image builds need a `CN_RELEASE_TAG=v*` override — small follow-up.

Part of the jenkins.jans.io offboarding (Phase C). Follows the merged artifact-publish (#14199) + consumer-repoint (#14210, #14212).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OTP authentication library usage across multiple modules to a different package and adjusted HOTP/TOTP enrollment URI generation for consistent behavior.
  * Streamlined CI/CD workflows: replaced cron/tag triggers with chained workflow_run triggers, added conditional gating for chained runs, and aligned checkout/tag resolution for chained nightly/release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->