### PR TITLE
ci: drop the last jenkins.jans.io reference (offboarding follow-up)

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -2,7 +2,7 @@ name: integration-tests
 
 # Java integration test-suite, run against an all-in-one (AIO) server with the
 # integration test-data loaded (CN_PERSISTENCE_LOAD_TEST_DATA=true). Replaces the
-# jenkins.jans.io test runner.
+# legacy Jenkins test runner.
 #
 # Flow per matrix leg (MYSQL / PGSQL):
 #   build persistence-loader + config-api (from this checkout) + assemble AIO


### PR DESCRIPTION
Follow-up to the Jenkins offboarding (#14225, #14277, #14314). The `test-integration.yml` header comment still named the retired `jenkins.jans.io` test runner — reworded to "the legacy Jenkins test runner". After this, `grep -ri 'jenkins.jans.io|maven.jans.io'` returns only historical CHANGELOG hits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->