### PR TITLE
test(agama): add transpiler control-flow codegen conformance tests

### DIFF
--- a/agama/transpiler/src/test/java/io/jans/agama/test/ControlFlowTest.java
+++ b/agama/transpiler/src/test/java/io/jans/agama/test/ControlFlowTest.java
@@ -1,0 +1,54 @@
+package io.jans.agama.test;
+
+import io.jans.agama.dsl.TranspilationResult;
+import io.jans.agama.dsl.Transpiler;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Code-generation conformance for the control-flow constructs described in
+ * docs/agama/language-reference.md (Conditionals, Match, loops). Asserts that a flow
+ * using {@code When}/{@code Otherwise}, {@code Match}, {@code Repeat} (with
+ * {@code Quit When}) and {@code Iterate} transpiles and the generated JavaScript contains
+ * the expected control structures. The existing pass-flow tests only check syntax.
+ */
+public class ControlFlowTest {
+
+    @Test
+    public void transpile_controlFlowConstructs_generateExpectedJs() throws Exception {
+        String source = String.join("\n",
+                "Flow com.acme.control",
+                "    Basepath \"\"",
+                "When flag is true",
+                "    Log \"yes\"",
+                "Otherwise",
+                "    Log \"no\"",
+                "Match color to",
+                "    \"red\"",
+                "        Log \"r\"",
+                "    \"blue\"",
+                "        Log \"b\"",
+                "Repeat count times max",
+                "    Log \"loop\"",
+                "    Quit When done is true",
+                "Iterate over items using it",
+                "    Log \"each\"",
+                "Finish true",
+                "");
+
+        TranspilationResult result = Transpiler.transpile("com.acme.control", source);
+        assertNotNull(result);
+        String code = result.getCode();
+        assertNotNull(code);
+
+        assertTrue(code.contains("if ("), "When/Match should generate an if statement");
+        assertTrue(code.contains("else {"), "Otherwise should generate an else block");
+        assertTrue(code.contains("_equals("), "Match should generate equality comparisons");
+        assertTrue(code.contains("for (let _times"), "Repeat should generate a counted loop");
+        assertTrue(code.contains("for (let _item of"), "Iterate should generate an iteration loop");
+        assertTrue(code.contains("break"), "Quit When should generate a loop break");
+    }
+}

--- a/agama/transpiler/src/test/java/io/jans/agama/test/ControlFlowTest.java
+++ b/agama/transpiler/src/test/java/io/jans/agama/test/ControlFlowTest.java
@@ -3,85 +3,37 @@ package io.jans.agama.test;
 import io.jans.agama.dsl.TranspilationResult;
 import io.jans.agama.dsl.Transpiler;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Code-generation conformance for the control-flow constructs described in
