### PR TITLE
fix(casa): correct otp-java import package (unblock casa compile)

### DIFF
--- a/docs/script-catalog/person_authentication/other/otp/OTPExternalAuthenticator.py
+++ b/docs/script-catalog/person_authentication/other/otp/OTPExternalAuthenticator.py
@@ -18,9 +18,9 @@ import jarray
 import json
 import sys
 from com.google.common.io import BaseEncoding
-from com.github.bastiaanjansen.otp import HMACAlgorithm
-from com.github.bastiaanjansen.otp import HOTPGenerator
-from com.github.bastiaanjansen.otp import TOTPGenerator
+from com.bastiaanjansen.otp import HMACAlgorithm
+from com.bastiaanjansen.otp import HOTPGenerator
+from com.bastiaanjansen.otp import TOTPGenerator
 from java.security import SecureRandom
 from java.time import Duration
 from java.util import Arrays

--- a/docs/script-catalog/person_authentication/otp-external-authenticator/OtpExternalAuthenticator.py
+++ b/docs/script-catalog/person_authentication/otp-external-authenticator/OtpExternalAuthenticator.py
@@ -18,9 +18,9 @@ import jarray
 import json
 import sys
 from com.google.common.io import BaseEncoding
-from com.github.bastiaanjansen.otp import HMACAlgorithm
-from com.github.bastiaanjansen.otp import HOTPGenerator
-from com.github.bastiaanjansen.otp import TOTPGenerator
+from com.bastiaanjansen.otp import HMACAlgorithm
+from com.bastiaanjansen.otp import HOTPGenerator
+from com.bastiaanjansen.otp import TOTPGenerator
 from java.security import SecureRandom
 from java.time import Duration
 from java.util import Arrays, HashMap

--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/HOTPAlgorithmService.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/HOTPAlgorithmService.java
@@ -1,7 +1,7 @@
 package io.jans.casa.plugins.authnmethod.service.otp;
 
-import com.github.bastiaanjansen.otp.HMACAlgorithm;
-import com.github.bastiaanjansen.otp.HOTPGenerator;
+import com.bastiaanjansen.otp.HMACAlgorithm;
+import com.bastiaanjansen.otp.HOTPGenerator;
 import io.jans.casa.misc.Utils;
 import io.jans.casa.plugins.authnmethod.conf.otp.HOTPConfig;
 import org.slf4j.Logger;

--- a/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/TOTPAlgorithmService.java
+++ b/jans-casa/app/src/main/java/io/jans/casa/plugins/authnmethod/service/otp/TOTPAlgorithmService.java
@@ -1,7 +1,7 @@
 package io.jans.casa.plugins.authnmethod.service.otp;
 
-import com.github.bastiaanjansen.otp.HMACAlgorithm;
-import com.github.bastiaanjansen.otp.TOTPGenerator;
+import com.bastiaanjansen.otp.HMACAlgorithm;
+import com.bastiaanjansen.otp.TOTPGenerator;
 import io.jans.casa.misc.Utils;
 import io.jans.casa.plugins.authnmethod.conf.otp.TOTPConfig;
 import org.slf4j.Logger;


### PR DESCRIPTION
## Problem (failing nightly — casa compile)

```
package com.github.bastiaanjansen.otp does not exist
cannot find symbol: class HOTPGenerator / TOTPGenerator / HMACAlgorithm
```

The otp-java migration used **`com.github.bastiaanjansen.otp`** as the Java import package. That's the Maven **groupId**, not the package. Verified from the published jar (`otp-java-2.1.0.jar`): the classes live in **`com.bastiaanjansen.otp`**:
```
com/bastiaanjansen/otp/HOTPGenerator.class
com/bastiaanjansen/otp/TOTPGenerator.class
com/bastiaanjansen/otp/HMACAlgorithm.class
```

## Fix

Correct the import package `com.github.bastiaanjansen.otp` → `com.bastiaanjansen.otp` in:
- `jans-casa/.../service/otp/TOTPAlgorithmService.java`, `HOTPAlgorithmService.java`
- the two OTP person-auth scripts (`OtpExternalAuthenticator.py`, `OTPExternalAuthenticator.py`)

The pom dependency **groupId stays `com.github.bastiaanjansen:otp-java:2.1.0`** (correct — that resolved fine; only the import was wrong).

Hotfix for the merged OTP migration. The method-level API (Builder/generate/verify/getURI) is from the v2.1.0 README and will be confirmed when casa compiles in CI.

Closes #14224, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OTP library dependencies for authentication modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->