### PR TITLE
feat(jans-fido2): add Fido2MetricsAggregation unit tests

### DIFF
--- a/jans-fido2/model/src/test/java/io/jans/fido2/model/metric/Fido2MetricsAggregationTest.java
+++ b/jans-fido2/model/src/test/java/io/jans/fido2/model/metric/Fido2MetricsAggregationTest.java
@@ -1,0 +1,273 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2024, Janssen Project
+ */
+
+package io.jans.fido2.model.metric;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the small computed surface on {@link Fido2MetricsAggregation}:
+ * 4-arg constructor id composition + UTC {@code lastUpdated} stamp,
+ * {@code getPeriod()} derivation from {@code id}, null-safe {@code getLongMetric}/
+ * {@code getDoubleMetric}, {@code Integer→Long} coercion on map metrics,
+ * {@code incrementMetric} null-safety, and the {@code equals}/{@code hashCode}
+ * contract over ({@code id}, {@code aggregationType}, {@code startTime}, {@code endTime}).
+ *
+ * @author Janssen Project
+ * @version 1.0
+ */
+class Fido2MetricsAggregationTest {
+
+    @Test
+    void testDefaultConstructorInitializesEmptyMetricsData() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+
+        assertNotNull(agg.getMetricsData(), "metricsData must be initialized, not null");
+        assertTrue(agg.getMetricsData().isEmpty(), "metricsData must start empty");
+        assertNull(agg.getId());
+        assertNull(agg.getAggregationType());
+        assertNull(agg.getStartTime());
+        assertNull(agg.getEndTime());
+        assertNull(agg.getLastUpdated());
+    }
+
+    @Test
+    void testFourArgConstructorComposesIdAndStampsLastUpdated() {
+        Date start = new Date(1_700_000_000_000L);
+        Date end = new Date(1_700_086_400_000L);
+        long beforeMillis = System.currentTimeMillis();
+
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation("DAILY", "2026-05-22", start, end);
+
+        long afterMillis = System.currentTimeMillis();
+
+        assertEquals("DAILY_2026-05-22", agg.getId(),
+                "id must be composed as aggregationType + \"_\" + period");
+        assertEquals("DAILY", agg.getAggregationType());
+        assertEquals(start, agg.getStartTime());
+        assertEquals(end, agg.getEndTime());
+        assertNotNull(agg.getLastUpdated(), "lastUpdated must be stamped by the 4-arg ctor");
+
+        long stamped = agg.getLastUpdated().getTime();
+        assertTrue(stamped >= beforeMillis - 1000 && stamped <= afterMillis + 1000,
+                "lastUpdated must be within ±1s of now (stamped=" + stamped
+                        + ", before=" + beforeMillis + ", after=" + afterMillis + ")");
+
+        // Default-ctor invariants must still hold via this() delegation.
+        assertNotNull(agg.getMetricsData());
+        assertTrue(agg.getMetricsData().isEmpty());
+    }
+
+    @Test
+    void testGetPeriodDerivesFromIdOnFirstUnderscore() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+
+        agg.setId("DAILY_2026-05-22");
+        assertEquals("2026-05-22", agg.getPeriod(),
+                "period is the substring after the first underscore");
+
+        // Multi-underscore period: split is on the FIRST underscore only,
+        // so the remaining underscores belong to the period.
+        agg.setId("HOURLY_2026-05-22_14");
+        assertEquals("2026-05-22_14", agg.getPeriod());
+
+        agg.setId("NOPERIOD");
+        assertEquals("NOPERIOD", agg.getPeriod(),
+                "id with no underscore returns the id unchanged");
+
+        agg.setId(null);
+        assertNull(agg.getPeriod(), "null id returns null period");
+    }
+
+    @Test
+    void testGetLongMetricAndGetDoubleMetricNullSafety() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+
+        // Absent key on an empty map.
+        assertNull(agg.getLongMetric("missing"));
+        assertNull(agg.getDoubleMetric("missing"));
+
+        // metricsData itself null.
+        agg.setMetricsData(null);
+        assertNull(agg.getLongMetric("anything"));
+        assertNull(agg.getDoubleMetric("anything"));
+    }
+
+    @Test
+    void testGetLongMetricReturnsValueAndWidensIntegerToLong() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+        Map<String, Object> data = new HashMap<>();
+        data.put("long-key", 42L);
+        data.put("int-key", 7);
+        data.put("double-key", 3.5d);
+        agg.setMetricsData(data);
+
+        assertEquals(42L, agg.getLongMetric("long-key"));
+        assertEquals(7L, agg.getLongMetric("int-key"),
+                "Integer values must be widened to Long");
+        // Double is also a Number — longValue() truncates toward zero.
+        assertEquals(3L, agg.getLongMetric("double-key"));
+    }
+
+    @Test
+    void testGetDoubleMetricReturnsValueForIntegerAndDouble() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+        Map<String, Object> data = new HashMap<>();
+        data.put("double-key", 0.85d);
+        data.put("int-key", 7);
+        agg.setMetricsData(data);
+
+        assertEquals(0.85d, agg.getDoubleMetric("double-key"), 1e-9);
+        assertEquals(7.0d, agg.getDoubleMetric("int-key"), 1e-9);
+    }
+
+    @Test
+    void testGetLongMetricReturnsNullForNonNumberValue() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+        Map<String, Object> data = new HashMap<>();
+        data.put("string-key", "not-a-number");
+        agg.setMetricsData(data);
+
+        assertNull(agg.getLongMetric("string-key"),
+                "non-Number value must return null, not throw ClassCastException");
+        assertNull(agg.getDoubleMetric("string-key"));
+    }
+
+    @Test
+    void testConvenienceSettersWireToConstantKeys() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+
+        // Long path.
+        agg.setRegistrationAttempts(42L);
+        assertEquals(42L, agg.getRegistrationAttempts());
+        assertEquals(42L,
+                agg.getMetricsData().get(Fido2MetricsConstants.REGISTRATION_ATTEMPTS),
+                "setRegistrationAttempts must store under the REGISTRATION_ATTEMPTS key");
+
+        // Double path.
+        agg.setAuthenticationSuccessRate(0.85d);
+        assertEquals(0.85d, agg.getAuthenticationSuccessRate(), 1e-9);
+        assertEquals(0.85d,
+                (Double) agg.getMetricsData().get(Fido2MetricsConstants.AUTHENTICATION_SUCCESS_RATE),
+                1e-9,
+                "setAuthenticationSuccessRate must store under the AUTHENTICATION_SUCCESS_RATE key");
+    }
+
+    @Test
+    void testGetDeviceTypesCoercesIntegerToLong() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+        Map<String, Object> inner = new HashMap<>();
+        inner.put("PLATFORM", 7);          // Integer — exactly what Jackson hands back for JSON numbers.
+        inner.put("CROSS_PLATFORM", 3);
+        Map<String, Object> data = new HashMap<>();
+        data.put(Fido2MetricsConstants.DEVICE_TYPES, inner);
+        agg.setMetricsData(data);
+
+        Map<String, Long> deviceTypes = agg.getDeviceTypes();
+
+        assertNotNull(deviceTypes);
+        assertEquals(2, deviceTypes.size());
+        assertEquals(Long.valueOf(7L), deviceTypes.get("PLATFORM"));
+        assertEquals(Long.valueOf(3L), deviceTypes.get("CROSS_PLATFORM"));
+    }
+
+    @Test
+    void testGetDeviceTypesReturnsEmptyMapWhenAbsent() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+
+        Map<String, Long> deviceTypes = agg.getDeviceTypes();
+        assertNotNull(deviceTypes, "must return empty map, not null, when key is missing");
+        assertTrue(deviceTypes.isEmpty());
+
+        Map<String, Long> errorCounts = agg.getErrorCounts();
+        assertNotNull(errorCounts);
+        assertTrue(errorCounts.isEmpty());
+    }
+
+    @Test
+    void testIncrementMetricIsNullSafeOnBothSides() {
+        Fido2MetricsAggregation agg = new Fido2MetricsAggregation();
+
+        // Starting from absent key + non-null increment.
+        agg.incrementMetric("foo", 5L);
+        assertEquals(5L, agg.getLongMetric("foo"));
+
+        // Subsequent increment accumulates.
+        agg.incrementMetric("foo", 3L);
+        assertEquals(8L, agg.getLongMetric("foo"));
+
+        // Null increment leaves the current value untouched.
+        agg.incrementMetric("foo", null);
+        assertEquals(8L, agg.getLongMetric("foo"));
+
+        // Both null on a fresh instance — current treated as 0, increment as 0.
+        Fido2MetricsAggregation fresh = new Fido2MetricsAggregation();
+        fresh.incrementMetric("bar", null);
+        assertEquals(0L, fresh.getLongMetric("bar"));
+    }
+
+    @Test
+    void testEqualsAndHashCodeContract() {
+        Date start = new Date(1_700_000_000_000L);
+        Date end = new Date(1_700_086_400_000L);
+
+        Fido2MetricsAggregation a = new Fido2MetricsAggregation("DAILY", "2026-05-22", start, end);
+        Fido2MetricsAggregation b = new Fido2MetricsAggregation("DAILY", "2026-05-22", start, end);
+
+        // Identical (id, aggregationType, startTime, endTime) — equal and same hash.
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+
+        // Unrelated fields don't affect equality.
+        a.setUniqueUsers(100L);
+        b.setUniqueUsers(999L);
+        a.setRegistrationAttempts(10L);
+        b.setRegistrationAttempts(20L);
+        assertEquals(a, b, "equality must ignore uniqueUsers and metricsData");
+        assertEquals(a.hashCode(), b.hashCode());
+
+        // Reflexive.
+        assertEquals(a, a);
+
+        // Null and other-type comparisons.
+        assertNotEquals(null, a);
+        assertNotEquals("string", a);
+        assertFalse(a.equals(null));
+        assertFalse(a.equals("string"));
+
+        // Differ in id (via setId, since the ctor composes it).
+        Fido2MetricsAggregation differentId = new Fido2MetricsAggregation("DAILY", "2026-05-22", start, end);
+        differentId.setId("DAILY_2026-05-23");
+        assertNotEquals(a, differentId);
+
+        // Differ in aggregationType.
+        Fido2MetricsAggregation differentType = new Fido2MetricsAggregation("HOURLY", "2026-05-22", start, end);
+        assertNotEquals(a, differentType);
+
+        // Differ in startTime.
+        Fido2MetricsAggregation differentStart = new Fido2MetricsAggregation("DAILY", "2026-05-22",
+                new Date(start.getTime() + 1), end);
+        differentStart.setId(a.getId()); // hold id steady to isolate startTime
+        assertNotEquals(a, differentStart);
+
+        // Differ in endTime.
+        Fido2MetricsAggregation differentEnd = new Fido2MetricsAggregation("DAILY", "2026-05-22",
+                start, new Date(end.getTime() + 1));
+        differentEnd.setId(a.getId());
+        assertNotEquals(a, differentEnd);
+    }
+}


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

