### PR TITLE
fix(ci): config-api release URL, flask-sidecar uv.lock, tf-authz post-build

### DIFF
--- a/.github/workflows/test-tf-authz-action.yml
+++ b/.github/workflows/test-tf-authz-action.yml
@@ -68,6 +68,8 @@ jobs:
           # its compose pins the published cedarling-opa:<version>. Otherwise the pushed/PR ref.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2
+          # this job runs repository code; don't leave the GITHUB_TOKEN in .git/config
+          persist-credentials: false
 
       - name: Check PERMISSIONS.md is in sync with Cedar policy IDs
         run: |

--- a/.github/workflows/test-tf-authz-action.yml
+++ b/.github/workflows/test-tf-authz-action.yml
@@ -14,6 +14,12 @@ permissions:
 
 on:
   push:
+    # Branch pushes only. A release tag push bumps the demo compose to
+    # cedarling-opa:<version> before that image is published; the workflow_run
+    # trigger below runs the tests once the image exists. Excluding tags here
+    # (a branch filter never matches a tag ref) stops the premature tag-push run.
+    branches:
+      - '**'
     paths:
       - 'jans-cedarling/cedarling_opa/demo/terraform/.github/actions/tf-authz/**'
       - 'jans-cedarling/cedarling_opa/demo/terraform/tf_authz.sh'
@@ -37,16 +43,30 @@ on:
       - 'jans-cedarling/cedarling_opa/demo/terraform/run-authz-tests.sh'
       - 'jans-cedarling/cedarling_opa/demo/terraform/PERMISSIONS.md'
       - 'jans-cedarling/cedarling_opa/demo/terraform/check-policy-checklist.sh'
+  # A tagged release builds cedarling-opa:<version> via "Build and Publish Releases
+  # to Hub"; run the demo tests only after that image is published, not on the tag push.
+  workflow_run:
+    workflows: ["Build and Publish Releases to Hub"]
+    types: [completed]
 
 jobs:
   test-authz-action:
     name: Test tf-authz composite action (data-driven)
     runs-on: ubuntu-latest
+    # push/PR events always run. On workflow_run, only proceed for a SUCCESSFUL
+    # release-tag build (head_branch is the vX.Y.Z tag, never main/nightly).
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          # On workflow_run (release) check out the tag tree that was just built --
+          # its compose pins the published cedarling-opa:<version>. Otherwise the pushed/PR ref.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2
 
       - name: Check PERMISSIONS.md is in sync with Cedar policy IDs

--- a/.github/workflows/test-tf-authz-jwt-selfhosted.yml
+++ b/.github/workflows/test-tf-authz-jwt-selfhosted.yml
@@ -74,6 +74,12 @@ name: Test tf-authz JWT self-hosted OPA path
 
 on:
   push:
+    # Branch pushes only. A release tag push bumps the demo compose to
+    # cedarling-opa:<version> before that image is published; the workflow_run
+    # trigger below runs the tests once the image exists. Excluding tags here
+    # (a branch filter never matches a tag ref) stops the premature tag-push run.
+    branches:
+      - '**'
     paths:
       - 'jans-cedarling/cedarling_opa/demo/terraform-jwt/**'
       - '.github/workflows/test-tf-authz-jwt-selfhosted.yml'
@@ -81,6 +87,11 @@ on:
     paths:
       - 'jans-cedarling/cedarling_opa/demo/terraform-jwt/**'
       - '.github/workflows/test-tf-authz-jwt-selfhosted.yml'
+  # A tagged release builds cedarling-opa:<version> via "Build and Publish Releases
+  # to Hub"; run the demo tests only after that image is published, not on the tag push.
+  workflow_run:
+    workflows: ["Build and Publish Releases to Hub"]
+    types: [completed]
 
 permissions: {}
 
@@ -88,6 +99,12 @@ jobs:
   test-selfhosted-opa:
     name: Self-hosted OPA (docker-compose.prod.yml) — health + authorize
     runs-on: ubuntu-latest
