### PR TITLE
fix(jans-cedarling): flush telemetry on receive

### DIFF
--- a/jans-cedarling/cedarling/src/lock/log_worker.rs
+++ b/jans-cedarling/cedarling/src/lock/log_worker.rs
@@ -66,18 +66,21 @@ where
                 entry = rx.next() => {
                     let Some(entry) = entry else { break; };
                     self.buffer.push_back(entry);
+                    if matches!(self.kind, AuditKind::Telemetry(_)) {
+                        self.flush(Some(&cancel_tkn)).await;
+                    }
                 },
 
                 // Send logs to the server
                 _ = flush_tick.tick() => {
-                    self.flush(&cancel_tkn).await;
+                    self.flush(Some(&cancel_tkn)).await;
                 },
 
                 () = cancel_tkn.cancelled() => {
                     while let Ok(entry) = rx.try_recv() {
                         self.buffer.push_back(entry);
                     }
-                    self.flush(&cancel_tkn).await;
+                    self.flush(None).await;
                     self.logger
                         .as_ref()
                         .and_then(std::sync::Weak::upgrade)
@@ -91,7 +94,7 @@ where
         }
     }
 
-    async fn flush(&mut self, cancel_tkn: &CancellationToken) {
+    async fn flush(&mut self, cancel_tkn: Option<&CancellationToken>) {
         // save the length at the time the function is called
         let batch_size = self.buffer.len();
         if batch_size == 0 {
@@ -118,14 +121,21 @@ where
                         self.kind,
                     )));
 
-                    tokio::select! {
-                        _ = backoff.snooze() => {},
-                        () = cancel_tkn.cancelled() => {
-                            logger.log_any(LockLogEntry::warn(format!(
-                                "cancellation requested during retry; dropping {batch_size} {} entries",
-                                self.kind,
-                            )));
-                            break;
+                    match cancel_tkn {
+                        Some(tkn) => {
+                            tokio::select! {
+                                _ = backoff.snooze() => {},
+                                () = tkn.cancelled() => {
+                                    logger.log_any(LockLogEntry::warn(format!(
+                                        "cancellation requested during retry; dropping {batch_size} {} entries",
+                                        self.kind,
+                                    )));
+                                    break;
+                                },
+                            }
+                        },
+                        None => {
+                            let _ = backoff.snooze().await;
                         },
                     }
                 },

--- a/jans-cedarling/cedarling/src/lock/log_worker.rs
+++ b/jans-cedarling/cedarling/src/lock/log_worker.rs
@@ -124,7 +124,15 @@ where
                     match cancel_tkn {
                         Some(tkn) => {
                             tokio::select! {
-                                _ = backoff.snooze() => {},
+                                result = backoff.snooze() => {
+                                    if result.is_err() {
+                                        logger.log_any(LockLogEntry::warn(format!(
+                                            "retries exhausted; dropping {batch_size} {} entries",
+                                            self.kind,
+                                        )));
+                                        break;
+                                    }
+                                },
                                 () = tkn.cancelled() => {
                                     logger.log_any(LockLogEntry::warn(format!(
                                         "cancellation requested during retry; dropping {batch_size} {} entries",
@@ -135,7 +143,13 @@ where
                             }
                         },
                         None => {
-                            let _ = backoff.snooze().await;
+                            if backoff.snooze().await.is_err() {
+                                logger.log_any(LockLogEntry::warn(format!(
+                                    "retries exhausted; dropping {batch_size} {} entries",
+                                    self.kind,
+                                )));
+                                break;
+                            }
                         },
                     }
                 },


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14395

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit log flushing so telemetry entries are dispatched immediately after buffering, while other buffered entries continue to flush on the normal tick cadence.
  * Updated flush retry/backoff behavior to respect cancellation during regular operation, preventing stalled or unnecessary retries.
  * Refined shutdown handling to drain any immediately available entries and perform a final flush to reduce the risk of losing pending logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->