### PR TITLE
docs(jans-cedarling): clarify exp/nbf validation is conditional in authz table

### DIFF
--- a/docs/cedarling/reference/cedarling-authz.md
+++ b/docs/cedarling/reference/cedarling-authz.md
@@ -54,7 +54,7 @@ Cedarling provides two authorization methods. Choose the one that fits your depl
 | | `authorize_multi_issuer` | `authorize_unsigned` |
 |---|---|---|
 | **When to use** | You have JWT tokens from trusted IDPs and want Cedarling to validate them | Your application has already authenticated the principal and wants to pass raw entity data directly |
-| **JWT validation** | Yes — full signature, expiration, and status validation | No — accepts raw entity data as-is |
+| **JWT validation** | Yes — signature and status validation; `exp`/`nbf` are validated when listed in `required_claims` | No — accepts raw entity data as-is |
 | **Principal source** | Derived from JWT token claims | Supplied directly by the application |
 | **Typical scenarios** | Production apps with OIDC/OAuth IDPs, federation, API gateways | Custom auth flows, testing, service-to-service with upstream verification |
 | **Security model** | Higher — Cedarling independently verifies token authenticity | Lower — trusts the calling application |


### PR DESCRIPTION
### Description

The `authorize_multi_issuer` vs `authorize_unsigned` comparison table in `docs/cedarling/reference/cedarling-authz.md` claims JWT validation always includes expiration checking. It doesn't: `exp`/`nbf` are validated only when present in a token's `required_claims`, which defaults to an empty set. This PR rewords the table cell to state the conditional behavior, matching what `cedarling-jwt-validation.md` already says.

#### Implementation Details

- In `docs/cedarling/reference/cedarling-authz.md`, change the "JWT validation" row's `authorize_multi_issuer` cell

-------------------
### Test and Document the changes

- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)
      Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
      Closes #14472,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the comparison between the two authorization options.
  * Updated the validation details so one method is described as accepting raw entity data without JWT validation, while the other now clearly notes signature and status checks, with time-based claims validated only when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->