### PR TITLE
ci(jans-cedarling): fix audit rate limit + add crates.io publish workflow

### DIFF
--- a/.github/workflows/publish-cedarling.yml
+++ b/.github/workflows/publish-cedarling.yml
@@ -1,0 +1,72 @@
+name: "Cedarling: publish to crates.io"
+
+# Publishes http_utils (internal dep) then cedarling to crates.io.
+# Triggered manually after a release tag has been pushed by release-trigger.yml,
+# or set dry_run=true to validate packaging without publishing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or ref to publish from (e.g. v1.2.0)'
+        required: true
+        default: 'main'
+      dry_run:
+        description: 'Package but do not upload (cargo publish --dry-run)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-cedarling
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'JanssenProject/jans'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.event.inputs.ref }}
+
+    - name: Install Protoc
+      uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      with:
+        toolchain: stable
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        workspaces: jans-cedarling
+
+    - name: Publish http_utils
+      working-directory: jans-cedarling
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        FLAGS=""
+        if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then FLAGS="--dry-run"; fi
+        cargo publish -p http_utils --locked $FLAGS
+
+    - name: Publish cedarling
+      working-directory: jans-cedarling
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        FLAGS=""
+        if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then FLAGS="--dry-run"; fi
+        # Allow time for the registry index to pick up http_utils before cedarling
+        # tries to resolve it.
+        if [ "${{ github.event.inputs.dry_run }}" != "true" ]; then sleep 30; fi
+        cargo publish -p cedarling --locked $FLAGS

--- a/.github/workflows/publish-cedarling.yml
+++ b/.github/workflows/publish-cedarling.yml
@@ -1,20 +1,20 @@
 name: "Cedarling: publish to crates.io"
 
 # Publishes http_utils (internal dep) then cedarling to crates.io.
-# Triggered manually after a release tag has been pushed by release-trigger.yml,
-# or set dry_run=true to validate packaging without publishing.
+# Triggered manually after a release tag has been pushed by release-trigger.yml.
+# Default dry_run=true so every manual dispatch is validation-first; set to
+# false explicitly to perform the real publish.
 
 on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Tag or ref to publish from (e.g. v1.2.0)'
+        description: 'Release tag to publish from (e.g. v1.2.0)'
         required: true
-        default: 'main'
       dry_run:
-        description: 'Package but do not upload (cargo publish --dry-run)'
+        description: 'Package but do not upload (cargo publish --dry-run). Default true — set false to publish for real.'
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read
@@ -36,6 +36,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.inputs.ref }}
+        persist-credentials: false
 
     - name: Install Protoc
       uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623
@@ -50,23 +51,48 @@ jobs:
       with:
         workspaces: jans-cedarling
 
+    - name: Dry-run package check (http_utils)
+      if: ${{ github.event.inputs.dry_run == 'true' }}
+      working-directory: jans-cedarling
+      run: cargo publish -p http_utils --locked --dry-run
+
     - name: Publish http_utils
+      if: ${{ github.event.inputs.dry_run != 'true' }}
       working-directory: jans-cedarling
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo publish -p http_utils --locked
+
+    - name: Dry-run package check (cedarling)
+      if: ${{ github.event.inputs.dry_run == 'true' }}
+      working-directory: jans-cedarling
+      run: cargo publish -p cedarling --locked --dry-run
+
+    - name: Wait for registry index to pick up http_utils
+      if: ${{ github.event.inputs.dry_run != 'true' }}
+      # Poll the crates.io JSON API until the version is visible, rather than
+      # sleeping a fixed interval that may under- or over-wait.
+      working-directory: jans-cedarling
       run: |
-        FLAGS=""
-        if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then FLAGS="--dry-run"; fi
-        cargo publish -p http_utils --locked $FLAGS
+        HTTP_UTILS_VERSION=$(cargo metadata --no-deps --format-version 1 \
+          | jq -r '.packages[] | select(.name == "http_utils") | .version')
+        echo "Waiting for http_utils@${HTTP_UTILS_VERSION} in the registry..."
+        for i in $(seq 1 20); do
+          STATUS=$(curl -sf \
+            -H "User-Agent: jans-cedarling-publish-workflow" \
+            "https://crates.io/api/v1/crates/http_utils/${HTTP_UTILS_VERSION}" \
+            | jq -r '.version.num // empty')
+          if [ "${STATUS}" = "${HTTP_UTILS_VERSION}" ]; then
+            echo "http_utils@${HTTP_UTILS_VERSION} is available."
+            break
+          fi
+          echo "Not yet available (attempt ${i}/20); retrying in 15s..."
+          sleep 15
+        done
 
     - name: Publish cedarling
+      if: ${{ github.event.inputs.dry_run != 'true' }}
       working-directory: jans-cedarling
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: |
-        FLAGS=""
-        if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then FLAGS="--dry-run"; fi
-        # Allow time for the registry index to pick up http_utils before cedarling
-        # tries to resolve it.
-        if [ "${{ github.event.inputs.dry_run }}" != "true" ]; then sleep 30; fi
-        cargo publish -p cedarling --locked $FLAGS
+      run: cargo publish -p cedarling --locked

--- a/.github/workflows/test-cedarling.yml
+++ b/.github/workflows/test-cedarling.yml
@@ -58,12 +58,20 @@ jobs:
       uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
       with:
         toolchain: stable
