### PR TITLE
Update checksum verification commands in ubuntu.md

### DIFF
--- a/docs/janssen-server/install/vm-install/debian.md
+++ b/docs/janssen-server/install/vm-install/debian.md
@@ -18,7 +18,8 @@ Before you install, check the [VM system requirements](vm-requirements.md).
 [Releases](https://github.com/JanssenProject/jans/releases/latest)
 
     ```shell title="Command"
-    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans_replace-janssen-version~debian13_amd64.deb -P /tmp
+    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans_replace-janssen-version-stable.debian13_amd64.deb
+ -P /tmp
     ```
 
 - Go to `/tmp` directory:
@@ -45,7 +46,7 @@ Before you install, check the [VM system requirements](vm-requirements.md).
           --bundle jans-debian13-replace-janssen-version-stable.bundle \
           --certificate-identity-regexp "https://github.com/JanssenProject/jans" \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          jans_replace-janssen-version~debian13_amd64.deb
+          jans_replace-janssen-version-stable.debian13_amd64.deb
         ```
 
         Output similar to below confirms the package was signed by the Janssen CI pipeline:
@@ -57,19 +58,19 @@ Before you install, check the [VM system requirements](vm-requirements.md).
 - Optionally, verify integrity using the published checksum file (secondary check):
 
     ```bash title="Command"
-    echo 'paste-release-sha256sum jans_replace-janssen-version~debian13_amd64.deb' | sed 's/^sha256://' >jans_replace-janssen-version~debian13_amd64.deb.sha256sum && sha256sum -c jans_replace-janssen-version~debian13_amd64.deb.sha256sum
+    echo 'paste-release-sha256sum jans_replace-janssen-version-stable.debian13_amd64.deb' | sed 's/^sha256://' >jans_replace-janssen-version-stable.debian13_amd64.deb.sha256sum && sha256sum -c jans_replace-janssen-version-stable.debian13_amd64.deb.sha256sum
     ```
 
     Output similar to below should confirm the integrity of the downloaded package.
 
     ```text title="Output"
-    jans_replace-janssen-version~debian13_amd64.deb: OK
+    jans_replace-janssen-version-stable.debian13_amd64.deb: OK
     ```
 
 - Install the package
 
 ```shell title="Command"
-sudo apt install ./jans_replace-janssen-version~debian13_amd64.deb
+sudo apt install ./jans_replace-janssen-version-stable.debian13_amd64.deb
 ```
 
 ## Run the setup script

--- a/docs/janssen-server/install/vm-install/debian.md
+++ b/docs/janssen-server/install/vm-install/debian.md
@@ -57,8 +57,7 @@ Before you install, check the [VM system requirements](vm-requirements.md).
 - Optionally, verify integrity using the published checksum file (secondary check):
 
     ```bash title="Command"
-    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans_replace-janssen-version~debian13_amd64.deb.sha256sum -P /tmp
-    sha256sum -c jans_replace-janssen-version~debian13_amd64.deb.sha256sum
+    echo 'paste-release-sha256sum jans_replace-janssen-version~debian13_amd64.deb' | sed 's/^sha256://' >jans_replace-janssen-version~debian13_amd64.deb.sha256sum && sha256sum -c jans_replace-janssen-version~debian13_amd64.deb.sha256sum
     ```
 
     Output similar to below should confirm the integrity of the downloaded package.

--- a/docs/janssen-server/install/vm-install/debian.md
+++ b/docs/janssen-server/install/vm-install/debian.md
@@ -18,8 +18,7 @@ Before you install, check the [VM system requirements](vm-requirements.md).
 [Releases](https://github.com/JanssenProject/jans/releases/latest)
 
     ```shell title="Command"
-    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans_replace-janssen-version-stable.debian13_amd64.deb
- -P /tmp
+    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans_replace-janssen-version-stable.debian13_amd64.deb -P /tmp
     ```
 
 - Go to `/tmp` directory:

--- a/docs/janssen-server/install/vm-install/rhel.md
+++ b/docs/janssen-server/install/vm-install/rhel.md
@@ -58,8 +58,7 @@ wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-v
 - Optionally, verify integrity using the published checksum file (secondary check):
 
     ```bash title="Command"
-    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans-replace-janssen-version-stable.el9.x86_64.rpm.sha256sum -P ~/
-    sha256sum -c jans-replace-janssen-version-stable.el9.x86_64.rpm.sha256sum
+   echo 'paste-release-sha256sum jans-replace-janssen-version-stable.el9.x86_64.rpm' | sed 's/^sha256://' >jans-replace-janssen-version-stable.el9.x86_64.rpm.sha256sum && sha256sum -c jans-replace-janssen-version-stable.el9.x86_64.rpm.sha256sum
     ```
 
     Output similar to below should confirm the integrity of the downloaded package.

--- a/docs/janssen-server/install/vm-install/rhel.md
+++ b/docs/janssen-server/install/vm-install/rhel.md
@@ -119,8 +119,7 @@ wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-v
 - Optionally, verify integrity using the published checksum file (secondary check):
 
     ```bash title="Command"
-    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans-replace-janssen-version-stable.el10.x86_64.rpm.sha256sum -P ~/
-    sha256sum -c jans-replace-janssen-version-stable.el10.x86_64.rpm.sha256sum
+    echo 'paste-release-sha256sum jans-replace-janssen-version-stable.el10.x86_64.rpm' | sed 's/^sha256://' >jans-replace-janssen-version-stable.el10.x86_64.rpm.sha256sum && sha256sum -c jans-replace-janssen-version-stable.el10.x86_64.rpm.sha256sum
     ```
 
     Output similar to below should confirm the integrity of the downloaded package.

--- a/docs/janssen-server/install/vm-install/rhel.md
+++ b/docs/janssen-server/install/vm-install/rhel.md
@@ -79,7 +79,7 @@ sudo yum install ~/jans-replace-janssen-version-stable.el9.x86_64.rpm
 
 ```
 sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
-sudo yum -y module enable mod_auth_openidc 
+sudo yum -y install mod_auth_openidc 
 ```
 
 - Download the release package from the GitHub Janssen Project

--- a/docs/janssen-server/install/vm-install/rhel.md
+++ b/docs/janssen-server/install/vm-install/rhel.md
@@ -18,7 +18,7 @@ Before you install, check the [VM system requirements](vm-requirements.md).
 
 ```
 sudo yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-sudo yum -y module enable mod_auth_openidc 
+sudo yum -y install mod_auth_openidc 
 ```
 
 - Download the release package from the GitHub Janssen Project

--- a/docs/janssen-server/install/vm-install/suse.md
+++ b/docs/janssen-server/install/vm-install/suse.md
@@ -68,8 +68,7 @@ wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-v
 - Optionally, verify integrity using the published checksum file (secondary check):
 
     ```bash title="Command"
-    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans-replace-janssen-version-stable.suse16.x86_64.rpm.sha256sum
-    sha256sum -c jans-replace-janssen-version-stable.suse16.x86_64.rpm.sha256sum
+    echo 'paste-release-sha256sum jans-replace-janssen-version-stable.suse16.x86_64.rpm' | sed 's/^sha256://' >jans-replace-janssen-version-stable.suse16.x86_64.rpm.sha256sum && sha256sum -c jans-replace-janssen-version-stable.suse16.x86_64.rpm.sha256sum
     ```
 
     Output similar to below should confirm the integrity of the downloaded package.

--- a/docs/janssen-server/install/vm-install/ubuntu.md
+++ b/docs/janssen-server/install/vm-install/ubuntu.md
@@ -57,8 +57,7 @@ Before you install, check the [VM system requirements](vm-requirements.md).
 - Optionally, verify integrity using the published checksum file (secondary check):
 
     ```bash title="Command"
-    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans_replace-janssen-version-stable.ubuntu24.04_amd64.deb.sha256sum -P /tmp
-    sha256sum -c jans_replace-janssen-version-stable.ubuntu24.04_amd64.deb.sha256sum
+    echo 'paste-release-sha256sum jans_replace-janssen-version-stable.ubuntu24.04_amd64.deb' | sed 's/^sha256://' >jans_replace-janssen-version-stable.ubuntu24.04_amd64.deb.sha256sum && sha256sum -c jans_replace-janssen-version-stable.ubuntu24.04_amd64.deb.sha256sum
     ```
 
     Output similar to below should confirm the integrity of the downloaded package.
@@ -118,8 +117,7 @@ sudo apt install  ./jans_replace-janssen-version-stable.ubuntu24.04_amd64.deb
 - Optionally, verify integrity using the published checksum file (secondary check):
 
     ```bash title="Command"
-    wget https://github.com/JanssenProject/jans/releases/download/vreplace-janssen-version/jans_replace-janssen-version-stable.ubuntu22.04_amd64.deb.sha256sum -P /tmp
-    sha256sum -c jans_replace-janssen-version-stable.ubuntu22.04_amd64.deb.sha256sum
+    echo 'paste-release-sha256sum jans_replace-janssen-version-stable.ubuntu22.04_amd64.deb' | sed 's/^sha256://' >jans_replace-janssen-version-stable.ubuntu22.04_amd64.deb.sha256sum && sha256sum -c jans_replace-janssen-version-stable.ubuntu22.04_amd64.deb.sha256sum
     ```
 
     Output similar to below should confirm the integrity of the downloaded package.


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Debian 13 VM instructions to use the correct “stable” package filename variant and aligned the cosign verification example accordingly.
  * Revised optional package integrity checks for Debian, RHEL, SUSE, and Ubuntu to generate expected checksum entries locally (from a provided value) and verify with `sha256sum -c`, instead of downloading published `*.sha256sum` artifacts.
  * Updated RHEL 9/10 instructions to install `mod_auth_openidc` directly rather than via module enabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->