### PR TITLE
fix(jans-auth-server): added safeguards for sector_identifier_uri in Dynamic Client Registration #14540

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/registration/RegisterParamsValidator.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/registration/RegisterParamsValidator.java
@@ -20,12 +20,12 @@ import io.jans.as.model.register.RegisterErrorResponseType;
 import io.jans.as.model.util.Pair;
 import io.jans.as.model.util.URLPatternList;
 import io.jans.as.model.util.Util;
+import io.jans.as.server.service.net.SectorIdentifierUriService;
 import io.jans.as.server.util.ServerUtil;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
@@ -56,6 +56,9 @@ public class RegisterParamsValidator {
 
     @Inject
     private ErrorResponseFactory errorResponseFactory;
+
+    @Inject
+    private SectorIdentifierUriService sectorIdentifierUriService;
 
     private static final String HTTP = "http";
     private static final String HTTPS = "https";
@@ -405,33 +408,25 @@ public class RegisterParamsValidator {
         // Validate Sector Identifier URL
         boolean noRedirectUriInSectorIdentifierUri = false;
         if (valid && StringUtils.isNotBlank(sectorIdentifierUrl)) {
-            try {
-                URI uri = new URI(sectorIdentifierUrl);
-                if (!HTTPS.equalsIgnoreCase(uri.getScheme())) {
-                    valid = false;
-                }
-
-                jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newClient();
-                String entity = null;
+            if (!sectorIdentifierUriService.isAllowedSectorIdentifierUri(sectorIdentifierUrl)) {
+                valid = false;
+                noRedirectUriInSectorIdentifierUri = true;
+            } else {
                 try {
-                    Response clientResponse = clientRequest.target(sectorIdentifierUrl).request().buildGet().invoke();
-                    int status = clientResponse.getStatus();
-
-                    if (status == 200) {
-                        entity = clientResponse.readEntity(String.class);
-
+                    String entity = sectorIdentifierUriService.fetchSectorIdentifierContent(sectorIdentifierUrl);
+                    if (StringUtils.isNotBlank(entity)) {
                         JSONArray sectorIdentifierJsonArray = new JSONArray(entity);
                         valid = Util.asList(sectorIdentifierJsonArray).containsAll(redirectUris);
+                    } else {
+                        valid = false;
                     }
+                } catch (Exception e) {
+                    log.debug(e.getMessage(), e);
+                    valid = false;
                 } finally {
-                    clientRequest.close();
-                }
-            } catch (Exception e) {
-                log.debug(e.getMessage(), e);
-                valid = false;
-            } finally {
-                if (!valid) {
-                    noRedirectUriInSectorIdentifierUri = true;
+                    if (!valid) {
+                        noRedirectUriInSectorIdentifierUri = true;
+                    }
                 }
             }
         }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectionUriService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/RedirectionUriService.java
@@ -15,13 +15,12 @@ import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
 import io.jans.as.model.session.EndSessionErrorResponseType;
 import io.jans.as.model.util.QueryStringDecoder;
-import io.jans.as.model.util.URLPatternList;
 import io.jans.as.model.util.Util;
+import io.jans.as.server.service.net.SectorIdentifierUriService;
 import io.jans.as.server.session.ws.rs.EndSessionService;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -34,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author Javier Rojas Blum
@@ -61,6 +59,9 @@ public class RedirectionUriService {
     @Inject
     private EndSessionService endSessionService;
 
+    @Inject
+    private SectorIdentifierUriService sectorIdentifierUriService;
+
     public String validateRedirectionUri(String clientIdentifier, String redirectionUri) {
         Client client = clientService.getClient(clientIdentifier);
         if (client == null) {
@@ -75,7 +76,7 @@ public class RedirectionUriService {
             return result;
         }
 
-        if (!isAllowedSectorIdentifierUri(sectorIdentiferUri)) {
+        if (!sectorIdentifierUriService.isAllowedSectorIdentifierUri(sectorIdentiferUri)) {
             return result;
         }
 
@@ -84,7 +85,7 @@ public class RedirectionUriService {
             return sectorRedirectUris;
         }
 
-        String entity = fetchSectorIdentifierContent(sectorIdentiferUri);
+        String entity = sectorIdentifierUriService.fetchSectorIdentifierContent(sectorIdentiferUri);
         if (StringUtils.isBlank(entity)) {
             return result;
         }
@@ -96,42 +97,6 @@ public class RedirectionUriService {
         }
         localResponseCache.putSectorRedirectUris(sectorIdentiferUri, result);
         return result;
-    }
-
-    boolean isAllowedSectorIdentifierUri(String sectorIdentiferUri) {
-        try {
-            java.net.URI uri = new java.net.URI(sectorIdentiferUri);
-            if (!"https".equalsIgnoreCase(uri.getScheme())) {
-                log.warn("sector_identifier_uri must use https scheme, got: {}", sectorIdentiferUri);
-                return false;
-            }
-        } catch (java.net.URISyntaxException e) {
-            log.warn("sector_identifier_uri is not a valid URI: {}", sectorIdentiferUri);
-            return false;
-        }
-
-        final List<String> blockList = appConfiguration.getRequestUriBlockList();
-        if (blockList != null && !blockList.isEmpty()) {
-            URLPatternList urlPatternList = new URLPatternList(blockList);
-            if (urlPatternList.isUrlListed(sectorIdentiferUri)) {
-                log.warn("sector_identifier_uri is forbidden by block list: {}", sectorIdentiferUri);
-                return false;
-            }
-        }
-        return true;
-    }
-
-    String fetchSectorIdentifierContent(String sectorIdentiferUri) {
-        try (jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newBuilder()
-                .connectTimeout(5, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
-                .build();
-             Response clientResponse = clientRequest.target(sectorIdentiferUri).request().buildGet().invoke()) {
-            if (clientResponse.getStatus() != 200) {
-                return null;
-            }
-            return clientResponse.readEntity(String.class);
-        }
     }
 
     public String validateRedirectionUri(@NotNull Client client, String redirectionUri) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/SectorIdentifierUriService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/SectorIdentifierUriService.java
@@ -1,0 +1,76 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.as.server.service.net;
+
+import io.jans.as.model.configuration.AppConfiguration;
+import io.jans.as.model.util.URLPatternList;
+import jakarta.ejb.Stateless;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.slf4j.Logger;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared validation and fetching for client-supplied sector_identifier_uri values, used both at
+ * client registration time ({@code RegisterParamsValidator}) and at authorization time
+ * ({@code RedirectionUriService}). Enforces https-only scheme and the {@code requestUriBlockList}
+ * before any outbound request is made, to prevent SSRF via sector_identifier_uri.
+ *
+ * @author Yuriy Z
+ */
+@Stateless
+@Named
+public class SectorIdentifierUriService {
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private AppConfiguration appConfiguration;
+
+    public boolean isAllowedSectorIdentifierUri(String sectorIdentifierUri) {
+        try {
+            URI uri = new URI(sectorIdentifierUri);
+            if (!"https".equalsIgnoreCase(uri.getScheme())) {
+                log.warn("sector_identifier_uri must use https scheme, got: {}", sectorIdentifierUri);
+                return false;
+            }
+        } catch (URISyntaxException e) {
+            log.warn("sector_identifier_uri is not a valid URI: {}", sectorIdentifierUri);
+            return false;
+        }
+
+        final List<String> blockList = appConfiguration.getRequestUriBlockList();
+        if (blockList != null && !blockList.isEmpty()) {
+            URLPatternList urlPatternList = new URLPatternList(blockList);
+            if (urlPatternList.isUrlListed(sectorIdentifierUri)) {
+                log.warn("sector_identifier_uri is forbidden by block list: {}", sectorIdentifierUri);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public String fetchSectorIdentifierContent(String sectorIdentifierUri) {
+        try (jakarta.ws.rs.client.Client clientRequest = ClientBuilder.newBuilder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
+             Response clientResponse = clientRequest.target(sectorIdentifierUri).request().buildGet().invoke()) {
+            if (clientResponse.getStatus() != 200) {
+                return null;
+            }
+            return clientResponse.readEntity(String.class);
+        }
+    }
+}

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/SectorIdentifierUriService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/SectorIdentifierUriService.java
@@ -13,10 +13,13 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -39,14 +42,20 @@ public class SectorIdentifierUriService {
     private AppConfiguration appConfiguration;
 
     public boolean isAllowedSectorIdentifierUri(String sectorIdentifierUri) {
+        URI uri;
         try {
-            URI uri = new URI(sectorIdentifierUri);
+            uri = new URI(sectorIdentifierUri);
             if (!"https".equalsIgnoreCase(uri.getScheme())) {
                 log.warn("sector_identifier_uri must use https scheme, got: {}", sectorIdentifierUri);
                 return false;
             }
         } catch (URISyntaxException e) {
             log.warn("sector_identifier_uri is not a valid URI: {}", sectorIdentifierUri);
+            return false;
+        }
+
+        if (isPrivateOrUnresolvableHost(uri.getHost())) {
+            log.warn("sector_identifier_uri resolves to a private, loopback or unresolvable host: {}", uri.getHost());
             return false;
         }
 
@@ -59,6 +68,36 @@ public class SectorIdentifierUriService {
             }
         }
         return true;
+    }
+
+    /**
+     * Resolves all IP addresses for the host and reports true if any resolves to a private/loopback/link-local
+     * address, or if the host cannot be resolved at all (fail closed). Checking all records (not just the first)
+     * mitigates DNS round-robin evasion.
+     */
+    boolean isPrivateOrUnresolvableHost(String host) {
+        if (StringUtils.isBlank(host)) {
+            return true;
+        }
+        try {
+            for (InetAddress address : InetAddress.getAllByName(host)) {
+                if (isPrivateAddress(address)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (UnknownHostException e) {
+            log.warn("Unable to resolve host for sector_identifier_uri: {}", host);
+            return true;
+        }
+    }
+
+    boolean isPrivateAddress(InetAddress address) {
+        return address.isLoopbackAddress()
+                || address.isSiteLocalAddress()
+                || address.isLinkLocalAddress()
+                || address.isAnyLocalAddress()
+                || address.isMulticastAddress();
     }
 
     public String fetchSectorIdentifierContent(String sectorIdentifierUri) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/SectorIdentifierUriService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/SectorIdentifierUriService.java
@@ -93,11 +93,16 @@ public class SectorIdentifierUriService {
     }
 
     boolean isPrivateAddress(InetAddress address) {
-        return address.isLoopbackAddress()
+        if (address.isLoopbackAddress()
                 || address.isSiteLocalAddress()
                 || address.isLinkLocalAddress()
                 || address.isAnyLocalAddress()
-                || address.isMulticastAddress();
+                || address.isMulticastAddress()) {
+            return true;
+        }
+        // IPv6 Unique Local Addresses (fc00::/7) are not covered by isSiteLocalAddress()
+        byte[] bytes = address.getAddress();
+        return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC;
     }
 
     public String fetchSectorIdentifierContent(String sectorIdentifierUri) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/model/registration/RegisterParamsValidatorTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/model/registration/RegisterParamsValidatorTest.java
@@ -10,6 +10,7 @@ import io.jans.as.model.crypto.signature.SignatureAlgorithm;
 import io.jans.as.model.error.ErrorResponseFactory;
 import io.jans.as.model.register.ApplicationType;
 import io.jans.as.model.register.RegisterErrorResponseType;
+import io.jans.as.server.service.net.SectorIdentifierUriService;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.mockito.InjectMocks;
@@ -44,6 +45,9 @@ public class RegisterParamsValidatorTest {
 
     @Mock
     private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private SectorIdentifierUriService sectorIdentifierUriService;
 
     // ---- WEB application type ----
     @Test
@@ -360,6 +364,45 @@ public class RegisterParamsValidatorTest {
         } catch (WebApplicationException e) {
             verify(errorResponseFactory, times(1)).createWebApplicationException(eq(Response.Status.BAD_REQUEST), eq(RegisterErrorResponseType.INVALID_CLIENT_METADATA), any());
         }
+    }
+
+    @Test
+    public void validateRedirectUris_sectorIdentifierNotAllowed_shouldSkipFetchAndThrow() {
+        when(sectorIdentifierUriService.isAllowedSectorIdentifierUri("http://169.254.169.254/latest/meta-data/")).thenReturn(false);
+        when(errorResponseFactory.createWebApplicationException(any(), any(), any())).thenCallRealMethod();
+
+        try {
+            registerParamsValidator.validateRedirectUris(
+                    Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+                    Collections.singletonList(ResponseType.CODE),
+                    ApplicationType.WEB,
+                    SubjectType.PUBLIC,
+                    Collections.singletonList("https://example.com/cb"),
+                    "http://169.254.169.254/latest/meta-data/");
+        } catch (WebApplicationException e) {
+            verify(errorResponseFactory, times(1)).createWebApplicationException(eq(Response.Status.BAD_REQUEST), eq(RegisterErrorResponseType.INVALID_CLIENT_METADATA), any());
+        }
+        verify(sectorIdentifierUriService, never()).fetchSectorIdentifierContent(anyString());
+    }
+
+    @Test
+    public void validateRedirectUris_sectorIdentifierAllowedAndContainsRedirectUris_shouldReturnTrue() {
+        when(appConfiguration.getClientWhiteList()).thenReturn(Collections.singletonList("*"));
+        when(appConfiguration.getClientBlackList()).thenReturn(Collections.emptyList());
+        when(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://rp.example/sector.json")).thenReturn(true);
+        when(sectorIdentifierUriService.fetchSectorIdentifierContent("https://rp.example/sector.json"))
+                .thenReturn("[\"https://example.com/cb\"]");
+
+        boolean result = registerParamsValidator.validateRedirectUris(
+                Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+                Collections.singletonList(ResponseType.CODE),
+                ApplicationType.WEB,
+                SubjectType.PUBLIC,
+                Collections.singletonList("https://example.com/cb"),
+                "https://rp.example/sector.json");
+
+        assertTrue(result);
+        verify(sectorIdentifierUriService).fetchSectorIdentifierContent("https://rp.example/sector.json");
     }
 
     @Test

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/RedirectionUriServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/RedirectionUriServiceTest.java
@@ -1,9 +1,9 @@
 package io.jans.as.server.service;
 
-import com.google.common.collect.Lists;
 import io.jans.as.common.model.registration.Client;
 import io.jans.as.model.configuration.AppConfiguration;
 import io.jans.as.model.error.ErrorResponseFactory;
+import io.jans.as.server.service.net.SectorIdentifierUriService;
 import io.jans.as.server.session.ws.rs.EndSessionService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -44,6 +44,9 @@ public class RedirectionUriServiceTest {
 
     @Mock
     private EndSessionService endSessionService;
+
+    @Mock
+    private SectorIdentifierUriService sectorIdentifierUriService;
 
     @Test
     public void validatePostLogoutRedirectUri_whenAllowedByClientWhiteList_shouldReturnUrl() {
@@ -140,46 +143,23 @@ public class RedirectionUriServiceTest {
     }
 
     @Test
-    public void getSectorRedirectUris_whenHttpScheme_shouldReturnEmptyAndSkipFetch() {
+    public void getSectorRedirectUris_whenNotAllowed_shouldReturnEmptyAndSkipFetch() {
+        when(sectorIdentifierUriService.isAllowedSectorIdentifierUri("http://169.254.169.254/latest/meta-data/")).thenReturn(false);
+
         final List<String> result = redirectionUriService.getSectorRedirectUris("http://169.254.169.254/latest/meta-data/");
         assertTrue(result.isEmpty());
-        verify(redirectionUriService, never()).fetchSectorIdentifierContent(anyString());
+        verify(sectorIdentifierUriService, never()).fetchSectorIdentifierContent(anyString());
     }
 
     @Test
-    public void getSectorRedirectUris_whenHttpsAndBlocklisted_shouldReturnEmptyAndSkipFetch() {
-        when(appConfiguration.getRequestUriBlockList()).thenReturn(Lists.newArrayList("https://internal.example/*"));
-
-        final List<String> result = redirectionUriService.getSectorRedirectUris("https://internal.example/sector.json");
-        assertTrue(result.isEmpty());
-        verify(redirectionUriService, never()).fetchSectorIdentifierContent(anyString());
-    }
-
-    @Test
-    public void getSectorRedirectUris_whenMalformedUri_shouldReturnEmptyAndSkipFetch() {
-        final List<String> result = redirectionUriService.getSectorRedirectUris("not a uri");
-        assertTrue(result.isEmpty());
-        verify(redirectionUriService, never()).fetchSectorIdentifierContent(anyString());
-    }
-
-    @Test
-    public void getSectorRedirectUris_whenHttpsAndAllowed_shouldInvokeFetch() {
+    public void getSectorRedirectUris_whenAllowed_shouldInvokeFetch() {
+        when(sectorIdentifierUriService.isAllowedSectorIdentifierUri(anyString())).thenReturn(true);
         when(localResponseCache.getSectorRedirectUris(anyString())).thenReturn(null);
-        doReturn(null).when(redirectionUriService).fetchSectorIdentifierContent(anyString());
+        when(sectorIdentifierUriService.fetchSectorIdentifierContent(anyString())).thenReturn(null);
 
         final List<String> result = redirectionUriService.getSectorRedirectUris("https://rp.example/sector.json");
         assertTrue(result.isEmpty());
-        verify(redirectionUriService).fetchSectorIdentifierContent("https://rp.example/sector.json");
-    }
-
-    @Test
-    public void isAllowedSectorIdentifierUri_httpsWithoutBlocklist_returnsTrue() {
-        assertTrue(redirectionUriService.isAllowedSectorIdentifierUri("https://rp.example/sector.json"));
-    }
-
-    @Test
-    public void isAllowedSectorIdentifierUri_httpScheme_returnsFalse() {
-        assertFalse(redirectionUriService.isAllowedSectorIdentifierUri("http://rp.example/sector.json"));
+        verify(sectorIdentifierUriService).fetchSectorIdentifierContent("https://rp.example/sector.json");
     }
 
     private Client getClientForValidateRedirectionUri_full() {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
@@ -1,0 +1,64 @@
+package io.jans.as.server.service.net;
+
+import com.google.common.collect.Lists;
+import io.jans.as.model.configuration.AppConfiguration;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class SectorIdentifierUriServiceTest {
+
+    @InjectMocks
+    private SectorIdentifierUriService sectorIdentifierUriService;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Test
+    public void isAllowedSectorIdentifierUri_httpsWithoutBlockList_shouldReturnTrue() {
+        assertTrue(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://rp.example/sector.json"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_httpScheme_shouldReturnFalse() {
+        assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("http://169.254.169.254/latest/meta-data/"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_nonHttpsScheme_shouldReturnFalseWithoutEvaluatingBlockList() {
+        assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("file:///etc/passwd"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_malformedUri_shouldReturnFalse() {
+        assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("not a uri"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_httpsAndBlockListed_shouldReturnFalse() {
+        when(appConfiguration.getRequestUriBlockList()).thenReturn(Lists.newArrayList("https://internal.example/*"));
+
+        assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://internal.example/sector.json"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_httpsAndNotBlockListed_shouldReturnTrue() {
+        when(appConfiguration.getRequestUriBlockList()).thenReturn(Lists.newArrayList("https://internal.example/*"));
+
+        assertTrue(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://rp.example/sector.json"));
+    }
+}

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
@@ -14,6 +14,8 @@ import java.net.InetAddress;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -49,6 +51,7 @@ public class SectorIdentifierUriServiceTest {
     @Test
     public void isAllowedSectorIdentifierUri_nonHttpsScheme_shouldReturnFalseWithoutEvaluatingBlockList() {
         assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("file:///etc/passwd"));
+        verify(appConfiguration, never()).getRequestUriBlockList();
     }
 
     @Test

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
@@ -90,19 +90,24 @@ public class SectorIdentifierUriServiceTest {
         assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://10.0.0.5/sector.json"));
     }
 
-    @Test
+    `@Test`
     public void isPrivateOrUnresolvableHost_loopbackIpLiteral_shouldReturnTrue() {
         assertTrue(sectorIdentifierUriService.isPrivateOrUnresolvableHost("127.0.0.1"));
     }
 
-    @Test
+    `@Test`
     public void isPrivateOrUnresolvableHost_blankHost_shouldReturnTrue() {
         assertTrue(sectorIdentifierUriService.isPrivateOrUnresolvableHost(""));
     }
 
-    @Test
+    `@Test`
     public void isPrivateOrUnresolvableHost_publicIpLiteral_shouldReturnFalse() {
         assertFalse(sectorIdentifierUriService.isPrivateOrUnresolvableHost("8.8.8.8"));
+    }
+
+    `@Test`
+    public void isPrivateOrUnresolvableHost_unresolvableHost_shouldReturnTrue() {
+        assertTrue(sectorIdentifierUriService.isPrivateOrUnresolvableHost("nonexistent.invalid"));
     }
 
     @Test

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
@@ -4,11 +4,16 @@ import com.google.common.collect.Lists;
 import io.jans.as.model.configuration.AppConfiguration;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.Logger;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import java.net.InetAddress;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -20,6 +25,7 @@ import static org.testng.Assert.assertTrue;
 public class SectorIdentifierUriServiceTest {
 
     @InjectMocks
+    @Spy
     private SectorIdentifierUriService sectorIdentifierUriService;
 
     @Mock
@@ -30,6 +36,8 @@ public class SectorIdentifierUriServiceTest {
 
     @Test
     public void isAllowedSectorIdentifierUri_httpsWithoutBlockList_shouldReturnTrue() {
+        doReturn(false).when(sectorIdentifierUriService).isPrivateOrUnresolvableHost(anyString());
+
         assertTrue(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://rp.example/sector.json"));
     }
 
@@ -50,6 +58,7 @@ public class SectorIdentifierUriServiceTest {
 
     @Test
     public void isAllowedSectorIdentifierUri_httpsAndBlockListed_shouldReturnFalse() {
+        doReturn(false).when(sectorIdentifierUriService).isPrivateOrUnresolvableHost(anyString());
         when(appConfiguration.getRequestUriBlockList()).thenReturn(Lists.newArrayList("https://internal.example/*"));
 
         assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://internal.example/sector.json"));
@@ -57,8 +66,69 @@ public class SectorIdentifierUriServiceTest {
 
     @Test
     public void isAllowedSectorIdentifierUri_httpsAndNotBlockListed_shouldReturnTrue() {
+        doReturn(false).when(sectorIdentifierUriService).isPrivateOrUnresolvableHost(anyString());
         when(appConfiguration.getRequestUriBlockList()).thenReturn(Lists.newArrayList("https://internal.example/*"));
 
         assertTrue(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://rp.example/sector.json"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_loopbackIpLiteral_shouldReturnFalseWithoutEvaluatingBlockList() {
+        assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://127.0.0.1/sector.json"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_linkLocalIpLiteral_shouldReturnFalse() {
+        assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://169.254.169.254/latest/meta-data/"));
+    }
+
+    @Test
+    public void isAllowedSectorIdentifierUri_privateNetworkIpLiteral_shouldReturnFalse() {
+        assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://10.0.0.5/sector.json"));
+    }
+
+    @Test
+    public void isPrivateOrUnresolvableHost_loopbackIpLiteral_shouldReturnTrue() {
+        assertTrue(sectorIdentifierUriService.isPrivateOrUnresolvableHost("127.0.0.1"));
+    }
+
+    @Test
+    public void isPrivateOrUnresolvableHost_blankHost_shouldReturnTrue() {
+        assertTrue(sectorIdentifierUriService.isPrivateOrUnresolvableHost(""));
+    }
+
+    @Test
+    public void isPrivateOrUnresolvableHost_publicIpLiteral_shouldReturnFalse() {
+        assertFalse(sectorIdentifierUriService.isPrivateOrUnresolvableHost("8.8.8.8"));
+    }
+
+    @Test
+    public void isPrivateAddress_withLoopback_shouldReturnTrue() throws Exception {
+        assertTrue(sectorIdentifierUriService.isPrivateAddress(InetAddress.getByName("127.0.0.1")));
+    }
+
+    @Test
+    public void isPrivateAddress_with10Network_shouldReturnTrue() throws Exception {
+        assertTrue(sectorIdentifierUriService.isPrivateAddress(InetAddress.getByName("10.0.0.1")));
+    }
+
+    @Test
+    public void isPrivateAddress_with192168Network_shouldReturnTrue() throws Exception {
+        assertTrue(sectorIdentifierUriService.isPrivateAddress(InetAddress.getByName("192.168.1.1")));
+    }
+
+    @Test
+    public void isPrivateAddress_with172Network_shouldReturnTrue() throws Exception {
+        assertTrue(sectorIdentifierUriService.isPrivateAddress(InetAddress.getByName("172.16.0.1")));
+    }
+
+    @Test
+    public void isPrivateAddress_withLinkLocal_shouldReturnTrue() throws Exception {
+        assertTrue(sectorIdentifierUriService.isPrivateAddress(InetAddress.getByName("169.254.169.254")));
+    }
+
+    @Test
+    public void isPrivateAddress_withPublicAddress_shouldReturnFalse() throws Exception {
+        assertFalse(sectorIdentifierUriService.isPrivateAddress(InetAddress.getByName("8.8.8.8")));
     }
 }


### PR DESCRIPTION
### Description

#### Target issue

fix(jans-auth-server): added safeguards for sector_identifier_uri in Dynamic Client Registration

closes #14540

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `sector_identifier_uri` service for shared validation and content retrieval (HTTPS-only, blocks private/loopback/link-local or blocklisted hosts).
  * Updated registration and redirection URI flows to use this shared service for sector checks and fetching.
* **Bug Fixes**
  * Prevents sector content fetching and improves error handling when `sector_identifier_uri` is invalid or not allowed (including DNS resolution failures).
* **Tests**
  * Added a dedicated test suite for sector validation/content fetching.
  * Updated existing validator and redirection service tests to cover allowed vs blocked/malformed cases and fetch/no-fetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->