+    - name: Get week stamp for advisory DB cache key
+      id: date
+      run: echo "week=$(date +%Y-%U)" >> $GITHUB_OUTPUT
     - name: Cache advisory database
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.cargo/advisory-db
-        key: advisory-db-${{ github.run_id }}
+        # Refresh weekly; advisory-db- fallback reuses the most recent weekly snapshot.
+        key: advisory-db-${{ steps.date.outputs.week }}
         restore-keys: advisory-db-
+    - name: Install cargo-audit
+      uses: taiki-e/install-action@735e5933943e3f52b993a0e2e5a7b0c3f79a6c1d # v2.50.4
+      with:
+        tool: cargo-audit
     - name: Run cargo-audit
       working-directory: jans-cedarling
       # rustsec/audit-check uses the GitHub API to fetch the advisory DB and hits
@@ -72,9 +80,7 @@ jobs:
       # RUSTSEC-2023-0071: `rsa` Marvin timing sidechannel affects RSA decryption.
       # Cedarling only uses `jsonwebtoken` for signature verification; the
       # decryption path is not reachable. No upstream fix available.
-      run: |
-        cargo install cargo-audit --locked
-        cargo audit --ignore RUSTSEC-2023-0071
+      run: cargo audit --ignore RUSTSEC-2023-0071
 
   cargo_deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-cedarling.yml
+++ b/.github/workflows/test-cedarling.yml
@@ -54,15 +54,27 @@ jobs:
       with:
         egress-policy: audit
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Run cargo-audit
-      uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: jans-cedarling
-        # RUSTSEC-2023-0071: `rsa` Marvin timing sidechannel affects RSA decryption.
-        # Cedarling only uses `jsonwebtoken` for signature verification; the
-        # decryption path is not reachable. No upstream fix available.
-        ignore: RUSTSEC-2023-0071
+        toolchain: stable
+    - name: Cache advisory database
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cargo/advisory-db
+        key: advisory-db-${{ github.run_id }}
+        restore-keys: advisory-db-
+    - name: Run cargo-audit
+      working-directory: jans-cedarling
+      # rustsec/audit-check uses the GitHub API to fetch the advisory DB and hits
+      # rate limits on PRs. Running cargo-audit directly with a cached advisory DB
+      # avoids the API calls entirely.
+      # RUSTSEC-2023-0071: `rsa` Marvin timing sidechannel affects RSA decryption.
+      # Cedarling only uses `jsonwebtoken` for signature verification; the
+      # decryption path is not reachable. No upstream fix available.
+      run: |
+        cargo install cargo-audit --locked
+        cargo audit --ignore RUSTSEC-2023-0071
 
   cargo_deny:
     runs-on: ubuntu-latest

--- a/jans-cedarling/Cargo.toml
+++ b/jans-cedarling/Cargo.toml
@@ -34,7 +34,7 @@ jsonwebtoken = { version = "10.3.0", features = [
 jsonwebkey = "0.4.0"
 chrono = "0.4"
 reqwest = { version = "0.13.2", features = ["json", "form"] }
-http_utils = { path = "http_utils" }
+http_utils = { path = "http_utils", version = "0.1.0" }
 cedarling = { path = "cedarling" }
 test_utils = { path = "test_utils" }
 wasm-bindgen = "0.2.103"

--- a/jans-cedarling/cedarling/Cargo.toml
+++ b/jans-cedarling/cedarling/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2024"
 description = "The Cedarling: a high-performance local authorization service powered by the Rust Cedar Engine."
 license = "Apache-2.0"
-publish = false
+publish = true
 
 [features]
 default = ["grpc"]

--- a/jans-cedarling/http_utils/Cargo.toml
+++ b/jans-cedarling/http_utils/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "HTTP utils that Cedarling uses internally"
 license = "Apache-2.0"
-publish = false
+publish = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Summary

- **Fix CI rate limit**: Replace `rustsec/audit-check` (uses GitHub REST API to clone advisory DB, hits rate limits on PR runs) with direct `cargo audit` + `actions/cache` on `~/.cargo/advisory-db`. Cache warms on first run; subsequent runs skip the network entirely.
- **New publish workflow**: `publish-cedarling.yml` — `workflow_dispatch` that publishes `http_utils` then `cedarling` to crates.io in dependency order. Includes a `dry_run` flag (validates packaging without uploading) and a `ref` input to target a specific release tag.
- **Enable crates.io publishing**: Remove `publish = false` from `cedarling` and `http_utils`; add `version = "0.1.0"` to the workspace `http_utils` dep so cargo can resolve it on crates.io (path dep takes precedence locally).

## Pre-flight before first publish
- [ ] Add `CARGO_REGISTRY_TOKEN` to repo secrets (Settings → Secrets → Actions)
- [ ] Run the publish workflow with `dry_run=true` first to validate packaging
- [ ] `cedarling` version is currently `0.0.0` — the release-trigger's `version_bump.py` will bump it; trigger the publish workflow after the release tag is pushed

## Test plan
- [ ] Verify `cargo_audit` CI job no longer hits rate limits on PRs
- [ ] Run publish workflow with `dry_run=true` against a release tag to confirm packaging succeeds
Closes #14446, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered release workflow to publish the Cedarling and HTTP utilities crates, including the ability to select a ref and run a dry run before publishing.
  * Enabled both crates to be published to the registry.

* **Chores**
  * Updated security auditing to run directly with improved advisory database caching and local handling.
  * Added safeguards to prevent overlapping publish runs and improve overall release reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->