Adds JUnit 5 test coverage for Fido2MetricsAggregation — the ORM entity that stores hourly/daily/weekly/monthly summary rows for the FIDO2 metrics feature. Most of the class is plain getters/setters, but the small computed surface (4-arg constructor id composition, getPeriod() derivation, null-safe Number coercion, Integer→Long map widening, incrementMetric accumulator, and the equals/hashCode contract) was completely untested. The new test class locks each of those behaviors. Test-only change; no production code or pom.xml changes. Step 7 of the FIDO2 metrics test rollout.

#### Target issue

Fido2MetricsAggregation (jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricsAggregation.java) carries six small bits of computed behavior that downstream aggregation/analytics code silently depends on, and none of them is tested today:

- A 4-arg constructor that builds the composite id as aggregationType + "_" + period and stamps lastUpdated in UTC.
- getPeriod() — derives the period string back out of id by splitting on the FIRST underscore.
- getLongMetric(key) / getDoubleMetric(key) — null-safe Number coercion that returns null (not NaN, not NPE) when the underlying map entry is absent or non-numeric.
- getDeviceTypes() / getErrorCounts() — Map accessors that coerce Integer values to Long for JSON-serialization compatibility (the exact shape Jackson hands back for JSON numbers).
- incrementMetric(key, increment) — null-safe accumulator (treats both nulls as 0).
- A custom equals/hashCode based on (id, aggregationType, startTime, endTime), ignoring uniqueUsers and metricsData.

