### PR TITLE
fix(ci): all-in-one poll needs actions:read (was silently 403 → timeout)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -285,8 +285,10 @@ jobs:
               for attempt in $(seq 1 60); do
                 # filter=all spans run attempts; proceed if the image built in ANY attempt
                 # (a re-running newer attempt must not block what an earlier one published).
+                # No 2>/dev/null: a failed query (e.g. missing perm) must show in the log,
+                # not masquerade as a stuck poll. `|| echo ""` still tolerates and retries.
                 CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?filter=all&per_page=100" \
-                  --jq "[.jobs[] | select(.name == \"docker ($img)\")] | if (map(.conclusion) | any(. == \"success\")) then \"success\" elif (map(.conclusion) | any(. == \"skipped\")) then \"skipped\" else (max_by(.run_attempt).conclusion // \"\") end" 2>/dev/null || echo "")
+                  --jq "[.jobs[] | select(.name == \"docker ($img)\")] | if (map(.conclusion) | any(. == \"success\")) then \"success\" elif (map(.conclusion) | any(. == \"skipped\")) then \"skipped\" else (max_by(.run_attempt).conclusion // \"\") end" || echo "")
                 if [[ "$CONCLUSION" == "success" || "$CONCLUSION" == "skipped" ]]; then
                   echo "  docker ($img): $CONCLUSION"; break
                 elif [[ "$CONCLUSION" == "failure" || "$CONCLUSION" == "cancelled" || "$CONCLUSION" == "timed_out" ]]; then

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -283,10 +283,7 @@ jobs:
               echo "Waiting for docker ($img) to complete..."
               CONCLUSION=""
               for attempt in $(seq 1 60); do
-                # filter=all spans run attempts; proceed if the image built in ANY attempt
-                # (a re-running newer attempt must not block what an earlier one published).
-                # No 2>/dev/null: a failed query (e.g. missing perm) must show in the log,
-                # not masquerade as a stuck poll. `|| echo ""` still tolerates and retries.
+                # filter=all + any-success: a re-run's earlier attempt may already hold the image.
                 CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?filter=all&per_page=100" \
                   --jq "[.jobs[] | select(.name == \"docker ($img)\")] | if (map(.conclusion) | any(. == \"success\")) then \"success\" elif (map(.conclusion) | any(. == \"skipped\")) then \"skipped\" else (max_by(.run_attempt).conclusion // \"\") end" || echo "")
                 if [[ "$CONCLUSION" == "success" || "$CONCLUSION" == "skipped" ]]; then

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -106,6 +106,7 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' &&
        (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v')))
     permissions:
+      actions: read   # all-in-one polls this run's jobs API to wait for its base images
       packages: write
       id-token: write
       attestations: write
@@ -282,10 +283,10 @@ jobs:
               echo "Waiting for docker ($img) to complete..."
               CONCLUSION=""
               for attempt in $(seq 1 60); do
-                # filter=all (not the default latest): on a re-run of all-in-one alone, a
-                # sibling that succeeded in an earlier attempt is otherwise invisible.
+                # filter=all spans run attempts; proceed if the image built in ANY attempt
+                # (a re-running newer attempt must not block what an earlier one published).
                 CONCLUSION=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?filter=all&per_page=100" \
-                  --jq "[.jobs[] | select(.name == \"docker ($img)\")] | max_by(.run_attempt) | .conclusion" 2>/dev/null || echo "")
+                  --jq "[.jobs[] | select(.name == \"docker ($img)\")] | if (map(.conclusion) | any(. == \"success\")) then \"success\" elif (map(.conclusion) | any(. == \"skipped\")) then \"skipped\" else (max_by(.run_attempt).conclusion // \"\") end" 2>/dev/null || echo "")
                 if [[ "$CONCLUSION" == "success" || "$CONCLUSION" == "skipped" ]]; then
                   echo "  docker ($img): $CONCLUSION"; break
                 elif [[ "$CONCLUSION" == "failure" || "$CONCLUSION" == "cancelled" || "$CONCLUSION" == "timed_out" ]]; then


### PR DESCRIPTION
The all-in-one image build kept hitting `docker (auth-server) timed out waiting` and aborting — on **every** run. [Run 27906128395](https://github.com/JanssenProject/jans/actions/runs/27906128395) shows it clearly: all base images succeeded at ~13:45, yet **both** all-in-one attempts (13:46 and 21:45) polled the full 30 min and failed.

**Root cause:** the all-in-one leg polls `/actions/runs/{id}/jobs` to wait for its base images, but the `docker` job's `permissions:` block grants only `packages/id-token/attestations/pull-requests` — **not `actions: read`** (and a job-level block overrides the top-level `contents/pull-requests`). That endpoint requires `actions: read`, so the call 403'd, was swallowed by `2>/dev/null || echo ""`, and `CONCLUSION` was empty every iteration → guaranteed timeout. (It passed in local testing only because a PAT has the scope.)

**Fixes:**
1. **`actions: read`** on the docker job — the actual blocker.
2. Poll proceeds if a sibling built in **any** run attempt (`filter=all` already spans attempts), instead of only the latest attempt's conclusion via `max_by`. On a re-run where a sibling's newer attempt is still pending, the earlier attempt already published the image, so all-in-one shouldn't block on it.

**Verified** against the failing run: with the new jq, all 7 required images (`auth-server`…`casa`) resolve to `success`, so the poll would proceed immediately.

Completes the all-in-one release fixes: #14394 made it *selected* on the chain; this makes its image-wait actually *work*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the automated build pipeline’s GitHub Actions permissions to support more reliable status checks.
  * Updated Docker build sequencing so dependent steps proceed when any relevant job attempt reports success or skipped; otherwise they use the latest attempt result.
  * Refreshed related workflow guidance to match the new “any attempt succeeded/skipped” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->