### PR TITLE
feat(jans-fido2): enforce TPM attestation certificate requirements

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/TPMProcessor.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/TPMProcessor.java
@@ -26,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -162,6 +163,8 @@ public class TPMProcessor implements AttestationFormatProcessor {
 				verifyAIKCertificate(aikCertificate, verifiedCert);
 
 				verifyTPMCertificateExtenstion(aikCertificate, authData);
+
+				verifyTpmAttestationCertRequirements(aikCertificate);
 
 				String signature = commonVerifiers.verifyBase64String(attStmt.get("sig"));
 				byte[] certInfoBuffer = base64Service.decode(certInfo);
@@ -332,6 +335,44 @@ public class TPMProcessor implements AttestationFormatProcessor {
 				throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
 						"Problem with TPM attestation : AAGUID in AIK certificate does not match authenticator data");
 			}
+		}
+	}
+
+	/**
+	 * Verify that the AIK certificate satisfies the TPM attestation statement
+	 * certificate requirements (WebAuthn Level 2, section 8.3.1).
+	 */
+	void verifyTpmAttestationCertRequirements(X509Certificate aikCertificate) {
+		// Version MUST be set to 3.
+		if (aikCertificate.getVersion() != 3) {
+			throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
+					"TPM attestation certificate version must be 3");
+		}
+		// Subject field MUST be set to empty.
+		if (!aikCertificate.getSubjectX500Principal().getName().isEmpty()) {
+			throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
+					"TPM attestation certificate subject must be empty");
+		}
+		// Basic Constraints extension MUST have the CA component set to false.
+		if (aikCertificate.getBasicConstraints() != -1) {
+			throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
+					"TPM attestation certificate must not be a CA certificate");
+		}
+		try {
+			// Extended Key Usage MUST contain tcg-kp-AIKCertificate (2.23.133.8.3).
+			List<String> extendedKeyUsage = aikCertificate.getExtendedKeyUsage();
+			if (extendedKeyUsage == null || !extendedKeyUsage.contains("2.23.133.8.3")) {
+				throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
+						"TPM attestation certificate must contain the tcg-kp-AIKCertificate extended key usage");
+			}
+			// Subject Alternative Name extension MUST be present.
+			if (aikCertificate.getSubjectAlternativeNames() == null) {
+				throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
+						"TPM attestation certificate must contain a subject alternative name");
+			}
+		} catch (CertificateParsingException e) {
+			throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
+					"Problem parsing TPM attestation certificate extensions: " + e.getMessage(), e);
 		}
 	}
 

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/TPMProcessorCertRequirementsTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/processor/attestation/TPMProcessorCertRequirementsTest.java
@@ -1,0 +1,158 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.processor.attestation;
+
+import io.jans.fido2.model.attestation.AttestationErrorResponseType;
+import io.jans.fido2.model.error.ErrorResponseFactory;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TPMProcessorCertRequirementsTest {
+
+    private static final String OID_AIK_CERTIFICATE = "2.23.133.8.3";
+
+    @InjectMocks
+    private TPMProcessor tpmProcessor;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    private X509Certificate compliantAikCertificate() throws Exception {
+        X509Certificate aikCertificate = mock(X509Certificate.class);
+        when(aikCertificate.getVersion()).thenReturn(3);
+        when(aikCertificate.getSubjectX500Principal()).thenReturn(new X500Principal(""));
+        when(aikCertificate.getBasicConstraints()).thenReturn(-1);
+        when(aikCertificate.getExtendedKeyUsage()).thenReturn(Collections.singletonList(OID_AIK_CERTIFICATE));
+        doReturn(Collections.singletonList(Collections.singletonList("tpm.example")))
+                .when(aikCertificate).getSubjectAlternativeNames();
+        return aikCertificate;
+    }
+
+    @Test
+    void verifyTpmAttestationCertRequirements_compliantCertificate_passes() throws Exception {
+        X509Certificate aikCertificate = compliantAikCertificate();
+        assertDoesNotThrow(() -> tpmProcessor.verifyTpmAttestationCertRequirements(aikCertificate));
+    }
+
+    @Test
+    void verifyTpmAttestationCertRequirements_versionNotThree_rejected() {
+        X509Certificate aikCertificate = mock(X509Certificate.class);
+        when(aikCertificate.getVersion()).thenReturn(1);
+        stubBadRequest();
+
+        WebApplicationException res = assertThrows(WebApplicationException.class,
+                () -> tpmProcessor.verifyTpmAttestationCertRequirements(aikCertificate));
+        assertResponse(res);
+    }
+
+    @Test
+    void verifyTpmAttestationCertRequirements_subjectNotEmpty_rejected() {
+        X509Certificate aikCertificate = mock(X509Certificate.class);
+        when(aikCertificate.getVersion()).thenReturn(3);
+        when(aikCertificate.getSubjectX500Principal()).thenReturn(new X500Principal("CN=should-be-empty"));
+        stubBadRequest();
+
+        WebApplicationException res = assertThrows(WebApplicationException.class,
+                () -> tpmProcessor.verifyTpmAttestationCertRequirements(aikCertificate));
+        assertResponse(res);
+    }
+
+    @Test
+    void verifyTpmAttestationCertRequirements_caCertificate_rejected() {
+        X509Certificate aikCertificate = mock(X509Certificate.class);
+        when(aikCertificate.getVersion()).thenReturn(3);
+        when(aikCertificate.getSubjectX500Principal()).thenReturn(new X500Principal(""));
+        when(aikCertificate.getBasicConstraints()).thenReturn(0);
+        stubBadRequest();
+
+        WebApplicationException res = assertThrows(WebApplicationException.class,
+                () -> tpmProcessor.verifyTpmAttestationCertRequirements(aikCertificate));
+        assertResponse(res);
+    }
+
+    @Test
+    void verifyTpmAttestationCertRequirements_missingAikExtendedKeyUsage_rejected() throws Exception {
+        X509Certificate aikCertificate = mock(X509Certificate.class);
+        when(aikCertificate.getVersion()).thenReturn(3);
+        when(aikCertificate.getSubjectX500Principal()).thenReturn(new X500Principal(""));
+        when(aikCertificate.getBasicConstraints()).thenReturn(-1);
+        when(aikCertificate.getExtendedKeyUsage()).thenReturn(Collections.singletonList("1.3.6.1.5.5.7.3.1"));
+        stubBadRequest();
+
+        WebApplicationException res = assertThrows(WebApplicationException.class,
+                () -> tpmProcessor.verifyTpmAttestationCertRequirements(aikCertificate));
+        assertResponse(res);
+    }
+
+    @Test
+    void verifyTpmAttestationCertRequirements_missingSubjectAlternativeName_rejected() throws Exception {
+        X509Certificate aikCertificate = mock(X509Certificate.class);
+        when(aikCertificate.getVersion()).thenReturn(3);
+        when(aikCertificate.getSubjectX500Principal()).thenReturn(new X500Principal(""));
+        when(aikCertificate.getBasicConstraints()).thenReturn(-1);
+        when(aikCertificate.getExtendedKeyUsage()).thenReturn(Collections.singletonList(OID_AIK_CERTIFICATE));
+        doReturn(null).when(aikCertificate).getSubjectAlternativeNames();
+        stubBadRequest();
+
+        WebApplicationException res = assertThrows(WebApplicationException.class,
+                () -> tpmProcessor.verifyTpmAttestationCertRequirements(aikCertificate));
+        assertResponse(res);
+    }
+
+    @Test
+    void verifyTpmAttestationCertRequirements_certificateParsingException_propagatesCause() throws Exception {
+        X509Certificate aikCertificate = mock(X509Certificate.class);
+        when(aikCertificate.getVersion()).thenReturn(3);
+        when(aikCertificate.getSubjectX500Principal()).thenReturn(new X500Principal(""));
+        when(aikCertificate.getBasicConstraints()).thenReturn(-1);
+        CertificateParsingException parsingException = new CertificateParsingException("malformed extension");
+        when(aikCertificate.getExtendedKeyUsage()).thenThrow(parsingException);
+        when(errorResponseFactory.badRequestException(any(AttestationErrorResponseType.class), anyString(),
+                any(Throwable.class)))
+                .thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+
+        WebApplicationException res = assertThrows(WebApplicationException.class,
+                () -> tpmProcessor.verifyTpmAttestationCertRequirements(aikCertificate));
+        assertResponse(res);
+
+        ArgumentCaptor<Throwable> causeCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(errorResponseFactory).badRequestException(any(AttestationErrorResponseType.class), anyString(),
+                causeCaptor.capture());
+        org.junit.jupiter.api.Assertions.assertSame(parsingException, causeCaptor.getValue());
+    }
+
+    private void stubBadRequest() {
+        when(errorResponseFactory.badRequestException(any(AttestationErrorResponseType.class), anyString()))
+                .thenThrow(new WebApplicationException(Response.status(400).entity("test exception").build()));
+    }
+
+    private void assertResponse(WebApplicationException res) {
+        org.junit.jupiter.api.Assertions.assertNotNull(res);
+        org.junit.jupiter.api.Assertions.assertEquals(400, res.getResponse().getStatus());
+    }
+}


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
   Adds verifyTpmAttestationCertRequirements(...) to TPMProcessor, invoked during TPM attestation verification, enforcing  the WebAuthn §8.3.1 AIK certificate requirements: Version 3, empty Subject, Basic Constraints CA = false, Extended Key Usage containing tcg-kp-AIKCertificate (2.23.133.8.3), and a present Subject Alternative Name. Non-conformant AIK certificates are rejected with a TPM attestation error.

#### Target issue
  The FIDO2 server validates the TPM attestation certificate chain, but it does not verify that the AIK (attestation)
  certificate itself satisfies the structural requirements defined in the WebAuthn specification (§8.3.1, "TPM
  Attestation Statement Certificate Requirements"). A malformed or non-conformant AIK certificate (e.g. wrong version,
  non-empty subject, CA certificate, or missing the AIK Extended Key Usage) is currently accepted.
  
closes #14374 

#### Implementation Details
   - Uses only standard java.security.cert.X509Certificate accessors; no new dependencies.
  - Certificate-parsing failures propagate the original exception as the cause.
  - New unit test TPMProcessorCertRequirementsTest covers the compliant case and each individual requirement violation.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened TPM attestation certificate validation to better align with WebAuthn Level 2 requirements.
  * Certificates now must meet additional checks before attestation continues, including expected version, empty subject, non-CA status, required extended key usage, and subject alternative name presence.
  * Improved error handling when certificate data cannot be parsed, returning a clearer request error.

* **Tests**
  * Added coverage for valid and invalid TPM attestation certificate cases, including parsing-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->