### PR TITLE
fix(jans-fido2): avoid spurious cluster ConfigurationException in metrics aggregation

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsAggregationScheduler.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsAggregationScheduler.java
@@ -431,7 +431,8 @@ public class Fido2MetricsAggregationScheduler {
                 }
             }, 30, 30, TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.error("Failed to start periodic lock updates: {}", e.getMessage(), e);
+            // Recoverable: caller falls back to single-node aggregation. Keep it concise.
+            log.warn("Could not start periodic lock updates, using single-node fallback: {}", e.getMessage());
             return null;
         }
     }
@@ -445,16 +446,29 @@ public class Fido2MetricsAggregationScheduler {
         // Try to detect cluster environment by checking if cluster service exists
         try {
             // Attempt to get cluster service via CDI lookup
-            clusterNodeService = CDI.current().select(Fido2ClusterNodeService.class).get();
+            Fido2ClusterNodeService service = CDI.current().select(Fido2ClusterNodeService.class).get();
+
+            // Cluster coordination requires "ou=node" in jansConfStatic. When it is not
+            // configured (the default single-node setup) cluster calls would throw, so
+            // treat this as single-node mode instead.
+            String nodeBaseDn = service.getBaseClusterNodeDn();
+            if (nodeBaseDn == null || nodeBaseDn.trim().isEmpty()) {
+                isClusterEnvironment = false;
+                updateExecutor = null;
+                log.info("FIDO2 metrics aggregation in SINGLE-NODE mode (ou=node not configured)");
+                return;
+            }
+
+            clusterNodeService = service;
             isClusterEnvironment = true;
             // Initialize update executor for cluster coordination
             updateExecutor = Executors.newScheduledThreadPool(1);
-            log.info("FIDO2 metrics aggregation enabled in CLUSTER mode - distributed locking will be used");
+            log.info("FIDO2 metrics aggregation in CLUSTER mode - distributed locking enabled");
         } catch (Exception e) {
             // Cluster service not available - single node deployment
             isClusterEnvironment = false;
             updateExecutor = null;
-            log.info("FIDO2 metrics aggregation enabled in SINGLE-NODE mode - no cluster coordination needed");
+            log.info("FIDO2 metrics aggregation in SINGLE-NODE mode: {}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)
fix(jans-fido2): avoid spurious cluster ConfigurationException in metrics aggregation

### Description

#### Target issue

closes #14221 

#### Implementation Details

Single-node FIDO2 deployments logged an `io.jans.exception.ConfigurationException: ou=node is not configured in static configuration of AS (jansConfStatic).` with a full stack trace on every metrics aggregation run (hourly/daily/weekly/monthly), making a healthy deployment look broken.

**Root cause:** `Fido2MetricsAggregationScheduler.initializeClusterEnvironment()` flagged the deployment as a cluster whenever the `Fido2ClusterNodeService` CDI bean was present — which is always, since it is `@ApplicationScoped`. But cluster coordination requires `ou=node` in `jansConfStatic`, which is absent in the default single-node setup. Every cluster call (`getClusterNodesLive()` via `startPeriodicLockUpdates()`) then threw the exception, which was logged at ERROR level with a full stack trace. Aggregation still completed via existing fallbacks, so this was misleading log noise rather than a functional failure.

**Fix:**
1. `initializeClusterEnvironment()` now checks `getBaseClusterNodeDn()` up front. If `ou=node` is unconfigured (blank), it runs in single-node mode and never makes cluster calls, so the exception is never thrown. It emits a clean INFO line: `FIDO2 metrics aggregation in SINGLE-NODE mode (ou=node not configured)`.
2. `startPeriodicLockUpdates()` now logs a concise one-line `warn` (message only) instead of `error` with a full stack trace, since the single-node fallback already handles the condition gracefully.

**No functional change:** cluster deployments (with `ou=node` configured) keep full distributed locking exactly as before; single-node deployments produce the same aggregation result, just without the misleading stack trace. Only one file changed: `jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsAggregationScheduler.java`.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
