### PR TITLE
test(agama): add transpiler foreign-call codegen conformance tests

### DIFF
--- a/agama/transpiler/src/test/java/io/jans/agama/test/ForeignCallTest.java
+++ b/agama/transpiler/src/test/java/io/jans/agama/test/ForeignCallTest.java
@@ -3,30 +3,29 @@ package io.jans.agama.test;
 import io.jans.agama.dsl.TranspilationResult;
 import io.jans.agama.dsl.Transpiler;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Code-generation conformance for foreign calls (`Call`) and their exception-capture
- * form, per the "Foreign routines" section of docs/agama/language-reference.md. Asserts
- * that a static `Call` generates an action call with the target class/method, and that
- * the `result | error = Call ...` form declares the capture variable.
+ * Code-generation conformance for foreign calls ({@code Call}) and their exception-capture
+ * form. Transpiles the existing pass flow {@code triggers_calls.txt} (which includes the
+ * static call {@code x256 = Call java.lang.Math#incrementExact 255} and the capture form
+ * {@code n | E = Call java.lang.Integer#parseInt "AGA" 16}) and asserts the generated
+ * JavaScript contains the action-call invocation with the target class/method and declares
+ * the capture variable. {@link ValidFlowsTest} only checks that this flow parses.
  */
 public class ForeignCallTest {
 
     @Test
-    public void transpile_foreignCallAndExceptionCapture_generateExpectedJs() throws Exception {
-        String source = String.join("\n",
-                "Flow com.acme.calls",
-                "    Basepath \"\"",
-                "x256 = Call java.lang.Math#incrementExact 255",
-                "n | E = Call java.lang.Integer#parseInt \"AGA\" 16",
-                "Finish true",
-                "");
+    public void transpile_triggersCallsFlow_generatesActionCallAndCaptureVariable() throws Exception {
+        String source = Files.readString(Paths.get("target/test-classes/pass", "triggers_calls.txt"));
 
-        TranspilationResult result = Transpiler.transpile("com.acme.calls", source);
+        TranspilationResult result = Transpiler.transpile("flow", source);
         assertNotNull(result);
         String code = result.getCode();
         assertNotNull(code);

--- a/agama/transpiler/src/test/java/io/jans/agama/test/ForeignCallTest.java
+++ b/agama/transpiler/src/test/java/io/jans/agama/test/ForeignCallTest.java
@@ -1,0 +1,39 @@
+package io.jans.agama.test;
+
+import io.jans.agama.dsl.TranspilationResult;
+import io.jans.agama.dsl.Transpiler;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Code-generation conformance for foreign calls (`Call`) and their exception-capture
+ * form, per the "Foreign routines" section of docs/agama/language-reference.md. Asserts
+ * that a static `Call` generates an action call with the target class/method, and that
+ * the `result | error = Call ...` form declares the capture variable.
+ */
+public class ForeignCallTest {
+
+    @Test
+    public void transpile_foreignCallAndExceptionCapture_generateExpectedJs() throws Exception {
+        String source = String.join("\n",
+                "Flow com.acme.calls",
+                "    Basepath \"\"",
+                "x256 = Call java.lang.Math#incrementExact 255",
+                "n | E = Call java.lang.Integer#parseInt \"AGA\" 16",
+                "Finish true",
+                "");
+
+        TranspilationResult result = Transpiler.transpile("com.acme.calls", source);
+        assertNotNull(result);
+        String code = result.getCode();
+        assertNotNull(code);
+
+        assertTrue(code.contains("_actionCall("), "Call should generate an action call");
+        assertTrue(code.contains("\"java.lang.Math\""), "static call target class should appear");
+        assertTrue(code.contains("\"incrementExact\""), "static call method name should appear");
+        assertTrue(code.contains("var E"), "exception-capture variable should be declared");
+    }
+}

--- a/agama/transpiler/src/test/resources/testng.xml
+++ b/agama/transpiler/src/test/resources/testng.xml
@@ -13,4 +13,10 @@
         </classes>
     </test>
 
+    <test name="Foreign call" enabled="true">
+        <classes>
+            <class name="io.jans.agama.test.ForeignCallTest" />
+        </classes>
+    </test>
+
 </suite>


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
  Adds `ForeignCallTest` to the Agama transpiler module. It transpiles a flow using a static `Call` and the exception-capture 
  form (`result | error = Call …`) and asserts the generated JavaScript contains the action-call invocation with the target 
  class/method and declares the capture variable. Registered in the module's TestNG suite. No production change — confirms 
  current code generation conforms to the language reference.

#### Target issue
  The transpiler's Call (foreign-routine) construct and its exception-capture form (result | error = Call …) are covered
  only by syntax-pass tests; nothing asserts they generate the expected action-call code and capture-variable
  declaration, so a code-generation regression could go unnoticed.
  
closes #14428 

#### Implementation Details
  - New test `agama/transpiler/src/test/java/io/jans/agama/test/ForeignCallTest.java`  using `Transpiler.transpile` and asserting   
    on the generated code.
  - Registered the class in `agama/transpiler/src/test/resources/testng.xml`.
  - Full transpiler suite passes (3 tests, 0 failures on this branch's base).

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for the transpiler’s foreign-call syntax.
  * Verified generated JavaScript for both standard calls and exception-capture call patterns.
  * Included the new foreign-call test in the automated TestNG suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->