+    # push/PR events always run. On workflow_run, only proceed for a SUCCESSFUL
+    # release-tag build (head_branch is the vX.Y.Z tag, never main/nightly).
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
 
     permissions:
       id-token: write   # Required to request a GitHub OIDC token
@@ -96,6 +113,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # On workflow_run (release) check out the tag tree that was just built --
+          # its compose pins the published cedarling-opa:<version>. Otherwise the pushed/PR ref.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Start OPA (self-hosted, production mode)
         working-directory: jans-cedarling/cedarling_opa/demo/terraform-jwt
@@ -373,11 +394,21 @@ jobs:
   test-deny-path-assertions:
     name: Self-hosted OPA (demo mode) — Deny-path assertions (wrong repository, branch & issuer) — prod + non-prod
     runs-on: ubuntu-latest
+    # push/PR events always run. On workflow_run, only proceed for a SUCCESSFUL
+    # release-tag build (head_branch is the vX.Y.Z tag, never main/nightly).
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     # This job does not need id-token: write because it uses a synthetic JWT
     # crafted in-step; no real GitHub OIDC token is requested.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # On workflow_run (release) check out the tag tree that was just built --
+          # its compose pins the published cedarling-opa:<version>. Otherwise the pushed/PR ref.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Start OPA (demo mode — JWT signature validation disabled)
         # The base docker-compose.yml (without the prod overlay) starts OPA with

--- a/.github/workflows/test-tf-authz-jwt-selfhosted.yml
+++ b/.github/workflows/test-tf-authz-jwt-selfhosted.yml
@@ -117,6 +117,8 @@ jobs:
           # On workflow_run (release) check out the tag tree that was just built --
           # its compose pins the published cedarling-opa:<version>. Otherwise the pushed/PR ref.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # this job runs repository code; don't leave the GITHUB_TOKEN in .git/config
+          persist-credentials: false
 
       - name: Start OPA (self-hosted, production mode)
         working-directory: jans-cedarling/cedarling_opa/demo/terraform-jwt
@@ -409,6 +411,8 @@ jobs:
           # On workflow_run (release) check out the tag tree that was just built --
           # its compose pins the published cedarling-opa:<version>. Otherwise the pushed/PR ref.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # this job runs repository code; don't leave the GITHUB_TOKEN in .git/config
+          persist-credentials: false
 
       - name: Start OPA (demo mode — JWT signature validation disabled)
         # The base docker-compose.yml (without the prod overlay) starts OPA with
@@ -1015,6 +1019,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # this job runs repository code; don't leave the GITHUB_TOKEN in .git/config
+          persist-credentials: false
 
       - name: Start OPA (self-hosted, production mode)
         working-directory: jans-cedarling/cedarling_opa/demo/terraform-jwt

--- a/automation/release/version_bump.py
+++ b/automation/release/version_bump.py
@@ -116,8 +116,13 @@ def bump(version, docker_suffix="1"):
         (r'(ghcr\.io/[^\s:"\']+:)0\.0\.0-nightly', rf"\g<1>{docker_tag}"),                  # any ghcr image reference
         (r'(org\.opencontainers\.image\.version=")0\.0\.0-nightly', rf"\g<1>{docker_tag}"),  # Dockerfile OCI label
         (r'(ARG\s+BASE_VERSION=)0\.0\.0-nightly', rf"\g<1>{docker_tag}"),                   # all-in-one base image tag
-        (r'(JANS_VERSION=["\']?)0\.0\.0-nightly', rf"\g<1>{docker_tag}"),                   # demo scripts call an image tag
     ]
+    # JANS_VERSION is NOT a blanket image-tag rule: it is context-dependent across the
+    # two demo scripts. start_janssen_aio_demo.sh uses it as the all-in-one IMAGE TAG
+    # (-> docker suffix), but startjanssendemo.sh passes it to `helm install --version`,
+    # i.e. the CHART version (-> bare, like every Chart.yaml version). Applied per-file
+    # in the loop below so the helm script falls through to the bare-version replace.
+    AIO_DEMO_REL = "automation/start_janssen_aio_demo.sh"
 
     # 1. The unambiguous "0.0.0-nightly" sentinel. Apply the image-tag rules first
     #    (-> suffixed docker tag), then replace whatever remains with the bare version.
