### PR TITLE
fix(ci): publish agama-inbound jar so the auth-server image can build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -324,7 +324,8 @@ jobs:
         M2="${HOME}/.m2/repository/io/jans"
         # Service WARs, config-api plugin distribution jars, casa plugin and
         # auth-client uber-jars, the casa-agama project zip, the lock
-        # service-deps pack, and the fido2 client/model + casa-config jars.
+        # service-deps pack, and the fido2 client/model + casa-config +
+        # agama-inbound jars consumed as auth-server custom libs.
         find "$M2" -type f -path "*/${VERSION}/*" \( \
                -name '*.war' \
             -o -name '*-distribution.jar' \
@@ -334,6 +335,7 @@ jobs:
             -o -name "jans-fido2-client-${VERSION}.jar" \
             -o -name "jans-fido2-model-${VERSION}.jar" \
             -o -name "casa-config-${VERSION}.jar" \
+            -o -name "agama-inbound-${VERSION}.jar" \
           \) -exec cp -v {} "$OUT/" \;
         echo "Collected:"; ls -la "$OUT"
         echo "dir=${OUT}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

`docker-jans-auth-server` pulls `casa-config`, `jans-fido2-client`, `jans-fido2-model` and **`agama-inbound`** as custom libs from the GitHub release, but `build-test.yml` only collected the first three. So `agama-inbound-0.0.0-nightly.jar` is 404 on the release and the **`docker (auth-server)`** image build fails (e.g. run [27098512184](https://github.com/JanssenProject/jans/actions/runs/27098512184/job/79974904570), even with all WARs present), leaving a stale/broken `ghcr.io/.../auth-server` image.

`agama-inbound` is a `jans-auth-server` submodule (`jans-auth-server/agama/inboundID`, artifactId `agama-inbound`), installed to `~/.m2` during the auth-server deploy. This adds it to the release-asset collection alongside the other auth-server custom libs.

## Why a standalone PR

Broken out of #14225 (the integration-test work that surfaced this) so it can merge ahead of the next **scheduled nightly** — otherwise the nightly `Build and Publish Releases to Hub` keeps failing the auth-server image build.

## Verification

- `agama-inbound` builds into `~/.m2/repository/io/jans/agama-inbound/0.0.0-nightly/` during the `jans-auth-server` deploy (already in the module matrix).
- After this lands, the next nightly publishes `agama-inbound-0.0.0-nightly.jar` and the `docker (auth-server)` build's custom-libs loop resolves it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release artifacts collection to include additional JAR binaries in release builds, ensuring expanded release asset availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->