### PR TITLE
fix(jans-cedarling): reject non-string extension claims instead of panicking

### DIFF
--- a/jans-cedarling/cedarling/src/entity_builder/build_expr.rs
+++ b/jans-cedarling/cedarling/src/entity_builder/build_expr.rs
@@ -153,7 +153,10 @@ fn build_expr_from_value(
             Ok(Some(RestrictedExpression::new_record(fields)?))
         },
         ExpectedClaimType::Extension(name) => {
-            let val = src.as_str().unwrap();
+            let val = src.as_str().ok_or_else(|| TypeMismatchError {
+                expected: "string".to_string(),
+                actual: TypeMismatchError::value_type_name(src).to_string(),
+            })?;
             let expr = match name.as_str() {
                 "decimal" => Some(RestrictedExpression::new_decimal(val)),
                 "ipaddr" => Some(RestrictedExpression::new_ip(val)),


### PR DESCRIPTION
### Description

`build_expr_from_value` in `entity_builder/build_expr.rs` turns token claims into Cedar expressions. It checks the JSON type in every branch except the one for extension values, which just calls `src.as_str().unwrap()`. So a token whose extension claim isn't a string panics the authorize call. This PR makes that branch reject the wrong type the way all the others do.

#### Implementation Details

- In `jans-cedarling/cedarling/src/entity_builder/build_expr.rs`, swap the `src.as_str().unwrap()` in the extension branch for the same `ok_or_else(|| TypeMismatchError { ... })?` the `String` branch right above it uses. A wrong-typed extension claim now returns a `TypeMismatchError` instead of panicking. The caller already knows what to do with that: a required attribute fails the entity build, an optional one gets skipped, same as any other wrong-typed claim.

-------------------

### Test and Document the changes

- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.

- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the system would crash when receiving invalid data in extension claims. Now provides a clear error message instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->