### PR TITLE
feat(agama): add transpiler variable naming and access conformance tests

### DIFF
--- a/agama/transpiler/src/test/java/io/jans/agama/test/VariableAccessTest.java
+++ b/agama/transpiler/src/test/java/io/jans/agama/test/VariableAccessTest.java
@@ -1,0 +1,67 @@
+package io.jans.agama.test;
+
+import io.jans.agama.dsl.TranspilationResult;
+import io.jans.agama.dsl.Transpiler;
+import io.jans.agama.dsl.TranspilerException;
+import io.jans.agama.dsl.error.SyntaxException;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+/**
+ * Spec-conformance checks for variable naming and data access, per the "Variables" and
+ * "Accessing and mutating data in variables" sections of docs/agama/language-reference.md.
+ * Positive: valid names and access forms (dot, numeric index, length, quoted and
+ * $-prefixed property access) transpile. Negative: a name that does not match
+ * {@code [a-zA-Z](_|[a-zA-Z]|[0-9])*} and expression-based indexing are rejected.
+ */
+public class VariableAccessTest {
+
+    @Test
+    public void transpile_validNamesAndAccessForms_succeeds() throws Exception {
+        String source = String.join("\n",
+                "Flow com.acme.vars",
+                "    Basepath \"\"",
+                "colors = [ \"red\", \"blue\" ]",
+                "firstColor = colors[0]",
+                "size = colors.length",
+                "person = { name: \"Jo\", age: 30 }",
+                "who = person.name",
+                "firstChar = who[0]",
+                "weird = person.\"- wow!\"",
+                "dollar = person.$who",
+                "Finish true",
+                "");
+
+        TranspilationResult result = Transpiler.transpile("com.acme.vars", source);
+        assertNotNull(result);
+        assertNotNull(result.getCode());
+    }
+
+    @Test
+    public void transpile_invalidNameAndExpressionIndexing_rejected() {
+        // Leading underscore violates the variable-name pattern; expression indexing is
+        // explicitly disallowed by the language reference.
+        String[] invalidBodies = {
+                "_a = 1",          // invalid variable name (leading underscore)
+                "x = a[b.c]",      // expression indexing: x[person.age]
+                "x = a[b[0]]"      // expression indexing: x[y[0]]
+        };
+        for (String body : invalidBodies) {
+            String source = String.join("\n",
+                    "Flow com.acme.badvar",
+                    "    Basepath \"\"",
+                    body,
+                    "Finish true",
+                    "");
+            try {
+                Transpiler.runSyntaxCheck(source);
+                fail("Source should be rejected per the language reference: " + body);
+            } catch (SyntaxException | TranspilerException e) {
+                // expected
+            }
+        }
+    }
+}

--- a/agama/transpiler/src/test/resources/testng.xml
+++ b/agama/transpiler/src/test/resources/testng.xml
@@ -13,4 +13,10 @@
         </classes>
     </test>
 
+    <test name="Variable access" enabled="true">
+        <classes>
+            <class name="io.jans.agama.test.VariableAccessTest" />
+        </classes>
+    </test>
+
 </suite>


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
   Adds `VariableAccessTest` to the Agama transpiler module, pinning the transpiler to the language reference's variable 
   naming and data-access rules: valid names and access forms (dot, numeric index, `.length`, quoted and `$`-prefixed property 
   access) transpile, while an invalid name (leading underscore) and expression-based indexing (`x[person.age]`, `x[y[0]]`) are  
   rejected. Registered in the module's TestNG suite. No production change —  confirms current behavior conforms to the    
   spec.

#### Target issue
  The Agama language reference defines the variable-name pattern [a-zA-Z](https://github.com/JanssenProject/jans/issues/_%7C%5Ba-zA-Z%5D%7C%5B0-9%5D)* and the rules for accessing
data (dot notation, zero-based indexing, .length, quoted/$-prefixed property access), and explicitly disallows
expression-based indexing (x[person.age], x[y[0]]). There is no test pinning the transpiler to these rules.

  
closes #14424 

#### Implementation Details
  - New test `agama/transpiler/src/test/java/io/jans/agama/test/VariableAccessTest.java` (positive valid names/access via    
    `Transpiler.transpile`; negative invalid name +expression indexing via  `Transpiler.runSyntaxCheck`).
  - Registered the class in `agama/transpiler/src/test/resources/testng.xml`.
  - Full transpiler suite passes (4 tests, 0 failures).

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14530, 