### PR TITLE
feat(jans-cedarling): embed git commit and build timestamp in Cedarling binary and log at startup

### DIFF
--- a/jans-cedarling/cedarling/Cargo.toml
+++ b/jans-cedarling/cedarling/Cargo.toml
@@ -123,6 +123,7 @@ tokio-stream = "0.1.18"
 pprof = { version = "0.15.0", features = ["flamegraph"] }
 
 [build-dependencies]
+chrono = { workspace = true }
 tonic-prost-build = { version = "0.14.3", optional = true }
 
 [package.metadata.cargo-machete]

--- a/jans-cedarling/cedarling/build.rs
+++ b/jans-cedarling/cedarling/build.rs
@@ -6,6 +6,80 @@
 fn main() {
     #[cfg(feature = "grpc")]
     compile_protos();
+    emit_build_metadata();
+}
+
+fn emit_build_metadata() {
+    git_rerun_if_changed();
+    let commit = std::env::var("CEDARLING_BUILD_COMMIT").unwrap_or_else(|_| {
+        std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                if o.status.success() {
+                    Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default()
+    });
+
+    let timestamp = std::env::var("CEDARLING_BUILD_TIMESTAMP").unwrap_or_else(|_| {
+        chrono::Utc::now().to_rfc3339()
+    });
+
+    println!("cargo:rustc-env=CEDARLING_BUILD_COMMIT={commit}");
+    println!("cargo:rustc-env=CEDARLING_BUILD_TIMESTAMP={timestamp}");
+}
+
+/// Emit `rerun-if-changed` for relevant git files so Cargo rebuilds when HEAD
+/// moves. Uses `git rev-parse --git-dir` to reliably locate `.git` regardless
+/// of worktrees, submodules, or workspace nesting.
+fn git_rerun_if_changed() {
+    let manifest_dir = match std::env::var("CARGO_MANIFEST_DIR") {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    let git_dir_output = std::process::Command::new("git")
+        .args(["-C", &manifest_dir, "rev-parse", "--git-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success());
+
+    let git_dir = match git_dir_output {
+        Some(ref o) => {
+            let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            let p = std::path::Path::new(&path);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                std::path::Path::new(&manifest_dir).join(p)
+            }
+        },
+        None => return,
+    };
+
+    let head = git_dir.join("HEAD");
+    if head.exists() {
+        println!("cargo:rerun-if-changed={}", head.display());
+
+        if let Ok(content) = std::fs::read_to_string(&head) {
+            if let Some(ref_path) = content.strip_prefix("ref: ") {
+                let ref_file = git_dir.join(ref_path.trim());
+                if ref_file.exists() {
+                    println!("cargo:rerun-if-changed={}", ref_file.display());
+                }
+            }
+        }
+    }
+
+    let packed_refs = git_dir.join("packed-refs");
+    if packed_refs.exists() {
+        println!("cargo:rerun-if-changed={}", packed_refs.display());
+    }
 }
 
 #[cfg(feature = "grpc")]

--- a/jans-cedarling/cedarling/build.rs
+++ b/jans-cedarling/cedarling/build.rs
@@ -43,10 +43,7 @@ fn emit_build_metadata() {
 /// Uses `--git-dir` / `--git-common-dir` so the lookup works correctly in
 /// linked worktrees, submodules, and nested workspaces.
 fn git_rerun_if_changed() {
-    let manifest_dir = match std::env::var("CARGO_MANIFEST_DIR") {
-        Ok(d) => d,
-        Err(_) => return,
-    };
+    let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") else { return };
 
     let git_dir_output = std::process::Command::new("git")
         .args(["-C", &manifest_dir, "rev-parse", "--git-dir"])
@@ -98,8 +95,8 @@ fn git_rerun_if_changed() {
     if head.exists() {
         println!("cargo:rerun-if-changed={}", head.display());
 
-        if let Ok(content) = std::fs::read_to_string(&head) {
-            if let Some(ref_path) = content.strip_prefix("ref: ") {
+        if let Ok(content) = std::fs::read_to_string(&head)
+            && let Some(ref_path) = content.strip_prefix("ref: ") {
                 let ref_file = git_dir.join(ref_path.trim());
                 let candidate = ref_file.exists().then_some(ref_file)
                     .or_else(|| {
@@ -109,7 +106,6 @@ fn git_rerun_if_changed() {
                 if let Some(f) = candidate {
                     println!("cargo:rerun-if-changed={}", f.display());
                 }
-            }
         }
     }
 

--- a/jans-cedarling/cedarling/build.rs
+++ b/jans-cedarling/cedarling/build.rs
@@ -9,6 +9,9 @@ fn main() {
     emit_build_metadata();
 }
 
+/// Embeds the current git commit hash and build timestamp as environment
+/// variables (`CEDARLING_BUILD_COMMIT`, `CEDARLING_BUILD_TIMESTAMP`) so they
+/// are available at compile time via `env!()`.
 fn emit_build_metadata() {
     git_rerun_if_changed();
     let commit = std::env::var("CEDARLING_BUILD_COMMIT").unwrap_or_else(|_| {
@@ -34,9 +37,11 @@ fn emit_build_metadata() {
     println!("cargo:rustc-env=CEDARLING_BUILD_TIMESTAMP={timestamp}");
 }
 
-/// Emit `rerun-if-changed` for relevant git files so Cargo rebuilds when HEAD
-/// moves. Uses `git rev-parse --git-dir` to reliably locate `.git` regardless
-/// of worktrees, submodules, or workspace nesting.
+/// Emits `rerun-if-changed` for `HEAD`, the resolved branch ref, and
+/// `packed-refs` so Cargo rebuilds when the checked-out commit changes.
+///
+/// Uses `--git-dir` / `--git-common-dir` so the lookup works correctly in
+/// linked worktrees, submodules, and nested workspaces.
 fn git_rerun_if_changed() {
     let manifest_dir = match std::env::var("CARGO_MANIFEST_DIR") {
         Ok(d) => d,
@@ -62,6 +67,33 @@ fn git_rerun_if_changed() {
         None => return,
     };
 
+    // In linked worktrees `--git-dir` points to `.git/worktrees/<name>`, but
+    // branch refs and `packed-refs` reside in the common directory
+    // (`.git/`).  `--git-common-dir` returns that shared location, or the
+    // same path as `--git-dir` for a normal repository.
+    let common_dir = std::process::Command::new("git")
+        .args(["-C", &manifest_dir, "rev-parse", "--git-common-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| {
+            let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if path.is_empty() {
+                return None;
+            }
+            let p = std::path::Path::new(&path);
+            let abs = if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                std::path::Path::new(&manifest_dir).join(p)
+            };
+            // Only keep the common dir when it differs from the worktree dir
+            (abs != git_dir).then_some(abs)
+        })
+        // Fall back to `git_dir` when the command fails or returns the same
+        // path (plain repos, detached HEAD, etc.)
+        .unwrap_or_else(|| git_dir.clone());
+
     let head = git_dir.join("HEAD");
     if head.exists() {
         println!("cargo:rerun-if-changed={}", head.display());
@@ -69,19 +101,30 @@ fn git_rerun_if_changed() {
         if let Ok(content) = std::fs::read_to_string(&head) {
             if let Some(ref_path) = content.strip_prefix("ref: ") {
                 let ref_file = git_dir.join(ref_path.trim());
-                if ref_file.exists() {
-                    println!("cargo:rerun-if-changed={}", ref_file.display());
+                let candidate = ref_file.exists().then_some(ref_file)
+                    .or_else(|| {
+                        let f = common_dir.join(ref_path.trim());
+                        f.exists().then_some(f)
+                    });
+                if let Some(f) = candidate {
+                    println!("cargo:rerun-if-changed={}", f.display());
                 }
             }
         }
     }
 
     let packed_refs = git_dir.join("packed-refs");
-    if packed_refs.exists() {
-        println!("cargo:rerun-if-changed={}", packed_refs.display());
+    let candidate = packed_refs.exists().then_some(packed_refs)
+        .or_else(|| {
+            let f = common_dir.join("packed-refs");
+            f.exists().then_some(f)
+        });
+    if let Some(f) = candidate {
+        println!("cargo:rerun-if-changed={}", f.display());
     }
 }
 
+/// Compiles the audit protobuf definition into Rust code via `tonic-build`.
 #[cfg(feature = "grpc")]
 fn compile_protos() {
     let audit_proto = "src/lock/proto/audit.proto";

--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -70,6 +70,13 @@ pub use log::{LogLevel, LogStorage};
 
 use semver::Version;
 
+/// Git commit hash at build time (`None` if git is unavailable or
+/// `CEDARLING_BUILD_COMMIT` was not set at compile time).
+pub const BUILD_COMMIT: Option<&str> = option_env!("CEDARLING_BUILD_COMMIT");
+/// Build timestamp in RFC 3339 format (`None` if
+/// `CEDARLING_BUILD_TIMESTAMP` was not set at compile time).
+pub const BUILD_TIMESTAMP: Option<&str> = option_env!("CEDARLING_BUILD_TIMESTAMP");
+
 #[doc(hidden)]
 pub mod bindings {
     pub use cedar_policy;
@@ -166,6 +173,15 @@ impl Cedarling {
             config.http_client_config,
         )
         .await?;
+
+        log.log_any(
+            LogEntry::new(BaseLogEntry::new_system_opt_request_id(
+                LogLevel::INFO,
+                None,
+            ))
+            .set_message("Cedarling initialization started".to_string())
+            .set_build_info(BUILD_COMMIT, BUILD_TIMESTAMP),
+        );
 
         // Bootstrap-load: build HttpClient + load policy store. Returns the
         // service config plus the refresh-worker seed in one shot so the

--- a/jans-cedarling/cedarling/src/log/log_entry.rs
+++ b/jans-cedarling/cedarling/src/log/log_entry.rs
@@ -49,6 +49,12 @@ pub struct LogEntry {
     /// cedar-policy sdk  version
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cedar_sdk_version: Option<semver::Version>,
+    /// Git commit hash at build time
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_commit: Option<String>,
+    /// Build timestamp in RFC 3339 format
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_timestamp: Option<String>,
 }
 
 impl LogEntry {
@@ -60,6 +66,8 @@ impl LogEntry {
             error_msg: None,
             cedar_lang_version: None,
             cedar_sdk_version: None,
+            build_commit: None,
+            build_timestamp: None,
         }
     }
 
@@ -81,6 +89,16 @@ impl LogEntry {
     pub(crate) fn set_cedar_version(mut self) -> Self {
         self.cedar_lang_version = Some(cedar_policy::get_lang_version());
         self.cedar_sdk_version = Some(cedar_policy::get_sdk_version());
+        self
+    }
+
+    pub(crate) fn set_build_info(
+        mut self,
+        build_commit: Option<&str>,
+        build_timestamp: Option<&str>,
+    ) -> Self {
+        self.build_commit = build_commit.map(ToString::to_string);
+        self.build_timestamp = build_timestamp.map(ToString::to_string);
         self
     }
 }

--- a/jans-cedarling/cedarling/src/log/stdout_logger/native_logger.rs
+++ b/jans-cedarling/cedarling/src/log/stdout_logger/native_logger.rs
@@ -299,6 +299,8 @@ mod tests {
             error_msg: None,
             cedar_lang_version: None,
             cedar_sdk_version: None,
+            build_commit: None,
+            build_timestamp: None,
         };
         let log_entry =
             LogEntryWithClientInfo::from_loggable(log_entry.clone(), pdp_id, app_name.clone());
@@ -357,6 +359,8 @@ mod tests {
             error_msg: None,
             cedar_lang_version: None,
             cedar_sdk_version: None,
+            build_commit: None,
+            build_timestamp: None,
         };
 
         // Create second log entry
@@ -367,6 +371,8 @@ mod tests {
             error_msg: None,
             cedar_lang_version: None,
             cedar_sdk_version: None,
+            build_commit: None,
+            build_timestamp: None,
         };
 
         // Log first entry
@@ -406,6 +412,8 @@ mod tests {
                 error_msg: None,
                 cedar_lang_version: None,
                 cedar_sdk_version: None,
+                build_commit: None,
+                build_timestamp: None,
             };
             let log_entry =
                 LogEntryWithClientInfo::from_loggable(log_entry.clone(), pdp_id, app_name.clone());

--- a/jans-cedarling/cedarling/src/log/test.rs
+++ b/jans-cedarling/cedarling/src/log/test.rs
@@ -91,9 +91,11 @@ async fn test_log_memory_logger() {
         auth_info: None,
         msg: "Test message".to_string(),
         error_msg: None,
-        cedar_lang_version: None,
-        cedar_sdk_version: None,
-    };
+            cedar_lang_version: None,
+            cedar_sdk_version: None,
+            build_commit: None,
+            build_timestamp: None,
+        };
 
     // Act
     strategy.log_any(entry);
@@ -175,9 +177,11 @@ fn test_log_stdout_logger() {
         auth_info: None,
         msg: "Test message".to_string(),
         error_msg: None,
-        cedar_lang_version: None,
-        cedar_sdk_version: None,
-    };
+            cedar_lang_version: None,
+            cedar_sdk_version: None,
+            build_commit: None,
+            build_timestamp: None,
+        };
     // Serialize the log entry to JSON
     let json_str = json!(LogEntryWithClientInfo::from_loggable(
         log_entry.clone(),


### PR DESCRIPTION


### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14336

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->
Expose BUILD_COMMIT and BUILD_TIMESTAMP as Option<&str> from build.rs, logged as structured fields (build_commit, build_timestamp) in the startup INFO entry. git_rerun_if_changed() watches .git/HEAD and the current ref so Cargo rebuilds when HEAD moves.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System logs now automatically include build metadata (build commit hash and build timestamp) to simplify troubleshooting and auditing.
  * Build commit and timestamp are now available as optional build-time values for programmatic access.

* **Tests**
  * Updated logging unit tests to match the enhanced log entry schema with build metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->