### PR TITLE
fix(ci): give the all-in-one poll a GH_TOKEN (was failing every gh api call)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -230,6 +230,8 @@ jobs:
       - name: Prepare
         if: steps.build_docker_image.outputs.build
         id: prep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           DOCKER_FILE_LOCATION=./docker-jans-${{ matrix.docker-images }}


### PR DESCRIPTION
The all-in-one build still timed out waiting for `docker (auth-server)`, but #14399 (dropping `2>/dev/null`) made the cause visible:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

**Root cause:** the all-in-one image-wait poll lives in the **`Prepare`** step, which has no `env:` block — so its `gh api` call ran without a token and failed on every iteration → guaranteed 30-min timeout. `GH_TOKEN` was set on the earlier `Check docker directories that changed` step, but the poll isn't there.

**Fix:** set `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the `Prepare` step.

This is the missing piece alongside #14399 (`actions: read`) and #14394 (chain selection): the poll can now **authenticate** (`GH_TOKEN`) **and** has **permission** (`actions: read`) to read this run's job status, so all-in-one will actually wait for its base images and build.

Verified: YAML parses and the `Prepare` step now carries `GH_TOKEN`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process authentication to ensure reliable artifact preparation and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->