### PR TITLE
fix(docker-fido2): make FIDO MDS TOC seed download best-effort

### DIFF
--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -96,14 +96,14 @@ RUN git clone --depth ${GIT_CLONE_DEPTH} --filter blob:none --no-checkout https:
 
 WORKDIR /
 
-# download external files
+# download external files; the MDS TOC is Cloudflare-rate-limited and jans-fido2
+# refreshes it at runtime, so its seed download is best-effort
 ARG MDS_DOWNLOAD_DATE='2022-10-03'
-# these are third-party endpoints (Apple, FIDO MDS, GlobalSign) and mds.fidoalliance.org
-# is prone to transient 429/5xx, so retry on connection + retryable HTTP errors
 RUN WGET_RETRY="--tries=5 --timeout=30 --waitretry=10 --retry-connrefused --retry-on-http-error=429,500,502,503,504" \
-    && wget -q ${WGET_RETRY} https://www.apple.com/certificateauthority/Apple_WebAuthn_Root_CA.pem -P /app/static/fido2/authenticator_cert/ \
-    && wget -q ${WGET_RETRY} https://mds.fidoalliance.org/ -O /etc/jans/conf/fido2/mds/toc/toc.jwt \
-    && wget -q ${WGET_RETRY} https://secure.globalsign.com/cacert/root-r3.crt -P /etc/jans/conf/fido2/mds/cert/
+    && wget -nv ${WGET_RETRY} https://www.apple.com/certificateauthority/Apple_WebAuthn_Root_CA.pem -P /app/static/fido2/authenticator_cert/ \
+    && wget -nv ${WGET_RETRY} https://secure.globalsign.com/cacert/root-r3.crt -P /etc/jans/conf/fido2/mds/cert/ \
+    && { wget -nv ${WGET_RETRY} -U "Mozilla/5.0" https://mds.fidoalliance.org/ -O /etc/jans/conf/fido2/mds/toc/toc.jwt \
+         || { : > /etc/jans/conf/fido2/mds/toc/toc.jwt; echo "WARN: FIDO MDS TOC seed download failed; jans-fido2 will fetch it at runtime"; }; }
 
 # ======
 # Python


### PR DESCRIPTION
## Summary

Follow-up to #14230. The `docker (fido2)` build kept failing (e.g. run 27128701465) — with `-nv` the cause is now clear: the **Apple** root downloads fine, but **`mds.fidoalliance.org`** (behind Cloudflare) rate-limits/resets the build's `wget` at the connection level (exit 4 — no HTTP response, so `--retry-on-http-error` can't help; all 5 retries fail).

`jans-fido2` refreshes the MDS TOC at runtime (`FetchMdsProviderService`), so the build-time copy is only a seed. This makes that one download **best-effort**:
- browser User-Agent (gets past Cloudflare's basic UA block when possible),
- non-fatal: on failure, remove the partial file and continue (the server fetches the TOC at runtime).

Apple WebAuthn + GlobalSign roots remain **required** (they download reliably and are static trust material). `-q`→`-nv` kept for diagnosability. (The earlier `-4` was dropped — the failure wasn't IPv6; downloads were already IPv4.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased verbosity for external downloads to improve diagnostics.
  * FIDO MDS TOC seed fetch is now best-effort: failures log a warning and no longer break builds; the seed file is still created (empty if necessary) so downstream steps find the expected file.

* **Chores**
  * Clarified comments to note the MDS TOC is refreshed at runtime and the seed fetch is best-effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->