### PR TITLE
refactor(jans-cedarling): expose per-item batch failures as Result<AuthorizeResult, BatchItemError>

### DIFF
--- a/docs/cedarling/integrations/postgres.md
+++ b/docs/cedarling/integrations/postgres.md
@@ -278,24 +278,36 @@ and CI fails the build if it drifts from the live `#[pg_extern]` set.
 | `cedarling_build_resource_row(record anyelement) → text` | Materializes a composite row into the canonical Cedar `EntityData` JSON string that `cedarling_authorized_row` would use — useful for debugging. Aborts the statement on invalid rows; do not use inside RLS policies. |
 | `cedarling_build_resource(resource jsonb, entity_type text, entity_id text) → text` | Builds `EntityData` JSON from an existing JSONB document; optional `entity_type` / `entity_id` override or inject `cedar_entity_mapping`. Same abort-on-error semantics as the row variant. |
 | `cedarling_where(table_name text, action text, tokens text) → text` | Predicate pushdown: lowers matching Cedar policies into a SQL `WHERE` fragment. On parse/engine errors returns `'FALSE'`. When at least one matched policy can't be lowered, returns the fragment chosen by `cedarling.where_partial_fallback` (default `'deny'` → `'FALSE'`; set to `'permit'` for the legacy `'TRUE'` behavior, safe only when paired with row-by-row RLS). Always emits a `WARN` listing the unhandled policy ids. |