@@ -130,6 +135,8 @@ def bump(version, docker_suffix="1"):
         new = text
         for pat, repl in image_tag_subs:
             new = re.sub(pat, repl, new)
+        if rel == AIO_DEMO_REL:
+            new = re.sub(r'(JANS_VERSION=["\']?)0\.0\.0-nightly', rf"\g<1>{docker_tag}", new)
         new = new.replace(NIGHTLY, version).replace(NIGHTLY_BADGE, version)
         if new != text:
             write(rel, new)
@@ -145,6 +152,21 @@ def bump(version, docker_suffix="1"):
            r"(<cedarling\.release\.tag>)nightly(</cedarling\.release\.tag>)",
            rf"\g<1>v{version}\g<2>"):
         changed.append(cedarling_pom)
+    # Some Dockerfiles (config-api) and docs hardcode the release download URL with
+    # /nightly instead of ${CN_RELEASE_TAG}; point it at the tag or the WAR/plugin
+    # downloads 404 against the nightly release.
+    for rel in grep_files("releases/download/nightly"):
+        if sub(rel, r"(releases/download/)nightly\b", rf"\g<1>v{version}"):
+            changed.append(rel)
+    # cedarling-krakend integration docs reference cedarling_go release assets by
+    # version (the download filenames AND the prebuilt-plugin table). Every "0.0.0"
+    # in these two files is the cedarling artifact version -- the adjacent "2.9.0" is
+    # the KrakenD builder version (not ours) -- so a file-scoped bump is safe and
+    # leaves the URL just rewritten above pointing at a real, versioned asset.
+    for rel in ("docs/cedarling/integrations/cedarling-krakend.md",
+                "jans-cedarling/cedarling-krakend/README.md"):
+        if (ROOT / rel).exists() and sub(rel, r"0\.0\.0", version) and rel not in changed:
+            changed.append(rel)
 
     # 3. Plain "0.0.0" -- anchored, structured edits on known owned fields only.
     # Rust crates: the package version sits on a line starting `version = `;
@@ -158,6 +180,12 @@ def bump(version, docker_suffix="1"):
     if (ROOT / cargo_lock).exists():
         if sub(cargo_lock, r'(?m)^version = "0\.0\.0"$', f'version = "{version}"'):
             changed.append(cargo_lock)
+    # uv.lock: the flask-sidecar project version is pinned here too; sync it or
+    # `uv sync --locked` (the cedarling-flask-sidecar image build) fails.
+    uv_lock = "jans-cedarling/flask-sidecar/uv.lock"
+    if (ROOT / uv_lock).exists():
+        if sub(uv_lock, r'(?m)^version = "0\.0\.0"$', f'version = "{version}"'):
+            changed.append(uv_lock)
     # Python __version__ (jans-pycloudlib, jans-cli-tui, jans-linux-setup)
     for rel in ls_files("*version.py"):
         if sub(rel, r'(__version__\s*=\s*")0\.0\.0(")', rf"\g<1>{version}\g<2>"):
@@ -220,6 +248,14 @@ def verify():
     for rel in grep_files("CN_RELEASE_TAG=nightly"):
         problems.append(f"{rel}: CN_RELEASE_TAG still 'nightly'")
 
+    for rel in grep_files("releases/download/nightly"):
+        problems.append(f"{rel}: release download URL still points at /nightly")
+
+    for rel in ("docs/cedarling/integrations/cedarling-krakend.md",
+                "jans-cedarling/cedarling-krakend/README.md"):
+        if (ROOT / rel).exists() and re.search(r"0\.0\.0", read(rel)):
+            problems.append(f"{rel}: cedarling asset version still '0.0.0'")
+
     cedarling_pom = "jans-cedarling/bindings/cedarling-java/pom.xml"
     if (ROOT / cedarling_pom).exists():
         txt = read(cedarling_pom)
