### PR TITLE
fix(ci): clean leftover draft nightly releases before recreating

### DIFF
--- a/.github/workflows/build-nightly-build.yml
+++ b/.github/workflows/build-nightly-build.yml
@@ -37,6 +37,14 @@ jobs:
         TARGET_BRANCH: ${{ github.event.inputs.branch }}
       run: |
         NIGHTLY_VERSION="nightly"
+        # Delete EVERY release pointing at the nightly tag, including leftover DRAFT
+        # releases (the SLSA provenance `upload-assets` step creates draft releases
+        # that `gh release delete <tag>` leaves behind, so they pile up over time).
+        for rid in $(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+            --jq ".[] | select(.tag_name==\"${NIGHTLY_VERSION}\") | .id"); do
+          echo "Deleting nightly release id=${rid}"
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${rid}" || true
+        done
         gh release delete "${NIGHTLY_VERSION}" --cleanup-tag --yes || echo "${NIGHTLY_VERSION} does not exist"
         git push --delete origin "${NIGHTLY_VERSION}" || echo "${NIGHTLY_VERSION} tag does not exist"
         if [ -z "$TARGET_BRANCH" ]; then


### PR DESCRIPTION
## Summary

The nightly `Build and Publish` leaves **draft** `nightly` releases lying around instead of a single pre-release, and they accumulate over time.

Cause: the SLSA provenance job (`slsa-github-generator` with `upload-assets: true`, `upload-tag-name: nightly`) creates a **draft** release on the `nightly` tag, and `build-nightly-build`'s `gh release delete nightly` only removes the *published* release — the draft sharing the tag is left behind, so a new draft piles up each cycle.

Fix: before recreating the nightly pre-release, delete **every** release pointing at the `nightly` tag (drafts included) by id, then drop the tag as before.

## Notes
- Standalone fix off `main` so it can merge ahead of the next scheduled nightly (sibling to #14228).
- The existing accumulated draft was removed manually; this prevents recurrence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the nightly build workflow's release artifact cleanup process for more reliable nightly build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->