### PR TITLE
docs(jans-cedarling): use iss not issuer in attribute checklist

### DIFF
--- a/docs/cedarling/reference/cedarling-policy-store.md
+++ b/docs/cedarling/reference/cedarling-policy-store.md
@@ -865,7 +865,7 @@ type TokensContext = {
 
 #### Key Requirements
 
-1. **Required Attributes**: Add `token_type`, `jti`, `issuer`, `exp`, `validated_at` to all token entities
+1. **Required Attributes**: Add `token_type`, `jti`, `iss`, `exp`, `validated_at` to all token entities
 2. **Optional Modifier**: All attributes must be optional (`?`) to support varying token structures
 3. **Tags Declaration**: All token entities must declare `tags Set<String>` for dynamic JWT claims
 4. **Context Update**: Add `tokens?: TokensContext` field to your Context type


### PR DESCRIPTION
The "Key Requirements" checklist in `docs/cedarling/reference/cedarling-policy-store.md` says to add a `issuer` attribute to token entities but the actual attribute is `iss`

#### Implementation Details
- In `docs/cedarling/reference/cedarling-policy-store.md`, "Key Requirements" → "Required Attributes": change `issuer` to `iss`

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)
Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14360,


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multi-issuer schema requirements documentation to specify the correct token entity attributes (`token_type`, `jti`, `iss`, `exp`, and `validated_at`), with the attribute name `iss` now properly defined as a required field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->