### PR TITLE
Fix(jans fido2) cosmetic   error message grammer fix

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/AuthenticationPersistenceService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/AuthenticationPersistenceService.java
@@ -88,7 +88,7 @@ public class AuthenticationPersistenceService {
                 user = userService.addDefaultUser(userName);
             } else {
                 log.debug("Building fido authentication entry");
-            	//throw errorResponseFactory.badRequestException(AttestationErrorResponseType.USER_AUTO_ENROLLMENT_IS_DISABLED, "Auto user enrollment was disabled. User not exists!");
+            	//throw errorResponseFactory.badRequestException(AttestationErrorResponseType.USER_AUTO_ENROLLMENT_IS_DISABLED, "User auto enrollment is disabled. User does not exist!");
             }
         }
         else

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/RegistrationPersistenceService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/RegistrationPersistenceService.java
@@ -75,7 +75,7 @@ public class RegistrationPersistenceService extends io.jans.as.common.service.co
             if (appConfiguration.getFido2Configuration().isUserAutoEnrollment()) {
                 user = userService.addDefaultUser(userName);
             } else {
-                throw errorResponseFactory.badRequestException(AttestationErrorResponseType.USER_AUTO_ENROLLMENT_IS_DISABLED, "Auto user enrollment was disabled. User not exists!");
+                throw errorResponseFactory.badRequestException(AttestationErrorResponseType.USER_AUTO_ENROLLMENT_IS_DISABLED, "User auto enrollment is disabled. User does not exist!");
             }
         }
         userInum = userService.getUserInum(user);


### PR DESCRIPTION
### Prepare

- [X] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [X] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Fix the grammar of the Error message being shown in case the User Auto Enrollment is disabled. 
User not Exists! -> User does not exist! 
Auto user enrollment was disabled -> Auto User Enrollment is disabled. 

-------------------
### Test and Document the changes
- [X] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [X] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error messages in user auto-enrollment validation to provide more accurate feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->