### PR TITLE
fix(ci): all-in-one re-run poll + build release packages from the tag

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -281,10 +281,8 @@ jobs:
               echo "Waiting for docker ($img) to complete..."
               CONCLUSION=""
               for attempt in $(seq 1 60); do
-                # ?filter=all + max_by(.run_attempt): when only all-in-one is re-run, the
-                # siblings that already succeeded live in an earlier run attempt, which the
-                # default filter=latest hides -- so the poll would never see them and would
-                # time out. Look across all attempts and take the latest one's conclusion.
+                # filter=all (not the default latest): on a re-run of all-in-one alone, a
+                # sibling that succeeded in an earlier attempt is otherwise invisible.
                 CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?filter=all&per_page=100" \
                   --jq "[.jobs[] | select(.name == \"docker ($img)\")] | max_by(.run_attempt) | .conclusion" 2>/dev/null || echo "")
                 if [[ "$CONCLUSION" == "success" || "$CONCLUSION" == "skipped" ]]; then

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -281,8 +281,12 @@ jobs:
               echo "Waiting for docker ($img) to complete..."
               CONCLUSION=""
               for attempt in $(seq 1 60); do
-                CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
-                  --paginate --jq ".jobs[] | select(.name == \"docker ($img)\") | .conclusion" 2>/dev/null || echo "")
+                # ?filter=all + max_by(.run_attempt): when only all-in-one is re-run, the
+                # siblings that already succeeded live in an earlier run attempt, which the
+                # default filter=latest hides -- so the poll would never see them and would
+                # time out. Look across all attempts and take the latest one's conclusion.
+                CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?filter=all&per_page=100" \
+                  --jq "[.jobs[] | select(.name == \"docker ($img)\")] | max_by(.run_attempt) | .conclusion" 2>/dev/null || echo "")
                 if [[ "$CONCLUSION" == "success" || "$CONCLUSION" == "skipped" ]]; then
                   echo "  docker ($img): $CONCLUSION"; break
                 elif [[ "$CONCLUSION" == "failure" || "$CONCLUSION" == "cancelled" || "$CONCLUSION" == "timed_out" ]]; then

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -170,7 +170,13 @@ jobs:
       id: run_build
       run: |
          cd jans/
-         sudo python${{ matrix.python_version }} install.py -download-exit -yes --keep-downloads --keep-setup -force-download
+         # -download-exit bakes the downloaded setup tree (incl. app_info.json, which is
+         # the reported "Janssen Version") into the package. Without --setup-branch,
+         # install.py defaults to the 'main' branch (0.0.0-nightly), so a release package
+         # would embed nightly regardless of the checkout. Pull setup from the release tag;
+         # install.py falls back from refs/heads/<tag> to refs/tags/<tag>, so vX.Y.Z and
+         # nightly both resolve to the matching tagged tree.
+         sudo python${{ matrix.python_version }} install.py --setup-branch "${{ steps.previoustag.outputs.tag }}" -download-exit -yes --keep-downloads --keep-setup -force-download
          cp -r /opt/dist jans-src/opt/
          cp -r /opt/jans jans-src/opt/
          touch jans-src/opt/jans/jans-setup/package

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+        ref: ${{ github.event.workflow_run.head_sha || inputs.target_tag || github.sha }}
         path: temp-jans
 
     - name: Getting build dependencies
@@ -262,7 +262,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+        ref: ${{ github.event.workflow_run.head_sha || inputs.target_tag || github.sha }}
 
     - name: Set up Python
       if: matrix.name != 'suse'
@@ -394,7 +394,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+        ref: ${{ github.event.workflow_run.head_sha || inputs.target_tag || github.sha }}
     - name: Install Protoc
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
     - name: Install Cosign
@@ -549,7 +549,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+        ref: ${{ github.event.workflow_run.head_sha || inputs.target_tag || github.sha }}
     - name: Build with Ubuntu
       continue-on-error: true
       env:
@@ -671,7 +671,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+        ref: ${{ github.event.workflow_run.head_sha || inputs.target_tag || github.sha }}
 
     - name: Install Protoc (macOS)
       if: runner.os == 'macOS'
@@ -890,7 +890,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || inputs.target_tag || github.sha }}
       - name: Install Protoc (Native)
         shell: bash
         run: |
@@ -1064,7 +1064,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+        ref: ${{ github.event.workflow_run.head_sha || inputs.target_tag || github.sha }}
     - name: Install Cosign
       uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
     - name: Set environment variables
