### PR TITLE
fix(ci): suffix release image tags and sync Cargo.lock on bump

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -30,6 +30,10 @@ on:
         description: 'Pin Dockerfile JANS_SOURCE_VERSION to the released base commit'
         type: boolean
         default: false
+      docker_suffix:
+        description: 'Image-tag suffix (image tags become X.Y.Z-<suffix>)'
+        required: false
+        default: '1'
 
 permissions:
   contents: read   # the tag push + release use MOAUTO_WORKFLOW_TOKEN, not GITHUB_TOKEN
@@ -53,10 +57,15 @@ jobs:
       # out of the shell command -- this step runs before any validation.
       env:
         VERSION_INPUT: ${{ github.event.inputs.version }}
+        SUFFIX_INPUT: ${{ github.event.inputs.docker_suffix }}
       run: |
         V="$VERSION_INPUT"
         if [[ ! "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
           echo "::error::version must be X.Y.Z (optionally -suffix)"
+          exit 1
+        fi
+        if [[ ! "$SUFFIX_INPUT" =~ ^[0-9A-Za-z.]+$ ]]; then
+          echo "::error::docker_suffix must be alphanumeric (got '$SUFFIX_INPUT')"
           exit 1
         fi
 
@@ -86,7 +95,8 @@ jobs:
         if [[ "${{ github.event.inputs.pin_source_sha }}" == "true" ]]; then
           EXTRA="--pin-source-sha $(git rev-parse HEAD)"
         fi
-        python3 automation/release/version_bump.py "${{ github.event.inputs.version }}" $EXTRA
+        python3 automation/release/version_bump.py "${{ github.event.inputs.version }}" \
+          --docker-suffix "${{ github.event.inputs.docker_suffix }}" $EXTRA
 
     # Safety net: abort BEFORE committing/pushing if any owned version was missed.
     - name: Verify the tree is fully bumped

--- a/automation/release/version_bump.py
+++ b/automation/release/version_bump.py
@@ -104,17 +104,35 @@ def sub(rel, pattern, repl, flags=0):
     return n
 
 
-def bump(version):
+def bump(version, docker_suffix="1"):
+    docker_tag = f"{version}-{docker_suffix}"
     changed = []
 
-    # 1. The unambiguous "0.0.0-nightly" sentinel -- whole-file text replace.
-    #    Covers ~120 poms, all charts (Chart.yaml/values.yaml/README.md), every
-    #    service Dockerfile (CN_VERSION, OCI label, BASE_VERSION), Agama
-    #    project.json, demo manifests, docs, and the shell/automation scripts.
+    # Image-tag references take the docker suffix (e.g. 2.2.0-1); everything else
+    # (artifact / chart / package versions) takes the bare version. Both appear as
+    # "0.0.0-nightly" in the tree, so they are distinguished by context below.
+    image_tag_subs = [
+        (r'(\btag:\s*["\']?)0\.0\.0-nightly', rf"\g<1>{docker_tag}"),                       # helm values.yaml image tag
+        (r'(ghcr\.io/[^\s:"\']+:)0\.0\.0-nightly', rf"\g<1>{docker_tag}"),                  # any ghcr image reference
+        (r'(org\.opencontainers\.image\.version=")0\.0\.0-nightly', rf"\g<1>{docker_tag}"),  # Dockerfile OCI label
+        (r'(ARG\s+BASE_VERSION=)0\.0\.0-nightly', rf"\g<1>{docker_tag}"),                   # all-in-one base image tag
+        (r'(JANS_VERSION=["\']?)0\.0\.0-nightly', rf"\g<1>{docker_tag}"),                   # demo scripts call an image tag
+    ]
+
+    # 1. The unambiguous "0.0.0-nightly" sentinel. Apply the image-tag rules first
+    #    (-> suffixed docker tag), then replace whatever remains with the bare version.
+    #    Covers ~120 poms, all charts, every Dockerfile (CN_VERSION stays bare = the
+    #    WAR version), Agama project.json, demos, docs, and the automation scripts.
     for rel in sorted(set(grep_files(NIGHTLY) + grep_files(NIGHTLY_BADGE))):
         if rel in EXCLUDE_NIGHTLY:
             continue
-        if replace_text(rel, [(NIGHTLY, version), (NIGHTLY_BADGE, version)]):
+        text = read(rel)
+        new = text
+        for pat, repl in image_tag_subs:
+            new = re.sub(pat, repl, new)
+        new = new.replace(NIGHTLY, version).replace(NIGHTLY_BADGE, version)
+        if new != text:
+            write(rel, new)
             changed.append(rel)
 
     # 2. Bare "nightly" release-tag pointers (download URLs resolve against these).
@@ -134,6 +152,12 @@ def bump(version):
     for rel in ls_files("*Cargo.toml"):
         if sub(rel, r'(?m)^version\s*=\s*"0\.0\.0"', f'version = "{version}"'):
             changed.append(rel)
+    # Cargo.lock: keep the workspace crates' lock entries in step with their
+    # Cargo.toml, or `cargo build --locked` fails on the stale lock.
+    cargo_lock = "jans-cedarling/Cargo.lock"
+    if (ROOT / cargo_lock).exists():
+        if sub(cargo_lock, r'(?m)^version = "0\.0\.0"$', f'version = "{version}"'):
+            changed.append(cargo_lock)
     # Python __version__ (jans-pycloudlib, jans-cli-tui, jans-linux-setup)
     for rel in ls_files("*version.py"):
         if sub(rel, r'(__version__\s*=\s*")0\.0\.0(")', rf"\g<1>{version}\g<2>"):
@@ -207,6 +231,9 @@ def verify():
     for rel in ls_files("*Cargo.toml") + ls_files("*pyproject.toml"):
         if re.search(r'(?m)^version\s*=\s*"0\.0\.0"', read(rel)):
             problems.append(f"{rel}: package version still '0.0.0'")
+    cargo_lock = "jans-cedarling/Cargo.lock"
+    if (ROOT / cargo_lock).exists() and re.search(r'(?m)^version = "0\.0\.0"$', read(cargo_lock)):
+        problems.append(f"{cargo_lock}: workspace crate version still '0.0.0'")
     for rel in ls_files("*version.py"):
         if re.search(r'__version__\s*=\s*"0\.0\.0"', read(rel)):
             problems.append(f"{rel}: __version__ still '0.0.0'")
@@ -242,6 +269,8 @@ def main():
     ap.add_argument("--root", type=Path, default=Path.cwd(), help="repo root (default: cwd)")
     ap.add_argument("--pin-source-sha", metavar="SHA",
                     help="also pin Dockerfile JANS_SOURCE_VERSION to this commit")
+    ap.add_argument("--docker-suffix", default="1",
+                    help="suffix for image tags: '1' -> X.Y.Z-1 (default: 1)")
     args = ap.parse_args()
 
     if not VERSION_RE.match(args.version):
@@ -253,7 +282,7 @@ def main():
     if args.verify:
         sys.exit(0 if verify() else 1)
 
-    changed = bump(args.version)
+    changed = bump(args.version, args.docker_suffix)
     if args.pin_source_sha:
         changed += pin_source_sha(args.pin_source_sha)
     changed = sorted(set(changed))


### PR DESCRIPTION
## Summary

Follow-up to the release tooling added in #14355. Running the **Release: bump & tag** workflow for `v2.2.0` surfaced two bump bugs, fixed here in `automation/release/version_bump.py`:

### 1. Image tags must carry the docker suffix (`X.Y.Z-1`)
Image-tag references were being bumped to the bare version (`2.2.0`) instead of the published image tag (`2.2.0-1`). The bump now distinguishes **image-tag** contexts from **artifact/version** contexts (both are written as `0.0.0-nightly` in the tree):

| Gets `X.Y.Z-<suffix>` (default `-1`) | Stays bare `X.Y.Z` |
|---|---|
| Helm `values.yaml` `tag:` | Maven poms `<version>` |
| ghcr image refs (Chart annotations, compose, `AIO_IMAGE_TAG`) | Chart `version` / `appVersion` / deps |
| Dockerfile `org.opencontainers.image.version` + `ARG BASE_VERSION` | `CN_VERSION` (the WAR version) |
| demo scripts' `JANS_VERSION` | Cargo / Python / Agama / app_info |

`CN_RELEASE_TAG` stays `vX.Y.Z`. A `docker_suffix` input (default `1`) is added to `release-trigger.yml`.

### 2. Sync `jans-cedarling/Cargo.lock`
The cedarling-uniffi build in `build-test.yml` runs `cargo build --locked`, which failed on the release tag because the bump changed the 5 cedarling `Cargo.toml` versions but left `Cargo.lock` stale. The bump now updates the workspace crates' lock entries to match.

## Validation
On a real `2.2.0` bump: `start_janssen_aio_demo.sh` → `JANS_VERSION="2.2.0-1"`, values `tag: 2.2.0-1`, OCI label `2.2.0-1`, `BASE_VERSION=2.2.0-1`, `AIO_IMAGE_TAG=…:2.2.0-1`; `CN_VERSION=2.2.0` / poms / Chart `version` stay bare; `Cargo.lock` cedarling → `2.2.0`; Shibboleth `5.1.6_dev` untouched; `--verify` passes.

## Note
This corrects the bump for future releases. To redo `2.2.0` cleanly, delete the existing `v2.2.0` tag + release first (the workflow refuses to overwrite an existing tag), then re-run **Release: bump & tag** with `2.2.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom Docker image version suffixes during release process, allowing tagged images as `X.Y.Z-<suffix>` while maintaining standard versioning for other artifacts.
  * Enhanced version validation with stricter alphanumeric pattern enforcement.

* **Chores**
  * Extended release verification checks for improved validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->