@@ -234,6 +270,9 @@ def verify():
     cargo_lock = "jans-cedarling/Cargo.lock"
     if (ROOT / cargo_lock).exists() and re.search(r'(?m)^version = "0\.0\.0"$', read(cargo_lock)):
         problems.append(f"{cargo_lock}: workspace crate version still '0.0.0'")
+    uv_lock = "jans-cedarling/flask-sidecar/uv.lock"
+    if (ROOT / uv_lock).exists() and re.search(r'(?m)^version = "0\.0\.0"$', read(uv_lock)):
+        problems.append(f"{uv_lock}: flask-sidecar version still '0.0.0'")
     for rel in ls_files("*version.py"):
         if re.search(r'__version__\s*=\s*"0\.0\.0"', read(rel)):
             problems.append(f"{rel}: __version__ still '0.0.0'")


### PR DESCRIPTION
Follow-up fixes surfaced by the **v2.2.0 release run** (the prior round merged as #14373). Each issue blocked or mis-sequenced the tag-triggered build chain.

## `automation/release/version_bump.py`

- **config-api image 404 → build failure.** `docker-jans-config-api/Dockerfile` hardcodes `ARG CN_RELEASE_DOWNLOAD_URL=.../releases/download/nightly` instead of using `${CN_RELEASE_TAG}`, so on a release tag `wget ${CN_SOURCE_URL}` fetched the WAR from `/nightly` and 404'd. The bump now rewrites `releases/download/nightly` → `releases/download/v<version>` (config-api Dockerfile + the two cedarling-krakend docs).
- **cedarling-flask-sidecar build failure.** `jans-cedarling/flask-sidecar/uv.lock` pins `flask-sidecar` at `0.0.0`; the image build's `uv sync --locked` failed on the stale lock. The bump now syncs it the same way it syncs `Cargo.lock`.
- **cedarling-krakend docs.** Also bump the `cedarling_go` asset version (`0.0.0` → `<version>`) in the krakend integration docs so the rewritten `/v<version>/` download links and the prebuilt-plugin table reference real release assets. The adjacent KrakenD `2.9.0` builder version is left untouched.
- `--verify` now also flags a leftover `/nightly` download URL, a stale `uv.lock`, and a stale cedarling-krakend asset version, so a missed one aborts the release before any tag is pushed.

> all-in-one built nothing because its image build depends on config-api; fixing config-api unblocks it.

## tf-authz workflows run **post** docker-build

`test-tf-authz-action.yml` and `test-tf-authz-jwt-selfhosted.yml` trigger on `push` to the demo `docker-compose.yml`, which the release bump rewrites to `cedarling-opa:<version>`. On a tag push that image doesn't exist yet (it's published later by **"Build and Publish Releases to Hub"**), so `docker compose up` failed pulling it. Now:

- `push` is scoped to `branches: ['**']`, so a release **tag** push no longer triggers them (a branch filter never matches a tag ref).
- A `workflow_run` trigger after **"Build and Publish Releases to Hub"** runs them once the image is published — gated to a *successful* `v*`-tag build and checking out the tag tree (`head_sha`).
- Branch pushes / PRs behave exactly as before.

## Validation

Ran `version_bump.py 2.2.0` against a clean tree: config-api URL → `/v2.2.0`, `uv.lock` flask-sidecar → `2.2.0`, krakend docs fully bumped (KrakenD `2.9.0` and the `0.0.0.0` Jetty bind address left untouched), `--verify` green. Both workflows YAML-validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflows so authorization and self-hosted Terraform/Opa tests run only after the release workflow completes, and use the release commit SHA for consistent compose/image pinning.
  * Enhanced release version bumping to rewrite nightly artifact URLs, update KrakenD integration documentation placeholders, and synchronize the Flask sidecar lockfile version.
  * Strengthened release verification so the release fails if leftover nightly artifact references or `0.0.0` placeholders remain, including the pinned lockfile version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->