### PR TITLE
fix(ci): build cedarling uniffi native lib in build-test (unblock nightly)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -210,8 +210,10 @@ jobs:
         echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
         if [[ "${TAG_NAME}" == "nightly" ]]; then
           echo "version=0.0.0-nightly" >> "$GITHUB_OUTPUT"
+          echo "native_version=0.0.0" >> "$GITHUB_OUTPUT"
         else
           echo "version=$(echo "${TAG_NAME}" | sed 's/^v//')" >> "$GITHUB_OUTPUT"
+          echo "native_version=$(echo "${TAG_NAME}" | sed 's/^v//')" >> "$GITHUB_OUTPUT"
         fi
 
     # Build the ordered module list. Non-dispatch events (tag push) and
@@ -246,6 +248,40 @@ jobs:
         echo "Selected modules: $MODULES"
         echo "modules=${MODULES}" >> "$GITHUB_OUTPUT"
 
+    # cedarling-java bundles the Rust uniffi native lib + Kotlin bindings, which
+    # its pom downloads from the release. build-nightly-build empties the release
+    # before this runs, and build-packages (which normally produces them) runs
+    # AFTER this workflow -> build them here and upload them so cedarling-java
+    # (and jans-lock, which depends on it) can build.
+    - name: Install Protoc (for cedarling native)
+      if: contains(steps.mods.outputs.modules, 'cedarling-java')
+      run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+    - name: Install Rust (for cedarling native)
+      if: contains(steps.mods.outputs.modules, 'cedarling-java')
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      with:
+        toolchain: stable
+
+    - name: Build and upload cedarling uniffi native lib + kotlin bindings
+      if: contains(steps.mods.outputs.modules, 'cedarling-java')
+      working-directory: ${{ github.workspace }}/jans-cedarling/bindings/cedarling_uniffi
+      env:
+        GH_TOKEN: ${{ secrets.MOAUTO_WORKFLOW_TOKEN }}
+        NV: ${{ steps.ver.outputs.native_version }}
+        TAG: ${{ steps.ver.outputs.tag }}
+      run: |
+        set -euo pipefail
+        cargo build -r --locked -p cedarling_uniffi
+        cp ../../target/release/libcedarling_uniffi.so "libcedarling_uniffi-${NV}.so"
+        cargo run --locked --bin uniffi-bindgen generate \
+          --library "${GITHUB_WORKSPACE}/jans-cedarling/target/release/libcedarling_uniffi.so" \
+          --language kotlin --out-dir ./
+        zip -r "cedarling_uniffi-kotlin-${NV}.zip" uniffi
+        gh release upload "${TAG}" \
+          "libcedarling_uniffi-${NV}.so" "cedarling_uniffi-kotlin-${NV}.zip" \
+          --repo "${{ github.repository }}" --clobber
+
     # For a versioned release the poms (fixed at 0.0.0-nightly) must be bumped
     # before deploy. Nightly publishes 0.0.0-nightly as-is.
     - name: Set release version in poms
@@ -268,6 +304,7 @@ jobs:
             -f "${m}" \
             -Dmaven.test.skip=true \
             -Dcedarling.release.tag="${{ steps.ver.outputs.tag }}" \
+            -Dcedarling.native.version="${{ steps.ver.outputs.native_version }}" \
             clean deploy
           echo "::endgroup::"
         done


### PR DESCRIPTION
## Problem (failing nightly)

`deploy jans-cedarling/bindings/cedarling-java` fails:
```
download-maven-plugin:1.9.0:wget (download-native-lib) ... Download failed with code 404: Not Found
```

cedarling-java bundles the Rust **`libcedarling_uniffi.so`** + Kotlin bindings, which its pom downloads from the GitHub release. But:
- `build-nightly-build` **deletes + recreates** the `nightly` release (emptying it) before this workflow runs, and
- `build-packages` (which normally builds + uploads those native artifacts) runs **after** this workflow.

So when build-test builds cedarling-java, the `.so` isn't on the release → 404. (cedarling-java was added to the Java build for jenkins parity; **jans-lock build-depends on it**, so it can't simply be dropped.)

## Fix

Build the uniffi `.so` + Kotlin bindings **in build-test, before the Maven loop**, and upload them to the release — mirroring `build-packages`' `build_cedarling_uniffi` steps (`cargo build -p cedarling_uniffi`, `uniffi-bindgen generate --language kotlin`, zip). cedarling-java's existing download then resolves them, and so does jans-lock.

- Gated with `if: contains(steps.mods.outputs.modules, 'cedarling-java')` — only adds the Rust toolchain + build when cedarling-java is actually being built.
- New `native_version` output (`0.0.0` for nightly, `X.Y.Z` for `v*`) passed as `-Dcedarling.native.version` so the artifact coordinates line up for both nightly and version builds.

## Validation

Needs a real nightly (or `workflow_dispatch` with `target_tag=nightly`) to confirm: the uniffi `.so`/kotlin zip upload succeeds and cedarling-java + jans-lock then build. Rust steps mirror the proven `build-packages` job.

Hotfix for the merged artifact-publish workflow (Phase A). Independent of the pipeline-chaining PR (#14215), which would otherwise make this 404 permanent (build-packages strictly after build-test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated CI/CD pipeline now generates and uploads platform-specific native libraries for Java modules
  * Nightly and version-tagged releases automatically include corresponding Kotlin bindings and native artifacts
  * Maven deployments improved with native library version tracking to ensure correct artifact resolution during builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->