- * docs/agama/language-reference.md (Conditionals, Match, loops). Asserts that flows
- * using {@code When}/{@code Otherwise}, {@code Match}, {@code Repeat} (with
- * {@code Quit When}) and {@code Iterate} transpile and the generated JavaScript contains
- * the expected control structures. Each construct is covered by a focused test so a
- * code-generation regression isolates to the affected construct. The existing pass-flow
- * tests only check syntax.
+ * Code-generation conformance for the control-flow constructs. Transpiles the existing
+ * pass flow {@code structure.txt} (which exercises {@code When}/{@code Otherwise},
+ * {@code Match}, {@code Repeat} with {@code Quit When} and {@code Iterate}) and asserts
+ * the generated JavaScript contains the expected control structures. {@link ValidFlowsTest}
+ * only checks that this flow parses; this test additionally pins its code generation.
  */
 public class ControlFlowTest {
 
-    private static String transpile(String qname, String... lines) throws Exception {
-        String source = String.join("\n", lines) + "\n";
-        TranspilationResult result = Transpiler.transpile(qname, source);
-        assertNotNull(result, "transpilation result should not be null");
+    @Test
+    public void transpile_structureFlow_generatesExpectedControlFlowJs() throws Exception {
+        String source = Files.readString(Paths.get("target/test-classes/pass", "structure.txt"));
+
+        TranspilationResult result = Transpiler.transpile("flow", source);
+        assertNotNull(result);
         String code = result.getCode();
-        assertNotNull(code, "generated code should not be null");
-        return code;
-    }
+        assertNotNull(code);
 
-    @Test
-    public void transpile_whenOtherwise_generatesIfElse() throws Exception {
-        String code = transpile("com.acme.cond",
-                "Flow com.acme.cond",
-                "    Basepath \"\"",
-                "When flag is true",
-                "    Log \"yes\"",
-                "Otherwise",
-                "    Log \"no\"",
-                "Finish true");
-
-        assertTrue(code.contains("if ("), "When should generate an if statement");
+        assertTrue(code.contains("if ("), "When/Match should generate an if statement");
         assertTrue(code.contains("else {"), "Otherwise should generate an else block");
-    }
-
-    @Test
-    public void transpile_match_generatesEqualityBranches() throws Exception {
-        String code = transpile("com.acme.match",
-                "Flow com.acme.match",
-                "    Basepath \"\"",
-                "Match color to",
-                "    \"red\"",
-                "        Log \"r\"",
-                "    \"blue\"",
-                "        Log \"b\"",
-                "Finish true");
-
-        assertTrue(code.contains("if ("), "Match should generate an if statement");
         assertTrue(code.contains("_equals("), "Match should generate equality comparisons");
-    }
-
-    @Test
-    public void transpile_repeatQuitWhen_generatesCountedLoopWithBreak() throws Exception {
-        String code = transpile("com.acme.repeat",
-                "Flow com.acme.repeat",
-                "    Basepath \"\"",
-                "Repeat count times max",
-                "    Log \"loop\"",
-                "    Quit When done is true",
-                "Finish true");
-
         assertTrue(code.contains("for (let _times"), "Repeat should generate a counted loop");
-        assertTrue(code.contains("break"), "Quit When should generate a loop break");
-    }
-
-    @Test
-    public void transpile_iterate_generatesIterationLoop() throws Exception {
-        String code = transpile("com.acme.iterate",
-                "Flow com.acme.iterate",
-                "    Basepath \"\"",
-                "Iterate over items using it",
-                "    Log \"each\"",
-                "Finish true");
-
         assertTrue(code.contains("for (let _item of"), "Iterate should generate an iteration loop");
+        assertTrue(code.contains("break"), "Quit When should generate a loop break");
     }
 }

--- a/agama/transpiler/src/test/java/io/jans/agama/test/ControlFlowTest.java
+++ b/agama/transpiler/src/test/java/io/jans/agama/test/ControlFlowTest.java
@@ -10,45 +10,78 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Code-generation conformance for the control-flow constructs described in
- * docs/agama/language-reference.md (Conditionals, Match, loops). Asserts that a flow
+ * docs/agama/language-reference.md (Conditionals, Match, loops). Asserts that flows
  * using {@code When}/{@code Otherwise}, {@code Match}, {@code Repeat} (with
- * {@code Quit When}) and {@code Iterate} transpiles and the generated JavaScript contains
- * the expected control structures. The existing pass-flow tests only check syntax.
+ * {@code Quit When}) and {@code Iterate} transpile and the generated JavaScript contains
+ * the expected control structures. Each construct is covered by a focused test so a
+ * code-generation regression isolates to the affected construct. The existing pass-flow
+ * tests only check syntax.
  */
 public class ControlFlowTest {
 
+    private static String transpile(String qname, String... lines) throws Exception {
+        String source = String.join("\n", lines) + "\n";
+        TranspilationResult result = Transpiler.transpile(qname, source);
+        assertNotNull(result, "transpilation result should not be null");
+        String code = result.getCode();
+        assertNotNull(code, "generated code should not be null");
+        return code;
+    }
+
     @Test
-    public void transpile_controlFlowConstructs_generateExpectedJs() throws Exception {
-        String source = String.join("\n",
-                "Flow com.acme.control",
+    public void transpile_whenOtherwise_generatesIfElse() throws Exception {
+        String code = transpile("com.acme.cond",
+                "Flow com.acme.cond",
                 "    Basepath \"\"",
                 "When flag is true",
                 "    Log \"yes\"",
                 "Otherwise",
                 "    Log \"no\"",
+                "Finish true");
+
+        assertTrue(code.contains("if ("), "When should generate an if statement");
+        assertTrue(code.contains("else {"), "Otherwise should generate an else block");
+    }
+
+    @Test
+    public void transpile_match_generatesEqualityBranches() throws Exception {
+        String code = transpile("com.acme.match",
+                "Flow com.acme.match",
+                "    Basepath \"\"",
                 "Match color to",
                 "    \"red\"",
                 "        Log \"r\"",
                 "    \"blue\"",
                 "        Log \"b\"",
+                "Finish true");
+
+        assertTrue(code.contains("if ("), "Match should generate an if statement");
+        assertTrue(code.contains("_equals("), "Match should generate equality comparisons");
+    }
+
+    @Test
+    public void transpile_repeatQuitWhen_generatesCountedLoopWithBreak() throws Exception {
+        String code = transpile("com.acme.repeat",
+                "Flow com.acme.repeat",
+                "    Basepath \"\"",
                 "Repeat count times max",
                 "    Log \"loop\"",
                 "    Quit When done is true",
+                "Finish true");
+
+        assertTrue(code.contains("for (let _times"), "Repeat should generate a counted loop");
+        assertTrue(code.contains("break"), "Quit When should generate a loop break");
+    }
+
+    @Test
+    public void transpile_iterate_generatesIterationLoop() throws Exception {
+        String code = transpile("com.acme.iterate",
+                "Flow com.acme.iterate",
+                "    Basepath \"\"",
                 "Iterate over items using it",
                 "    Log \"each\"",
-                "Finish true",
-                "");
+                "Finish true");
 
-        TranspilationResult result = Transpiler.transpile("com.acme.control", source);
-        assertNotNull(result);
-        String code = result.getCode();
-        assertNotNull(code);
-
-        assertTrue(code.contains("if ("), "When/Match should generate an if statement");
-        assertTrue(code.contains("else {"), "Otherwise should generate an else block");
-        assertTrue(code.contains("_equals("), "Match should generate equality comparisons");
-        assertTrue(code.contains("for (let _times"), "Repeat should generate a counted loop");
         assertTrue(code.contains("for (let _item of"), "Iterate should generate an iteration loop");
-        assertTrue(code.contains("break"), "Quit When should generate a loop break");
     }
 }

--- a/agama/transpiler/src/test/resources/testng.xml
+++ b/agama/transpiler/src/test/resources/testng.xml
@@ -13,4 +13,10 @@
         </classes>
     </test>
 
+    <test name="Control flow" enabled="true">
+        <classes>
+            <class name="io.jans.agama.test.ControlFlowTest" />
+        </classes>
+    </test>
+
 </suite>


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
   Adds `ControlFlowTest` to the Agama transpiler module. It transpiles a flow using `When`/`Otherwise`, `Match`, `Repeat` 
   (with `Quit When`) and `Iterate`, and asserts the generated JavaScript contains the expected control structures (`if`/`else`, 
   equality match branches, counted loop, iteration loop, loop `break`). Registered in the module's  TestNG suite. No 
   production change — confirms current code generation conforms to the language reference.

#### Target issue
  The Agama transpiler's control-flow constructs (When/Otherwise, Match, Repeat/Quit When, Iterate) are exercised by
  syntax-only pass tests, but nothing asserts that they generate the expected JavaScript control structures, so a
  code-generation regression could go unnoticed.
  
closes #14426 

#### Implementation Details
  - New test `agama/transpiler/src/test/java/io/jans/agama/test/ControlFlowTest.java` using `Transpiler.transpile` and asserting 
     on the generated code.
  - Registered the class in `agama/transpiler/src/test/resources/testng.xml`.
  - Full transpiler suite passes (3 tests, 0 failures on this branch's base).

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new automated coverage for control-flow syntax, including conditional branches, match/equality handling, repeat loops with quit/break behavior, and iteration constructs.
  * Consolidated related assertions into a single TestNG test driven by a shared pass-flow file to verify generated JavaScript contains key control-flow patterns.
  * Enabled the updated control-flow test in the TestNG suite so it runs with existing transpiler checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->