### PR TITLE
fix(jans-cedarling): update Cedarling build triggers to workflow_run

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1702,7 +1702,7 @@ jobs:
   build_cedarling_pg:
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_pg))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_pg))
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
@@ -1852,7 +1852,7 @@ jobs:
     needs: [build_cedarling_pg]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_pg))
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_pg))
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.merge.outputs.hashes }}
@@ -1883,7 +1883,7 @@ jobs:
     needs: [collect-cedarling-pg-digests]
     if: |
       github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_pg)) &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || (github.event_name == 'workflow_dispatch' && inputs.run_cedarling_pg)) &&
       needs.collect-cedarling-pg-digests.outputs.hashes != ''
     permissions:
       actions: read

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1766,7 +1766,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="${TARGET_TAG}"
           else
-            VERSION="${GITHUB_REF_NAME}"
+            VERSION="${{ github.event.workflow_run.head_branch }}"
           fi
           TAG=$(echo "${VERSION}" | sed 's/^v//')
           if [ "${TAG}" == "nightly" ]; then
@@ -1821,7 +1821,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="${TARGET_TAG}"
           else
-            VERSION="${GITHUB_REF_NAME}"
+            VERSION="${{ github.event.workflow_run.head_branch }}"
           fi
 
           BASE="${{ steps.stage.outputs.base }}"
@@ -1864,7 +1864,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
           fi
       - name: Download cedarling_pg digest artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Adjust the build-packages workflow to trigger on successful workflow runs
for nightly and version branches instead of pushes.

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14327

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Cedarling PostgreSQL build pipeline to run only after the successful completion of the Janssen Build & Publish workflow on nightly and release branches, or via manual trigger.
  * Applied the same gating logic to digest collection and provenance steps, preserving the existing condition for when provenance is produced.
  * Adjusted release/version tag selection for artifact uploads to use the triggering workflow’s branch context for non-manual runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->