-| `cedarling_authorize_unsigned_batch(request_json text) → TABLE(item_index int, decision bool, batch_id text)` | Batch unsigned authorization. `request_json` deserializes to `BatchAuthorizeUnsignedRequest`. Emits one row per input item in order, each carrying the shared `batch_id`. See [Batch functions](#batch-functions) below for the row contract on failure and the mode / fail_mode interaction. |
-| `cedarling_authorize_multi_issuer_batch(request_json text) → TABLE(item_index int, decision bool, batch_id text)` | Batch multi-issuer authorization. `request_json` deserializes to `BatchAuthorizeMultiIssuerRequest`. Same row shape and failure contract as `cedarling_authorize_unsigned_batch`. |
+| `cedarling_authorize_unsigned_batch(request_json text) → TABLE(item_index int, decision bool, error_category text, batch_id text)` | Batch unsigned authorization. `request_json` deserializes to `BatchAuthorizeUnsignedRequest`. Emits one row per input item in order. `error_category` is `NULL` when Cedar evaluated the item; it carries a variant slug (e.g. `action_parse`) when the item failed to build. See [Batch functions](#batch-functions) below for the row contract on failure and the mode / fail_mode interaction. |
+| `cedarling_authorize_multi_issuer_batch(request_json text) → TABLE(item_index int, decision bool, error_category text, batch_id text)` | Batch multi-issuer authorization. `request_json` deserializes to `BatchAuthorizeMultiIssuerRequest`. Same row shape and failure contract as `cedarling_authorize_unsigned_batch`. |
 
 #### Batch functions
 
-Both `cedarling_authorize_*_batch` functions honor `cedarling.mode` and `cedarling.fail_mode` on both the success and failure paths, matching the single-item contract.
+Both `cedarling_authorize_*_batch` functions honor `cedarling.mode` and `cedarling.fail_mode` on success and failure paths, matching the single-item contract.
 
 **Row contract:**
 
 | Case | Rows returned |
 |---|---|
-| Success (N items) | N rows with real `batch_id`, `decision` = the raw Cedar decision (flipped to `true` under `cedarling.mode = 'shadow'`). |
-| Batch-level failure, item count peekable | N rows, `batch_id = ''`, `decision` = `finalize_error` result (`false` under fail-closed, `true` under fail-open / shadow). |
-| Batch-level failure, no item count recoverable (unparseable JSON, missing `items`, empty `items`) | 1 sentinel row at `item_index = -1`, `batch_id = ''`, `decision` = `finalize_error` result. |
+| Cedar reached a decision | Real `batch_id`, `decision` = raw Cedar decision (flipped `true` under `mode = 'shadow'`), `error_category` = `NULL`. |
+| Per-item build failure | Real `batch_id`, `decision` = `finalize_error`, `error_category` = variant slug (`action_parse`, `resource_build`, `context_build`, `principal_build`, `schema_validation`, `multi_issuer_entity`, `request_validation`). |
+| Batch-level failure, item count peekable | N rows, `batch_id = ''`, `decision` = `finalize_error`, `error_category` set. |
+| Batch-level failure, no item count (unparseable / missing / empty `items`) | 1 sentinel row at `item_index = -1`, `batch_id = ''`, `error_category` set. |
 
-The sentinel row exists so `bool_and(decision)` over the result set never collapses to `NULL` on a batch-level failure — the aggregate stays fail-closed under the default `cedarling.fail_mode = 'closed'`. Consumers migrating from N separate `cedarling_authorized` calls to a single batch call get the same aggregate behavior under any mode / fail_mode combination.
+The sentinel row keeps `bool_and(decision)` from collapsing to `NULL` under `fail_mode = 'closed'`.
 
-**Observability parity with single-item:** one `cedarling_status().total_requests` increment per SQL call; one `record_decision` per item on success (raw pre-shadow-flip decision drives `allowed` / `denied`); one `errors` increment on batch-level failure. Per-item traces land in the ring buffer with the shared `batch_id` field so operators can group them via `cedarling_recent_traces()`.
+```sql
+-- Cedar Allow only:
+SELECT item_index FROM cedarling_authorize_unsigned_batch($1)
+ WHERE decision AND error_category IS NULL;
+
+-- Build failures grouped by reason:
+SELECT error_category, count(*)
+  FROM cedarling_authorize_unsigned_batch($1)
+ WHERE error_category IS NOT NULL GROUP BY error_category;
+```
+
+**Observability:** one `total_requests` per SQL call; one `record_decision` per Ok item; one `errors` per Err item + one on batch-level failure. Per-item traces carry the shared `batch_id` for grouping via `cedarling_recent_traces()`; error traces carry the variant slug.
 
 ### Tokens (session / transaction scoped)
 

--- a/docs/cedarling/reference/cedarling-authz.md
+++ b/docs/cedarling/reference/cedarling-authz.md
@@ -536,47 +536,54 @@ Both variants share a common `BatchItem`:
 ### Response Shape
 
 ```json
-{ "batch_id": "01945...uuidv7...", "results": [ /* per-item result, ... */ ] }
+{
+  "batch_id": "01945...uuidv7...",
+  "results": [
+    { "Ok":  { "decision": true,  "request_id": "...", "response": { ... } } },
+    { "Err": { "variant": "action_parse", "message": "...", "item_index": 1 } },
+    { "Ok":  { "decision": false, "request_id": "...", "response": { ... } } }
+  ]
+}
 ```
 
-- `results[i]` corresponds to `items[i]` in the request.
-- `batch_id` is a UUIDv7 stamped on every per-item decision-log entry emitted by the batch. Retrieve all entries for a batch via `LogStorage::get_logs_by_request_id(batch_id.to_string())`.
-- The per-item result type is the same as the single-item call: `AuthorizeResult` for the unsigned batch, `MultiIssuerAuthorizeResult` for the multi-issuer batch.
+Each slot is `Ok(AuthorizeResult)` (Cedar reached a decision) or `Err(BatchItemError)` (item couldn't be built). `results[i]` corresponds to `items[i]` — including `Err` slots. `batch_id` (UUIDv7) is stamped on every per-item decision-log entry; retrieve them via `LogStorage::get_logs_by_request_id(batch_id.to_string())`. Each binding wraps the `Ok`/`Err` split in an idiomatic shape — see [per-binding tutorials](../tutorials/).
+
+### `BatchItemError` variants
+
+| Variant slug | Meaning |
+|---|---|
+| `action_parse` | `action` didn't parse as a Cedar `EntityUid`. |
+| `resource_build` | `resource` `EntityData` failed to build a Cedar entity. |
+| `context_build` | Per-item `context` couldn't be built. |
+| `principal_build` | Unsigned role-entity build failed. |
+| `schema_validation` | Assembled `Entities` failed schema validation. |
+| `multi_issuer_entity` | Multi-issuer resource entity build failed. |
+| `request_validation` | Cedar rejected the assembled request against the schema's `appliesTo`. |
+
+Every variant carries a `message` (diagnostic, Cedar-authored — subject to change) and an `item_index` matching the failing item's position, stable under reordering.
 
 ### Failure Model
 
-| Kind | Examples | Effect |
-|---|---|---|
-| **Batch-level** | Empty `items`, empty `tokens` (multi-issuer), non-object item context, principal parse failure, JWT verification / status-list refresh failure | Returns `Err`; no items are evaluated and no `batch_id` is issued. |
-| **Per-item** | Action UID parse, resource build, context build, schema validation | Synthesizes a fail-closed `Deny` at `results[i]`; other items are unaffected. |
-
-Per-item Deny synthesis preserves positional correspondence between `items` and `results`, so callers can zip the two arrays without filtering.
+| Kind | Effect |
+|---|---|
+| **Batch-level** (empty `items`, empty `tokens`, JWT / status-list refresh failure, principal parse) | Returns `Err` at the call level; no `batch_id` issued. |
+| **Per-item** (any variant above) | Surfaces as `Err(BatchItemError)` at `results[i]`; other items unaffected. |
 
 ### Example
 
 ```js
-const bootstrap_config = {...};
-const cedarling = await init(bootstrap_config);
-
-const request = {
-  principal: {
-    cedar_entity_mapping: { entity_type: "Jans::User", id: "alice" },
-    email: "alice@example.com"
-  },
-  items: [
-    { resource: { cedar_entity_mapping: { entity_type: "Jans::Issue", id: "doc-1" }, org_id: "Acme" },
-      action: "Jans::Action::\"View\"", context: {} },
-    { resource: { cedar_entity_mapping: { entity_type: "Jans::Issue", id: "doc-2" }, org_id: "Acme" },
-      action: "Jans::Action::\"View\"", context: {} }
-  ]
-};
-
 const response = await cedarling.authorize_unsigned_batch(request);
 console.log(response.batch_id);
-response.results.forEach((r, i) => console.log(i, r.decision));
+response.results.forEach((r, i) => {
+  if (r.is_ok) {
+    console.log(i, r.unwrap().decision ? "allow" : "deny");
+  } else {
+    console.log(i, "error:", r.error.category);
+  }
+});
 ```
 
-The multi-issuer batch has the same call shape but takes `tokens` in place of `principal` — see [Multi-Issuer Authorization](#multi-issuer-authorization-authorize_multi_issuer--recommended) for the token contract.
+Multi-issuer batch takes `tokens` in place of `principal` — see [Multi-Issuer Authorization](#multi-issuer-authorization-authorize_multi_issuer--recommended) for the token contract.
 
 ## Policy Introspection
 

--- a/docs/cedarling/tutorials/c.md
+++ b/docs/cedarling/tutorials/c.md
@@ -242,9 +242,9 @@ cedarling_free_result(&auth_result);
 
 ### Batch Authorization
 
-Both methods have a batch variant that runs one setup phase and evaluates N `{resource, action, context}` items against the shared snapshot. `results[i]` corresponds to `items[i]`; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry emitted for the batch.
+The response body is a JSON string. Each `results[i]` is either `{"Ok": {decision, request_id, response}}` (Cedar reached a decision) or `{"Err": {"variant": "...", "message": "...", "item_index": i}}` (item failed to build). Positional mapping to `items[i]` is preserved for both branches; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry.
 
-The batch request body is a JSON object of the shape `{ "principal": {...} | null, "items": [ { "resource": ..., "action": "...", "context": {} }, ... ] }`.
+Request body: `{ "principal": {...} | null, "items": [ { "resource": ..., "action": "...", "context": {} }, ... ] }`.
 
 ```c
 const char* request =
@@ -261,7 +261,13 @@ const char* request =
 CedarlingResult batch_result;
 int ret = cedarling_authorize_unsigned_batch(instance_id, request, &batch_result);
 if (ret == 0) {
-    // batch_result.data is a JSON string: { "batch_id": "...", "results": [ ... ] }
+    // batch_result.data is a JSON string. Feed it through your JSON parser to
+    // switch on `"Ok"` / `"Err"` per item, e.g.:
+    //   { "batch_id": "01945...",
+    //     "results": [
+    //       { "Ok":  { "decision": true, "request_id": "...", "response": {...} } },
+    //       { "Err": { "variant": "action_parse", "message": "...", "item_index": 1 } }
+    //     ] }
     printf("%s\n", (char*)batch_result.data);
 } else {
     printf("Batch error: %s\n", batch_result.error_message);
@@ -269,7 +275,7 @@ if (ret == 0) {
 cedarling_free_result(&batch_result);
 ```
 
-For multi-issuer, the request body is `{ "tokens": [...], "items": [...] }` and the call is `cedarling_authorize_multi_issuer_batch`. Same response shape and lifecycle (`cedarling_free_result` when done). See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and audit correlation.
+For multi-issuer, the request body is `{ "tokens": [...], "items": [...] }` and the call is `cedarling_authorize_multi_issuer_batch`. Same response shape and lifecycle (`cedarling_free_result` when done). See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and `BatchItemError` variant list.
 
 ## Context Data API
 

--- a/docs/cedarling/tutorials/go.md
+++ b/docs/cedarling/tutorials/go.md
@@ -400,7 +400,7 @@ permit(
 
 #### Batch Authorization
 
-Both methods have a batch variant that runs one setup phase and evaluates N `{resource, action, context}` items against the shared snapshot. `Results[i]` corresponds to `Items[i]`; the shared `BatchID` (UUIDv7) is stamped on every per-item decision-log entry emitted for the batch.
+Each entry in `Results` is a `BatchItemUnsignedResult` — `IsOk()` reports whether Cedar reached a decision; `.Ok` and `.Err` are pointer-nullable to the `AuthorizeResult` / `BatchItemError`. Positional mapping to `Items[i]` is preserved for both branches; the shared `BatchID` (UUIDv7) is stamped on every per-item decision-log entry.
 
 ```go
 request := cedarling_go.BatchAuthorizeUnsignedRequest{
@@ -419,15 +419,20 @@ if err != nil {
 
 fmt.Println("batch_id:", response.BatchID)
 for i, r := range response.Results {
-    decision := "deny"
-    if r.Decision {
-        decision = "allow"
+    if r.IsOk() {
+        decision := "deny"
+        if r.Ok.Decision {
+            decision = "allow"
+        }
+        fmt.Printf("item %d: %s\n", i, decision)
+    } else {
+        fmt.Printf("item %d: build error: %s at index %d\n",
+            i, r.Err.Variant, r.Err.ItemIndex)
     }
-    fmt.Printf("item %d: %s\n", i, decision)
 }
 ```
 
-For multi-issuer, use `cedarling_go.BatchAuthorizeMultiIssuerRequest{ Tokens: tokens, Items: items }` and call `AuthorizeMultiIssuerBatch`. `BatchItem.Context` is optional and serializes as `{}` when omitted. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and audit correlation.
+For multi-issuer, use `cedarling_go.BatchAuthorizeMultiIssuerRequest{ Tokens: tokens, Items: items }` and call `AuthorizeMultiIssuerBatch`; each `Results[i]` is a `BatchItemMultiIssuerResult` with the same `IsOk()` / `Ok` / `Err` shape. `BatchItem.Context` is optional and serializes as `{}` when omitted. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and `BatchItemError` variant list.
 
 ### Logging
 

--- a/docs/cedarling/tutorials/java.md
+++ b/docs/cedarling/tutorials/java.md
@@ -269,9 +269,7 @@ if(result.getDecision()) {
 
 #### Batch Authorization
 
-Both methods have a batch variant that runs one setup phase and evaluates N `{resource, action, context}` items against the shared snapshot. `results[i]` corresponds to `items[i]`; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry emitted for the batch.
-
-Use `adapter.batchItemFromJson(resource, action, context)` to build items from JSON pieces without importing UniFFI types, then call `authorizeUnsignedBatch` (JSON principal, nullable) or `authorizeUnsignedBatchEntity` (`EntityData` principal):
+Each entry in `getResults()` is a `BatchItemUnsignedOutcome` sealed subclass — `Success` when Cedar reached a decision, `Failed` otherwise. Positional mapping to `items[i]` is preserved for both branches; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry. `CedarlingAdapter` exposes static `isOk` / `unwrap` / `getError` helpers so JDK 11 callers don't need pattern-matching `instanceof`. Build items with `adapter.batchItemFromJson(resource, action, context)`:
 
 ```java
 List<BatchItem> items = List.of(
@@ -284,12 +282,19 @@ BatchAuthorizeUnsignedResponse response =
 
 System.out.println("batch_id: " + response.getBatchId());
 for (int i = 0; i < response.getResults().size(); i++) {
-    AuthorizeResult r = response.getResults().get(i);
-    System.out.println("item " + i + ": " + (r.getDecision() ? "allow" : "deny"));
+    BatchItemUnsignedOutcome r = response.getResults().get(i);
+    if (CedarlingAdapter.isOk(r)) {
+        AuthorizeResult ok = CedarlingAdapter.unwrap(r);
+        System.out.println("item " + i + ": " + (ok.getDecision() ? "allow" : "deny"));
+    } else {
+        BatchItemError err = CedarlingAdapter.getError(r);
+        System.out.println("item " + i + ": build error: "
+                + err.getCategory() + " at index " + err.getItemIndex());
+    }
 }
 ```
 
-For multi-issuer, call `adapter.authorizeMultiIssuerBatch(tokens, items)` — either `List<TokenInput>` or a `Map<String, String>` of mapping → JWT is accepted. Pass `null` for `context` on `batchItemFromJson` to default to `{}`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and audit correlation.
+For multi-issuer, call `adapter.authorizeMultiIssuerBatch(tokens, items)` — either `List<TokenInput>` or a `Map<String, String>` of mapping → JWT is accepted. Each `getResults().get(i)` is a `BatchItemMultiIssuerOutcome`; the same `CedarlingAdapter.isOk / unwrap / getError` helpers are overloaded for it. Pass `null` for `context` on `batchItemFromJson` to default to `{}`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and `BatchItemError` variant list.
 
 ### Logging
 

--- a/docs/cedarling/tutorials/javascript.md
+++ b/docs/cedarling/tutorials/javascript.md
@@ -295,7 +295,7 @@ const result = await cedarling.authorize_unsigned(request);
 
 #### Batch Authorization
 
-Both methods have a batch variant that runs one setup phase and evaluates N `{resource, action, context}` items against the shared snapshot. `results[i]` corresponds to `items[i]`; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry emitted for the batch.
+Each entry in `results` is a `BatchItemUnsignedResult` — `.is_ok` reports whether Cedar reached a decision; `.unwrap()` returns the `AuthorizeResult` on Ok, `.error` returns the `BatchItemError` on Err. Positional mapping to `items[i]` is preserved for both branches; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry.
 
 ```js
 const request = {
@@ -310,11 +310,17 @@ const response = await cedarling.authorize_unsigned_batch(request);
 
 console.log('batch_id:', response.batch_id);
 response.results.forEach((r, i) => {
-  console.log(`item ${i}: ${r.decision ? 'allow' : 'deny'}`);
+  if (r.is_ok) {
+    const ok = r.unwrap();
+    console.log(`item ${i}: ${ok.decision ? 'allow' : 'deny'}`);
+  } else {
+    // r.error carries { category, item_index, message }
+    console.log(`item ${i}: build error: ${r.error.category} at index ${r.error.item_index}`);
+  }
 });
 ```
 
-For multi-issuer, swap `{ principal, items }` for `{ tokens, items }` and call `authorize_multi_issuer_batch`. `context` is optional on each item and defaults to `{}`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and audit correlation.
+For multi-issuer, swap `{ principal, items }` for `{ tokens, items }` and call `authorize_multi_issuer_batch`. `context` is optional on each item and defaults to `{}`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and `BatchItemError` variant list.
 
 ### Logging
 

--- a/docs/cedarling/tutorials/kotlin.md
+++ b/docs/cedarling/tutorials/kotlin.md
@@ -280,7 +280,7 @@ if (result.decision) {
 
 #### Batch Authorization
 
-Both methods have a batch variant that runs one setup phase and evaluates N `{resource, action, context}` items against the shared snapshot. `results[i]` corresponds to `items[i]`; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry emitted for the batch.
+Each entry in `results` is a `BatchItemUnsignedOutcome` sealed class — pattern-match on `Success` / `Failed` to distinguish a Cedar decision from a build failure. Positional mapping to `items[i]` is preserved for both branches; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry.
 
 Use `adapter.batchItemFromJson(resource, action, context)` to build items without importing UniFFI types, then call `authorizeUnsignedBatch` (JSON principal, nullable) or `authorizeUnsignedBatchEntity` (`EntityData` principal):
 
@@ -294,11 +294,16 @@ val response = adapter.authorizeUnsignedBatch(principalJson, items)
 
 println("batch_id: ${response.batchId}")
 response.results.forEachIndexed { i, r ->
-    println("item $i: ${if (r.decision) "allow" else "deny"}")
+    when (r) {
+        is BatchItemUnsignedOutcome.Success ->
+            println("item $i: ${if (r.result.decision) "allow" else "deny"}")
+        is BatchItemUnsignedOutcome.Failed ->
+            println("item $i: build error: ${r.error.category} at index ${r.error.itemIndex}")
+    }
 }
 ```
 
-For multi-issuer, call `adapter.authorizeMultiIssuerBatch(tokens, items)` (accepts either `List<TokenInput>` or a `Map<String, String>` of mapping → JWT). Pass `null` for `context` on `batchItemFromJson` to default to `{}`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and audit correlation.
+For multi-issuer, call `adapter.authorizeMultiIssuerBatch(tokens, items)` (accepts either `List<TokenInput>` or a `Map<String, String>` of mapping → JWT); each `results[i]` is a `BatchItemMultiIssuerOutcome`. Pass `null` for `context` on `batchItemFromJson` to default to `{}`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and `BatchItemError` variant list.
 
 ---
 

--- a/docs/cedarling/tutorials/python.md
+++ b/docs/cedarling/tutorials/python.md
@@ -362,7 +362,7 @@ else:
 
 #### Batch Authorization
 
-Both methods have a batch variant that runs one setup phase and evaluates N `{resource, action, context}` items against the shared snapshot. `results[i]` corresponds to `items[i]`; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry emitted for the batch.
+Each `results[i]` is a `BatchItemUnsignedResult` — `.is_ok()` checks whether Cedar reached a decision; `.unwrap()` returns the `AuthorizeResult` on Ok, `.error` returns the `BatchItemError` on Err. Positional mapping to `items[i]` is preserved for both branches; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry.
 
 ```py
 from cedarling_python import BatchAuthorizeUnsignedRequest, BatchItem
@@ -377,10 +377,15 @@ response = cedarling.authorize_unsigned_batch(request)
 
 print(f"batch_id: {response.batch_id}")
 for i, r in enumerate(response.results):
-    print(f"item {i}: {'allow' if r.is_allowed() else 'deny'}")
+    if r.is_ok():
+        ok = r.unwrap()
+        print(f"item {i}: {'allow' if ok.is_allowed() else 'deny'}")
+    else:
+        err = r.error
+        print(f"item {i}: build error: {err.category} at index {err.item_index}")
 ```
 
-For multi-issuer, swap `BatchAuthorizeUnsignedRequest(items=items, principal=principal)` for `BatchAuthorizeMultiIssuerRequest(tokens=tokens, items=items)` and call `authorize_multi_issuer_batch`. `context` is optional on `BatchItem` and defaults to `{}`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and audit correlation.
+For multi-issuer, swap `BatchAuthorizeUnsignedRequest(items=items, principal=principal)` for `BatchAuthorizeMultiIssuerRequest(tokens=tokens, items=items)` and call `authorize_multi_issuer_batch`. `context` is optional on `BatchItem` and defaults to `{}`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and `BatchItemError` variant list.
 
 ### Logging
 

--- a/docs/cedarling/tutorials/rust.md
+++ b/docs/cedarling/tutorials/rust.md
@@ -318,7 +318,7 @@ match result.decision {
 
 #### Batch Authorization
 
-Both methods have a batch variant that runs one setup phase and evaluates N `{resource, action, context}` items against the shared snapshot. `results[i]` corresponds to `items[i]`; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry emitted for the batch.
+Each `results[i]` is a `Result<AuthorizeResult, BatchItemError>` — `Ok` when Cedar reached a decision, `Err` when the item couldn't be built. Positional mapping to `items[i]` is preserved for both branches; the shared `batch_id` (UUIDv7) is stamped on every per-item decision-log entry.
 
 ```rust
 use cedarling::{BatchAuthorizeUnsignedRequest, BatchItem};
@@ -342,11 +342,16 @@ let response = cedarling.authorize_unsigned_batch(request).await?;
 
 println!("batch_id: {}", response.batch_id);
 for (i, r) in response.results.iter().enumerate() {
-    println!("item {i}: {}", if r.decision { "allow" } else { "deny" });
+    match r {
+        Ok(a) if a.decision => println!("item {i}: allow"),
+        Ok(_)               => println!("item {i}: deny"),
+        Err(e)              => println!("item {i}: build error: {} at index {}",
+                                        e.category(), e.item_index()),
+    }
 }
 ```
 
-For multi-issuer, swap `BatchAuthorizeUnsignedRequest::new(Some(principal), items)` for `BatchAuthorizeMultiIssuerRequest::new(tokens, items)` and call `authorize_multi_issuer_batch`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and audit correlation.
+For multi-issuer, swap `BatchAuthorizeUnsignedRequest::new(Some(principal), items)` for `BatchAuthorizeMultiIssuerRequest::new(tokens, items)` and call `authorize_multi_issuer_batch`. See [Batch Authorization](../reference/cedarling-authz.md#batch-authorization) for the request / response shape, failure model, and `BatchItemError` variant list.
 
 ### Logging
 

--- a/jans-cedarling/bindings/cedarling-java/src/main/java/io/jans/cedarling/binding/wrapper/CedarlingAdapter.java
+++ b/jans-cedarling/bindings/cedarling-java/src/main/java/io/jans/cedarling/binding/wrapper/CedarlingAdapter.java
@@ -274,6 +274,59 @@ public class CedarlingAdapter implements AutoCloseable {
         return new BatchItem(resourceObj, action, contextStr);
     }
 
+    /**
+     * Returns {@code true} when the batch item was evaluated by Cedar (Allow or
+     * Deny); {@code false} when it failed to build.
+     */
+    public static boolean isOk(BatchItemUnsignedOutcome outcome) {
+        return outcome instanceof BatchItemUnsignedOutcome.Success;
+    }
+
+    /**
+     * Extract the {@link AuthorizeResult} from a Success outcome.
+     *
+     * @throws IllegalStateException when the outcome is Failed (call
+     *     {@link #getError(BatchItemUnsignedOutcome)} to inspect the error).
+     */
+    public static AuthorizeResult unwrap(BatchItemUnsignedOutcome outcome) {
+        if (outcome instanceof BatchItemUnsignedOutcome.Success) {
+            return ((BatchItemUnsignedOutcome.Success) outcome).getResult();
+        }
+        throw new IllegalStateException("BatchItemUnsignedOutcome is Failed");
+    }
+
+    /**
+     * Return the {@link BatchItemError} when the outcome is Failed, or
+     * {@code null} on Success.
+     */
+    public static BatchItemError getError(BatchItemUnsignedOutcome outcome) {
+        if (outcome instanceof BatchItemUnsignedOutcome.Failed) {
+            return ((BatchItemUnsignedOutcome.Failed) outcome).getError();
+        }
+        return null;
+    }
+
+    /** Multi-issuer analog of {@link #isOk(BatchItemUnsignedOutcome)}. */
+    public static boolean isOk(BatchItemMultiIssuerOutcome outcome) {
+        return outcome instanceof BatchItemMultiIssuerOutcome.Success;
+    }
+
+    /** Multi-issuer analog of {@link #unwrap(BatchItemUnsignedOutcome)}. */
+    public static MultiIssuerAuthorizeResult unwrap(BatchItemMultiIssuerOutcome outcome) {
+        if (outcome instanceof BatchItemMultiIssuerOutcome.Success) {
+            return ((BatchItemMultiIssuerOutcome.Success) outcome).getResult();
+        }
+        throw new IllegalStateException("BatchItemMultiIssuerOutcome is Failed");
+    }
+
+    /** Multi-issuer analog of {@link #getError(BatchItemUnsignedOutcome)}. */
+    public static BatchItemError getError(BatchItemMultiIssuerOutcome outcome) {
+        if (outcome instanceof BatchItemMultiIssuerOutcome.Failed) {
+            return ((BatchItemMultiIssuerOutcome.Failed) outcome).getError();
+        }
+        return null;
+    }
+
     public String getLogById(String id) throws LogException {
         return cedarling.getLogById(id);
     }

--- a/jans-cedarling/bindings/cedarling-java/src/test/java/io/jans/cedarling/binding/wrapper/MultiIssuerBatchAuthzTest.java
+++ b/jans-cedarling/bindings/cedarling-java/src/test/java/io/jans/cedarling/binding/wrapper/MultiIssuerBatchAuthzTest.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import uniffi.cedarling_uniffi.AuthorizeException;
 import uniffi.cedarling_uniffi.BatchAuthorizeMultiIssuerResponse;
 import uniffi.cedarling_uniffi.BatchItem;
+import uniffi.cedarling_uniffi.BatchItemError;
+import uniffi.cedarling_uniffi.BatchItemMultiIssuerOutcome;
 import uniffi.cedarling_uniffi.EntityData;
 import uniffi.cedarling_uniffi.EntityException;
 import uniffi.cedarling_uniffi.MultiIssuerAuthorizeResult;
@@ -115,8 +117,11 @@ public class MultiIssuerBatchAuthzTest {
         assertNotNull(response.getBatchId(), "batch_id should not be null");
         assertFalse(response.getBatchId().isEmpty(), "batch_id should be populated");
         assertEquals(response.getResults().size(), 3, "N=3 items produce N=3 results");
-        for (MultiIssuerAuthorizeResult r : response.getResults()) {
-            assertTrue(r.getDecision(), "item should allow with valid multi-issuer tokens");
+        for (BatchItemMultiIssuerOutcome r : response.getResults()) {
+            assertTrue(CedarlingAdapter.isOk(r), "item should be Ok");
+            assertTrue(
+                    CedarlingAdapter.unwrap(r).getDecision(),
+                    "item should allow with valid multi-issuer tokens");
         }
     }
 
@@ -129,8 +134,9 @@ public class MultiIssuerBatchAuthzTest {
                 adapter.authorizeMultiIssuerBatch(tokens, List.of(sameItem()));
 
         assertEquals(batch.getResults().size(), 1);
+        assertTrue(CedarlingAdapter.isOk(batch.getResults().get(0)));
         assertEquals(
-                batch.getResults().get(0).getDecision(),
+                CedarlingAdapter.unwrap(batch.getResults().get(0)).getDecision(),
                 single.getDecision(),
                 "single-item and batch decisions must agree on the same input");
     }
@@ -142,7 +148,8 @@ public class MultiIssuerBatchAuthzTest {
                 adapter.authorizeMultiIssuerBatch(validTokensMap(), List.of(item));
 
         assertEquals(response.getResults().size(), 1);
-        assertTrue(response.getResults().get(0).getDecision());
+        assertTrue(CedarlingAdapter.isOk(response.getResults().get(0)));
+        assertTrue(CedarlingAdapter.unwrap(response.getResults().get(0)).getDecision());
     }
 
     @Test
@@ -158,7 +165,8 @@ public class MultiIssuerBatchAuthzTest {
                 adapter.authorizeMultiIssuerBatch(tokens, List.of(sameItem()));
 
         assertEquals(response.getResults().size(), 1);
-        assertTrue(response.getResults().get(0).getDecision());
+        assertTrue(CedarlingAdapter.isOk(response.getResults().get(0)));
+        assertTrue(CedarlingAdapter.unwrap(response.getResults().get(0)).getDecision());
     }
 
     @Test
@@ -184,10 +192,8 @@ public class MultiIssuerBatchAuthzTest {
     }
 
     /**
-     * Ordering: N=3 items where item[1] has a malformed action UID
-     * (synthesizes a fail-closed Deny) sandwiched between two valid items.
-     * Verifies each results[i] carries the decision produced by items[i]
-     * rather than a uniform pass/fail across the batch.
+     * Ordering: N=3 items where item[1] has a malformed action UID (surfaces
+     * as a Failed outcome) sandwiched between two valid items.
      */
     @Test
     public void batchMixedDecisionsPreserveOrder() throws Exception {
@@ -205,10 +211,20 @@ public class MultiIssuerBatchAuthzTest {
                 adapter.authorizeMultiIssuerBatch(tokens, items);
 
         assertEquals(response.getResults().size(), 3, "N=3 items → N=3 results");
-        assertTrue(response.getResults().get(0).getDecision(), "item 0 must allow");
+        assertTrue(CedarlingAdapter.isOk(response.getResults().get(0)), "item 0 must be Ok");
+        assertTrue(
+                CedarlingAdapter.unwrap(response.getResults().get(0)).getDecision(),
+                "item 0 must allow");
         assertFalse(
-                response.getResults().get(1).getDecision(),
-                "item 1 with bad action must fail closed");
-        assertTrue(response.getResults().get(2).getDecision(), "item 2 must allow");
+                CedarlingAdapter.isOk(response.getResults().get(1)),
+                "item 1 with bad action must be Failed");
+        BatchItemError err = CedarlingAdapter.getError(response.getResults().get(1));
+        assertNotNull(err, "item 1 must carry a BatchItemError");
+        assertEquals(err.getCategory(), "action_parse");
+        assertEquals(err.getItemIndex(), 1L);
+        assertTrue(CedarlingAdapter.isOk(response.getResults().get(2)), "item 2 must be Ok");
+        assertTrue(
+                CedarlingAdapter.unwrap(response.getResults().get(2)).getDecision(),
+                "item 2 must allow");
     }
 }

--- a/jans-cedarling/bindings/cedarling-java/src/test/java/io/jans/cedarling/binding/wrapper/UnsignedBatchAuthzTest.java
+++ b/jans-cedarling/bindings/cedarling-java/src/test/java/io/jans/cedarling/binding/wrapper/UnsignedBatchAuthzTest.java
@@ -18,6 +18,8 @@ import uniffi.cedarling_uniffi.AuthorizeException;
 import uniffi.cedarling_uniffi.AuthorizeResult;
 import uniffi.cedarling_uniffi.BatchAuthorizeUnsignedResponse;
 import uniffi.cedarling_uniffi.BatchItem;
+import uniffi.cedarling_uniffi.BatchItemError;
+import uniffi.cedarling_uniffi.BatchItemUnsignedOutcome;
 import uniffi.cedarling_uniffi.EntityData;
 import uniffi.cedarling_uniffi.EntityException;
 
@@ -98,8 +100,9 @@ public class UnsignedBatchAuthzTest {
         assertNotNull(response.getBatchId(), "batch_id should not be null");
         assertFalse(response.getBatchId().isEmpty(), "batch_id should be populated");
         assertEquals(response.getResults().size(), 3, "N=3 items produce N=3 results");
-        for (AuthorizeResult r : response.getResults()) {
-            assertTrue(r.getDecision(), "item should allow");
+        for (BatchItemUnsignedOutcome r : response.getResults()) {
+            assertTrue(CedarlingAdapter.isOk(r), "item should be Ok");
+            assertTrue(CedarlingAdapter.unwrap(r).getDecision(), "item should allow");
         }
     }
 
@@ -110,8 +113,9 @@ public class UnsignedBatchAuthzTest {
                 adapter.authorizeUnsignedBatch(principalsString, List.of(sameItem()));
 
         assertEquals(batch.getResults().size(), 1);
+        assertTrue(CedarlingAdapter.isOk(batch.getResults().get(0)));
         assertEquals(
-                batch.getResults().get(0).getDecision(),
+                CedarlingAdapter.unwrap(batch.getResults().get(0)).getDecision(),
                 single.getDecision(),
                 "single-item and batch decisions must agree on the same input");
     }
@@ -123,7 +127,8 @@ public class UnsignedBatchAuthzTest {
                 adapter.authorizeUnsignedBatch(principalsString, List.of(item));
 
         assertEquals(response.getResults().size(), 1);
-        assertTrue(response.getResults().get(0).getDecision());
+        assertTrue(CedarlingAdapter.isOk(response.getResults().get(0)));
+        assertTrue(CedarlingAdapter.unwrap(response.getResults().get(0)).getDecision());
     }
 
     @Test
@@ -138,9 +143,9 @@ public class UnsignedBatchAuthzTest {
     }
 
     /**
-     * Ordering: N=3 items where item[1] has a malformed action UID (synthesizes
-     * a fail-closed Deny) sandwiched between two valid items. Verifies each
-     * results[i] carries the decision produced by items[i] rather than a
+     * Ordering: N=3 items where item[1] has a malformed action UID (surfaces as
+     * a Failed outcome) sandwiched between two valid items. Verifies each
+     * results[i] carries the outcome produced by items[i] rather than a
      * uniform pass/fail across the batch.
      */
     @Test
@@ -157,10 +162,20 @@ public class UnsignedBatchAuthzTest {
                 adapter.authorizeUnsignedBatch(principalsString, items);
 
         assertEquals(response.getResults().size(), 3, "N=3 items → N=3 results");
-        assertTrue(response.getResults().get(0).getDecision(), "item 0 must allow");
+        assertTrue(CedarlingAdapter.isOk(response.getResults().get(0)), "item 0 must be Ok");
+        assertTrue(
+                CedarlingAdapter.unwrap(response.getResults().get(0)).getDecision(),
+                "item 0 must allow");
         assertFalse(
-                response.getResults().get(1).getDecision(),
-                "item 1 with bad action must fail closed");
-        assertTrue(response.getResults().get(2).getDecision(), "item 2 must allow");
+                CedarlingAdapter.isOk(response.getResults().get(1)),
+                "item 1 with bad action must be Failed");
+        BatchItemError err = CedarlingAdapter.getError(response.getResults().get(1));
+        assertNotNull(err, "item 1 must carry a BatchItemError");
+        assertEquals(err.getCategory(), "action_parse");
+        assertEquals(err.getItemIndex(), 1L);
+        assertTrue(CedarlingAdapter.isOk(response.getResults().get(2)), "item 2 must be Ok");
+        assertTrue(
+                CedarlingAdapter.unwrap(response.getResults().get(2)).getDecision(),
+                "item 2 must allow");
     }
 }

--- a/jans-cedarling/bindings/cedarling_c/benchmarks/benchmark_cedarling.c
+++ b/jans-cedarling/bindings/cedarling_c/benchmarks/benchmark_cedarling.c
@@ -135,13 +135,13 @@ static authorize_fn_t pick_authorize_fn(const char *kind) {
     return NULL;
 }
 
-// All-Allow means at least one `"decision":true` and no `"decision":false` —
-// works for both single-item (`{decision:...}`) and batch (`{results:[...]}`)
-// response shapes; the deny check catches mixed batches.
+// All-Allow means at least one `"decision":true`, no `"decision":false`, and
+// no per-item `"Err":{` envelope in the batch response.
 static int response_all_allow(const char *data) {
     if (data == NULL) return 0;
     if (strstr(data, "\"decision\":true") == NULL) return 0;
     if (strstr(data, "\"decision\":false") != NULL) return 0;
+    if (strstr(data, "\"Err\":{") != NULL) return 0;
     return 1;
 }
 

--- a/jans-cedarling/bindings/cedarling_c/tests/test_cedarling.c
+++ b/jans-cedarling/bindings/cedarling_c/tests/test_cedarling.c
@@ -715,17 +715,18 @@ void test_authorize_unsigned_batch(void) {
         char* result_str = auth_result.data;
         printf(" Batch response: %.200s...\n", result_str);
         TEST_ASSERT(strstr(result_str, "\"batch_id\"") != NULL, "Response carries batch_id");
-        // Three Allow decisions expected — the response embeds them as
-        // "decision":true (top-level per-item), so a naive count works here.
-        int allow_count = 0;
+        // Each item lands as {"Ok":{decision:true,...}}; expect three envelopes.
+        int ok_count = 0;
         const char* p = result_str;
-        const char* needle = "\"decision\":true";
-        while ((p = strstr(p, needle)) != NULL) {
-            allow_count++;
-            p += strlen(needle);
-        }
-        // 3 top-level `decision:true` entries per item = 3 (Cedar's nested
-        // response.decision uses the string "allow", not the bool).
+        while ((p = strstr(p, "\"Ok\":{")) != NULL) { ok_count++; p += 6; }
+        TEST_ASSERT(ok_count == 3, "3 Ok items in the response");
+        TEST_ASSERT(strstr(result_str, "\"Err\":{") == NULL,
+                    "No Err items in an all-Allow batch");
+        // Every Ok decision must be true (Cedar's nested response.decision
+        // uses the string "allow"/"deny" so no collision with the bool).
+        int allow_count = 0;
+        p = result_str;
+        while ((p = strstr(p, "\"decision\":true")) != NULL) { allow_count++; p += 15; }
         TEST_ASSERT(allow_count == 3, "3 per-item Allow decisions");
     }
     cedarling_free_result(&auth_result);
@@ -806,40 +807,35 @@ void test_authorize_unsigned_batch_mixed_ordering(void) {
     if (ret == 0) {
         TEST_ASSERT(auth_result.data != NULL, "Response has data");
         const char* r = auth_result.data;
-        // Collect per-item bool decisions in serialization order. Nested
-        // `response.decision` uses "allow"/"deny" strings so no collision.
-        int decisions[3] = { -1, -1, -1 };
-        int seen = 0;
+        // Wire shape per item is either {"Ok":{decision,...}} or
+        // {"Err":{variant,message,item_index,...}}. Two Ok slots (items 0/2)
+        // and one Err slot (item 1) — count each envelope key.
+        int ok_count = 0;
         const char* p = r;
-        while (seen < 3) {
-            const char* next_true = strstr(p, "\"decision\":true");
-            const char* next_false = strstr(p, "\"decision\":false");
-            const char* next;
-            int value;
-            if (next_true && (!next_false || next_true < next_false)) {
-                next = next_true;
-                value = 1;
-                p = next + 15;
-            } else if (next_false) {
-                next = next_false;
-                value = 0;
-                p = next + 16;
-            } else {
-                break;
-            }
-            (void)next;
-            decisions[seen++] = value;
-        }
-        TEST_ASSERT(seen == 3, "Response contains exactly 3 per-item decisions");
-        TEST_ASSERT(decisions[0] == 1, "item[0] must Allow (positional check)");
-        TEST_ASSERT(decisions[1] == 0, "item[1] with bad action must Deny (positional check)");
-        TEST_ASSERT(decisions[2] == 1, "item[2] must Allow (positional check)");
-        // Envelope: shared batch_id + one request_id per item.
+        while ((p = strstr(p, "\"Ok\":{")) != NULL) { ok_count++; p += 6; }
+        int err_count = 0;
+        p = r;
+        while ((p = strstr(p, "\"Err\":{")) != NULL) { err_count++; p += 7; }
+        TEST_ASSERT(ok_count == 2, "2 Ok items (positions 0 and 2)");
+        TEST_ASSERT(err_count == 1, "1 Err item (position 1, bad action)");
+        // The Err's variant + item_index must land in the response.
+        TEST_ASSERT(strstr(r, "\"variant\":\"action_parse\"") != NULL,
+                    "Err carries variant=action_parse");
+        TEST_ASSERT(strstr(r, "\"item_index\":1") != NULL,
+                    "Err carries item_index=1");
+        // Both Ok items must be Allow.
+        int allow_count = 0;
+        p = r;
+        while ((p = strstr(p, "\"decision\":true")) != NULL) { allow_count++; p += 15; }
+        TEST_ASSERT(allow_count == 2, "Both Ok items decision=true");
+        TEST_ASSERT(strstr(r, "\"decision\":false") == NULL,
+                    "No fail-closed Deny anywhere in the response");
+        // Envelope: shared batch_id + one request_id per Ok item.
         TEST_ASSERT(strstr(r, "\"batch_id\"") != NULL, "batch_id present");
         int request_ids = 0;
         p = r;
         while ((p = strstr(p, "\"request_id\"")) != NULL) { request_ids++; p += 12; }
-        TEST_ASSERT(request_ids == 3, "3 per-item request_ids (one per input)");
+        TEST_ASSERT(request_ids == 2, "2 per-item request_ids (one per Ok item)");
     }
     cedarling_free_result(&auth_result);
 

--- a/jans-cedarling/bindings/cedarling_go/benchmarks/main.go
+++ b/jans-cedarling/bindings/cedarling_go/benchmarks/main.go
@@ -318,18 +318,18 @@ func clonePayload(src map[string]any) map[string]any {
 	return dst
 }
 
-func allAllow(rs []cedarling.AuthorizeResult) bool {
+func allAllow(rs []cedarling.BatchItemUnsignedResult) bool {
 	for _, r := range rs {
-		if !r.Decision {
+		if !r.IsOk() || !r.Ok.Decision {
 			return false
 		}
 	}
 	return len(rs) > 0
 }
 
-func allAllowMulti(rs []cedarling.MultiIssuerAuthorizeResult) bool {
+func allAllowMulti(rs []cedarling.BatchItemMultiIssuerResult) bool {
 	for _, r := range rs {
-		if !r.Decision {
+		if !r.IsOk() || !r.Ok.Decision {
 			return false
 		}
 	}

--- a/jans-cedarling/bindings/cedarling_go/cedarling_batch_test.go
+++ b/jans-cedarling/bindings/cedarling_go/cedarling_batch_test.go
@@ -55,7 +55,11 @@ func TestAuthorizeUnsignedBatchOrderedAllow(t *testing.T) {
 		t.Error("batch_id should be populated")
 	}
 	for i, r := range response.Results {
-		if !r.Decision {
+		if !r.IsOk() {
+			t.Errorf("item %d expected Ok, got Err: %+v", i, r.Err)
+			continue
+		}
+		if !r.Ok.Decision {
 			t.Errorf("item %d should allow, got Deny", i)
 		}
 	}
@@ -91,10 +95,10 @@ func TestAuthorizeUnsignedBatchNoPrincipalResidualDenies(t *testing.T) {
 	if len(response.Results) != 2 {
 		t.Fatalf("Expected 2 results, got %d", len(response.Results))
 	}
-	if !response.Results[0].Decision {
+	if !response.Results[0].IsOk() || !response.Results[0].Ok.Decision {
 		t.Error("public action must allow under partial eval")
 	}
-	if response.Results[1].Decision {
+	if !response.Results[1].IsOk() || response.Results[1].Ok.Decision {
 		t.Error("principal-dependent action must fail closed")
 	}
 }
@@ -157,7 +161,11 @@ func TestAuthorizeMultiIssuerBatchOrdered(t *testing.T) {
 	// Same token+resource+action combo the single-item test uses; every
 	// result must Allow. Position-wise iteration also proves ordering.
 	for i, r := range response.Results {
-		if !r.Decision {
+		if !r.IsOk() {
+			t.Errorf("item %d expected Ok, got Err: %+v", i, r.Err)
+			continue
+		}
+		if !r.Ok.Decision {
 			t.Errorf("item %d should allow", i)
 		}
 	}
@@ -202,5 +210,52 @@ func TestAuthorizeMultiIssuerBatchEmptyItemsRejected(t *testing.T) {
 	}
 	if !strings.Contains(strings.ToLower(err.Error()), "empty") {
 		t.Errorf("expected error to mention empty items, got: %v", err)
+	}
+}
+
+// TestAuthorizeUnsignedBatchBadActionSurfacesError checks that a per-item
+// malformed action UID surfaces as Err(BatchItemError{ActionParse}) at that
+// position and doesn't affect adjacent Ok items.
+func TestAuthorizeUnsignedBatchBadActionSurfacesError(t *testing.T) {
+	config, err := loadUnsignedTestConfig()
+	if err != nil {
+		t.Fatalf("Failed to load test config: %v", err)
+	}
+	instance, err := NewCedarling(config)
+	if err != nil {
+		t.Fatalf("Failed to create Cedarling instance: %v", err)
+	}
+	defer instance.ShutDown()
+
+	good := unsignedBatchItem()
+	bad := BatchItem{
+		Resource: unsignedTestResource(),
+		Action:   "this is not a valid uid",
+	}
+
+	response, err := instance.AuthorizeUnsignedBatch(BatchAuthorizeUnsignedRequest{
+		Principal: unsignedPrincipal(true),
+		Items:     []BatchItem{good, bad, good},
+	})
+	if err != nil {
+		t.Fatalf("batch call failed: %v", err)
+	}
+	if len(response.Results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(response.Results))
+	}
+	if !response.Results[0].IsOk() || !response.Results[0].Ok.Decision {
+		t.Error("item 0 must be Ok+Allow")
+	}
+	if response.Results[1].IsOk() {
+		t.Fatalf("item 1 must be Err, got Ok: %+v", response.Results[1].Ok)
+	}
+	if response.Results[1].Err.Variant != "action_parse" {
+		t.Errorf("item 1 variant = %q, want action_parse", response.Results[1].Err.Variant)
+	}
+	if response.Results[1].Err.ItemIndex != 1 {
+		t.Errorf("item 1 item_index = %d, want 1", response.Results[1].Err.ItemIndex)
+	}
+	if !response.Results[2].IsOk() || !response.Results[2].Ok.Decision {
+		t.Error("item 2 must be Ok+Allow")
 	}
 }

--- a/jans-cedarling/bindings/cedarling_go/structs.go
+++ b/jans-cedarling/bindings/cedarling_go/structs.go
@@ -262,11 +262,69 @@ type BatchAuthorizeMultiIssuerRequest struct {
 	Items  []BatchItem  `json:"items"`
 }
 
+// BatchItemError is the per-item build failure surfaced inside a batch
+// response when Cedar couldn't be reached for that item. Category is the
+// stable variant slug ("action_parse", "resource_build", …); ItemIndex is
+// the position of the failing item in the original items list.
+type BatchItemError struct {
+	Variant   string `json:"variant"`
+	Message   string `json:"message"`
+	ItemIndex uint64 `json:"item_index"`
+}
+
+// BatchItemUnsignedResult is one slot in BatchAuthorizeUnsignedResponse.Results.
+// Exactly one of Ok / Err is non-nil: Ok when Cedar evaluated the item
+// (Allow or Deny), Err when the item failed to build. Use IsOk() to switch.
+type BatchItemUnsignedResult struct {
+	Ok  *AuthorizeResult
+	Err *BatchItemError
+}
+
+// IsOk reports whether Cedar reached a decision on this item.
+func (r BatchItemUnsignedResult) IsOk() bool { return r.Ok != nil }
+
+// UnmarshalJSON decodes the {"Ok":{...}} / {"Err":{...}} discriminated
+// union emitted by the core lib.
+func (r *BatchItemUnsignedResult) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Ok  *AuthorizeResult `json:"Ok,omitempty"`
+		Err *BatchItemError  `json:"Err,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*r = BatchItemUnsignedResult{Ok: raw.Ok, Err: raw.Err}
+	return nil
+}
+
+// BatchItemMultiIssuerResult is the multi-issuer analog of
+// BatchItemUnsignedResult.
+type BatchItemMultiIssuerResult struct {
+	Ok  *MultiIssuerAuthorizeResult
+	Err *BatchItemError
+}
+
+// IsOk reports whether Cedar reached a decision on this item.
+func (r BatchItemMultiIssuerResult) IsOk() bool { return r.Ok != nil }
+
+// UnmarshalJSON decodes the {"Ok":{...}} / {"Err":{...}} discriminated union.
+func (r *BatchItemMultiIssuerResult) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Ok  *MultiIssuerAuthorizeResult `json:"Ok,omitempty"`
+		Err *BatchItemError             `json:"Err,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*r = BatchItemMultiIssuerResult{Ok: raw.Ok, Err: raw.Err}
+	return nil
+}
+
 // BatchAuthorizeUnsignedResponse carries a shared batch_id alongside per-item
 // results. Results[i] corresponds to the Items[i] supplied in the request.
 type BatchAuthorizeUnsignedResponse struct {
-	BatchID string            `json:"batch_id"`
-	Results []AuthorizeResult `json:"results"`
+	BatchID string                    `json:"batch_id"`
+	Results []BatchItemUnsignedResult `json:"results"`
 }
 
 // BatchAuthorizeMultiIssuerResponse carries a shared batch_id alongside
@@ -274,7 +332,7 @@ type BatchAuthorizeUnsignedResponse struct {
 // supplied in the request.
 type BatchAuthorizeMultiIssuerResponse struct {
 	BatchID string                       `json:"batch_id"`
-	Results []MultiIssuerAuthorizeResult `json:"results"`
+	Results []BatchItemMultiIssuerResult `json:"results"`
 }
 
 // DataEntry represents a single entry in the data store with metadata

--- a/jans-cedarling/bindings/cedarling_python/PYTHON_TYPES.md
+++ b/jans-cedarling/bindings/cedarling_python/PYTHON_TYPES.md
@@ -90,14 +90,8 @@ req = BatchAuthorizeMultiIssuerRequest(
 BatchAuthorizeMultiIssuerResponse
 =================================
 
-A Python wrapper for `cedarling::BatchAuthorizeResponse<MultiIssuerAuthorizeResult>`.
-Carries a shared `batch_id` (UUIDv7) alongside per-item results.
-`results[i]` corresponds to the `items[i]` supplied to the request.
-
-Attributes
-----------  
-:param batch_id: Shared UUIDv7 correlation id stamped on every per-item decision log entry.  
-:param results: Per-item `MultiIssuerAuthorizeResult` list in input order (`results[i]` maps to `items[i]`).
+Multi-issuer analog of `BatchAuthorizeUnsignedResponse`. Each entry in
+`results` is a `BatchItemMultiIssuerResult`.
 ---
 
 BatchAuthorizeUnsignedRequest
@@ -125,14 +119,12 @@ req = BatchAuthorizeUnsignedRequest(
 BatchAuthorizeUnsignedResponse
 ==============================
 
-A Python wrapper for `cedarling::BatchAuthorizeResponse<AuthorizeResult>`.
-Carries a shared `batch_id` (UUIDv7) alongside per-item results.
-`results[i]` corresponds to the `items[i]` supplied to the request.
-
-Attributes
-----------  
-:param batch_id: Shared UUIDv7 correlation id stamped on every per-item decision log entry.  
-:param results: Per-item `AuthorizeResult` list in input order (`results[i]` maps to `items[i]`).
+A Python wrapper for
+`cedarling::BatchAuthorizeResponse<Result<AuthorizeResult, BatchItemError>>`.
+Carries a shared `batch_id` (UUIDv7) alongside per-item results. Each entry
+in `results` is a `BatchItemUnsignedResult` — an `AuthorizeResult` when
+Cedar reached a decision, or a `BatchItemError` when the item failed to
+build. `results[i]` corresponds to the `items[i]` supplied to the request.
 ---
 
 BatchItem
@@ -152,6 +144,35 @@ Example
 ```python
 item = BatchItem(resource=resource, action="Jans::Action::\"Read\"", context={})
 ```
+---
+
+BatchItemError
+==============
+
+Per-item build failure surfaced inside a batch response at
+`results[i].error()` when Cedar couldn't be reached for that item.
+
+Attributes
+----------  
+:param category: Stable variant slug (`action_parse`, `resource_build`,
+    `context_build`, `principal_build`, `schema_validation`,
+    `multi_issuer_entity`, `request_validation`).  
+:param item_index: Position of the failing item in the original `items` list.  
+:param message: Human-readable diagnostic. Safe to log.
+---
+
+BatchItemMultiIssuerResult
+==========================
+
+Multi-issuer analog of `BatchItemUnsignedResult`.
+---
+
+BatchItemUnsignedResult
+=======================
+
+One slot in a batch unsigned response's `results` list. Callers switch on
+`is_ok()` — on `True`, call `unwrap()` for the `AuthorizeResult`; on `False`,
+read `.error` for the `BatchItemError`.
 ---
 
 BootstrapConfig

--- a/jans-cedarling/bindings/cedarling_python/benchmarks/benchmark_cedarling.py
+++ b/jans-cedarling/bindings/cedarling_python/benchmarks/benchmark_cedarling.py
@@ -130,7 +130,7 @@ def _build_batch_items(scenario: dict, action: str, context: dict) -> list[Batch
 
 
 def _all_allow(results: list) -> bool:
-    return bool(results) and all(r.is_allowed() for r in results)
+    return bool(results) and all(r.is_ok() and r.unwrap().is_allowed() for r in results)
 
 
 def _percentile(sorted_samples: list[int], frac: float) -> int:

--- a/jans-cedarling/bindings/cedarling_python/cedarling_python/cedarling_python.pyi
+++ b/jans-cedarling/bindings/cedarling_python/cedarling_python/cedarling_python.pyi
@@ -653,6 +653,8 @@ class BatchItemError:
     item_index: int
     message: str
 
+    def __repr__(self) -> str: ...
+
 @final
 class BatchItemUnsignedResult:
     """One slot in `BatchAuthorizeUnsignedResponse.results`. Switch on

--- a/jans-cedarling/bindings/cedarling_python/cedarling_python/cedarling_python.pyi
+++ b/jans-cedarling/bindings/cedarling_python/cedarling_python/cedarling_python.pyi
@@ -644,18 +644,48 @@ class BatchAuthorizeMultiIssuerRequest:
     ) -> None: ...
 
 @final
+class BatchItemError:
+    """Per-item build failure inside a batch response — Cedar was never
+    reached for that item. Carries the variant tag, item position, and a
+    human-readable diagnostic."""
+
+    category: str
+    item_index: int
+    message: str
+
+@final
+class BatchItemUnsignedResult:
+    """One slot in `BatchAuthorizeUnsignedResponse.results`. Switch on
+    `is_ok()` — on True call `unwrap()` for the `AuthorizeResult`; on False
+    read `.error` for the `BatchItemError`."""
+
+    error: Optional[BatchItemError]
+
+    def is_ok(self) -> bool: ...
+    def unwrap(self) -> AuthorizeResult: ...
+
+@final
+class BatchItemMultiIssuerResult:
+    """Multi-issuer analog of `BatchItemUnsignedResult`."""
+
+    error: Optional[BatchItemError]
+
+    def is_ok(self) -> bool: ...
+    def unwrap(self) -> MultiIssuerAuthorizeResult: ...
+
+@final
 class BatchAuthorizeUnsignedResponse:
     """Result of `Cedarling.authorize_unsigned_batch`."""
 
     batch_id: str
-    results: List[AuthorizeResult]
+    results: List[BatchItemUnsignedResult]
 
 @final
 class BatchAuthorizeMultiIssuerResponse:
     """Result of `Cedarling.authorize_multi_issuer_batch`."""
 
     batch_id: str
-    results: List[MultiIssuerAuthorizeResult]
+    results: List[BatchItemMultiIssuerResult]
 
 @final
 class DataEntry:

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/batch_authorize_response.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/batch_authorize_response.rs
@@ -8,15 +8,16 @@
 use super::batch_item_result::{BatchItemMultiIssuerResult, BatchItemUnsignedResult};
 use pyo3::prelude::*;
 
-/// BatchAuthorizeUnsignedResponse
-/// ==============================
-///
-/// A Python wrapper for
-/// `cedarling::BatchAuthorizeResponse<Result<AuthorizeResult, BatchItemError>>`.
+/// A Python wrapper for `cedarling::BatchAuthorizeResponse<Result<AuthorizeResult, BatchItemError>>`.
+/// 
 /// Carries a shared `batch_id` (UUIDv7) alongside per-item results. Each entry
 /// in `results` is a `BatchItemUnsignedResult` — an `AuthorizeResult` when
 /// Cedar reached a decision, or a `BatchItemError` when the item failed to
 /// build. `results[i]` corresponds to the `items[i]` supplied to the request.
+///
+/// Attributes:
+///     batch_id (str): The shared UUIDv7 identifier for this batch evaluation.
+///     results (List[BatchItemUnsignedResult]): The evaluation results, in input order.
 #[pyclass]
 pub(crate) struct BatchAuthorizeUnsignedResponse {
     batch_id: String,
@@ -55,11 +56,11 @@ impl BatchAuthorizeUnsignedResponse {
     }
 }
 
-/// BatchAuthorizeMultiIssuerResponse
-/// =================================
+/// Multi-issuer analog of `BatchAuthorizeUnsignedResponse`.
 ///
-/// Multi-issuer analog of `BatchAuthorizeUnsignedResponse`. Each entry in
-/// `results` is a `BatchItemMultiIssuerResult`.
+/// Attributes:
+///     batch_id (str): The shared UUIDv7 identifier for this batch evaluation.
+///     results (List[BatchItemMultiIssuerResult]): The evaluation results, in input order.
 #[pyclass]
 pub(crate) struct BatchAuthorizeMultiIssuerResponse {
     batch_id: String,

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/batch_authorize_response.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/batch_authorize_response.rs
@@ -5,38 +5,33 @@
  * Copyright (c) 2024, Gluu, Inc.
  */
 
-use super::authorize_result::AuthorizeResult;
-use super::multi_issuer_authorize_result::MultiIssuerAuthorizeResult;
+use super::batch_item_result::{BatchItemMultiIssuerResult, BatchItemUnsignedResult};
 use pyo3::prelude::*;
 
 /// BatchAuthorizeUnsignedResponse
 /// ==============================
 ///
-/// A Python wrapper for `cedarling::BatchAuthorizeResponse<AuthorizeResult>`.
-/// Carries a shared `batch_id` (UUIDv7) alongside per-item results.
-/// `results[i]` corresponds to the `items[i]` supplied to the request.
-///
-/// Attributes
-/// ----------
-/// :param batch_id: Shared UUIDv7 correlation id stamped on every per-item decision log entry.
-/// :param results: Per-item `AuthorizeResult` list in input order (`results[i]` maps to `items[i]`).
+/// A Python wrapper for
+/// `cedarling::BatchAuthorizeResponse<Result<AuthorizeResult, BatchItemError>>`.
+/// Carries a shared `batch_id` (UUIDv7) alongside per-item results. Each entry
+/// in `results` is a `BatchItemUnsignedResult` — an `AuthorizeResult` when
+/// Cedar reached a decision, or a `BatchItemError` when the item failed to
+/// build. `results[i]` corresponds to the `items[i]` supplied to the request.
 #[pyclass]
 pub(crate) struct BatchAuthorizeUnsignedResponse {
     batch_id: String,
-    results: Vec<Py<AuthorizeResult>>,
+    results: Vec<Py<BatchItemUnsignedResult>>,
 }
 
 #[pymethods]
 impl BatchAuthorizeUnsignedResponse {
-    /// Shared correlation id stamped on every per-item decision log entry.
     #[getter]
     fn batch_id(&self) -> String {
         self.batch_id.clone()
     }
 
-    /// Per-item results in input order.
     #[getter]
-    fn results(&self, py: Python) -> Vec<Py<AuthorizeResult>> {
+    fn results(&self, py: Python) -> Vec<Py<BatchItemUnsignedResult>> {
         self.results.iter().map(|r| r.clone_ref(py)).collect()
     }
 }
@@ -44,12 +39,14 @@ impl BatchAuthorizeUnsignedResponse {
 impl BatchAuthorizeUnsignedResponse {
     pub(crate) fn from_cedarling(
         py: Python,
-        value: cedarling::BatchAuthorizeResponse<cedarling::AuthorizeResult>,
+        value: cedarling::BatchAuthorizeResponse<
+            Result<cedarling::AuthorizeResult, cedarling::BatchItemError>,
+        >,
     ) -> PyResult<Self> {
         let results = value
             .results
             .into_iter()
-            .map(|r| Py::new(py, AuthorizeResult::from(r)))
+            .map(|r| Py::new(py, BatchItemUnsignedResult::from_cedarling(py, r)?))
             .collect::<PyResult<Vec<_>>>()?;
         Ok(Self {
             batch_id: value.batch_id.to_string(),
@@ -61,31 +58,23 @@ impl BatchAuthorizeUnsignedResponse {
 /// BatchAuthorizeMultiIssuerResponse
 /// =================================
 ///
-/// A Python wrapper for `cedarling::BatchAuthorizeResponse<MultiIssuerAuthorizeResult>`.
-/// Carries a shared `batch_id` (UUIDv7) alongside per-item results.
-/// `results[i]` corresponds to the `items[i]` supplied to the request.
-///
-/// Attributes
-/// ----------
-/// :param batch_id: Shared UUIDv7 correlation id stamped on every per-item decision log entry.
-/// :param results: Per-item `MultiIssuerAuthorizeResult` list in input order (`results[i]` maps to `items[i]`).
+/// Multi-issuer analog of `BatchAuthorizeUnsignedResponse`. Each entry in
+/// `results` is a `BatchItemMultiIssuerResult`.
 #[pyclass]
 pub(crate) struct BatchAuthorizeMultiIssuerResponse {
     batch_id: String,
-    results: Vec<Py<MultiIssuerAuthorizeResult>>,
+    results: Vec<Py<BatchItemMultiIssuerResult>>,
 }
 
 #[pymethods]
 impl BatchAuthorizeMultiIssuerResponse {
-    /// Shared correlation id stamped on every per-item decision log entry.
     #[getter]
     fn batch_id(&self) -> String {
         self.batch_id.clone()
     }
 
-    /// Per-item results in input order.
     #[getter]
-    fn results(&self, py: Python) -> Vec<Py<MultiIssuerAuthorizeResult>> {
+    fn results(&self, py: Python) -> Vec<Py<BatchItemMultiIssuerResult>> {
         self.results.iter().map(|r| r.clone_ref(py)).collect()
     }
 }
@@ -93,12 +82,14 @@ impl BatchAuthorizeMultiIssuerResponse {
 impl BatchAuthorizeMultiIssuerResponse {
     pub(crate) fn from_cedarling(
         py: Python,
-        value: cedarling::BatchAuthorizeResponse<cedarling::MultiIssuerAuthorizeResult>,
+        value: cedarling::BatchAuthorizeResponse<
+            Result<cedarling::MultiIssuerAuthorizeResult, cedarling::BatchItemError>,
+        >,
     ) -> PyResult<Self> {
         let results = value
             .results
             .into_iter()
-            .map(|r| Py::new(py, MultiIssuerAuthorizeResult::from(r)))
+            .map(|r| Py::new(py, BatchItemMultiIssuerResult::from_cedarling(py, r)?))
             .collect::<PyResult<Vec<_>>>()?;
         Ok(Self {
             batch_id: value.batch_id.to_string(),

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/batch_authorize_response.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/batch_authorize_response.rs
@@ -12,8 +12,9 @@ use pyo3::prelude::*;
 /// 
 /// Carries a shared `batch_id` (UUIDv7) alongside per-item results. Each entry
 /// in `results` is a `BatchItemUnsignedResult` — an `AuthorizeResult` when
-/// Cedar reached a decision, or a `BatchItemError` when the item failed to
-/// build. `results[i]` corresponds to the `items[i]` supplied to the request.
+/// Cedar reached a decision, or a `BatchItemError` when the item failed during
+/// per-item preparation or request validation. `results[i]` corresponds to the
+/// `items[i]` supplied to the request.
 ///
 /// Attributes:
 ///     batch_id (str): The shared UUIDv7 identifier for this batch evaluation.

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/batch_item_error.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/batch_item_error.rs
@@ -1,0 +1,60 @@
+/*
+ * This software is available under the Apache-2.0 license.
+ * See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+ *
+ * Copyright (c) 2024, Gluu, Inc.
+ */
+
+use pyo3::prelude::*;
+
+/// BatchItemError
+/// ==============
+///
+/// Per-item build failure surfaced inside a batch response at
+/// `results[i].error()` when Cedar couldn't be reached for that item.
+///
+/// Attributes
+/// ----------
+/// :param category: Stable variant slug (`action_parse`, `resource_build`,
+///     `context_build`, `principal_build`, `schema_validation`,
+///     `multi_issuer_entity`, `request_validation`).
+/// :param item_index: Position of the failing item in the original `items` list.
+/// :param message: Human-readable diagnostic. Safe to log.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub(crate) struct BatchItemError {
+    inner: cedarling::BatchItemError,
+}
+
+#[pymethods]
+impl BatchItemError {
+    #[getter]
+    fn category(&self) -> &'static str {
+        self.inner.category()
+    }
+
+    #[getter]
+    fn item_index(&self) -> usize {
+        self.inner.item_index()
+    }
+
+    #[getter]
+    fn message(&self) -> String {
+        self.inner.to_string()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "BatchItemError(category={:?}, item_index={}, message={:?})",
+            self.category(),
+            self.item_index(),
+            self.message(),
+        )
+    }
+}
+
+impl From<cedarling::BatchItemError> for BatchItemError {
+    fn from(inner: cedarling::BatchItemError) -> Self {
+        Self { inner }
+    }
+}

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/batch_item_result.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/batch_item_result.rs
@@ -5,7 +5,7 @@
  * Copyright (c) 2024, Gluu, Inc.
  */
 
-use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use super::authorize_result::AuthorizeResult;
@@ -37,7 +37,7 @@ impl BatchItemUnsignedResult {
         self.ok
             .as_ref()
             .map(|o| o.clone_ref(py))
-            .ok_or_else(|| PyRuntimeError::new_err("BatchItemUnsignedResult is Err"))
+            .ok_or_else(|| PyValueError::new_err("BatchItemUnsignedResult is Err"))
     }
 
     /// The per-item `BatchItemError` if `!is_ok()`; `None` otherwise.
@@ -85,7 +85,7 @@ impl BatchItemMultiIssuerResult {
         self.ok
             .as_ref()
             .map(|o| o.clone_ref(py))
-            .ok_or_else(|| PyRuntimeError::new_err("BatchItemMultiIssuerResult is Err"))
+            .ok_or_else(|| PyValueError::new_err("BatchItemMultiIssuerResult is Err"))
     }
 
     #[getter]

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/batch_item_result.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/batch_item_result.rs
@@ -32,7 +32,7 @@ impl BatchItemUnsignedResult {
         self.ok.is_some()
     }
 
-    /// The `AuthorizeResult` if `is_ok()`; raises `RuntimeError` otherwise.
+    /// The `AuthorizeResult` if `is_ok()`; raises `ValueError` otherwise.
     fn unwrap(&self, py: Python) -> PyResult<Py<AuthorizeResult>> {
         self.ok
             .as_ref()

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/batch_item_result.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/batch_item_result.rs
@@ -1,0 +1,113 @@
+/*
+ * This software is available under the Apache-2.0 license.
+ * See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+ *
+ * Copyright (c) 2024, Gluu, Inc.
+ */
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+use super::authorize_result::AuthorizeResult;
+use super::batch_item_error::BatchItemError;
+use super::multi_issuer_authorize_result::MultiIssuerAuthorizeResult;
+
+/// BatchItemUnsignedResult
+/// =======================
+///
+/// One slot in a batch unsigned response's `results` list. Callers switch on
+/// `is_ok()` — on `True`, call `unwrap()` for the `AuthorizeResult`; on `False`,
+/// read `.error` for the `BatchItemError`.
+#[pyclass]
+pub(crate) struct BatchItemUnsignedResult {
+    ok: Option<Py<AuthorizeResult>>,
+    err: Option<Py<BatchItemError>>,
+}
+
+#[pymethods]
+impl BatchItemUnsignedResult {
+    /// `True` when Cedar evaluated this item (Allow or Deny); `False` when the
+    /// item failed to build.
+    fn is_ok(&self) -> bool {
+        self.ok.is_some()
+    }
+
+    /// The `AuthorizeResult` if `is_ok()`; raises `RuntimeError` otherwise.
+    fn unwrap(&self, py: Python) -> PyResult<Py<AuthorizeResult>> {
+        self.ok
+            .as_ref()
+            .map(|o| o.clone_ref(py))
+            .ok_or_else(|| PyRuntimeError::new_err("BatchItemUnsignedResult is Err"))
+    }
+
+    /// The per-item `BatchItemError` if `!is_ok()`; `None` otherwise.
+    #[getter]
+    fn error(&self, py: Python) -> Option<Py<BatchItemError>> {
+        self.err.as_ref().map(|e| e.clone_ref(py))
+    }
+}
+
+impl BatchItemUnsignedResult {
+    pub(crate) fn from_cedarling(
+        py: Python,
+        value: Result<cedarling::AuthorizeResult, cedarling::BatchItemError>,
+    ) -> PyResult<Self> {
+        match value {
+            Ok(r) => Ok(Self {
+                ok: Some(Py::new(py, AuthorizeResult::from(r))?),
+                err: None,
+            }),
+            Err(e) => Ok(Self {
+                ok: None,
+                err: Some(Py::new(py, BatchItemError::from(e))?),
+            }),
+        }
+    }
+}
+
+/// BatchItemMultiIssuerResult
+/// ==========================
+///
+/// Multi-issuer analog of `BatchItemUnsignedResult`.
+#[pyclass]
+pub(crate) struct BatchItemMultiIssuerResult {
+    ok: Option<Py<MultiIssuerAuthorizeResult>>,
+    err: Option<Py<BatchItemError>>,
+}
+
+#[pymethods]
+impl BatchItemMultiIssuerResult {
+    fn is_ok(&self) -> bool {
+        self.ok.is_some()
+    }
+
+    fn unwrap(&self, py: Python) -> PyResult<Py<MultiIssuerAuthorizeResult>> {
+        self.ok
+            .as_ref()
+            .map(|o| o.clone_ref(py))
+            .ok_or_else(|| PyRuntimeError::new_err("BatchItemMultiIssuerResult is Err"))
+    }
+
+    #[getter]
+    fn error(&self, py: Python) -> Option<Py<BatchItemError>> {
+        self.err.as_ref().map(|e| e.clone_ref(py))
+    }
+}
+
+impl BatchItemMultiIssuerResult {
+    pub(crate) fn from_cedarling(
+        py: Python,
+        value: Result<cedarling::MultiIssuerAuthorizeResult, cedarling::BatchItemError>,
+    ) -> PyResult<Self> {
+        match value {
+            Ok(r) => Ok(Self {
+                ok: Some(Py::new(py, MultiIssuerAuthorizeResult::from(r))?),
+                err: None,
+            }),
+            Err(e) => Ok(Self {
+                ok: None,
+                err: Some(Py::new(py, BatchItemError::from(e))?),
+            }),
+        }
+    }
+}

--- a/jans-cedarling/bindings/cedarling_python/src/authorize/mod.rs
+++ b/jans-cedarling/bindings/cedarling_python/src/authorize/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod authorize_result;
 mod authorize_result_response;
 pub(crate) mod batch_authorize_response;
 pub(crate) mod batch_item;
+pub(crate) mod batch_item_error;
+pub(crate) mod batch_item_result;
 mod decision;
 mod diagnostics;
 pub(crate) mod entity_data;
@@ -35,6 +37,9 @@ pub fn register_entities(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<token_input::TokenInput>()?;
     m.add_class::<request_multi_issuer::AuthorizeMultiIssuerRequest>()?;
     m.add_class::<batch_item::BatchItem>()?;
+    m.add_class::<batch_item_error::BatchItemError>()?;
+    m.add_class::<batch_item_result::BatchItemUnsignedResult>()?;
+    m.add_class::<batch_item_result::BatchItemMultiIssuerResult>()?;
     m.add_class::<request_batch_unsigned::BatchAuthorizeUnsignedRequest>()?;
     m.add_class::<request_batch_multi_issuer::BatchAuthorizeMultiIssuerRequest>()?;
     m.add_class::<batch_authorize_response::BatchAuthorizeUnsignedResponse>()?;

--- a/jans-cedarling/bindings/cedarling_python/tests/test_authorize_multi_issuer_batch.py
+++ b/jans-cedarling/bindings/cedarling_python/tests/test_authorize_multi_issuer_batch.py
@@ -67,7 +67,8 @@ def test_batch_multi_issuer_single_item():
     response = instance.authorize_multi_issuer_batch(request)
 
     assert len(response.results) == 1
-    assert response.results[0].is_allowed(), "single item should allow"
+    assert response.results[0].is_ok()
+    assert response.results[0].unwrap().is_allowed(), "single item should allow"
     assert response.batch_id
 
 
@@ -84,7 +85,8 @@ def test_batch_multi_issuer_n5_ordered():
 
     assert len(response.results) == 5
     for i, r in enumerate(response.results):
-        assert r.is_allowed(), f"item {i} should allow"
+        assert r.is_ok(), f"item {i} should be Ok"
+        assert r.unwrap().is_allowed(), f"item {i} should allow"
 
 
 def test_batch_multi_issuer_empty_tokens_rejected():
@@ -105,9 +107,9 @@ def test_batch_multi_issuer_empty_items_rejected():
         instance.authorize_multi_issuer_batch(request)
 
 
-def test_batch_multi_issuer_bad_action_denies_only_that_item():
-    """A per-item malformed action UID synthesizes a Deny for that item but
-    does not fail other items in the batch."""
+def test_batch_multi_issuer_bad_action_surfaces_error_only_at_that_item():
+    """A per-item malformed action UID surfaces as a BatchItemError at that
+    position; adjacent items still evaluate cleanly."""
     instance = Cedarling(load_bootstrap_config(config_cb=_multi_issuer_config()))
 
     bad = BatchItem(
@@ -122,8 +124,12 @@ def test_batch_multi_issuer_bad_action_denies_only_that_item():
     response = instance.authorize_multi_issuer_batch(request)
 
     assert len(response.results) == 3
-    assert response.results[0].is_allowed(), "item 0 allowed"
-    assert not response.results[1].is_allowed(), (
-        "item 1 with bad action must fail closed"
-    )
-    assert response.results[2].is_allowed(), "item 2 allowed"
+    assert response.results[0].is_ok()
+    assert response.results[0].unwrap().is_allowed(), "item 0 allowed"
+    assert not response.results[1].is_ok(), "item 1 must be Err"
+    err = response.results[1].error
+    assert err is not None
+    assert err.category == "action_parse"
+    assert err.item_index == 1
+    assert response.results[2].is_ok()
+    assert response.results[2].unwrap().is_allowed(), "item 2 allowed"

--- a/jans-cedarling/bindings/cedarling_python/tests/test_authorize_unsigned_batch.py
+++ b/jans-cedarling/bindings/cedarling_python/tests/test_authorize_unsigned_batch.py
@@ -58,7 +58,8 @@ def test_batch_unsigned_single_item_allow():
     response = instance.authorize_unsigned_batch(request)
 
     assert len(response.results) == 1
-    assert response.results[0].is_allowed()
+    assert response.results[0].is_ok()
+    assert response.results[0].unwrap().is_allowed()
     assert response.batch_id  # non-empty
 
 
@@ -74,7 +75,8 @@ def test_batch_unsigned_n5_ordered_all_allow():
 
     assert len(response.results) == 5
     for i, result in enumerate(response.results):
-        assert result.is_allowed(), f"item {i} should allow"
+        assert result.is_ok(), f"item {i} should be Ok"
+        assert result.unwrap().is_allowed(), f"item {i} should allow"
 
 
 def test_batch_unsigned_deny_propagates_per_item():
@@ -89,7 +91,8 @@ def test_batch_unsigned_deny_propagates_per_item():
 
     assert len(response.results) == 2
     for result in response.results:
-        assert not result.is_allowed()
+        assert result.is_ok()
+        assert not result.unwrap().is_allowed()
 
 
 def test_batch_unsigned_no_principal_residual_denies_that_item_only():
@@ -111,8 +114,12 @@ def test_batch_unsigned_no_principal_residual_denies_that_item_only():
     response = instance.authorize_unsigned_batch(request)
 
     assert len(response.results) == 2
-    assert response.results[0].is_allowed(), "public action must allow"
-    assert not response.results[1].is_allowed(), "principal-dependent action must deny"
+    assert response.results[0].is_ok()
+    assert response.results[0].unwrap().is_allowed(), "public action must allow"
+    assert response.results[1].is_ok()
+    assert not response.results[1].unwrap().is_allowed(), (
+        "principal-dependent action must deny"
+    )
 
 
 def test_batch_unsigned_empty_items_rejected():
@@ -136,4 +143,33 @@ def test_batch_unsigned_context_defaults_when_omitted():
     response = instance.authorize_unsigned_batch(request)
 
     assert len(response.results) == 1
-    assert response.results[0].is_allowed()
+    assert response.results[0].is_ok()
+    assert response.results[0].unwrap().is_allowed()
+
+
+def test_batch_unsigned_bad_action_surfaces_error_only_at_that_item():
+    """A per-item malformed action UID surfaces as a BatchItemError at that
+    position; adjacent items still evaluate cleanly."""
+    instance = Cedarling(load_bootstrap_config(POLICY_STORE_LOCATION))
+
+    bad = BatchItem(
+        resource=_resource("bad"),
+        action="this is not a valid uid",
+        context={},
+    )
+    request = BatchAuthorizeUnsignedRequest(
+        items=[_item("ok-0"), bad, _item("ok-2")],
+        principal=_principal(True),
+    )
+    response = instance.authorize_unsigned_batch(request)
+
+    assert len(response.results) == 3
+    assert response.results[0].is_ok()
+    assert response.results[0].unwrap().is_allowed(), "item 0 allowed"
+    assert not response.results[1].is_ok(), "item 1 must be Err"
+    err = response.results[1].error
+    assert err is not None
+    assert err.category == "action_parse"
+    assert err.item_index == 1
+    assert response.results[2].is_ok()
+    assert response.results[2].unwrap().is_allowed(), "item 2 allowed"

--- a/jans-cedarling/bindings/cedarling_uniffi/javaApp/src/main/java/org/example/Benchmark.java
+++ b/jans-cedarling/bindings/cedarling_uniffi/javaApp/src/main/java/org/example/Benchmark.java
@@ -12,13 +12,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import uniffi.cedarling_uniffi.AuthorizeResult;
 import uniffi.cedarling_uniffi.BatchAuthorizeMultiIssuerResponse;
 import uniffi.cedarling_uniffi.BatchAuthorizeUnsignedResponse;
 import uniffi.cedarling_uniffi.BatchItem;
+import uniffi.cedarling_uniffi.BatchItemMultiIssuerOutcome;
+import uniffi.cedarling_uniffi.BatchItemUnsignedOutcome;
 import uniffi.cedarling_uniffi.Cedarling;
 import uniffi.cedarling_uniffi.EntityData;
-import uniffi.cedarling_uniffi.MultiIssuerAuthorizeResult;
 import uniffi.cedarling_uniffi.TokenInput;
 
 /**
@@ -223,8 +223,11 @@ public class Benchmark {
         return () -> {
             BatchAuthorizeUnsignedResponse resp =
                 cedarling.authorizeUnsignedBatch(principal, items);
-            for (AuthorizeResult r : resp.getResults()) {
-                if (!r.getDecision()) {
+            for (BatchItemUnsignedOutcome r : resp.getResults()) {
+                if (!(r instanceof BatchItemUnsignedOutcome.Success)) {
+                    return false;
+                }
+                if (!((BatchItemUnsignedOutcome.Success) r).getResult().getDecision()) {
                     return false;
                 }
             }
@@ -249,8 +252,11 @@ public class Benchmark {
         return () -> {
             BatchAuthorizeMultiIssuerResponse resp =
                 cedarling.authorizeMultiIssuerBatch(tokens, items);
-            for (MultiIssuerAuthorizeResult r : resp.getResults()) {
-                if (!r.getDecision()) {
+            for (BatchItemMultiIssuerOutcome r : resp.getResults()) {
+                if (!(r instanceof BatchItemMultiIssuerOutcome.Success)) {
+                    return false;
+                }
+                if (!((BatchItemMultiIssuerOutcome.Success) r).getResult().getDecision()) {
                     return false;
                 }
             }

--- a/jans-cedarling/bindings/cedarling_uniffi/src/result.rs
+++ b/jans-cedarling/bindings/cedarling_uniffi/src/result.rs
@@ -86,17 +86,83 @@ impl From<core::MultiIssuerAuthorizeResult> for MultiIssuerAuthorizeResult {
     }
 }
 
+/// Per-item build failure surfaced inside a batch response when Cedar
+/// couldn't be reached for that item. `category` is the stable variant slug
+/// (`action_parse`, `resource_build`, …), `item_index` is the position of
+/// the failing item in the original `items` list.
+#[derive(Debug, uniffi::Record)]
+pub struct BatchItemError {
+    pub category: String,
+    // i64 (not u64) so the Kotlin/Java binding exposes it as a signed Long
+    // rather than a JVM-hostile ULong. usize casts fit trivially.
+    pub item_index: i64,
+    pub message: String,
+}
+
+impl From<core::BatchItemError> for BatchItemError {
+    fn from(e: core::BatchItemError) -> Self {
+        let message = e.to_string();
+        Self {
+            category: e.category().to_string(),
+            item_index: e.item_index() as i64,
+            message,
+        }
+    }
+}
+
+/// One slot in `BatchAuthorizeUnsignedResponse.results`. Pattern-match on
+/// `Success(_)` to read the Cedar decision, or `Failed(_)` to read the
+/// per-item build failure.
+#[derive(Debug, uniffi::Enum)]
+pub enum BatchItemUnsignedOutcome {
+    Success { result: AuthorizeResult },
+    Failed { error: BatchItemError },
+}
+
+impl From<Result<core::AuthorizeResult, core::BatchItemError>> for BatchItemUnsignedOutcome {
+    fn from(r: Result<core::AuthorizeResult, core::BatchItemError>) -> Self {
+        match r {
+            Ok(ok) => Self::Success { result: ok.into() },
+            Err(err) => Self::Failed { error: err.into() },
+        }
+    }
+}
+
+/// Multi-issuer analog of [`BatchItemUnsignedOutcome`].
+#[derive(Debug, uniffi::Enum)]
+pub enum BatchItemMultiIssuerOutcome {
+    Success { result: MultiIssuerAuthorizeResult },
+    Failed { error: BatchItemError },
+}
+
+impl From<Result<core::MultiIssuerAuthorizeResult, core::BatchItemError>>
+    for BatchItemMultiIssuerOutcome
+{
+    fn from(r: Result<core::MultiIssuerAuthorizeResult, core::BatchItemError>) -> Self {
+        match r {
+            Ok(ok) => Self::Success { result: ok.into() },
+            Err(err) => Self::Failed { error: err.into() },
+        }
+    }
+}
+
 /// Result of `Cedarling.authorize_unsigned_batch`. Carries a shared `batch_id`
-/// (UUIDv7) alongside per-item results. `results[i]` corresponds to the
+/// (UUIDv7) alongside per-item outcomes. `results[i]` corresponds to the
 /// `items[i]` supplied in the request.
 #[derive(Debug, uniffi::Record)]
 pub struct BatchAuthorizeUnsignedResponse {
     pub batch_id: String,
-    pub results: Vec<AuthorizeResult>,
+    pub results: Vec<BatchItemUnsignedOutcome>,
 }
 
-impl From<core::BatchAuthorizeResponse<core::AuthorizeResult>> for BatchAuthorizeUnsignedResponse {
-    fn from(value: core::BatchAuthorizeResponse<core::AuthorizeResult>) -> Self {
+impl From<core::BatchAuthorizeResponse<Result<core::AuthorizeResult, core::BatchItemError>>>
+    for BatchAuthorizeUnsignedResponse
+{
+    fn from(
+        value: core::BatchAuthorizeResponse<
+            Result<core::AuthorizeResult, core::BatchItemError>,
+        >,
+    ) -> Self {
         Self {
             batch_id: value.batch_id.to_string(),
             results: value.results.into_iter().map(Into::into).collect(),
@@ -104,19 +170,26 @@ impl From<core::BatchAuthorizeResponse<core::AuthorizeResult>> for BatchAuthoriz
     }
 }
 
-/// Result of `Cedarling.authorize_multi_issuer_batch`. Carries a shared
-/// `batch_id` (UUIDv7) alongside per-item results. `results[i]` corresponds
-/// to the `items[i]` supplied in the request.
+/// Result of `Cedarling.authorize_multi_issuer_batch`. Same shape as
+/// [`BatchAuthorizeUnsignedResponse`] with multi-issuer results.
 #[derive(Debug, uniffi::Record)]
 pub struct BatchAuthorizeMultiIssuerResponse {
     pub batch_id: String,
-    pub results: Vec<MultiIssuerAuthorizeResult>,
+    pub results: Vec<BatchItemMultiIssuerOutcome>,
 }
 
-impl From<core::BatchAuthorizeResponse<core::MultiIssuerAuthorizeResult>>
-    for BatchAuthorizeMultiIssuerResponse
+impl
+    From<
+        core::BatchAuthorizeResponse<
+            Result<core::MultiIssuerAuthorizeResult, core::BatchItemError>,
+        >,
+    > for BatchAuthorizeMultiIssuerResponse
 {
-    fn from(value: core::BatchAuthorizeResponse<core::MultiIssuerAuthorizeResult>) -> Self {
+    fn from(
+        value: core::BatchAuthorizeResponse<
+            Result<core::MultiIssuerAuthorizeResult, core::BatchItemError>,
+        >,
+    ) -> Self {
         Self {
             batch_id: value.batch_id.to_string(),
             results: value.results.into_iter().map(Into::into).collect(),

--- a/jans-cedarling/bindings/cedarling_uniffi/src/tests.rs
+++ b/jans-cedarling/bindings/cedarling_uniffi/src/tests.rs
@@ -678,8 +678,14 @@ fn test_authorize_multi_issuer_batch_bad_action_surfaces_error_at_that_item() {
     assert_eq!(response.results.len(), 3, "batch size should match the 3 request items");
     match &response.results[1] {
         BatchItemMultiIssuerOutcome::Failed { error } => {
-            assert_eq!(error.category, "action_parse", "expected action_parse category for malformed action");
-            assert_eq!(error.item_index, 1, "error item_index must match its position in the batch");
+            assert_eq!(
+                error.category, "action_parse",
+                "expected action_parse category for malformed action"
+            );
+            assert_eq!(
+                error.item_index, 1,
+                "error item_index must match its position in the batch"
+            );
         },
         other => panic!("item 1 must be Failed(action_parse), got: {other:?}"),
     }

--- a/jans-cedarling/bindings/cedarling_uniffi/src/tests.rs
+++ b/jans-cedarling/bindings/cedarling_uniffi/src/tests.rs
@@ -7,6 +7,7 @@ use crate::BatchItem;
 use crate::Cedarling;
 use crate::CedarlingError;
 use crate::TokenInput;
+use crate::result::{BatchItemMultiIssuerOutcome, BatchItemUnsignedOutcome};
 use crate::{EntityData, JsonValue};
 use serde_json::json;
 use std::sync::Arc;
@@ -473,12 +474,25 @@ fn test_authorize_unsigned_batch_ordered_mixed_decisions() {
         .expect("batch call should succeed");
 
     assert_eq!(response.results.len(), 3, "N=3 items → N=3 results");
-    assert!(response.results[0].decision, "item 0 must allow");
-    assert!(
-        !response.results[1].decision,
-        "item 1 with bad action must fail closed"
-    );
-    assert!(response.results[2].decision, "item 2 must allow");
+    match &response.results[0] {
+        BatchItemUnsignedOutcome::Success { result } => {
+            assert!(result.decision, "item 0 must allow");
+        },
+        other => panic!("item 0 must be Success, got: {other:?}"),
+    }
+    match &response.results[1] {
+        BatchItemUnsignedOutcome::Failed { error } => {
+            assert_eq!(error.category, "action_parse");
+            assert_eq!(error.item_index, 1);
+        },
+        other => panic!("item 1 must be Failed(action_parse), got: {other:?}"),
+    }
+    match &response.results[2] {
+        BatchItemUnsignedOutcome::Success { result } => {
+            assert!(result.decision, "item 2 must allow");
+        },
+        other => panic!("item 2 must be Success, got: {other:?}"),
+    }
     assert!(!response.batch_id.is_empty(), "batch_id must be populated");
 }
 
@@ -514,10 +528,13 @@ fn test_authorize_unsigned_batch_context_defaults_when_none() {
         1,
         "single-item batch must produce exactly one result"
     );
-    assert!(
-        response.results[0].decision,
-        "None context defaults to {{}} and the is_ok=true principal must Allow"
-    );
+    match &response.results[0] {
+        BatchItemUnsignedOutcome::Success { result } => assert!(
+            result.decision,
+            "None context defaults to {{}} and the is_ok=true principal must Allow"
+        ),
+        other => panic!("must be Success, got: {other:?}"),
+    }
 }
 
 // ── Multi-issuer batch tests ────────────────────────────────────────
@@ -637,4 +654,34 @@ fn test_authorize_multi_issuer_batch_context_none_defaults() {
         !response.batch_id.is_empty(),
         "batch_id must be populated (UUIDv7)"
     );
+}
+
+#[test]
+fn test_authorize_multi_issuer_batch_bad_action_surfaces_error_at_that_item() {
+    // Proves BatchItemMultiIssuerOutcome::Failed round-trips across the UniFFI
+    // boundary — the Err variant survives with category/item_index intact.
+    let cedarling = create_test_cedarling();
+    let items = vec![
+        multi_issuer_item("ok-0"),
+        BatchItem {
+            resource: multi_issuer_resource("bad-1"),
+            action: "this is not a valid uid".to_string(),
+            context: Some(JsonValue("{}".to_string())),
+        },
+        multi_issuer_item("ok-2"),
+    ];
+
+    let response = cedarling
+        .authorize_multi_issuer_batch(vec![multi_issuer_access_token()], items)
+        .expect("batch call should succeed at the UniFFI boundary");
+
+    assert_eq!(response.results.len(), 3);
+    match &response.results[1] {
+        BatchItemMultiIssuerOutcome::Failed { error } => {
+            assert_eq!(error.category, "action_parse");
+            assert_eq!(error.item_index, 1);
+        },
+        other => panic!("item 1 must be Failed(action_parse), got: {other:?}"),
+    }
+    assert!(!response.batch_id.is_empty(), "batch_id must be populated");
 }

--- a/jans-cedarling/bindings/cedarling_uniffi/src/tests.rs
+++ b/jans-cedarling/bindings/cedarling_uniffi/src/tests.rs
@@ -675,11 +675,11 @@ fn test_authorize_multi_issuer_batch_bad_action_surfaces_error_at_that_item() {
         .authorize_multi_issuer_batch(vec![multi_issuer_access_token()], items)
         .expect("batch call should succeed at the UniFFI boundary");
 
-    assert_eq!(response.results.len(), 3);
+    assert_eq!(response.results.len(), 3, "batch size should match the 3 request items");
     match &response.results[1] {
         BatchItemMultiIssuerOutcome::Failed { error } => {
-            assert_eq!(error.category, "action_parse");
-            assert_eq!(error.item_index, 1);
+            assert_eq!(error.category, "action_parse", "expected action_parse category for malformed action");
+            assert_eq!(error.item_index, 1, "error item_index must match its position in the batch");
         },
         other => panic!("item 1 must be Failed(action_parse), got: {other:?}"),
     }

--- a/jans-cedarling/bindings/cedarling_wasm/benchmarks/benchmark.mjs
+++ b/jans-cedarling/bindings/cedarling_wasm/benchmarks/benchmark.mjs
@@ -117,7 +117,8 @@ function buildBatchItems(scenario, ctx) {
 function batchAllAllow(results) {
   if (!results || results.length === 0) return false;
   for (const r of results) {
-    if (!r.decision) return false;
+    if (!r.is_ok) return false;
+    if (!r.unwrap().decision) return false;
   }
   return true;
 }

--- a/jans-cedarling/bindings/cedarling_wasm/src/lib.rs
+++ b/jans-cedarling/bindings/cedarling_wasm/src/lib.rs
@@ -7,6 +7,7 @@ use cedarling::bindings::cedar_policy;
 use cedarling::{
     AuthorizeMultiIssuerRequest, BatchAuthorizeMultiIssuerRequest,
     BatchAuthorizeResponse as CedarBatchAuthorizeResponse, BatchAuthorizeUnsignedRequest,
+    BatchItemError as CedarBatchItemError,
     BootstrapConfig, BootstrapConfigRaw, DataApi, DataEntry as CedarDataEntry,
     DataStoreStats as CedarDataStoreStats, LogStorage, RequestUnsigned, TrustedIssuerLoadingInfo,
 };
@@ -656,15 +657,133 @@ impl From<cedarling::AuthorizeResult> for AuthorizeResult {
     }
 }
 
-/// WASM wrapper for `cedarling::BatchAuthorizeResponse<AuthorizeResult>`.
+/// Per-item build failure surfaced inside a batch response at `results[i]`
+/// when Cedar couldn't be reached for that item.
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct BatchItemError {
+    inner: CedarBatchItemError,
+}
+
+#[wasm_bindgen]
+impl BatchItemError {
+    /// Stable variant slug — `action_parse`, `resource_build`, `context_build`,
+    /// `principal_build`, `schema_validation`, `multi_issuer_entity`,
+    /// `request_validation`.
+    #[wasm_bindgen(getter)]
+    pub fn category(&self) -> String {
+        self.inner.category().to_string()
+    }
+
+    /// Position of the failing item in the original `items` vector.
+    #[wasm_bindgen(getter)]
+    pub fn item_index(&self) -> usize {
+        self.inner.item_index()
+    }
+
+    /// Human-readable diagnostic. Safe to log.
+    #[wasm_bindgen(getter)]
+    pub fn message(&self) -> String {
+        self.inner.to_string()
+    }
+}
+
+impl From<CedarBatchItemError> for BatchItemError {
+    fn from(inner: CedarBatchItemError) -> Self {
+        Self { inner }
+    }
+}
+
+/// One slot in a batch response's `results` array. Callers switch on
+/// `is_ok()` — on `true`, read `unwrap()`; on `false`, read `error()`.
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct BatchItemUnsignedResult {
+    inner: Result<AuthorizeResult, BatchItemError>,
+}
+
+#[wasm_bindgen]
+impl BatchItemUnsignedResult {
+    /// `true` when Cedar evaluated this item (Allow or Deny); `false` when it
+    /// failed to build.
+    #[wasm_bindgen(getter)]
+    pub fn is_ok(&self) -> bool {
+        self.inner.is_ok()
+    }
+
+    /// The Cedar decision if `is_ok()`; throws otherwise.
+    pub fn unwrap(&self) -> Result<AuthorizeResult, Error> {
+        self.inner
+            .as_ref()
+            .cloned()
+            .map_err(|e| Error::new(&e.message()))
+    }
+
+    /// The per-item error if `!is_ok()`; `undefined` otherwise.
+    #[wasm_bindgen(getter)]
+    pub fn error(&self) -> Option<BatchItemError> {
+        self.inner.as_ref().err().cloned()
+    }
+}
+
+impl From<Result<cedarling::AuthorizeResult, CedarBatchItemError>> for BatchItemUnsignedResult {
+    fn from(r: Result<cedarling::AuthorizeResult, CedarBatchItemError>) -> Self {
+        Self {
+            inner: r.map(Into::into).map_err(Into::into),
+        }
+    }
+}
+
+/// Multi-issuer analog of [`BatchItemUnsignedResult`].
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct BatchItemMultiIssuerResult {
+    inner: Result<MultiIssuerAuthorizeResult, BatchItemError>,
+}
+
+#[wasm_bindgen]
+impl BatchItemMultiIssuerResult {
+    /// `true` when Cedar evaluated this item.
+    #[wasm_bindgen(getter)]
+    pub fn is_ok(&self) -> bool {
+        self.inner.is_ok()
+    }
+
+    /// The multi-issuer decision if `is_ok()`; throws otherwise.
+    pub fn unwrap(&self) -> Result<MultiIssuerAuthorizeResult, Error> {
+        self.inner
+            .as_ref()
+            .cloned()
+            .map_err(|e| Error::new(&e.message()))
+    }
+
+    /// The per-item error if `!is_ok()`; `undefined` otherwise.
+    #[wasm_bindgen(getter)]
+    pub fn error(&self) -> Option<BatchItemError> {
+        self.inner.as_ref().err().cloned()
+    }
+}
+
+impl From<Result<cedarling::MultiIssuerAuthorizeResult, CedarBatchItemError>>
+    for BatchItemMultiIssuerResult
+{
+    fn from(r: Result<cedarling::MultiIssuerAuthorizeResult, CedarBatchItemError>) -> Self {
+        Self {
+            inner: r.map(Into::into).map_err(Into::into),
+        }
+    }
+}
+
+/// WASM wrapper for `cedarling::BatchAuthorizeResponse<Result<AuthorizeResult, BatchItemError>>`.
 ///
-/// Carries a shared `batch_id` (UUIDv7) alongside per-item results. `results[i]`
-/// corresponds to the `items[i]` supplied to `authorize_unsigned_batch`.
+/// Carries a shared `batch_id` (UUIDv7) alongside per-item results. Each result
+/// is a [`BatchItemUnsignedResult`] — Cedar decision on `is_ok()`, per-item
+/// build failure on `error`. `results[i]` corresponds to `items[i]`.
 #[wasm_bindgen]
 #[derive(Debug)]
 pub struct BatchAuthorizeUnsignedResponse {
     inner_batch_id: String,
-    inner_results: Vec<AuthorizeResult>,
+    inner_results: Vec<BatchItemUnsignedResult>,
 }
 
 #[wasm_bindgen]
@@ -675,17 +794,22 @@ impl BatchAuthorizeUnsignedResponse {
         self.inner_batch_id.clone()
     }
 
-    /// Per-item results in input order.
+    /// Per-item results in input order — each slot is a
+    /// [`BatchItemUnsignedResult`].
     #[wasm_bindgen(getter)]
-    pub fn results(&self) -> Vec<AuthorizeResult> {
+    pub fn results(&self) -> Vec<BatchItemUnsignedResult> {
         self.inner_results.clone()
     }
 }
 
-impl From<CedarBatchAuthorizeResponse<cedarling::AuthorizeResult>>
+impl From<CedarBatchAuthorizeResponse<Result<cedarling::AuthorizeResult, CedarBatchItemError>>>
     for BatchAuthorizeUnsignedResponse
 {
-    fn from(value: CedarBatchAuthorizeResponse<cedarling::AuthorizeResult>) -> Self {
+    fn from(
+        value: CedarBatchAuthorizeResponse<
+            Result<cedarling::AuthorizeResult, CedarBatchItemError>,
+        >,
+    ) -> Self {
         Self {
             inner_batch_id: value.batch_id.to_string(),
             inner_results: value.results.into_iter().map(Into::into).collect(),
@@ -693,15 +817,14 @@ impl From<CedarBatchAuthorizeResponse<cedarling::AuthorizeResult>>
     }
 }
 
-/// WASM wrapper for `cedarling::BatchAuthorizeResponse<MultiIssuerAuthorizeResult>`.
-///
-/// Carries a shared `batch_id` (UUIDv7) alongside per-item results. `results[i]`
-/// corresponds to the `items[i]` supplied to `authorize_multi_issuer_batch`.
+/// WASM wrapper for
+/// `cedarling::BatchAuthorizeResponse<Result<MultiIssuerAuthorizeResult, BatchItemError>>`.
+/// Same shape as [`BatchAuthorizeUnsignedResponse`] with multi-issuer results.
 #[wasm_bindgen]
 #[derive(Debug)]
 pub struct BatchAuthorizeMultiIssuerResponse {
     inner_batch_id: String,
-    inner_results: Vec<MultiIssuerAuthorizeResult>,
+    inner_results: Vec<BatchItemMultiIssuerResult>,
 }
 
 #[wasm_bindgen]
@@ -712,17 +835,26 @@ impl BatchAuthorizeMultiIssuerResponse {
         self.inner_batch_id.clone()
     }
 
-    /// Per-item results in input order.
+    /// Per-item results in input order — each slot is a
+    /// [`BatchItemMultiIssuerResult`].
     #[wasm_bindgen(getter)]
-    pub fn results(&self) -> Vec<MultiIssuerAuthorizeResult> {
+    pub fn results(&self) -> Vec<BatchItemMultiIssuerResult> {
         self.inner_results.clone()
     }
 }
 
-impl From<CedarBatchAuthorizeResponse<cedarling::MultiIssuerAuthorizeResult>>
-    for BatchAuthorizeMultiIssuerResponse
+impl
+    From<
+        CedarBatchAuthorizeResponse<
+            Result<cedarling::MultiIssuerAuthorizeResult, CedarBatchItemError>,
+        >,
+    > for BatchAuthorizeMultiIssuerResponse
 {
-    fn from(value: CedarBatchAuthorizeResponse<cedarling::MultiIssuerAuthorizeResult>) -> Self {
+    fn from(
+        value: CedarBatchAuthorizeResponse<
+            Result<cedarling::MultiIssuerAuthorizeResult, CedarBatchItemError>,
+        >,
+    ) -> Self {
         Self {
             inner_batch_id: value.batch_id.to_string(),
             inner_results: value.results.into_iter().map(Into::into).collect(),

--- a/jans-cedarling/bindings/cedarling_wasm/src/tests.rs
+++ b/jans-cedarling/bindings/cedarling_wasm/src/tests.rs
@@ -1347,7 +1347,7 @@ async fn test_authorize_multi_issuer_batch_ordered() {
     };
     let ok_action = "Jans::Action::\"Update\"".to_string();
     let bad_action = "this is not a valid uid".to_string();
-    // Mixed items: 0=valid, 1=malformed action (fail-closed Deny), 2=valid.
+    // Mixed items: 0=valid, 1=malformed action (Err(BatchItemError) with action_parse category), 2=valid.
     // Verifies results[i] maps to items[i] by producing distinguishable
     // decisions instead of a uniform result set.
     let batch_request = BatchAuthorizeMultiIssuerRequest::new(

--- a/jans-cedarling/bindings/cedarling_wasm/src/tests.rs
+++ b/jans-cedarling/bindings/cedarling_wasm/src/tests.rs
@@ -1247,12 +1247,23 @@ async fn test_authorize_unsigned_batch_allow_ordered() {
 
     let results = response.results();
     assert_eq!(results.len(), 3, "N=3 items produce N=3 results");
-    assert!(results[0].decision, "item 0 must allow");
+    assert!(results[0].is_ok(), "item 0 must be Ok");
     assert!(
-        !results[1].decision,
-        "item 1 with bad action must fail closed"
+        results[0].unwrap().expect("item 0 Ok").decision,
+        "item 0 must allow"
     );
-    assert!(results[2].decision, "item 2 must allow");
+    assert!(
+        !results[1].is_ok(),
+        "item 1 with bad action must surface as Err"
+    );
+    let err = results[1].error().expect("item 1 must carry BatchItemError");
+    assert_eq!(err.category(), "action_parse");
+    assert_eq!(err.item_index(), 1);
+    assert!(results[2].is_ok(), "item 2 must be Ok");
+    assert!(
+        results[2].unwrap().expect("item 2 Ok").decision,
+        "item 2 must allow"
+    );
     assert!(!response.batch_id().is_empty(), "batch_id must be set");
 }
 
@@ -1372,11 +1383,22 @@ async fn test_authorize_multi_issuer_batch_ordered() {
 
     let results = response.results();
     assert_eq!(results.len(), 3, "N=3 items produce N=3 results");
-    assert!(results[0].decision, "item 0 must allow");
+    assert!(results[0].is_ok(), "item 0 must be Ok");
     assert!(
-        !results[1].decision,
-        "item 1 with bad action must fail closed"
+        results[0].unwrap().expect("item 0 Ok").decision,
+        "item 0 must allow"
     );
-    assert!(results[2].decision, "item 2 must allow");
+    assert!(
+        !results[1].is_ok(),
+        "item 1 with bad action must surface as Err"
+    );
+    let err = results[1].error().expect("item 1 must carry BatchItemError");
+    assert_eq!(err.category(), "action_parse");
+    assert_eq!(err.item_index(), 1);
+    assert!(results[2].is_ok(), "item 2 must be Ok");
+    assert!(
+        results[2].unwrap().expect("item 2 Ok").decision,
+        "item 2 must allow"
+    );
     assert!(!response.batch_id().is_empty(), "batch_id must be set");
 }

--- a/jans-cedarling/cedarling/benches/authz_authorize_batch_benchmark.rs
+++ b/jans-cedarling/cedarling/benches/authz_authorize_batch_benchmark.rs
@@ -15,20 +15,19 @@ use cedarling::{
     EntityData, HttpClientConfig, InitCedarlingError, JwtConfig, LogConfig, LogLevel,
     LogTypeConfig, PolicyStoreConfig, PolicyStoreSource, RequestUnsigned, TokenInput,
 };
+use criterion::measurement::WallTime;
 use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
-use criterion::measurement::WallTime;
 use jsonwebtoken::Algorithm;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use test_utils::MockServer;
+use test_utils::gen_mock_server;
 use test_utils::token_claims::generate_token_using_claims_and_keypair;
-use test_utils::{gen_mock_server};
 use tokio::runtime::Runtime;
 
-const UNSIGNED_POLICY_STORE: &str =
-    include_str!("../../test_files/policy-store_ok_2.yaml");
+const UNSIGNED_POLICY_STORE: &str = include_str!("../../test_files/policy-store_ok_2.yaml");
 const MULTI_ISSUER_POLICY_STORE: &str =
     include_str!("../../test_files/policy-store-multi-issuer-basic.yaml");
 
@@ -48,13 +47,9 @@ fn unsigned_batch_vs_sequence(c: &mut Criterion) {
         group.measurement_time(Duration::from_secs(5));
         group.warm_up_time(Duration::from_secs(3));
 
-        let items: Vec<BatchItem> = (0..n)
-            .map(|i| build_batch_item(&template, i))
-            .collect();
-        let batch_request = BatchAuthorizeUnsignedRequest::new(
-            template.principal.clone(),
-            items.clone(),
-        );
+        let items: Vec<BatchItem> = (0..n).map(|i| build_batch_item(&template, i)).collect();
+        let batch_request =
+            BatchAuthorizeUnsignedRequest::new(template.principal.clone(), items.clone());
         let sequence_requests: Vec<RequestUnsigned> = items
             .iter()
             .map(|item| RequestUnsigned {
@@ -84,7 +79,7 @@ fn bench_unsigned_batch(
         .expect("trial unsigned batch must succeed — fixture should Allow");
     assert_eq!(trial.results.len(), n, "batch size must match");
     assert!(
-        trial.results.iter().all(|r| r.decision),
+        trial.results.iter().all(|r| r.as_ref().is_ok_and(|res| res.decision)),
         "all batch items must Allow — check fixtures"
     );
 
@@ -189,7 +184,7 @@ fn bench_multi_issuer_batch(
         .expect("trial multi-issuer batch must succeed — fixture should Allow");
     assert_eq!(trial.results.len(), n, "batch size must match");
     assert!(
-        trial.results.iter().all(|r| r.decision),
+        trial.results.iter().all(|r| r.as_ref().is_ok_and(|res| res.decision)),
         "all batch items must Allow — check fixtures"
     );
 
@@ -316,8 +311,7 @@ async fn prepare_multi_issuer_cedarling(
 ) -> Result<Cedarling, InitCedarlingError> {
     let mut policy_store: serde_yaml_ng::Value =
         serde_yaml_ng::from_str(MULTI_ISSUER_POLICY_STORE).expect("valid YAML");
-    policy_store["policy_stores"]["multi_issuer_basic_store"]["trusted_issuers"]["AcmeIssuer"]
-        ["openid_configuration_endpoint"] =
+    policy_store["policy_stores"]["multi_issuer_basic_store"]["trusted_issuers"]["AcmeIssuer"]["openid_configuration_endpoint"] =
         format!("{base_idp_url1}/.well-known/openid-configuration").into();
     policy_store["policy_stores"]["multi_issuer_basic_store"]["trusted_issuers"]["DolphinIssuer"]
         ["openid_configuration_endpoint"] =
@@ -361,7 +355,11 @@ fn prepare_multi_issuer_request(
         &mock1.keys,
     );
     let dolphin_token = generate_token_using_claims_and_keypair(
-        &claim_set(&mock2.base_idp_url, "dolphin_bench_sub", "dolphin_client_bench"),
+        &claim_set(
+            &mock2.base_idp_url,
+            "dolphin_bench_sub",
+            "dolphin_client_bench",
+        ),
         &mock2.keys,
     );
     AuthorizeMultiIssuerRequest::new_with_fields(

--- a/jans-cedarling/cedarling/src/authz/errors.rs
+++ b/jans-cedarling/cedarling/src/authz/errors.rs
@@ -4,6 +4,7 @@
 // Copyright (c) 2024, Gluu, Inc.
 
 use cedar_policy::{ContextJsonError, ParseErrors, RequestValidationError};
+use serde::{Deserialize, Serialize};
 use serde_json::Error as SerdeJsonError;
 
 // Re-export commonly used error types
@@ -58,6 +59,70 @@ pub enum BatchValidationError {
     /// A batch item's context field is not a JSON object.
     #[error("Context for item {index} must be a JSON object")]
     InvalidItemContext { index: usize },
+}
+
+/// Per-item build failure surfaced inside a batch authorize response at
+/// `results[item_index] = Err(_)`. Serializable + `Clone`-able so bindings
+/// can round-trip it through JSON / FFI; the `variant` tag is the wire
+/// discriminant.
+#[allow(missing_docs)] // per-variant docs above each `#[error(...)]`; fields are self-descriptive
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
+#[serde(tag = "variant", rename_all = "snake_case")]
+pub enum BatchItemError {
+    /// Item's action string didn't parse as a Cedar `EntityUid`.
+    #[error("item {item_index}: action parse failed: {message}")]
+    ActionParse { message: String, item_index: usize },
+    /// Item's resource `EntityData` failed to build a Cedar entity (unsigned).
+    #[error("item {item_index}: resource build failed: {message}")]
+    ResourceBuild { message: String, item_index: usize },
+    /// Per-item context couldn't be built (invalid shape, missing entity ref, …).
+    #[error("item {item_index}: context build failed: {message}")]
+    ContextBuild { message: String, item_index: usize },
+    /// Unsigned role-entity build for this item failed.
+    #[error("item {item_index}: principal build failed: {message}")]
+    PrincipalBuild { message: String, item_index: usize },
+    /// Assembled Cedar `Entities` didn't validate against the policy-store schema.
+    #[error("item {item_index}: schema validation failed: {message}")]
+    SchemaValidation { message: String, item_index: usize },
+    /// Multi-issuer resource entity for this item couldn't be built.
+    #[error("item {item_index}: multi-issuer entity build failed: {message}")]
+    MultiIssuerEntity { message: String, item_index: usize },
+    /// Cedar rejected the assembled request (principal / action / resource /
+    /// context didn't line up with the schema's `appliesTo`).
+    #[error("item {item_index}: request validation failed: {message}")]
+    RequestValidation { message: String, item_index: usize },
+}
+
+impl BatchItemError {
+    /// Stable slug identifying this variant — safe to use as a metric label
+    /// or a structured log field.
+    #[must_use]
+    pub const fn category(&self) -> &'static str {
+        match self {
+            Self::ActionParse { .. } => "action_parse",
+            Self::ResourceBuild { .. } => "resource_build",
+            Self::ContextBuild { .. } => "context_build",
+            Self::PrincipalBuild { .. } => "principal_build",
+            Self::SchemaValidation { .. } => "schema_validation",
+            Self::MultiIssuerEntity { .. } => "multi_issuer_entity",
+            Self::RequestValidation { .. } => "request_validation",
+        }
+    }
+
+    /// Position of the failing item in the original `items` vector — matches
+    /// its position in the returned `results` vector.
+    #[must_use]
+    pub const fn item_index(&self) -> usize {
+        match self {
+            Self::ActionParse { item_index, .. }
+            | Self::ResourceBuild { item_index, .. }
+            | Self::ContextBuild { item_index, .. }
+            | Self::PrincipalBuild { item_index, .. }
+            | Self::SchemaValidation { item_index, .. }
+            | Self::MultiIssuerEntity { item_index, .. }
+            | Self::RequestValidation { item_index, .. } => *item_index,
+        }
+    }
 }
 
 /// Error type for Authorization Service

--- a/jans-cedarling/cedarling/src/authz/errors.rs
+++ b/jans-cedarling/cedarling/src/authz/errors.rs
@@ -233,3 +233,35 @@ impl InvalidPrincipalError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_item_error_category_matches_wire_variant() {
+        let cases = vec![
+            BatchItemError::ActionParse { message: String::new(), item_index: 0 },
+            BatchItemError::ResourceBuild { message: String::new(), item_index: 0 },
+            BatchItemError::ContextBuild { message: String::new(), item_index: 0 },
+            BatchItemError::PrincipalBuild { message: String::new(), item_index: 0 },
+            BatchItemError::SchemaValidation { message: String::new(), item_index: 0 },
+            BatchItemError::MultiIssuerEntity { message: String::new(), item_index: 0 },
+            BatchItemError::RequestValidation { message: String::new(), item_index: 0 },
+        ];
+
+        for error in cases {
+            let json = serde_json::to_value(&error).expect("serialize");
+            let wire_variant = json
+                .get("variant")
+                .and_then(|v| v.as_str())
+                .expect("missing variant field");
+            assert_eq!(
+                wire_variant,
+                error.category(),
+                "wire variant {wire_variant:?} must match category() for {:?}",
+                error
+            );
+        }
+    }
+}

--- a/jans-cedarling/cedarling/src/authz/mod.rs
+++ b/jans-cedarling/cedarling/src/authz/mod.rs
@@ -484,7 +484,7 @@ impl Authz {
     }
 
     /// Per-item core of [`Self::authorize_multi_issuer_batch`]. Setup errors
-    /// on one item are caught by the caller and converted to fail-closed `Deny`.
+    /// on one item are caught by the caller and returned as `Err(item_err)`.
     fn try_batch_item_multi_issuer(
         &self,
         item: &BatchItem,
@@ -842,8 +842,8 @@ impl Authz {
     }
 
     /// Per-item core of [`Self::authorize_unsigned_batch`]. Kept separate so
-    /// setup errors on a single item can be caught and converted to a
-    /// fail-closed `Deny` without a large `match` in the loop body.
+    /// setup errors on a single item can be caught and returned as
+    /// `Err(item_err)` without a large `match` in the loop body.
     fn try_batch_item_unsigned(
         &self,
         item: &BatchItem,

--- a/jans-cedarling/cedarling/src/authz/mod.rs
+++ b/jans-cedarling/cedarling/src/authz/mod.rs
@@ -70,6 +70,43 @@ pub(super) struct Authz {
     authorizer: cedar_policy::Authorizer,
 }
 
+/// Map a per-item [`AuthorizeError`] surfaced from `try_batch_item_*` into
+/// the wire-serializable [`BatchItemError`]. The `AuthorizeError` message is
+/// carried through verbatim so callers keep the Cedar diagnostic detail;
+/// only the classification / wire shape changes.
+fn classify_batch_item_error(err: &AuthorizeError, item_index: usize) -> BatchItemError {
+    let message = err.to_string();
+    match err {
+        AuthorizeError::Action(_) | AuthorizeError::IdentifierParsing(_) => {
+            BatchItemError::ActionParse { message, item_index }
+        },
+        AuthorizeError::MultiIssuerEntity(_) => {
+            BatchItemError::MultiIssuerEntity { message, item_index }
+        },
+        AuthorizeError::BuildContext(_) | AuthorizeError::CreateContext(_) => {
+            BatchItemError::ContextBuild { message, item_index }
+        },
+        AuthorizeError::BuildEntity(_) => BatchItemError::ResourceBuild { message, item_index },
+        AuthorizeError::BuildUnsignedRoleEntity(_) => {
+            BatchItemError::PrincipalBuild { message, item_index }
+        },
+        AuthorizeError::ValidateEntities(_) | AuthorizeError::EntitiesToJson(_) => {
+            BatchItemError::SchemaValidation { message, item_index }
+        },
+        AuthorizeError::RequestValidation(_) | AuthorizeError::InvalidPrincipal(_) => {
+            BatchItemError::RequestValidation { message, item_index }
+        },
+        // These variants can't reach the per-item path — try_batch_item_* is
+        // called after batch validation and token/principal setup succeeded.
+        // Classify as request_validation to keep the wire shape closed.
+        AuthorizeError::ProcessTokens(_)
+        | AuthorizeError::MultiIssuerValidation(_)
+        | AuthorizeError::BatchValidation(_) => {
+            BatchItemError::RequestValidation { message, item_index }
+        },
+    }
+}
+
 impl Authz {
     /// Create a new Authorization Service
     pub(crate) fn new(config: AuthzConfig) -> Self {
@@ -319,14 +356,14 @@ impl Authz {
     /// * Batch-level failures (validation, JWT verification, status-list
     ///   refresh, all-tokens-invalid) return `Err` and fail the whole call.
     /// * Per-item failures (invalid action UID, resource build, context
-    ///   build, schema validation, Cedar request validation) synthesize a
-    ///   fail-closed `Deny` for that item and record an error metric — they
-    ///   never fail other items in the batch.
+    ///   build, schema validation, Cedar request validation) surface as
+    ///   `results[i] = Err(BatchItemError::…)` — they never fail other items.
     #[allow(clippy::too_many_lines)]
     pub(super) fn authorize_multi_issuer_batch(
         &self,
         request: &BatchAuthorizeMultiIssuerRequest,
-    ) -> Result<BatchAuthorizeResponse<MultiIssuerAuthorizeResult>, AuthorizeError> {
+    ) -> Result<BatchAuthorizeResponse<Result<MultiIssuerAuthorizeResult, BatchItemError>>, AuthorizeError>
+    {
         let batch_start_time = Utc::now();
         let batch_id = gen_uuid7();
 
@@ -355,7 +392,7 @@ impl Authz {
         );
 
         let mut results = Vec::with_capacity(request.items.len());
-        for item in &request.items {
+        for (item_index, item) in request.items.iter().enumerate() {
             let item_start = Utc::now();
             let item_request_id = gen_uuid7();
 
@@ -367,25 +404,19 @@ impl Authz {
             ) {
                 Ok((resp, uid)) => (resp, uid.to_string()),
                 Err(e) => {
+                    let item_err = classify_batch_item_error(&e, item_index);
                     self.config.metrics.record_error(&e);
                     self.config.metrics.record_authz_error();
                     let log_entry = LogEntry::new(BaseLogEntry::new_decision(item_request_id))
                         .set_batch_id(batch_id)
-                        .set_message(format!("Batch item failed setup for batch {batch_id}"))
-                        .set_error(e.to_string());
+                        .set_message(format!(
+                            "Batch item {item_index} failed setup ({}) for batch {batch_id}",
+                            item_err.category(),
+                        ))
+                        .set_error(item_err.to_string());
                     self.config.log_service.log_any(log_entry);
-                    let uid_str = format!(
-                        "{}::\"{}\"",
-                        item.resource.cedar_mapping.entity_type, item.resource.cedar_mapping.id,
-                    );
-                    (
-                        cedar_policy::Response::new(
-                            cedar_policy::Decision::Deny,
-                            HashSet::new(),
-                            Vec::new(),
-                        ),
-                        uid_str,
-                    )
+                    results.push(Err(item_err));
+                    continue;
                 },
             };
 
@@ -433,7 +464,7 @@ impl Authz {
                 policy_decisions,
             );
 
-            results.push(MultiIssuerAuthorizeResult::new(response, item_request_id));
+            results.push(Ok(MultiIssuerAuthorizeResult::new(response, item_request_id)));
         }
 
         self.config
@@ -684,14 +715,14 @@ impl Authz {
     /// * Batch-level failures (validation, principal parse) return `Err` and
     ///   fail the whole call.
     /// * Per-item failures (invalid action UID, resource build, context
-    ///   build, schema validation, Cedar request validation) synthesize a
-    ///   fail-closed `Deny` for that item and record an error metric — they
-    ///   never fail other items in the batch.
+    ///   build, schema validation, Cedar request validation) surface as
+    ///   `results[i] = Err(BatchItemError::…)` — they never fail other items.
     #[allow(clippy::too_many_lines)]
     pub(super) fn authorize_unsigned_batch(
         &self,
         request: &BatchAuthorizeUnsignedRequest,
-    ) -> Result<BatchAuthorizeResponse<AuthorizeResult>, AuthorizeError> {
+    ) -> Result<BatchAuthorizeResponse<Result<AuthorizeResult, BatchItemError>>, AuthorizeError>
+    {
         let batch_start_time = Utc::now();
         let batch_id = gen_uuid7();
 
@@ -714,7 +745,7 @@ impl Authz {
         let schema_ref = schema.as_ref().map(|s| &s.schema);
 
         let mut results = Vec::with_capacity(request.items.len());
-        for item in &request.items {
+        for (item_index, item) in request.items.iter().enumerate() {
             let item_start = Utc::now();
             let item_request_id = gen_uuid7();
 
@@ -731,25 +762,19 @@ impl Authz {
                     (resp, uid_str)
                 },
                 Err(e) => {
+                    let item_err = classify_batch_item_error(&e, item_index);
                     self.config.metrics.record_error(&e);
                     self.config.metrics.record_authz_error();
                     let log_entry = LogEntry::new(BaseLogEntry::new_decision(item_request_id))
                         .set_batch_id(batch_id)
-                        .set_message(format!("Batch item failed setup for batch {batch_id}"))
-                        .set_error(e.to_string());
+                        .set_message(format!(
+                            "Batch item {item_index} failed setup ({}) for batch {batch_id}",
+                            item_err.category(),
+                        ))
+                        .set_error(item_err.to_string());
                     self.config.log_service.log_any(log_entry);
-                    let uid_str = format!(
-                        "{}::\"{}\"",
-                        item.resource.cedar_mapping.entity_type, item.resource.cedar_mapping.id,
-                    );
-                    (
-                        cedar_policy::Response::new(
-                            cedar_policy::Decision::Deny,
-                            HashSet::new(),
-                            Vec::new(),
-                        ),
-                        uid_str,
-                    )
+                    results.push(Err(item_err));
+                    continue;
                 },
             };
 
@@ -797,7 +822,7 @@ impl Authz {
                 policy_decisions,
             );
 
-            results.push(AuthorizeResult::new(response, item_request_id));
+            results.push(Ok(AuthorizeResult::new(response, item_request_id)));
         }
 
         self.config

--- a/jans-cedarling/cedarling/src/authz/mod.rs
+++ b/jans-cedarling/cedarling/src/authz/mod.rs
@@ -101,9 +101,9 @@ fn classify_batch_item_error(err: &AuthorizeError, item_index: usize) -> BatchIt
         // Classify as request_validation to keep the wire shape closed.
         AuthorizeError::ProcessTokens(_)
         | AuthorizeError::MultiIssuerValidation(_)
-        | AuthorizeError::BatchValidation(_) => {
-            BatchItemError::RequestValidation { message, item_index }
-        },
+        | AuthorizeError::BatchValidation(_) => unreachable!(
+            "batch-level error {err:?} reached per-item error classification for item {item_index}"
+        ),
     }
 }
 

--- a/jans-cedarling/cedarling/src/authz/mod.rs
+++ b/jans-cedarling/cedarling/src/authz/mod.rs
@@ -98,7 +98,7 @@ fn classify_batch_item_error(err: &AuthorizeError, item_index: usize) -> BatchIt
         },
         // These variants can't reach the per-item path — try_batch_item_* is
         // called after batch validation and token/principal setup succeeded.
-        // Classify as request_validation to keep the wire shape closed.
+        // Reaching this arm indicates an invariant violation that fails fast.
         AuthorizeError::ProcessTokens(_)
         | AuthorizeError::MultiIssuerValidation(_)
         | AuthorizeError::BatchValidation(_) => unreachable!(

--- a/jans-cedarling/cedarling/src/blocking.rs
+++ b/jans-cedarling/cedarling/src/blocking.rs
@@ -9,9 +9,9 @@
 
 use crate::{
     AuthorizeError, AuthorizeResult, BatchAuthorizeMultiIssuerRequest, BatchAuthorizeResponse,
-    BatchAuthorizeUnsignedRequest, BootstrapConfig, DataApi, DataEntry, DataError, DataStoreStats,
-    EntityData, InitCedarlingError, LogStorage, MultiIssuerAuthorizeResult, PolicyMetadata,
-    RequestUnsigned, TokenInput, TrustedIssuerLoadingInfo,
+    BatchAuthorizeUnsignedRequest, BatchItemError, BootstrapConfig, DataApi, DataEntry, DataError,
+    DataStoreStats, EntityData, InitCedarlingError, LogStorage, MultiIssuerAuthorizeResult,
+    PolicyMetadata, RequestUnsigned, TokenInput, TrustedIssuerLoadingInfo,
 };
 use crate::{BootstrapConfigRaw, Cedarling as AsyncCedarling};
 use std::sync::Arc;
@@ -64,7 +64,8 @@ impl Cedarling {
     pub fn authorize_unsigned_batch(
         &self,
         request: BatchAuthorizeUnsignedRequest,
-    ) -> Result<BatchAuthorizeResponse<AuthorizeResult>, AuthorizeError> {
+    ) -> Result<BatchAuthorizeResponse<Result<AuthorizeResult, BatchItemError>>, AuthorizeError>
+    {
         self.instance
             .authz
             .load()
@@ -87,7 +88,10 @@ impl Cedarling {
     pub fn authorize_multi_issuer_batch(
         &self,
         request: BatchAuthorizeMultiIssuerRequest,
-    ) -> Result<BatchAuthorizeResponse<MultiIssuerAuthorizeResult>, AuthorizeError> {
+    ) -> Result<
+        BatchAuthorizeResponse<Result<MultiIssuerAuthorizeResult, BatchItemError>>,
+        AuthorizeError,
+    > {
         self.instance
             .authz
             .load()

--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -55,7 +55,9 @@ pub use authz::request::{
     BatchAuthorizeUnsignedRequest, BatchItem, CedarEntityMapping, EntityData, RequestUnsigned,
     TokenInput,
 };
-pub use authz::{AuthorizeError, AuthorizeResult, MultiIssuerAuthorizeResult};
+pub use authz::{
+    AuthorizeError, AuthorizeResult, BatchItemError, MultiIssuerAuthorizeResult,
+};
 pub use bootstrap_config::*;
 use common::app_types::{self, ApplicationName};
 pub use common::policy_store::{PolicyEffect, PolicyMetadata};
@@ -283,7 +285,8 @@ impl Cedarling {
     pub async fn authorize_unsigned_batch(
         &self,
         request: BatchAuthorizeUnsignedRequest,
-    ) -> Result<BatchAuthorizeResponse<AuthorizeResult>, AuthorizeError> {
+    ) -> Result<BatchAuthorizeResponse<Result<AuthorizeResult, BatchItemError>>, AuthorizeError>
+    {
         self.authz.load().authorize_unsigned_batch(&request)
     }
 
@@ -309,7 +312,10 @@ impl Cedarling {
     pub async fn authorize_multi_issuer_batch(
         &self,
         request: BatchAuthorizeMultiIssuerRequest,
-    ) -> Result<BatchAuthorizeResponse<MultiIssuerAuthorizeResult>, AuthorizeError> {
+    ) -> Result<
+        BatchAuthorizeResponse<Result<MultiIssuerAuthorizeResult, BatchItemError>>,
+        AuthorizeError,
+    > {
         self.authz.load().authorize_multi_issuer_batch(&request)
     }
 

--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -278,8 +278,8 @@ impl Cedarling {
     /// returned in input order, wrapped in a [`BatchAuthorizeResponse`] that
     /// carries a shared `batch_id` for audit correlation.
     ///
-    /// Batch-level failures (validation, principal parse) return `Err`;
-    /// per-item failures synthesize a fail-closed `Deny` for that item
+    /// Batch-level failures (validation, principal parse) return `Err(AuthorizeError)`;
+    /// per-item failures are returned as `Err(BatchItemError)` for that item
     /// without affecting other items.
     #[allow(clippy::unused_async)]
     pub async fn authorize_unsigned_batch(
@@ -306,8 +306,8 @@ impl Cedarling {
     /// each item with its own resource and context. Results are returned in
     /// input order, wrapped in a [`BatchAuthorizeResponse`] carrying a shared
     /// `batch_id`. Batch-level failures (validation, JWT verification,
-    /// status-list refresh) return `Err`; per-item failures synthesize a
-    /// fail-closed `Deny` without affecting other items.
+    /// status-list refresh) return `Err(AuthorizeError)`; per-item failures are
+    /// returned as `Err(BatchItemError)` without affecting other items.
     #[allow(clippy::unused_async)]
     pub async fn authorize_multi_issuer_batch(
         &self,

--- a/jans-cedarling/cedarling/src/tests/authorize_multi_issuer_batch.rs
+++ b/jans-cedarling/cedarling/src/tests/authorize_multi_issuer_batch.rs
@@ -5,12 +5,20 @@
 
 use super::utils::cedarling_util::get_cedarling_with_callback;
 use super::utils::*;
-use crate::Cedarling;
 use crate::authz::BatchValidationError;
 use crate::authz::request::{
     BatchAuthorizeMultiIssuerRequest, BatchItem, EntityData, TokenInput,
 };
+use crate::{BatchItemError, Cedarling, MultiIssuerAuthorizeResult};
 use serde_json::json;
+
+fn expect_ok(
+    r: &Result<MultiIssuerAuthorizeResult, BatchItemError>,
+    idx: usize,
+) -> &MultiIssuerAuthorizeResult {
+    r.as_ref()
+        .unwrap_or_else(|e| panic!("item {idx} expected Ok, got Err: {e:?}"))
+}
 
 async fn get_cedarling_for_multi_issuer_tests() -> Cedarling {
     static POLICY_STORE_RAW_YAML: &str =
@@ -88,7 +96,7 @@ async fn batch_multi_issuer_single_item_allow() {
 
     assert_eq!(response.results.len(), 1);
     assert!(
-        response.results[0].decision,
+        expect_ok(&response.results[0], 0).decision,
         "single item should allow via role mapping"
     );
     assert!(!response.batch_id.to_string().is_empty());
@@ -119,7 +127,8 @@ async fn batch_multi_issuer_alternating_decisions_preserve_order() {
     for (i, r) in response.results.iter().enumerate() {
         let expected_allow = i % 2 == 0;
         assert_eq!(
-            r.decision, expected_allow,
+            expect_ok(r, i).decision,
+            expected_allow,
             "item {i} decision must match its input position"
         );
     }
@@ -141,7 +150,7 @@ async fn batch_multi_issuer_n25_all_allow() {
 
     assert_eq!(response.results.len(), 25);
     for (i, r) in response.results.iter().enumerate() {
-        assert!(r.decision, "item {i} should allow");
+        assert!(expect_ok(r, i).decision, "item {i} should allow");
     }
 }
 
@@ -219,10 +228,10 @@ async fn batch_multi_issuer_non_object_context_rejected() {
     );
 }
 
-/// A per-item malformed action UID synthesizes a Deny for that item but does
-/// not fail other items in the batch.
+/// A per-item malformed action UID surfaces as `Err(BatchItemError::ActionParse)`
+/// at that position; adjacent items still evaluate cleanly.
 #[tokio::test]
-async fn batch_multi_issuer_bad_action_denies_only_that_item() {
+async fn batch_multi_issuer_bad_action_surfaces_error_only_at_that_item() {
     let cedarling = get_cedarling_for_multi_issuer_tests().await;
 
     let request = BatchAuthorizeMultiIssuerRequest::new(
@@ -244,10 +253,12 @@ async fn batch_multi_issuer_bad_action_denies_only_that_item() {
         .expect("batch succeeds even when one item has a bad action");
 
     assert_eq!(response.results.len(), 3);
-    assert!(response.results[0].decision, "item 0 allowed");
-    assert!(
-        !response.results[1].decision,
-        "item 1 with bad action must fail closed"
-    );
-    assert!(response.results[2].decision, "item 2 allowed");
+    assert!(expect_ok(&response.results[0], 0).decision, "item 0 allowed");
+    match &response.results[1] {
+        Err(BatchItemError::ActionParse { item_index, .. }) => {
+            assert_eq!(*item_index, 1, "item_index in error must match position");
+        },
+        other => panic!("item 1 must surface ActionParse error, got: {other:?}"),
+    }
+    assert!(expect_ok(&response.results[2], 2).decision, "item 2 allowed");
 }

--- a/jans-cedarling/cedarling/src/tests/authorize_unsigned_batch.rs
+++ b/jans-cedarling/cedarling/src/tests/authorize_unsigned_batch.rs
@@ -342,7 +342,7 @@ async fn batch_unsigned_multiple_errors_do_not_leak_across_items() {
         .await
         .expect("batch itself succeeds");
 
-    assert_eq!(response.results.len(), 6);
+    assert_eq!(response.results.len(), 6, "batch size should match the 6 request items");
     for ok_idx in [0, 2, 3, 5] {
         assert!(
             expect_ok(&response.results[ok_idx], ok_idx).decision,
@@ -352,7 +352,7 @@ async fn batch_unsigned_multiple_errors_do_not_leak_across_items() {
     for err_idx in [1, 4] {
         match &response.results[err_idx] {
             Err(BatchItemError::ActionParse { item_index, .. }) => {
-                assert_eq!(*item_index, err_idx);
+                assert_eq!(*item_index, err_idx, "error item_index must match its position in the batch");
             },
             other => panic!("item {err_idx} must surface ActionParse error, got: {other:?}"),
         }

--- a/jans-cedarling/cedarling/src/tests/authorize_unsigned_batch.rs
+++ b/jans-cedarling/cedarling/src/tests/authorize_unsigned_batch.rs
@@ -8,11 +8,16 @@ use tokio::test;
 
 use super::utils::*;
 use crate::{
-    BatchAuthorizeUnsignedRequest, BatchItem, EntityData,
+    AuthorizeResult, BatchAuthorizeUnsignedRequest, BatchItem, BatchItemError, EntityData,
     authz::BatchValidationError,
     tests::utils::cedarling_util::get_cedarling_with_callback,
     tests::utils::test_helpers::create_test_principal,
 };
+
+fn expect_ok(r: &Result<AuthorizeResult, BatchItemError>, idx: usize) -> &AuthorizeResult {
+    r.as_ref()
+        .unwrap_or_else(|e| panic!("item {idx} expected Ok, got Err: {e:?}"))
+}
 
 static POLICY_STORE_RAW_YAML: &str =
     include_str!("../../../test_files/policy-store_no_trusted_issuers.yaml");
@@ -60,7 +65,10 @@ async fn batch_unsigned_single_item_allow() {
         .expect("batch should be processed");
 
     assert_eq!(response.results.len(), 1);
-    assert!(response.results[0].decision, "single item should allow");
+    assert!(
+        expect_ok(&response.results[0], 0).decision,
+        "single item should allow"
+    );
     // batch_id is a UUIDv7 — a non-nil value.
     assert!(!response.batch_id.to_string().is_empty());
 }
@@ -99,7 +107,7 @@ async fn batch_unsigned_n25_mixed_results_ordered() {
     assert_eq!(response.results.len(), 25);
     for (i, result) in response.results.iter().enumerate() {
         assert!(
-            result.decision,
+            expect_ok(result, i).decision,
             "item {i} should allow with is_ok=true principal"
         );
     }
@@ -137,8 +145,8 @@ async fn batch_unsigned_deny_propagates_per_item() {
         .expect("batch should be processed");
 
     assert_eq!(response.results.len(), 2);
-    for r in &response.results {
-        assert!(!r.decision, "is_ok=false must deny");
+    for (i, r) in response.results.iter().enumerate() {
+        assert!(!expect_ok(r, i).decision, "is_ok=false must deny");
     }
 }
 
@@ -175,11 +183,11 @@ async fn batch_unsigned_no_principal_residual_denies_that_item_only() {
 
     assert_eq!(response.results.len(), 2);
     assert!(
-        response.results[0].decision,
+        expect_ok(&response.results[0], 0).decision,
         "public action must allow under partial eval"
     );
     assert!(
-        !response.results[1].decision,
+        !expect_ok(&response.results[1], 1).decision,
         "residual-dependent action must fail closed"
     );
 }
@@ -258,10 +266,10 @@ async fn batch_unsigned_non_object_context_rejected() {
     );
 }
 
-/// A per-item malformed action UID synthesizes a Deny for that item but
-/// leaves other items alone — the batch as a whole succeeds.
+/// A per-item malformed action UID surfaces as `Err(BatchItemError::ActionParse)`
+/// at that position; adjacent items still evaluate cleanly.
 #[test]
-async fn batch_unsigned_bad_action_denies_only_that_item() {
+async fn batch_unsigned_bad_action_surfaces_error_only_at_that_item() {
     let cedarling = get_cedarling_with_callback(
         PolicyStoreSource::Yaml(POLICY_STORE_RAW_YAML.to_string()),
         |_| {},
@@ -293,10 +301,60 @@ async fn batch_unsigned_bad_action_denies_only_that_item() {
         .expect("batch itself succeeds even when one item has a bad action");
 
     assert_eq!(response.results.len(), 3);
-    assert!(response.results[0].decision, "item 0 allowed");
-    assert!(
-        !response.results[1].decision,
-        "item 1 with bad action must fail closed"
+    assert!(expect_ok(&response.results[0], 0).decision, "item 0 allowed");
+    match &response.results[1] {
+        Err(BatchItemError::ActionParse { item_index, .. }) => {
+            assert_eq!(*item_index, 1, "item_index in error must match position");
+        },
+        other => panic!("item 1 must surface ActionParse error, got: {other:?}"),
+    }
+    assert!(expect_ok(&response.results[2], 2).decision, "item 2 allowed");
+}
+
+/// Two Err items at non-adjacent positions must not disturb the Ok items
+/// between and around them — proves per-item Err partitioning.
+#[test]
+async fn batch_unsigned_multiple_errors_do_not_leak_across_items() {
+    let cedarling = get_cedarling_with_callback(
+        PolicyStoreSource::Yaml(POLICY_STORE_RAW_YAML.to_string()),
+        |_| {},
+    )
+    .await;
+
+    let ok_action = "Jans::Action::\"UpdateForTestPrincipals\"";
+    let request = BatchAuthorizeUnsignedRequest::new(
+        Some(
+            create_test_principal("Jans::TestPrincipal1", "id1", json!({"is_ok": true}))
+                .expect("principal should build"),
+        ),
+        vec![
+            make_item(ok_action, make_issue("ok-0", "org")),
+            make_item("bad-uid-1", make_issue("bad-1", "org")),
+            make_item(ok_action, make_issue("ok-2", "org")),
+            make_item(ok_action, make_issue("ok-3", "org")),
+            make_item("bad-uid-4", make_issue("bad-4", "org")),
+            make_item(ok_action, make_issue("ok-5", "org")),
+        ],
     );
-    assert!(response.results[2].decision, "item 2 allowed");
+
+    let response = cedarling
+        .authorize_unsigned_batch(request)
+        .await
+        .expect("batch itself succeeds");
+
+    assert_eq!(response.results.len(), 6);
+    for ok_idx in [0, 2, 3, 5] {
+        assert!(
+            expect_ok(&response.results[ok_idx], ok_idx).decision,
+            "item {ok_idx} must Allow (unaffected by the bad items)"
+        );
+    }
+    for err_idx in [1, 4] {
+        match &response.results[err_idx] {
+            Err(BatchItemError::ActionParse { item_index, .. }) => {
+                assert_eq!(*item_index, err_idx);
+            },
+            other => panic!("item {err_idx} must surface ActionParse error, got: {other:?}"),
+        }
+    }
 }

--- a/jans-cedarling/cedarling/src/tests/authorize_unsigned_batch.rs
+++ b/jans-cedarling/cedarling/src/tests/authorize_unsigned_batch.rs
@@ -352,7 +352,10 @@ async fn batch_unsigned_multiple_errors_do_not_leak_across_items() {
     for err_idx in [1, 4] {
         match &response.results[err_idx] {
             Err(BatchItemError::ActionParse { item_index, .. }) => {
-                assert_eq!(*item_index, err_idx, "error item_index must match its position in the batch");
+                assert_eq!(
+                    *item_index, err_idx,
+                    "error item_index must match its position in the batch"
+                );
             },
             other => panic!("item {err_idx} must surface ActionParse error, got: {other:?}"),
         }

--- a/jans-cedarling/cedarling/src/tests/batch_contract.rs
+++ b/jans-cedarling/cedarling/src/tests/batch_contract.rs
@@ -14,7 +14,25 @@ use crate::authz::request::{
     BatchItem, EntityData, RequestUnsigned, TokenInput,
 };
 use crate::tests::utils::test_helpers::create_test_principal;
-use crate::{Cedarling, LogStorage};
+use crate::{
+    AuthorizeResult, BatchItemError, Cedarling, LogStorage, MultiIssuerAuthorizeResult,
+};
+
+fn expect_ok_unsigned(
+    r: &Result<AuthorizeResult, BatchItemError>,
+    idx: usize,
+) -> &AuthorizeResult {
+    r.as_ref()
+        .unwrap_or_else(|e| panic!("item {idx} expected Ok, got Err: {e:?}"))
+}
+
+fn expect_ok_multi(
+    r: &Result<MultiIssuerAuthorizeResult, BatchItemError>,
+    idx: usize,
+) -> &MultiIssuerAuthorizeResult {
+    r.as_ref()
+        .unwrap_or_else(|e| panic!("item {idx} expected Ok, got Err: {e:?}"))
+}
 
 static UNSIGNED_POLICY_STORE: &str =
     include_str!("../../../test_files/policy-store_no_trusted_issuers.yaml");
@@ -163,14 +181,19 @@ async fn batch_unsigned_matches_sequence_of_single() {
         "batch must return same number of results as sequence"
     );
     assert!(
-        batch_ok.results.iter().all(|r| r.decision),
+        batch_ok
+            .results
+            .iter()
+            .enumerate()
+            .all(|(i, r)| expect_ok_unsigned(r, i).decision),
         "is_ok=true principal must Allow every item — check fixture drift"
     );
     for (i, (s, b)) in seq_ok.iter().zip(batch_ok.results.iter()).enumerate() {
-        assert_eq!(s.decision, b.decision, "decision mismatch at item {i}");
+        let bo = expect_ok_unsigned(b, i);
+        assert_eq!(s.decision, bo.decision, "decision mismatch at item {i}");
         assert_eq!(
             diagnostic_reasons(&s.response),
-            diagnostic_reasons(&b.response),
+            diagnostic_reasons(&bo.response),
             "diagnostic reasons mismatch at item {i}"
         );
     }
@@ -198,14 +221,19 @@ async fn batch_unsigned_matches_sequence_of_single() {
         .expect("batch should succeed");
 
     assert!(
-        batch_bad.results.iter().all(|r| !r.decision),
+        batch_bad
+            .results
+            .iter()
+            .enumerate()
+            .all(|(i, r)| !expect_ok_unsigned(r, i).decision),
         "is_ok=false principal must Deny every item — check fixture drift"
     );
     for (i, (s, b)) in seq_bad.iter().zip(batch_bad.results.iter()).enumerate() {
-        assert_eq!(s.decision, b.decision, "deny decision mismatch at item {i}");
+        let bo = expect_ok_unsigned(b, i);
+        assert_eq!(s.decision, bo.decision, "deny decision mismatch at item {i}");
         assert_eq!(
             diagnostic_reasons(&s.response),
-            diagnostic_reasons(&b.response),
+            diagnostic_reasons(&bo.response),
             "deny diagnostic reasons mismatch at item {i}"
         );
     }
@@ -252,17 +280,23 @@ async fn batch_multi_issuer_matches_sequence_of_single() {
     );
     // Positive/negative anchors — allow items at 0/2, deny items at 1/3.
     // Guards against a fixture drift where both sides silently all-Deny.
-    let decisions: Vec<bool> = batch.results.iter().map(|r| r.decision).collect();
+    let decisions: Vec<bool> = batch
+        .results
+        .iter()
+        .enumerate()
+        .map(|(i, r)| expect_ok_multi(r, i).decision)
+        .collect();
     assert_eq!(
         decisions,
         vec![true, false, true, false],
         "batch decisions must match the allow/deny/allow/deny item pattern"
     );
     for (i, (s, b)) in sequence.iter().zip(batch.results.iter()).enumerate() {
-        assert_eq!(s.decision, b.decision, "decision mismatch at item {i}");
+        let bo = expect_ok_multi(b, i);
+        assert_eq!(s.decision, bo.decision, "decision mismatch at item {i}");
         assert_eq!(
             diagnostic_reasons(&s.response),
-            diagnostic_reasons(&b.response),
+            diagnostic_reasons(&bo.response),
             "diagnostic reasons mismatch at item {i}"
         );
     }
@@ -308,19 +342,39 @@ async fn batch_unsigned_reverse_order_preserves_positional_mapping() {
         .await
         .expect("reversed batch should succeed");
 
-    let baseline_decisions: Vec<bool> = baseline.results.iter().map(|r| r.decision).collect();
-    let shuffled_decisions: Vec<bool> = shuffled.results.iter().map(|r| r.decision).collect();
+    // Map each per-item Result to a Some(bool) / None slot so an Err from a
+    // bad-action item is a distinguishable position (not silently folded into
+    // the same "false" as a Cedar-Deny).
+    let baseline_slots: Vec<Option<bool>> = baseline
+        .results
+        .iter()
+        .map(|r| r.as_ref().ok().map(|ok| ok.decision))
+        .collect();
+    let shuffled_slots: Vec<Option<bool>> = shuffled
+        .results
+        .iter()
+        .map(|r| r.as_ref().ok().map(|ok| ok.decision))
+        .collect();
 
-    let mut expected: Vec<bool> = baseline_decisions.clone();
+    let mut expected = baseline_slots.clone();
     expected.reverse();
     assert_eq!(
-        shuffled_decisions, expected,
+        shuffled_slots, expected,
         "reversing items must reverse the result positions exactly"
     );
     assert_eq!(
-        baseline_decisions,
-        vec![true, false, true, false, true, false, true, false],
-        "sanity: even indices allow, odd deny under the fixture"
+        baseline_slots,
+        vec![
+            Some(true),
+            None,
+            Some(true),
+            None,
+            Some(true),
+            None,
+            Some(true),
+            None
+        ],
+        "sanity: even indices Ok(true), odd indices Err(ActionParse)"
     );
 }
 

--- a/jans-cedarling/cedarling/src/tests/batch_contract.rs
+++ b/jans-cedarling/cedarling/src/tests/batch_contract.rs
@@ -312,7 +312,7 @@ async fn batch_unsigned_reverse_order_preserves_positional_mapping() {
     let principal = create_test_principal("Jans::TestPrincipal1", "p1", json!({"is_ok": true}))
         .expect("principal");
 
-    // Even index → good action (Allow); odd → bad action (fail-closed Deny).
+    // Even index → good action (Allow); odd → bad action (Err/ActionParse).
     let items: Vec<BatchItem> = (0..8)
         .map(|i| {
             let action = if i % 2 == 0 {

--- a/jans-cedarling/cedarling/src/tests/batch_contract.rs
+++ b/jans-cedarling/cedarling/src/tests/batch_contract.rs
@@ -191,7 +191,7 @@ async fn batch_unsigned_matches_sequence_of_single() {
     for (i, (s, b)) in seq_ok.iter().zip(batch_ok.results.iter()).enumerate() {
         let bo = expect_ok_unsigned(b, i);
         assert_eq!(s.decision, bo.decision, "decision mismatch at item {i}");
-        assert_eq!(
+        test_utils::assert_eq!(
             diagnostic_reasons(&s.response),
             diagnostic_reasons(&bo.response),
             "diagnostic reasons mismatch at item {i}"
@@ -231,7 +231,7 @@ async fn batch_unsigned_matches_sequence_of_single() {
     for (i, (s, b)) in seq_bad.iter().zip(batch_bad.results.iter()).enumerate() {
         let bo = expect_ok_unsigned(b, i);
         assert_eq!(s.decision, bo.decision, "deny decision mismatch at item {i}");
-        assert_eq!(
+        test_utils::assert_eq!(
             diagnostic_reasons(&s.response),
             diagnostic_reasons(&bo.response),
             "deny diagnostic reasons mismatch at item {i}"
@@ -294,7 +294,7 @@ async fn batch_multi_issuer_matches_sequence_of_single() {
     for (i, (s, b)) in sequence.iter().zip(batch.results.iter()).enumerate() {
         let bo = expect_ok_multi(b, i);
         assert_eq!(s.decision, bo.decision, "decision mismatch at item {i}");
-        assert_eq!(
+        test_utils::assert_eq!(
             diagnostic_reasons(&s.response),
             diagnostic_reasons(&bo.response),
             "diagnostic reasons mismatch at item {i}"
@@ -358,7 +358,7 @@ async fn batch_unsigned_reverse_order_preserves_positional_mapping() {
 
     let mut expected = baseline_slots.clone();
     expected.reverse();
-    assert_eq!(
+    test_utils::assert_eq!(
         shuffled_slots, expected,
         "reversing items must reverse the result positions exactly"
     );

--- a/jans-cedarling/cedarling_pg/sql/cedarling_pg--0.1.0.sql
+++ b/jans-cedarling/cedarling_pg/sql/cedarling_pg--0.1.0.sql
@@ -79,6 +79,7 @@ CREATE  FUNCTION "cedarling_authorize_multi_issuer_batch"(
 ) RETURNS TABLE (
 	"item_index" INT,  /* i32 */
 	"decision" bool,  /* bool */
+	"error_category" TEXT,  /* Option<String> */
 	"batch_id" TEXT  /* String */
 )
 STRICT VOLATILE PARALLEL RESTRICTED
@@ -108,6 +109,7 @@ CREATE  FUNCTION "cedarling_authorize_unsigned_batch"(
 ) RETURNS TABLE (
 	"item_index" INT,  /* i32 */
 	"decision" bool,  /* bool */
+	"error_category" TEXT,  /* Option<String> */
 	"batch_id" TEXT  /* String */
 )
 STRICT VOLATILE PARALLEL RESTRICTED

--- a/jans-cedarling/cedarling_pg/src/authz/bridge.rs
+++ b/jans-cedarling/cedarling_pg/src/authz/bridge.rs
@@ -178,13 +178,36 @@ pub(crate) struct BatchOutcome {
     pub items: Vec<BatchItemResult>,
 }
 
-/// Per-item slice of a [`BatchOutcome`]: request-side metadata (`action`,
-/// `resource_type`, `resource_id`) alongside the engine outcome.
+/// Per-item slice of a [`BatchOutcome`]: request-side metadata alongside
+/// either the Cedar-evaluated outcome (`Ok`) or a per-item build error (`Err`).
 pub(crate) struct BatchItemResult {
     pub action: String,
     pub resource_type: String,
     pub resource_id: String,
-    pub outcome: AuthorizeOutcome,
+    pub kind: BatchItemKind,
+}
+
+/// Discriminates a per-item batch outcome: Cedar reached a decision, or the
+/// item failed to build.
+pub(crate) enum BatchItemKind {
+    Ok(AuthorizeOutcome),
+    Err(BatchItemBuildError),
+}
+
+/// Wire-friendly projection of `cedarling::BatchItemError` — we drop the
+/// enum shape into a category slug + message for logs / SQL / traces.
+pub(crate) struct BatchItemBuildError {
+    pub category: &'static str,
+    pub message: String,
+}
+
+impl From<cedarling::BatchItemError> for BatchItemBuildError {
+    fn from(err: cedarling::BatchItemError) -> Self {
+        Self {
+            category: err.category(),
+            message: err.to_string(),
+        }
+    }
 }
 
 /// Errors specific to batch bridging.
@@ -227,7 +250,14 @@ pub(crate) fn authorize_unsigned_batch_outcome(
                 action,
                 resource_type: rt,
                 resource_id: rid,
-                outcome: map_authorize_result(r.decision, r.request_id, &r.response),
+                kind: match r {
+                    Ok(ok) => BatchItemKind::Ok(map_authorize_result(
+                        ok.decision,
+                        ok.request_id,
+                        &ok.response,
+                    )),
+                    Err(e) => BatchItemKind::Err(e.into()),
+                },
             })
             .collect(),
     })
@@ -262,7 +292,14 @@ pub(crate) fn authorize_multi_issuer_batch_outcome(
                 action,
                 resource_type: rt,
                 resource_id: rid,
-                outcome: map_authorize_result(r.decision, r.request_id, &r.response),
+                kind: match r {
+                    Ok(ok) => BatchItemKind::Ok(map_authorize_result(
+                        ok.decision,
+                        ok.request_id,
+                        &ok.response,
+                    )),
+                    Err(e) => BatchItemKind::Err(e.into()),
+                },
             })
             .collect(),
     })

--- a/jans-cedarling/cedarling_pg/src/authz/bridge.rs
+++ b/jans-cedarling/cedarling_pg/src/authz/bridge.rs
@@ -19,6 +19,7 @@ use crate::resource;
 use crate::tokens::bundle as token_bundle;
 
 /// A richer authorization result that includes decision plus diagnostics.
+#[derive(Debug)]
 pub struct AuthorizeOutcome {
     pub decision: bool,
     pub request_id: String,
@@ -173,6 +174,7 @@ pub fn authorize_unsigned_outcome_for_request(
 
 /// Result of a batch authorize call: shared `batch_id` plus per-item outcomes
 /// with the request-side metadata needed for per-item trace records.
+#[derive(Debug)]
 pub(crate) struct BatchOutcome {
     pub batch_id: String,
     pub items: Vec<BatchItemResult>,
@@ -180,6 +182,7 @@ pub(crate) struct BatchOutcome {
 
 /// Per-item slice of a [`BatchOutcome`]: request-side metadata alongside
 /// either the Cedar-evaluated outcome (`Ok`) or a per-item build error (`Err`).
+#[derive(Debug)]
 pub(crate) struct BatchItemResult {
     pub action: String,
     pub resource_type: String,
@@ -189,6 +192,7 @@ pub(crate) struct BatchItemResult {
 
 /// Discriminates a per-item batch outcome: Cedar reached a decision, or the
 /// item failed to build.
+#[derive(Debug)]
 pub(crate) enum BatchItemKind {
     Ok(AuthorizeOutcome),
     Err(BatchItemBuildError),
@@ -196,6 +200,7 @@ pub(crate) enum BatchItemKind {
 
 /// Wire-friendly projection of `cedarling::BatchItemError` — we drop the
 /// enum shape into a category slug + message for logs / SQL / traces.
+#[derive(Debug)]
 pub(crate) struct BatchItemBuildError {
     pub category: &'static str,
     pub message: String,

--- a/jans-cedarling/cedarling_pg/src/functions/authorized.rs
+++ b/jans-cedarling/cedarling_pg/src/functions/authorized.rs
@@ -380,21 +380,27 @@ fn batch_failure_rows(
     let timestamp = chrono::Utc::now().to_rfc3339();
     let category = err.category();
     let error_col = Some(category.to_string());
+    
+    // Generate a batch_id for correlation of these failure rows
+    let batch_id_val = uuid::Uuid::new_v4().to_string();
+    let batch_id_trace = Some(batch_id_val.clone());
+    let diag_errors = vec![err.to_string()];
+
     match peek_batch_item_count(request_json) {
         Some(n) if n > 0 => (0..n)
             .map(|idx| {
-                push_batch_error_trace(&timestamp, shadow, category, None, idx as i32);
+                push_batch_error_trace(&timestamp, shadow, category, batch_id_trace.clone(), idx as i32, diag_errors.clone());
                 (
                     i32::try_from(idx).unwrap_or(i32::MAX),
                     decision,
                     error_col.clone(),
-                    String::new(),
+                    batch_id_val.clone(),
                 )
             })
             .collect(),
         _ => {
-            push_batch_error_trace(&timestamp, shadow, category, None, -1);
-            vec![(-1, decision, error_col, String::new())]
+            push_batch_error_trace(&timestamp, shadow, category, batch_id_trace, -1, diag_errors);
+            vec![(-1, decision, error_col, batch_id_val)]
         },
     }
 }
@@ -405,6 +411,7 @@ fn push_batch_error_trace(
     error_category: &'static str,
     batch_id: Option<String>,
     item_index: i32,
+    diag_errors: Vec<String>,
 ) {
     push_trace(AuthorizationTrace {
         timestamp: timestamp.to_string(),
@@ -418,8 +425,8 @@ fn push_batch_error_trace(
         principal_id: None,
         shadow,
         cache_hit: false,
-        policy_hits: vec![],
-        diag_errors: vec![],
+        policy_hits: Vec::new(),
+        diag_errors,
         masked: false,
         policy_version: None,
         batch_id,
@@ -545,7 +552,7 @@ fn success_rows(
                         principal_id: None,
                         shadow,
                         cache_hit: false,
-                        policy_hits: vec![],
+                        policy_hits: Vec::new(),
                         diag_errors: vec![e.message],
                         masked: false,
                         policy_version: None,
@@ -553,7 +560,7 @@ fn success_rows(
                     });
                     (
                         idx_i32,
-                        finalize_error(&CedarlingError::RequestInvalid(e.category.to_string())),
+                        finalize_error(&CedarlingError::PolicyEvaluation(e.category.to_string())),
                         Some(e.category.to_string()),
                         batch_id.clone(),
                     )

--- a/jans-cedarling/cedarling_pg/src/functions/authorized.rs
+++ b/jans-cedarling/cedarling_pg/src/functions/authorized.rs
@@ -560,7 +560,7 @@ fn success_rows(
                     });
                     (
                         idx_i32,
-                        finalize_error(&CedarlingError::PolicyEvaluation(e.category.to_string())),
+                        finalize_error(&CedarlingError::BatchItem(e.category, e.message.clone())),
                         Some(e.category.to_string()),
                         batch_id.clone(),
                     )

--- a/jans-cedarling/cedarling_pg/src/functions/authorized.rs
+++ b/jans-cedarling/cedarling_pg/src/functions/authorized.rs
@@ -371,21 +371,30 @@ fn peek_batch_item_count(request_json: &str) -> Option<usize> {
 /// Fail-closed / mode-respecting rows on batch-level failure: N rows when the
 /// item count is peekable, otherwise one sentinel row at `item_index = -1`.
 /// Also pushes one per-row error trace so operators see item-level detail.
-fn batch_failure_rows(request_json: &str, err: &CedarlingError) -> Vec<(i32, bool, String)> {
+fn batch_failure_rows(
+    request_json: &str,
+    err: &CedarlingError,
+) -> Vec<(i32, bool, Option<String>, String)> {
     let decision = finalize_error(err);
     let shadow = matches!(guc_config::mode(), CedarlingMode::Shadow);
     let timestamp = chrono::Utc::now().to_rfc3339();
     let category = err.category();
+    let error_col = Some(category.to_string());
     match peek_batch_item_count(request_json) {
         Some(n) if n > 0 => (0..n)
             .map(|idx| {
                 push_batch_error_trace(&timestamp, shadow, category, None, idx as i32);
-                (i32::try_from(idx).unwrap_or(i32::MAX), decision, String::new())
+                (
+                    i32::try_from(idx).unwrap_or(i32::MAX),
+                    decision,
+                    error_col.clone(),
+                    String::new(),
+                )
             })
             .collect(),
         _ => {
             push_batch_error_trace(&timestamp, shadow, category, None, -1);
-            vec![(-1, decision, String::new())]
+            vec![(-1, decision, error_col, String::new())]
         },
     }
 }
@@ -434,6 +443,7 @@ pub fn cedarling_authorize_unsigned_batch(
     (
         name!(item_index, i32),
         name!(decision, bool),
+        name!(error_category, Option<String>),
         name!(batch_id, String),
     ),
 > {
@@ -457,6 +467,7 @@ pub fn cedarling_authorize_multi_issuer_batch(
     (
         name!(item_index, i32),
         name!(decision, bool),
+        name!(error_category, Option<String>),
         name!(batch_id, String),
     ),
 > {
@@ -469,14 +480,14 @@ pub fn cedarling_authorize_multi_issuer_batch(
     TableIterator::new(rows)
 }
 
-/// Build the per-item success rows and emit `record_decision` + `push_trace`
-/// once per item. Raw (pre-shadow-flip) decisions drive counters and traces;
-/// shadow flip only touches the returned SQL rows so `cedarling_status()`
-/// still shows what Cedar actually decided.
+/// Build the per-item response rows and emit `record_decision` + `push_trace`
+/// once per item. Ok slots use the raw Cedar decision (shadow flip only
+/// touches the returned SQL row); Err slots synthesize a fail-closed decision
+/// via [`finalize_error`], populate `error_category`, and emit an error trace.
 fn success_rows(
     outcome: authz_bridge::BatchOutcome,
     total_elapsed: std::time::Duration,
-) -> Vec<(i32, bool, String)> {
+) -> Vec<(i32, bool, Option<String>, String)> {
     let batch_id = outcome.batch_id;
     let batch_id_trace = Some(batch_id.clone());
     let shadow = matches!(guc_config::mode(), CedarlingMode::Shadow);
@@ -487,28 +498,67 @@ fn success_rows(
         .into_iter()
         .enumerate()
         .map(|(idx, item)| {
-            let raw_decision = item.outcome.decision;
-            status::record_decision(raw_decision);
-            push_trace(AuthorizationTrace {
-                timestamp: timestamp.clone(),
-                action: item.action,
-                duration_ms: total_ms,
-                decision: Some(raw_decision),
-                error_category: None,
-                request_id: item.outcome.request_id,
-                resource_type: item.resource_type,
-                resource_id: item.resource_id,
-                principal_id: None,
-                shadow,
-                cache_hit: false,
-                policy_hits: item.outcome.policy_hits,
-                diag_errors: item.outcome.diag_errors,
-                masked: false,
-                policy_version: None,
-                batch_id: batch_id_trace.clone(),
-            });
             let idx_i32 = i32::try_from(idx).unwrap_or(i32::MAX);
-            (idx_i32, finalize_batch_decision(raw_decision), batch_id.clone())
+            match item.kind {
+                authz_bridge::BatchItemKind::Ok(ok) => {
+                    let raw_decision = ok.decision;
+                    status::record_decision(raw_decision);
+                    push_trace(AuthorizationTrace {
+                        timestamp: timestamp.clone(),
+                        action: item.action,
+                        duration_ms: total_ms,
+                        decision: Some(raw_decision),
+                        error_category: None,
+                        request_id: ok.request_id,
+                        resource_type: item.resource_type,
+                        resource_id: item.resource_id,
+                        principal_id: None,
+                        shadow,
+                        cache_hit: false,
+                        policy_hits: ok.policy_hits,
+                        diag_errors: ok.diag_errors,
+                        masked: false,
+                        policy_version: None,
+                        batch_id: batch_id_trace.clone(),
+                    });
+                    (
+                        idx_i32,
+                        finalize_batch_decision(raw_decision),
+                        None,
+                        batch_id.clone(),
+                    )
+                },
+                authz_bridge::BatchItemKind::Err(e) => {
+                    // Item never reached Cedar. Fail-closed decision via
+                    // `finalize_error` preserves the single-item contract;
+                    // `error_category` surfaces the reason to consumers.
+                    status::record_error_msg(&e.message);
+                    push_trace(AuthorizationTrace {
+                        timestamp: timestamp.clone(),
+                        action: item.action,
+                        duration_ms: total_ms,
+                        decision: None,
+                        error_category: Some(e.category),
+                        request_id: String::new(),
+                        resource_type: item.resource_type,
+                        resource_id: item.resource_id,
+                        principal_id: None,
+                        shadow,
+                        cache_hit: false,
+                        policy_hits: vec![],
+                        diag_errors: vec![e.message],
+                        masked: false,
+                        policy_version: None,
+                        batch_id: batch_id_trace.clone(),
+                    });
+                    (
+                        idx_i32,
+                        finalize_error(&CedarlingError::RequestInvalid(e.category.to_string())),
+                        Some(e.category.to_string()),
+                        batch_id.clone(),
+                    )
+                },
+            }
         })
         .collect()
 }

--- a/jans-cedarling/cedarling_pg/src/functions/error.rs
+++ b/jans-cedarling/cedarling_pg/src/functions/error.rs
@@ -43,6 +43,9 @@ pub enum CedarlingError {
     #[error("schema validation failed: {0}")]
     SchemaValidation(String),
 
+    #[error("batch item failed: {1}")]
+    BatchItem(&'static str, String),
+
     #[error("engine unavailable: {0}")]
     Engine(String),
 
@@ -102,6 +105,7 @@ impl CedarlingError {
             Self::PolicyEvaluation(_) => "policy_evaluation",
             Self::PolicyLoading(_) => "policy_loading",
             Self::SchemaValidation(_) => "schema_validation",
+            Self::BatchItem(cat, _) => *cat,
             Self::Engine(_) => "engine",
             Self::Configuration(_) => "configuration",
             Self::JsonParsing(_) => "json_parsing",

--- a/jans-cedarling/cedarling_pg/src/functions/pg_test_authorize_batch.rs
+++ b/jans-cedarling/cedarling_pg/src/functions/pg_test_authorize_batch.rs
@@ -150,31 +150,33 @@ pub(crate) fn run_unsigned_batch_mixed_decisions_preserve_order() {
     .expect("count is not NULL");
     assert_eq!(row_count, 3, "N=3 items must yield 3 rows");
 
-    // Read decisions in item_index order and assert positional agreement.
-    let decisions: Vec<(i32, bool)> = Spi::connect(|client| {
+    // Read (item_index, decision, error_category) and assert positional agreement.
+    let rows: Vec<(i32, bool, Option<String>)> = Spi::connect(|client| {
         client
             .select(
-                "SELECT item_index, decision FROM cedarling_authorize_unsigned_batch($1) \
-                 ORDER BY item_index",
+                "SELECT item_index, decision, error_category \
+                 FROM cedarling_authorize_unsigned_batch($1) ORDER BY item_index",
                 None,
                 &[request.as_str().into()],
             )
             .expect("SPI select")
             .map(|row| {
                 let idx: i32 = row.get::<i32>(1).expect("item_index col").expect("non-null");
-                let decision: bool = row.get::<bool>(2).expect("decision col").expect("non-null");
-                (idx, decision)
+                let decision: bool =
+                    row.get::<bool>(2).expect("decision col").expect("non-null");
+                let error_category: Option<String> = row.get::<String>(3).expect("error_category col");
+                (idx, decision, error_category)
             })
             .collect()
     });
-    assert_eq!(decisions.len(), 3);
-    assert_eq!(decisions[0], (0, true), "item 0 must allow");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0], (0, true, None), "item 0 must allow (no error)");
     assert_eq!(
-        decisions[1],
-        (1, false),
-        "item 1 with bad action must fail closed"
+        rows[1],
+        (1, false, Some("action_parse".to_string())),
+        "item 1 with bad action must be Err(action_parse) + fail-closed decision"
     );
-    assert_eq!(decisions[2], (2, true), "item 2 must allow");
+    assert_eq!(rows[2], (2, true, None), "item 2 must allow (no error)");
 }
 
 /// Empty `items` → single sentinel row at `item_index = -1` with fail-closed
@@ -193,10 +195,10 @@ pub(crate) fn run_unsigned_batch_empty_items_synthesizes_fail_closed_row() {
     })
     .to_string();
 
-    let rows: Vec<(i32, bool, String)> = Spi::connect(|client| {
+    let rows: Vec<(i32, bool, Option<String>, String)> = Spi::connect(|client| {
         client
             .select(
-                "SELECT item_index, decision, batch_id \
+                "SELECT item_index, decision, error_category, batch_id \
                  FROM cedarling_authorize_unsigned_batch($1) ORDER BY item_index",
                 None,
                 &[request.as_str().into()],
@@ -206,16 +208,19 @@ pub(crate) fn run_unsigned_batch_empty_items_synthesizes_fail_closed_row() {
                 let idx: i32 = row.get::<i32>(1).expect("item_index col").expect("non-null");
                 let decision: bool =
                     row.get::<bool>(2).expect("decision col").expect("non-null");
+                let error_category: Option<String> = row.get::<String>(3).expect("error_category col");
                 let batch_id: String =
-                    row.get::<String>(3).expect("batch_id col").expect("non-null");
-                (idx, decision, batch_id)
+                    row.get::<String>(4).expect("batch_id col").expect("non-null");
+                (idx, decision, error_category, batch_id)
             })
             .collect()
     });
-    assert_eq!(
-        rows,
-        vec![(-1, false, String::new())],
-        "empty items must synthesize a single fail-closed sentinel row at -1"
+    assert_eq!(rows.len(), 1);
+    let (idx, decision, error_category, batch_id) = &rows[0];
+    assert_eq!((*idx, *decision, batch_id.as_str()), (-1, false, ""));
+    assert!(
+        error_category.is_some(),
+        "batch-level failure must populate error_category"
     );
 }
 
@@ -236,10 +241,10 @@ pub(crate) fn run_multi_issuer_batch_empty_tokens_synthesizes_fail_closed_rows()
     })
     .to_string();
 
-    let rows: Vec<(i32, bool, String)> = Spi::connect(|client| {
+    let rows: Vec<(i32, bool, Option<String>, String)> = Spi::connect(|client| {
         client
             .select(
-                "SELECT item_index, decision, batch_id \
+                "SELECT item_index, decision, error_category, batch_id \
                  FROM cedarling_authorize_multi_issuer_batch($1) ORDER BY item_index",
                 None,
                 &[request.as_str().into()],
@@ -249,16 +254,19 @@ pub(crate) fn run_multi_issuer_batch_empty_tokens_synthesizes_fail_closed_rows()
                 let idx: i32 = row.get::<i32>(1).expect("item_index col").expect("non-null");
                 let decision: bool =
                     row.get::<bool>(2).expect("decision col").expect("non-null");
+                let error_category: Option<String> = row.get::<String>(3).expect("error_category col");
                 let batch_id: String =
-                    row.get::<String>(3).expect("batch_id col").expect("non-null");
-                (idx, decision, batch_id)
+                    row.get::<String>(4).expect("batch_id col").expect("non-null");
+                (idx, decision, error_category, batch_id)
             })
             .collect()
     });
-    assert_eq!(
-        rows,
-        vec![(0, false, String::new())],
-        "empty tokens with N=1 item must synthesize one fail-closed row per input item"
+    assert_eq!(rows.len(), 1);
+    let (idx, decision, error_category, batch_id) = &rows[0];
+    assert_eq!((*idx, *decision, batch_id.as_str()), (0, false, ""));
+    assert!(
+        error_category.is_some(),
+        "batch-level failure must populate error_category"
     );
 }
 
@@ -271,10 +279,10 @@ pub(crate) fn run_unsigned_batch_malformed_json_synthesizes_sentinel_row() {
 
     let request = "{ not valid json";
 
-    let rows: Vec<(i32, bool, String)> = Spi::connect(|client| {
+    let rows: Vec<(i32, bool, Option<String>, String)> = Spi::connect(|client| {
         client
             .select(
-                "SELECT item_index, decision, batch_id \
+                "SELECT item_index, decision, error_category, batch_id \
                  FROM cedarling_authorize_unsigned_batch($1) ORDER BY item_index",
                 None,
                 &[request.into()],
@@ -284,16 +292,19 @@ pub(crate) fn run_unsigned_batch_malformed_json_synthesizes_sentinel_row() {
                 let idx: i32 = row.get::<i32>(1).expect("item_index col").expect("non-null");
                 let decision: bool =
                     row.get::<bool>(2).expect("decision col").expect("non-null");
+                let error_category: Option<String> = row.get::<String>(3).expect("error_category col");
                 let batch_id: String =
-                    row.get::<String>(3).expect("batch_id col").expect("non-null");
-                (idx, decision, batch_id)
+                    row.get::<String>(4).expect("batch_id col").expect("non-null");
+                (idx, decision, error_category, batch_id)
             })
             .collect()
     });
-    assert_eq!(
-        rows,
-        vec![(-1, false, String::new())],
-        "malformed JSON must synthesize a single fail-closed sentinel row at -1"
+    assert_eq!(rows.len(), 1);
+    let (idx, decision, error_category, batch_id) = &rows[0];
+    assert_eq!((*idx, *decision, batch_id.as_str()), (-1, false, ""));
+    assert!(
+        error_category.is_some(),
+        "malformed JSON must populate error_category"
     );
 }
 
@@ -442,10 +453,10 @@ pub(crate) fn run_unsigned_batch_clean_policy_deny() {
     })
     .to_string();
 
-    let rows: Vec<(i32, bool, String)> = Spi::connect(|client| {
+    let rows: Vec<(i32, bool, Option<String>, String)> = Spi::connect(|client| {
         client
             .select(
-                "SELECT item_index, decision, batch_id \
+                "SELECT item_index, decision, error_category, batch_id \
                  FROM cedarling_authorize_unsigned_batch($1) ORDER BY item_index",
                 None,
                 &[request.as_str().into()],
@@ -454,9 +465,10 @@ pub(crate) fn run_unsigned_batch_clean_policy_deny() {
             .map(|row| {
                 let idx: i32 = row.get::<i32>(1).expect("item_index").expect("non-null");
                 let decision: bool = row.get::<bool>(2).expect("decision").expect("non-null");
+                let error_category: Option<String> = row.get::<String>(3).expect("error_category");
                 let batch_id: String =
-                    row.get::<String>(3).expect("batch_id").expect("non-null");
-                (idx, decision, batch_id)
+                    row.get::<String>(4).expect("batch_id").expect("non-null");
+                (idx, decision, error_category, batch_id)
             })
             .collect()
     });
@@ -464,7 +476,11 @@ pub(crate) fn run_unsigned_batch_clean_policy_deny() {
     assert_eq!(rows[0].0, 0);
     assert!(!rows[0].1, "policy-Deny item must return decision = false");
     assert!(
-        !rows[0].2.is_empty(),
+        rows[0].2.is_none(),
+        "clean policy-Deny must NOT tag error_category (Cedar reached a decision)"
+    );
+    assert!(
+        !rows[0].3.is_empty(),
         "clean-Deny row must still carry a real batch_id (engine ran successfully)"
     );
 
@@ -551,10 +567,10 @@ pub(crate) fn run_unsigned_batch_fail_open_synthesizes_true_rows() {
     Spi::run("SET cedarling.fail_mode = 'open'").expect("SET fail_mode");
 
     let malformed = "{ not valid json";
-    let rows: Vec<(i32, bool, String)> = Spi::connect(|client| {
+    let rows: Vec<(i32, bool, Option<String>, String)> = Spi::connect(|client| {
         client
             .select(
-                "SELECT item_index, decision, batch_id \
+                "SELECT item_index, decision, error_category, batch_id \
                  FROM cedarling_authorize_unsigned_batch($1) ORDER BY item_index",
                 None,
                 &[malformed.into()],
@@ -563,15 +579,22 @@ pub(crate) fn run_unsigned_batch_fail_open_synthesizes_true_rows() {
             .map(|row| {
                 let idx: i32 = row.get::<i32>(1).expect("item_index").expect("non-null");
                 let decision: bool = row.get::<bool>(2).expect("decision").expect("non-null");
+                let error_category: Option<String> = row.get::<String>(3).expect("error_category");
                 let batch_id: String =
-                    row.get::<String>(3).expect("batch_id").expect("non-null");
-                (idx, decision, batch_id)
+                    row.get::<String>(4).expect("batch_id").expect("non-null");
+                (idx, decision, error_category, batch_id)
             })
             .collect()
     });
+    assert_eq!(rows.len(), 1);
+    let (idx, decision, error_category, batch_id) = &rows[0];
     assert_eq!(
-        rows,
-        vec![(-1, true, String::new())],
+        (*idx, *decision, batch_id.as_str()),
+        (-1, true, ""),
         "fail_mode=open must flip the sentinel row's decision to true"
+    );
+    assert!(
+        error_category.is_some(),
+        "fail-open failure must still populate error_category so the reason isn't lost"
     );
 }


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14566

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch authorization now returns per-item success/failure outcomes (with failures not blocking evaluation of other items).
  * Failures include structured error details: stable error category, item index, and a log-safe message.
  * Java, Go, Kotlin, JavaScript, Python, Rust, UniFFI, and WASM batch bindings now expose helper/result wrappers for the per-item outcome model.
  * PostgreSQL batch results now include an `error_category` column.
* **Documentation**
  * Updated batch reference and multi-language tutorials to reflect the revised per-item response shape, error semantics, and handling examples (including shared `batch_id` correlation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->