### PR TITLE
fix(jans-cli-tui): dipslay no scopes available message

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/edit_client_dialog.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/edit_client_dialog.py
@@ -1213,6 +1213,11 @@ class EditClientDialog(JansGDialog, DialogUtils):
 
             scopes_list.sort(key=lambda x: x[1])
 
+        if not scopes_list:
+            self.myparent.show_message(_(common_strings.oops), _(
+                "No scope available to add."))
+            return
+
         def on_text_changed(event):
             search_text = event.text
             matching_items = []
@@ -1237,11 +1242,6 @@ class EditClientDialog(JansGDialog, DialogUtils):
         )
 
         ta.buffer.on_text_changed += on_text_changed
-
-        if not scopes_list:
-            self.myparent.show_message(_(common_strings.oops), _(
-                "No scope available to add."))
-            return
 
         self.add_scope_checkbox.values = scopes_list
         self.add_scope_frame = Frame(

--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/edit_client_dialog.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/edit_client_dialog.py
@@ -1238,6 +1238,11 @@ class EditClientDialog(JansGDialog, DialogUtils):
 
         ta.buffer.on_text_changed += on_text_changed
 
+        if not scopes_list:
+            self.myparent.show_message(_(common_strings.oops), _(
+                "No scope available to add."))
+            return
+
         self.add_scope_checkbox.values = scopes_list
         self.add_scope_frame = Frame(
             title="Checkbox list",


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14164

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope management when editing clients.
  * Now shows a clear “No scope available to add” message and stops the flow when there are no scopes available, avoiding unnecessary UI and filtering actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->