### PR TITLE
fix(jans-cedarling): replace sleep-based flush with interval tick

### DIFF
--- a/jans-cedarling/cedarling/src/lock/log_worker.rs
+++ b/jans-cedarling/cedarling/src/lock/log_worker.rs
@@ -18,7 +18,7 @@ use http_utils::Backoff;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::sleep;
+use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
 
 /// Responsible for sending logs to the lock server
@@ -57,6 +57,10 @@ where
         mut rx: mpsc::Receiver<SerializedAuditEntry>,
         cancel_tkn: CancellationToken,
     ) {
+        let mut flush_tick = interval(self.audit_interval);
+        flush_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        flush_tick.tick().await;
+
         loop {
             tokio::select! {
                 entry = rx.next() => {
@@ -65,11 +69,14 @@ where
                 },
 
                 // Send logs to the server
-                () = sleep(self.audit_interval) => {
+                _ = flush_tick.tick() => {
                     self.flush(&cancel_tkn).await;
                 },
 
                 () = cancel_tkn.cancelled() => {
+                    while let Ok(entry) = rx.try_recv() {
+                        self.buffer.push_back(entry);
+                    }
                     self.flush(&cancel_tkn).await;
                     self.logger
                         .as_ref()

--- a/jans-cedarling/cedarling/src/lock/mod.rs
+++ b/jans-cedarling/cedarling/src/lock/mod.rs
@@ -389,7 +389,6 @@ impl LockService {
     }
 
     pub(crate) async fn shut_down(&mut self) {
-        self.cancel_tkn.cancel();
         if let Some((cancel_tkn, handle)) = self.telemetry_ticker.take() {
             cancel_tkn.cancel();
             () = handle.await_result().await;
@@ -398,6 +397,8 @@ impl LockService {
             cancel_tkn.cancel();
             () = handle.await_result().await;
         }
+
+        self.cancel_tkn.cancel();
         if let Some(worker) = self.log_worker.take() {
             () = worker.handle.await_result().await;
         }


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14395

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced audit logging flushing mechanism for more reliable log capture during shutdown
  * Optimized shutdown sequence to ensure proper task handling and resource cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->