### PR TITLE
fix(ci): build all-in-one on the release/nightly chain (was silently skipped)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -180,8 +180,9 @@ jobs:
               # PR: get changed files via GitHub API
               DIRECTORIES_CHANGED=$(gh pr view "$pull_number" --json files --jq '.files.[].path' | cut -d/ -f1 | sort -u | grep -E '^docker-jans|^flask-sidecar|^cedarling_opa' || echo "$ALL_SERVICES")
             elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-              # Chained: the nightly/release publish completed -> build all images
-              DIRECTORIES_CHANGED="$ALL_SERVICES"
+              # Chained nightly/release publish -> build all images. all-in-one is matrix-
+              # only (absent from ALL_SERVICES), so add it or the chain silently skips it.
+              DIRECTORIES_CHANGED="$ALL_SERVICES docker-jans-all-in-one"
             else
               # Direct branch push: use git diff to find which docker dirs changed.
               # Falls back to ALL_SERVICES if before-SHA is unavailable (initial push).


### PR DESCRIPTION
On a real release the all-in-one job ran green but **never built or pushed the image** — every build step (Prepare, Buildx, Build and push, sign, attest) was `skipped` while the job reported success. Seen in [run 27881577725](https://github.com/JanssenProject/jans/actions/runs/27881577725/job/82509963515) (`event=workflow_run`, the chain after "Janssen Build & Publish").

**Root cause:** `build-docker-image.yml` decides whether to build each matrix image. On the `workflow_run` chain it sets `DIRECTORIES_CHANGED=$ALL_SERVICES`, but `all-in-one` is **in the matrix yet absent from `ALL_SERVICES`** — so it never matched and `build` was never set, skipping every build step (the job still succeeds). The `ref_type=='tag'` force-build can't save it either: on the chain `github.ref` is `main` (a branch), not the tag.

**Fix:** add `docker-jans-all-in-one` to the `workflow_run` build set so the chain actually builds it. `shibboleth` is likewise matrix-only but stays excluded — it's intentionally not published yet (matches its exclusion from `DEFAULT_MODULES` in build-test.yml).

This complements the all-in-one poll fix from #14392 (which made the wait re-run-aware); together the chain now both *selects* and *waits for* all-in-one correctly. The earlier timeouts only happened on `workflow_dispatch`-on-a-tag runs where the tag-override forced the build — the automatic chain silently skipped it instead.

Validated: YAML parses; net change is the single selection line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Docker build workflow to properly include the all-in-one image in build processes, preventing it from being inadvertently skipped during chained builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->