@@ -1150,7 +1150,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+        ref: ${{ github.event.workflow_run.head_sha || inputs.target_tag || github.sha }}
     - name: Install Protoc
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
     - name: Install Cosign

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -170,12 +170,9 @@ jobs:
       id: run_build
       run: |
          cd jans/
-         # -download-exit bakes the downloaded setup tree (incl. app_info.json, which is
-         # the reported "Janssen Version") into the package. Without --setup-branch,
-         # install.py defaults to the 'main' branch (0.0.0-nightly), so a release package
-         # would embed nightly regardless of the checkout. Pull setup from the release tag;
-         # install.py falls back from refs/heads/<tag> to refs/tags/<tag>, so vX.Y.Z and
-         # nightly both resolve to the matching tagged tree.
+         # install.py re-downloads the setup source from --setup-branch (default 'main' =
+         # nightly) and bakes its app_info.json in, so a release package embeds the wrong
+         # version unless we point it at the tag.
          sudo python${{ matrix.python_version }} install.py --setup-branch "${{ steps.previoustag.outputs.tag }}" -download-exit -yes --keep-downloads --keep-setup -force-download
          cp -r /opt/dist jans-src/opt/
          cp -r /opt/jans jans-src/opt/


### PR DESCRIPTION
Release-build failures observed running v2.2.0 (distinct from the Maven-409 fix in #14389).

## 1. all-in-one image times out waiting for `auth-server` (build-docker-image.yml)
The all-in-one matrix leg polls its sibling jobs (`docker (auth-server)`, …) via the run's jobs API. The default `filter=latest` returns only the **current attempt's** jobs, so when all-in-one is **re-run alone** (run_attempt 2) the siblings that succeeded in attempt 1 are invisible — it polls the full 30 min and aborts (`docker (auth-server) timed out waiting`). Confirmed in the failing run: `auth-server`/`config-api` succeeded at 02:38, the re-run all-in-one at 14:06 couldn't see them.

**Fix:** query `?filter=all` and take the latest attempt's conclusion via `max_by(.run_attempt)`.

## 2. release `.deb` reports `0.0.0-nightly` (build-packages.yml)
The package job bakes its setup tree with `install.py -download-exit`. **`install.py` re-downloads the source at build time**, and with no `--setup-branch` it defaults to the `main` branch → `archive/refs/heads/main.zip` = `0.0.0-nightly`. That downloaded tree — including `app_info.json`, which is the **"Janssen Version"** shown at install time — is what gets packaged (install.py itself is then removed). So `jans_2.2.0-stable…deb` embedded `0.0.0-nightly` even though the `v2.2.0` tag tree was correctly bumped (`app_info.json` = `2.2.0`) and the filename said `2.2.0-stable`.

This is the "it didn't build from the tag" the report describes — the checkout ref could **not** fix it, because install.py fetches the source itself.

**Fixes (two commits):**
- **`install.py --setup-branch <tag>`** (the actual fix): pull the setup tree from the release tag. install.py falls back from `refs/heads/<tag>` to `refs/tags/<tag>`, so both `vX.Y.Z` and `nightly` resolve to the matching tagged tree.
- **checkout `ref` → `inputs.target_tag`** on `workflow_dispatch`: so the bootstrap/packaging scripts (`run-build.sh`, packaging metadata) also come from the tag rather than `github.sha` (main). The `workflow_run` path is unchanged (`head_sha` wins).

## Verified
`v2.2.0` tag tree is correctly bumped (`app_info.json`=`2.2.0`, Cargo/chart/Dockerfile all `2.2.0`) — so the bump is sound; the gap was purely the package build re-fetching `main`. Both workflows YAML-parse; the reworked all-in-one poll passes `bash -n`.

> Note: a manual `workflow_dispatch` of **build-docker-image.yml** still builds images from `main` (no `target_tag` input; image tag derived from the Dockerfile OCI label). The intended release path is the automatic chain (tag push → "Janssen Build & Publish" → "Build and Publish Releases to Hub" → "Publish packages"), where every step resolves the tag via `head_sha`. Left as-is to keep scope tight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image build workflow job status detection to correctly account for prior retry attempts, preventing false failures.

* **Chores**
  * Enhanced build workflows to add an additional checkout fallback (target tag) when the workflow run SHA is unavailable.
  * Updated binary publishing to resolve the setup tree from the appropriate release tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->