### PR TITLE
fix(jans-cedarling):  make constants BUILD_COMMIT and BUILD_TIMESTAMPprivate

### DIFF
--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -76,10 +76,10 @@ use semver::Version;
 
 /// Git commit hash at build time (`None` if git is unavailable or
 /// `CEDARLING_BUILD_COMMIT` was not set at compile time).
-pub const BUILD_COMMIT: Option<&str> = option_env!("CEDARLING_BUILD_COMMIT");
+const BUILD_COMMIT: Option<&str> = option_env!("CEDARLING_BUILD_COMMIT");
 /// Build timestamp in RFC 3339 format (`None` if
 /// `CEDARLING_BUILD_TIMESTAMP` was not set at compile time).
-pub const BUILD_TIMESTAMP: Option<&str> = option_env!("CEDARLING_BUILD_TIMESTAMP");
+const BUILD_TIMESTAMP: Option<&str> = option_env!("CEDARLING_BUILD_TIMESTAMP");
 
 #[doc(hidden)]
 pub mod bindings {


### PR DESCRIPTION


### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14500

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->
Suppress public visibility of constants  `BUILD_COMMIT` and `BUILD_TIMESTAMP`
-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal build information handling so it is no longer exposed publicly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->