### PR TITLE
ci(docker): pass JANS_SOURCE_VERSION as build-arg from current commit SHA

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -386,7 +386,7 @@ jobs:
           # add to platforms comma seperated ,linux/arm64:  : PyDev issue only
 
           build-args: |
-            JANS_SOURCE_VERSION=${{ github.event.workflow_run.head_sha || github.sha }}
+            JANS_SOURCE_VERSION=${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
           platforms: ${{ steps.prep.outputs.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -385,6 +385,8 @@ jobs:
           # add to platforms comma seperated ,linux/s390x: All images with openjdk hav an issue with linux/s390x Problematic frame: J 6 c1 java.lang.String.hashCode()I java.base@11.0.9 (49 bytes) : Issue: openjdk11-jre-headles
           # add to platforms comma seperated ,linux/arm64:  : PyDev issue only
 
+          build-args: |
+            JANS_SOURCE_VERSION=${{ github.event.workflow_run.head_sha || github.sha }}
           platforms: ${{ steps.prep.outputs.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}

--- a/docker-jans-all-in-one/Dockerfile
+++ b/docker-jans-all-in-one/Dockerfile
@@ -59,7 +59,8 @@ RUN apk update \
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the assets

--- a/docker-jans-auth-server/Dockerfile
+++ b/docker-jans-auth-server/Dockerfile
@@ -103,7 +103,8 @@ RUN mkdir -p ${JETTY_BASE}/jans-auth/agama/fl \
     /app/static/rdbm \
     /app/schema
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-casa/Dockerfile
+++ b/docker-jans-casa/Dockerfile
@@ -63,7 +63,8 @@ RUN mkdir -p /app/static/rdbm \
     /app/schema \
     /app/templates/jans-casa
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-cloudtools/Dockerfile
+++ b/docker-jans-cloudtools/Dockerfile
@@ -26,7 +26,8 @@ RUN wget -q ${CN_SOURCE_URL} -P /app/javalibs/
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 
 # note that as we're pulling from a monorepo (with multiple project in it)
 # we are using partial-clone and sparse-checkout to get the assets

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -77,7 +77,8 @@ RUN mkdir -p /etc/jans/conf \
     /usr/share/java \
     /opt/jans/bin
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 ARG JANS_CONFIG_API_RESOURCES=jans-config-api/server/src/main/resources
 

--- a/docker-jans-configurator/Dockerfile
+++ b/docker-jans-configurator/Dockerfile
@@ -28,7 +28,8 @@ RUN mkdir -p /opt/jans/configurator/javalibs \
 # Assets sync
 # ===========
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 
 ARG GIT_CLONE_DEPTH=100
 WORKDIR /tmp/jans

--- a/docker-jans-fido2/Dockerfile
+++ b/docker-jans-fido2/Dockerfile
@@ -68,7 +68,8 @@ RUN mkdir -p /etc/jans/conf \
     /app/templates/jans-fido2 \
     /app/static/fido2
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-link/Dockerfile
+++ b/docker-jans-link/Dockerfile
@@ -64,7 +64,8 @@ RUN mkdir -p /etc/jans/conf \
     /app/schema \
     /app/templates/jans-link
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-monolith/Dockerfile
+++ b/docker-jans-monolith/Dockerfile
@@ -41,7 +41,8 @@ EXPOSE 443 8080 1636
 # jans-linux-setup
 # =====================
 
-ENV JANS_SOURCE_VERSION=9c3537daa64fa9e2a63a9a1ce2decd8aa355c069
+ARG JANS_SOURCE_VERSION=9c3537daa64fa9e2a63a9a1ce2decd8aa355c069
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 
 # cleanup
 RUN rm -rf /tmp/jans

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -18,7 +18,8 @@ RUN apk update \
 RUN mkdir -p /app/static /app/schema /app/static/opendj /app/templates
 
 # janssenproject/jans SHA commit
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 ARG JANS_SCRIPT_CATALOG_DIR=docs/script-catalog
 ARG JANS_CONFIG_API_RESOURCES=jans-config-api/server/src/main/resources

--- a/docker-jans-scim/Dockerfile
+++ b/docker-jans-scim/Dockerfile
@@ -63,7 +63,8 @@ RUN mkdir -p /etc/jans/conf \
     /app/schema \
     /app/templates/jans-scim
 
-ENV JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ARG JANS_SOURCE_VERSION=f5b81afbb2be4834e9caf2e518af9f5ec42f4dd9
+ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 ARG JANS_SCIM_RESOURCE_DIR=jans-scim/server/src/main/resources
 


### PR DESCRIPTION
## Summary

- All `docker-jans-*` Dockerfiles had `JANS_SOURCE_VERSION` hardcoded as an `ENV`. Nightly images were always cloning `janssenproject/jans` at that stale hash.
- Changed `ENV JANS_SOURCE_VERSION=<hash>` to `ARG JANS_SOURCE_VERSION=<hash>` + `ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}` across all 11 Dockerfiles. The hardcoded hash remains as a fallback default for local builds.
- Added `build-args: JANS_SOURCE_VERSION=${{ github.event.workflow_run.head_sha || github.sha }}` to the `build-push-action` step in `build-docker-image.yml`. This uses the same SHA already referenced in the checkout step, so nightly images always reflect the latest main commit.
- `jans-cedarling/cedarling_opa/Dockerfile` already used `ARG` (not `ENV`) — no change needed there.

## Test plan

- [ ] Verify nightly build picks up latest main SHA in docker image labels / `JANS_SOURCE_VERSION` env inside the container
- [ ] Verify local `docker build` (no `--build-arg`) still uses the hardcoded default and builds successfully
Closes #14270, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker images now accept a build-time source version argument and preserve it as a runtime environment variable across all service images.
  * CI workflow build step passes the computed source-version build arg into image builds, enabling custom source versions while keeping previous defaults and runtime behavior intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->