### PR TITLE
fix(jans-cli-tuı): don't diplay 'no matching' after deleting ssa

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/ssa.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/ssa.py
@@ -140,7 +140,7 @@ class SSA(DialogUtils):
         self.app.show_jans_dialog(templatesDialog)
 
 
-    def update_ssa_container(self, start_index=0, search_str='', display_no_matching=True):
+    def update_ssa_container(self, start_index=0, search_str='', *, display_no_matching=True):
 
         self.working_container.clear()
         data_display = []

--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/ssa.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/ssa.py
@@ -140,7 +140,7 @@ class SSA(DialogUtils):
         self.app.show_jans_dialog(templatesDialog)
 
 
-    def update_ssa_container(self, start_index=0, search_str=''):
+    def update_ssa_container(self, start_index=0, search_str='', display_no_matching=True):
 
         self.working_container.clear()
         data_display = []
@@ -160,7 +160,7 @@ class SSA(DialogUtils):
                         '{:02d}/{:02d}/{}'.format(dt_object.day, dt_object.month, str(dt_object.year))
                     ))
 
-        if not data_display:
+        if not data_display and display_no_matching:
             self.app.show_message(_("Oops"), _(common_strings.no_matching_result), tobefocused = self.main_container)
             return
 
@@ -170,7 +170,7 @@ class SSA(DialogUtils):
 
         self.app.layout.focus(self.working_container)
 
-    def get_ssa(self, search_str=''):
+    def get_ssa(self, search_str='', display_no_matching=True):
         async def coroutine():
             cli_args = {'operation_id': 'get-ssa', 'cli_object': self.cli_object}
             self.app.start_progressing(_("Retreiving ssa..."))
@@ -178,7 +178,7 @@ class SSA(DialogUtils):
             self.app.stop_progressing()
             self.data = response.json()
             self.working_container.all_data = self.data
-            self.update_ssa_container(search_str=search_str)
+            self.update_ssa_container(search_str=search_str, display_no_matching=display_no_matching)
 
         asyncio.ensure_future(coroutine())
 
@@ -603,7 +603,7 @@ class SSA(DialogUtils):
         def do_delete_ssa(result):
             async def coroutine():
                 await self.delete_ssa_coroutine(jti)
-                self.get_ssa()
+                self.get_ssa(display_no_matching=False)
                 close_dialog = kwargs.get('close_dialog')
                 if close_dialog:
                     close_dialog.future.set_result(True)


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14571 
#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSA list refresh behavior after deletion.
  * Prevented the “no matching result” message from showing during post-delete refreshes.
  * Added a controllable option to show or hide the empty-results message when updating and fetching filtered SSA results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->