Silent failure modes — wrong aggregation totals, dropped Integer→Long conversions, NPE against partially-loaded ORM entries, or a refactor of getPeriod() that swaps indexOf("_") for split("_") or lastIndexOf("_") — would corrupt every downstream summary without any compile-time signal.

This PR is step 7 of the FIDO2 metrics test rollout.

closes #14220 

#### Implementation Details

Adds a single new JUnit 5 test class — jans-fido2/model/src/test/java/io/jans/fido2/model/metric/Fido2MetricsAggregationTest.java — with 12 grouped @Test methods, one per spec'd behavior group:

Behavior | Test method
--- | ---
Default ctor — metricsData is non-null empty map, other fields null | testDefaultConstructorInitializesEmptyMetricsData
4-arg ctor — composes id, wires aggregationType/startTime/endTime, stamps lastUpdated within ±1s of now, preserves default-ctor invariant via this() | testFourArgConstructorComposesIdAndStampsLastUpdated
getPeriod() — single-underscore, multi-underscore (split on FIRST _), no-underscore, null-id | testGetPeriodDerivesFromIdOnFirstUnderscore
getLongMetric / getDoubleMetric — null metricsData and absent key both return null | testGetLongMetricAndGetDoubleMetricNullSafety
getLongMetric — Long pass-through, Integer widened to Long, Double truncated toward zero | testGetLongMetricReturnsValueAndWidensIntegerToLong
getDoubleMetric — Double pass-through, Integer accepted via Number path | testGetDoubleMetricReturnsValueForIntegerAndDouble
getLongMetric / getDoubleMetric — String value returns null, not ClassCastException | testGetLongMetricReturnsNullForNonNumberValue
Convenience setters — setRegistrationAttempts stores under REGISTRATION_ATTEMPTS; setAuthenticationSuccessRate proves the Double path under AUTHENTICATION_SUCCESS_RATE | testConvenienceSettersWireToConstantKeys
getDeviceTypes — inner Integer values widened to Long (Jackson-compat) | testGetDeviceTypesCoercesIntegerToLong
getDeviceTypes / getErrorCounts — empty map (not null) when the key is missing | testGetDeviceTypesReturnsEmptyMapWhenAbsent
incrementMetric — absent→5, 5+3=8, null increment keeps 8, both-null on fresh instance → 0 | testIncrementMetricIsNullSafeOnBothSides
equals / hashCode — identity-4-tuple equality, reflexive, null/other-type, each of the 4 fields differing breaks equality, unrelated fields (uniqueUsers, metricsData) preserve it | testEqualsAndHashCodeContract

