### PR TITLE
fix(ci): purge the deploy target version so a re-release overwrites (409)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -126,17 +126,21 @@ jobs:
         fi
         echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
     - name: Delete the deploy target's package versions (so a re-release overwrites)
+      # TAG is passed via env (not inline ${{ }}) so a crafted tag name cannot inject
+      # shell into this step, which runs destructive package deletions.
+      env:
+        TAG: ${{ steps.tag.outputs.tag }}
       run: |
-        TAG="${{ steps.tag.outputs.tag }}"
-        # Mirror the version the build-and-publish deploy step uses: nightly stays
-        # 0.0.0-nightly; a release tag drops the leading 'v' (v2.2.0 -> 2.2.0).
+        # Only the nightly tag or a semver release tag (vX.Y.Z[-suffix]) is a valid
+        # deploy target; mirror the version the deploy step uses (nightly ->
+        # 0.0.0-nightly, vX.Y.Z -> X.Y.Z). Any other tag is a no-op so we never
+        # delete an unintended package version.
         if [ "$TAG" = "nightly" ]; then
           TARGET="0.0.0-nightly"
-        else
+        elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
           TARGET="${TAG#v}"
-        fi
-        if [ -z "$TARGET" ]; then
-          echo "No target version resolved from tag '$TAG'; nothing to purge."
+        else
+          echo "Tag '$TAG' is not a deploy target (expected 'nightly' or vX.Y.Z); nothing to purge."
           exit 0
         fi
         echo "Purging Maven package version '$TARGET' so the deploy can re-publish it."

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -98,8 +98,11 @@ env:
   DEFAULT_MODULES: 'jans-bom jans-orm jans-core agama jans-auth-server jans-cedarling/bindings/cedarling-java jans-lock/lock-server jans-fido2 jans-scim jans-link jans-config-api jans-casa'
 
 jobs:
-  # Delete the existing 0.0.0-nightly Maven package versions so the nightly
-  # deploy can re-publish them (GitHub Packages Maven is immutable per-version).
+  # GitHub Packages Maven is immutable per-version: re-running a build whose
+  # version was already published fails the deploy with 409 Conflict. Delete the
+  # deploy target's package versions first so the deploy can re-publish them --
+  # nightly on every run, and a release version when its tag is re-released
+  # (an intentional "overwrite" of that release).
   cleanup:
     if: github.repository == 'JanssenProject/jans'
     runs-on: ubuntu-22.04
@@ -122,9 +125,22 @@ jobs:
           TAG_NAME=$(echo "${{ github.event.ref }}" | cut -d '/' -f 3)
         fi
         echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
-    - name: Delete 0.0.0-nightly package versions
-      if: steps.tag.outputs.tag == 'nightly'
+    - name: Delete the deploy target's package versions (so a re-release overwrites)
       run: |
+        TAG="${{ steps.tag.outputs.tag }}"
+        # Mirror the version the build-and-publish deploy step uses: nightly stays
+        # 0.0.0-nightly; a release tag drops the leading 'v' (v2.2.0 -> 2.2.0).
+        if [ "$TAG" = "nightly" ]; then
+          TARGET="0.0.0-nightly"
+        else
+          TARGET="${TAG#v}"
+        fi
+        if [ -z "$TARGET" ]; then
+          echo "No target version resolved from tag '$TAG'; nothing to purge."
+          exit 0
+        fi
+        echo "Purging Maven package version '$TARGET' so the deploy can re-publish it."
+
         page=1
         services=""
         while true; do
@@ -142,25 +158,25 @@ jobs:
         echo "Services: $services"
         for service in $services; do
           echo "Checking $service"
-          # --paginate walks every page: a 0.0.0-nightly buried under newer
-          # release versions (e.g. 1.16.0) is missed by a first-page-only lookup,
-          # leaving it to fail the later deploy with 409 Conflict.
+          # --paginate walks every page: the target version buried under newer
+          # release versions is missed by a first-page-only lookup, leaving it to
+          # fail the later deploy with 409 Conflict.
           versions=$(gh api --paginate -H "Accept: application/vnd.github+json" \
             "/orgs/JanssenProject/packages/maven/${service}/versions" \
             --jq '.[] | "\(.id) \(.name)"')
           [ -z "$versions" ] && continue
           total=$(printf '%s\n' "$versions" | grep -c .)
-          nightly_ids=$(printf '%s\n' "$versions" | awk '$2=="0.0.0-nightly"{print $1}')
-          [ -z "$nightly_ids" ] && continue
-          nightly_count=$(printf '%s\n' "$nightly_ids" | grep -c .)
-          if [ "$total" -le "$nightly_count" ]; then
-            # GitHub forbids deleting the last version of a package, so a brand-new
-            # package whose only version is 0.0.0-nightly must be deleted wholesale.
-            echo "Only nightly version(s) present; deleting package $service"
+          target_ids=$(printf '%s\n' "$versions" | awk -v t="$TARGET" '$2==t{print $1}')
+          [ -z "$target_ids" ] && continue
+          target_count=$(printf '%s\n' "$target_ids" | grep -c .)
+          if [ "$total" -le "$target_count" ]; then
+            # GitHub forbids deleting the last version of a package, so a package
+            # whose only version is the target must be deleted wholesale.
+            echo "Only target version(s) present; deleting package $service"
             gh api --method DELETE -H "Accept: application/vnd.github+json" \
               "/orgs/JanssenProject/packages/maven/${service}" || echo "Failed to delete package $service"
           else
-            for version_id in $nightly_ids; do
+            for version_id in $target_ids; do
               echo "Deleting version $version_id of $service"
               gh api --method DELETE -H "Accept: application/vnd.github+json" \
                 "/orgs/JanssenProject/packages/maven/${service}/versions/${version_id}" || echo "Failed to delete $service version $version_id"


### PR DESCRIPTION
Re-running a release whose artifacts a prior run already published failed `build-test` ("Janssen Build & Publish") at the **Build and deploy to GitHub Packages Maven** step with a **409 Conflict** (observed deploying `io.jans:jans-bom:2.2.0` in [run 27826724986](https://github.com/JanssenProject/jans/actions/runs/27826724986/job/82352984400)). GitHub Packages Maven is immutable per-version, so the same release version cannot be re-deployed without deleting it first.

The `cleanup` job already deletes the `0.0.0-nightly` package versions before the nightly deploy. This generalizes it to delete the **resolved deploy target** so a re-release overwrites cleanly:

- `nightly` → purge `0.0.0-nightly` (unchanged behaviour)
- `vX.Y.Z` → purge `X.Y.Z` (leading `v` stripped to mirror the deploy's version)
- the nightly-only `if:` gate is removed; an empty/unknown tag is a no-op

On a **first** release of a version nothing matches, so nothing is deleted and the deploy publishes fresh. On a **re-release**, the prior version is purged first, then re-published.

Release **asset** uploads already overwrite via `gh release upload --clobber`, so no change is needed there.

Verified: YAML parses; the extracted step passes `bash -n`; the target-version computation matches the deploy step (`nightly`→`0.0.0-nightly`, `v2.2.0`→`2.2.0`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the release pipeline’s cleanup process to better support re-releases across nightly and version-tagged builds.
  * Maven package cleanup now targets the correct release artifacts based on the resolved release type, and safely exits when no matching versions are found.
  * Updated cleanup to use paginated retrieval to remove only the intended package versions without disrupting required artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->