Design choices worth flagging:

- Multi-underscore id in the getPeriod() test. Asserts "HOURLY_2026-05-22_14" → "2026-05-22_14", not "2026-05-22". This is the load-bearing detail of the implementation (substring after the FIRST underscore) and catches a refactor that switches to split("_") or lastIndexOf("_") — both compile fine and pass a naive single-underscore test.
- ±1s tolerance window on lastUpdated rather than exact equality. The test snapshots System.currentTimeMillis() before and after the ctor call and asserts stamped ∈ [before − 1000, after + 1000]. Tight enough to catch a missing stamp; loose enough to absorb scheduling jitter on slow CI.
- Integer values (not Long) in the getDeviceTypes() Integer→Long coercion test. The whole reason getMapMetric exists is that Jackson hands back JSON numbers as Integer by default; using Integer in the test setup mirrors the actual production code path, not a hand-crafted Long map.
- assertNotEquals(null, a) AND assertFalse(a.equals(null)) in the equals contract test. JUnit's assertNotEquals can be implemented in ways that don't always exercise a.equals(null) directly; the explicit a.equals(null) call locks the documented Object#equals contract.
- Sampled (not exhaustive) convenience getter/setter coverage. One Long pair (setRegistrationAttempts) and one Double pair (setAuthenticationSuccessRate) prove the wiring; the remaining ~12 pairs are mechanical wrappers around setMetric(constant, value) and would just be near-identical assertions.

Scope:

- Test-only addition under src/test.
- No production-code changes under src/main.
- No pom.xml changes (the JUnit 5 test-scope dependencies are already declared from earlier rollout steps).

Local verification: mvn -pl model -am test from jans-fido2/ runs the new class alongside the existing two (Fido2MetricsConstantsTest and Fido2UserMetricsRateCalculationsTest). Test class runtime is well under 1 second — no I/O, no Thread.sleep, no async.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

- [x] I confirm that there is no impact on the docs due to the code changes in this PR.

Closes #14220, 