### PR TITLE
fix(jans-auth-server): protected bypass via IPv6 transition addresses in sector_identifier_uri and client_id URL validation

### DIFF
--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientIdMetadataService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/ClientIdMetadataService.java
@@ -16,6 +16,7 @@ import io.jans.as.model.register.ApplicationType;
 import io.jans.as.persistence.model.ClientAttributes;
 import io.jans.as.server.model.registration.RegisterParamsValidator;
 import io.jans.as.server.register.ws.rs.RegisterService;
+import io.jans.as.server.service.net.PrivateAddressUtil;
 import io.jans.as.server.service.external.ExternalDynamicClientRegistrationService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -341,11 +342,17 @@ public class ClientIdMetadataService {
         try {
             InetAddress[] addresses = InetAddress.getAllByName(host);
             for (InetAddress address : addresses) {
-                if (isPrivateAddress(address)) {
+                String reason = PrivateAddressUtil.reasonForPrivateAddress(address);
+                if (reason != null) {
+                    log.warn("Rejecting client_id URL: host '{}' resolves to address '{}', which is a {} " +
+                                    "(ClientIdMetadataService#validateNotPrivateIp, rule: PrivateAddressUtil#isPrivateAddress)",
+                            host, address.getHostAddress(), reason);
                     throw badRequest("Client ID URL resolves to private/local address");
                 }
             }
         } catch (UnknownHostException e) {
+            log.warn("Rejecting client_id URL: host '{}' could not be resolved via DNS, failing closed " +
+                    "(ClientIdMetadataService#validateNotPrivateIp): {}", host, e.getMessage());
             throw badRequest("Cannot resolve client_id host: " + host);
         }
     }
@@ -357,10 +364,7 @@ public class ClientIdMetadataService {
      * @return true if private/internal
      */
     public boolean isPrivateAddress(InetAddress address) {
-        return address.isLoopbackAddress() ||
-                address.isSiteLocalAddress() ||
-                address.isLinkLocalAddress() ||
-                address.isAnyLocalAddress();
+        return PrivateAddressUtil.isPrivateAddress(address);
     }
 
     /**

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/PrivateAddressUtil.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/PrivateAddressUtil.java
@@ -1,0 +1,142 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.as.server.service.net;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+/**
+ * Shared SSRF-protection check for client-supplied URLs (sector_identifier_uri, client_id URL).
+ * In addition to the standard {@link InetAddress} private/loopback/link-local/multicast checks and
+ * the IPv6 Unique Local Address range (fc00::/7, not covered by {@link InetAddress#isSiteLocalAddress()}),
+ * this also unwraps IPv6 transition mechanisms that embed an IPv4 address (NAT64, 6to4, Teredo,
+ * IPv4-mapped and IPv4-compatible addresses) and re-checks the embedded address, since those can be
+ * used to reach private IPv4 destinations under an address that otherwise looks globally routable.
+ *
+ * @author Yuriy Z
+ */
+public class PrivateAddressUtil {
+
+    private static final byte[] NAT64_WELL_KNOWN_PREFIX = {0x00, 0x64, (byte) 0xff, (byte) 0x9b};
+    private static final byte SIXTOFOUR_PREFIX_HIGH = 0x20;
+    private static final byte SIXTOFOUR_PREFIX_LOW = 0x02;
+    private static final byte TEREDO_PREFIX_HIGH = 0x20;
+    private static final byte TEREDO_PREFIX_LOW_1 = 0x01;
+
+    private PrivateAddressUtil() {
+    }
+
+    public static boolean isPrivateAddress(InetAddress address) {
+        return reasonForPrivateAddress(address) != null;
+    }
+
+    /**
+     * Same check as {@link #isPrivateAddress(InetAddress)}, but returns a human-readable reason
+     * identifying exactly which rule matched (and, for IPv6 transition mechanisms, which embedded
+     * IPv4 address and rule it resolved to), for use in rejection log messages. Returns null if the
+     * address is public.
+     */
+    public static String reasonForPrivateAddress(InetAddress address) {
+        if (address.isLoopbackAddress()) {
+            return "loopback address (InetAddress.isLoopbackAddress)";
+        }
+        if (address.isSiteLocalAddress()) {
+            return "site-local/RFC1918 private address (InetAddress.isSiteLocalAddress)";
+        }
+        if (address.isLinkLocalAddress()) {
+            return "link-local address, e.g. cloud metadata range 169.254.0.0/16 (InetAddress.isLinkLocalAddress)";
+        }
+        if (address.isAnyLocalAddress()) {
+            return "wildcard/any-local address (InetAddress.isAnyLocalAddress)";
+        }
+        if (address.isMulticastAddress()) {
+            return "multicast address (InetAddress.isMulticastAddress)";
+        }
+
+        final byte[] bytes = address.getAddress();
+        if (bytes.length != 16) {
+            return null;
+        }
+        if ((bytes[0] & 0xFE) == 0xFC) {
+            return "IPv6 Unique Local Address in fc00::/7 (PrivateAddressUtil ULA check)";
+        }
+
+        final EmbeddedIpv4 embedded = extractEmbeddedIpv4(bytes);
+        if (embedded == null) {
+            return null;
+        }
+        final String embeddedReason = reasonForPrivateAddress(embedded.address);
+        if (embeddedReason == null) {
+            return null;
+        }
+        return embedded.mechanism + " address embedding IPv4 " + embedded.address.getHostAddress()
+                + ", which is a " + embeddedReason;
+    }
+
+    private static final class EmbeddedIpv4 {
+        final String mechanism;
+        final InetAddress address;
+
+        EmbeddedIpv4(String mechanism, InetAddress address) {
+            this.mechanism = mechanism;
+            this.address = address;
+        }
+    }
+
+    /**
+     * Extracts an embedded IPv4 address from known IPv6 transition mechanisms, or returns null if
+     * none of them match. Recognizes: NAT64 (64:ff9b::/96), 6to4 (2002::/16), Teredo (2001:0::/32),
+     * IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d, deprecated).
+     */
+    private static EmbeddedIpv4 extractEmbeddedIpv4(byte[] bytes) {
+        try {
+            if (matches(bytes, 0, NAT64_WELL_KNOWN_PREFIX) && allZero(bytes, 4, 12)) {
+                return new EmbeddedIpv4("NAT64 (64:ff9b::/96)", InetAddress.getByAddress(Arrays.copyOfRange(bytes, 12, 16)));
+            }
+            if (bytes[0] == SIXTOFOUR_PREFIX_HIGH && bytes[1] == SIXTOFOUR_PREFIX_LOW) {
+                return new EmbeddedIpv4("6to4 (2002::/16)", InetAddress.getByAddress(Arrays.copyOfRange(bytes, 2, 6)));
+            }
+            if (bytes[0] == TEREDO_PREFIX_HIGH && bytes[1] == TEREDO_PREFIX_LOW_1 && bytes[2] == 0x00 && bytes[3] == 0x00) {
+                // Teredo obfuscates the embedded client IPv4 address by XOR-ing it with 0xff
+                final byte[] ipv4 = new byte[4];
+                for (int i = 0; i < 4; i++) {
+                    ipv4[i] = (byte) (bytes[12 + i] ^ 0xFF);
+                }
+                return new EmbeddedIpv4("Teredo (2001::/32)", InetAddress.getByAddress(ipv4));
+            }
+            if (allZero(bytes, 0, 10) && (bytes[10] & 0xFF) == 0xFF && (bytes[11] & 0xFF) == 0xFF) {
+                return new EmbeddedIpv4("IPv4-mapped (::ffff:a.b.c.d)", InetAddress.getByAddress(Arrays.copyOfRange(bytes, 12, 16)));
+            }
+            if (allZero(bytes, 0, 12) && !allZero(bytes, 12, 16)) {
+                return new EmbeddedIpv4("IPv4-compatible (::a.b.c.d)", InetAddress.getByAddress(Arrays.copyOfRange(bytes, 12, 16)));
+            }
+        } catch (UnknownHostException e) {
+            // 4-byte address, always resolvable without I/O; not reachable in practice
+            return null;
+        }
+        return null;
+    }
+
+    private static boolean matches(byte[] bytes, int offset, byte[] prefix) {
+        for (int i = 0; i < prefix.length; i++) {
+            if (bytes[offset + i] != prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean allZero(byte[] bytes, int from, int to) {
+        for (int i = from; i < to; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/SectorIdentifierUriService.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/service/net/SectorIdentifierUriService.java
@@ -55,7 +55,6 @@ public class SectorIdentifierUriService {
         }
 
         if (isPrivateOrUnresolvableHost(uri.getHost())) {
-            log.warn("sector_identifier_uri resolves to a private, loopback or unresolvable host: {}", uri.getHost());
             return false;
         }
 
@@ -77,32 +76,29 @@ public class SectorIdentifierUriService {
      */
     boolean isPrivateOrUnresolvableHost(String host) {
         if (StringUtils.isBlank(host)) {
+            log.warn("Rejecting sector_identifier_uri: host is blank (SectorIdentifierUriService#isPrivateOrUnresolvableHost)");
             return true;
         }
         try {
             for (InetAddress address : InetAddress.getAllByName(host)) {
-                if (isPrivateAddress(address)) {
+                final String reason = PrivateAddressUtil.reasonForPrivateAddress(address);
+                if (reason != null) {
+                    log.warn("Rejecting sector_identifier_uri: host '{}' resolves to address '{}', which is a {} " +
+                                    "(SectorIdentifierUriService#isPrivateOrUnresolvableHost, rule: PrivateAddressUtil#isPrivateAddress)",
+                            host, address.getHostAddress(), reason);
                     return true;
                 }
             }
             return false;
         } catch (UnknownHostException e) {
-            log.warn("Unable to resolve host for sector_identifier_uri: {}", host);
+            log.warn("Rejecting sector_identifier_uri: host '{}' could not be resolved via DNS, failing closed " +
+                    "(SectorIdentifierUriService#isPrivateOrUnresolvableHost): {}", host, e.getMessage());
             return true;
         }
     }
 
-    boolean isPrivateAddress(InetAddress address) {
-        if (address.isLoopbackAddress()
-                || address.isSiteLocalAddress()
-                || address.isLinkLocalAddress()
-                || address.isAnyLocalAddress()
-                || address.isMulticastAddress()) {
-            return true;
-        }
-        // IPv6 Unique Local Addresses (fc00::/7) are not covered by isSiteLocalAddress()
-        byte[] bytes = address.getAddress();
-        return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC;
+    public static boolean isPrivateAddress(InetAddress address) {
+        return PrivateAddressUtil.isPrivateAddress(address);
     }
 
     public String fetchSectorIdentifierContent(String sectorIdentifierUri) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/PrivateAddressUtilTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/PrivateAddressUtilTest.java
@@ -1,0 +1,112 @@
+package io.jans.as.server.service.net;
+
+import org.testng.annotations.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Z
+ */
+public class PrivateAddressUtilTest {
+
+    @Test
+    public void isPrivateAddress_withNat64EmbeddingLinkLocal_shouldReturnTrue() throws Exception {
+        assertTrue(PrivateAddressUtil.isPrivateAddress(inet6(0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 169, 254, 169, 254)));
+    }
+
+    @Test
+    public void isPrivateAddress_withNat64EmbeddingPublicAddress_shouldReturnFalse() throws Exception {
+        assertFalse(PrivateAddressUtil.isPrivateAddress(inet6(0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8)));
+    }
+
+    @Test
+    public void isPrivateAddress_with6to4EmbeddingPrivateAddress_shouldReturnTrue() throws Exception {
+        assertTrue(PrivateAddressUtil.isPrivateAddress(inet6(0x20, 0x02, 10, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
+    }
+
+    @Test
+    public void isPrivateAddress_with6to4EmbeddingPublicAddress_shouldReturnFalse() throws Exception {
+        assertFalse(PrivateAddressUtil.isPrivateAddress(inet6(0x20, 0x02, 8, 8, 8, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)));
+    }
+
+    @Test
+    public void isPrivateAddress_withTeredoEmbeddingPrivateAddress_shouldReturnTrue() throws Exception {
+        // client IPv4 192.168.1.1 obfuscated by XOR 0xff
+        assertTrue(PrivateAddressUtil.isPrivateAddress(inet6(0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x3f, 0x57, 0xfe, 0xfe)));
+    }
+
+    @Test
+    public void isPrivateAddress_withTeredoEmbeddingPublicAddress_shouldReturnFalse() throws Exception {
+        // client IPv4 8.8.8.8 obfuscated by XOR 0xff
+        assertFalse(PrivateAddressUtil.isPrivateAddress(inet6(0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xf7, 0xf7, 0xf7, 0xf7)));
+    }
+
+    @Test
+    public void isPrivateAddress_withIpv4MappedPrivateAddress_shouldReturnTrue() throws Exception {
+        assertTrue(PrivateAddressUtil.isPrivateAddress(inet6(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 1)));
+    }
+
+    @Test
+    public void isPrivateAddress_withIpv4MappedPublicAddress_shouldReturnFalse() throws Exception {
+        assertFalse(PrivateAddressUtil.isPrivateAddress(inet6(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 8, 8, 8, 8)));
+    }
+
+    @Test
+    public void isPrivateAddress_withIpv4CompatiblePrivateAddress_shouldReturnTrue() throws Exception {
+        assertTrue(PrivateAddressUtil.isPrivateAddress(inet6(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 1)));
+    }
+
+    @Test
+    public void isPrivateAddress_withUniqueLocalAddress_shouldReturnTrue() throws Exception {
+        assertTrue(PrivateAddressUtil.isPrivateAddress(InetAddress.getByName("fc00::1")));
+    }
+
+    @Test
+    public void isPrivateAddress_withPublicIpv6Address_shouldReturnFalse() throws Exception {
+        assertFalse(PrivateAddressUtil.isPrivateAddress(InetAddress.getByName("2001:4860:4860::8888")));
+    }
+
+    @Test
+    public void isPrivateAddress_withLoopbackIpv6Address_shouldReturnTrue() throws Exception {
+        assertTrue(PrivateAddressUtil.isPrivateAddress(InetAddress.getByName("::1")));
+    }
+
+    @Test
+    public void reasonForPrivateAddress_withLoopback_shouldNameLoopbackRule() throws Exception {
+        assertTrue(PrivateAddressUtil.reasonForPrivateAddress(InetAddress.getByName("127.0.0.1")).contains("loopback"));
+    }
+
+    @Test
+    public void reasonForPrivateAddress_withNat64EmbeddingLinkLocal_shouldNameNat64AndEmbeddedAddress() throws Exception {
+        String reason = PrivateAddressUtil.reasonForPrivateAddress(
+                inet6(0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 169, 254, 169, 254));
+        assertTrue(reason.contains("NAT64"));
+        assertTrue(reason.contains("169.254.169.254"));
+        assertTrue(reason.contains("link-local"));
+    }
+
+    @Test
+    public void reasonForPrivateAddress_with6to4EmbeddingPrivateAddress_shouldName6to4AndEmbeddedAddress() throws Exception {
+        String reason = PrivateAddressUtil.reasonForPrivateAddress(inet6(0x20, 0x02, 10, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+        assertTrue(reason.contains("6to4"));
+        assertTrue(reason.contains("10.0.0.1"));
+    }
+
+    @Test
+    public void reasonForPrivateAddress_withPublicAddress_shouldReturnNull() throws Exception {
+        assertNull(PrivateAddressUtil.reasonForPrivateAddress(InetAddress.getByName("8.8.8.8")));
+    }
+
+    private static InetAddress inet6(int... unsignedBytes) throws UnknownHostException {
+        byte[] bytes = new byte[unsignedBytes.length];
+        for (int i = 0; i < unsignedBytes.length; i++) {
+            bytes[i] = (byte) unsignedBytes[i];
+        }
+        return InetAddress.getByAddress(bytes);
+    }
+}

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/service/net/SectorIdentifierUriServiceTest.java
@@ -90,22 +90,22 @@ public class SectorIdentifierUriServiceTest {
         assertFalse(sectorIdentifierUriService.isAllowedSectorIdentifierUri("https://10.0.0.5/sector.json"));
     }
 
-    `@Test`
+    @Test
     public void isPrivateOrUnresolvableHost_loopbackIpLiteral_shouldReturnTrue() {
         assertTrue(sectorIdentifierUriService.isPrivateOrUnresolvableHost("127.0.0.1"));
     }
 
-    `@Test`
+    @Test
     public void isPrivateOrUnresolvableHost_blankHost_shouldReturnTrue() {
         assertTrue(sectorIdentifierUriService.isPrivateOrUnresolvableHost(""));
     }
 
-    `@Test`
+    @Test
     public void isPrivateOrUnresolvableHost_publicIpLiteral_shouldReturnFalse() {
         assertFalse(sectorIdentifierUriService.isPrivateOrUnresolvableHost("8.8.8.8"));
     }
 
-    `@Test`
+    @Test
     public void isPrivateOrUnresolvableHost_unresolvableHost_shouldReturnTrue() {
         assertTrue(sectorIdentifierUriService.isPrivateOrUnresolvableHost("nonexistent.invalid"));
     }


### PR DESCRIPTION
### Description

protected bypass via IPv6 transition addresses in sector_identifier_uri and client_id URL validation

#### Target issue
  
closes #14597


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened protection against requests to private, loopback, link-local, multicast, and IPv6 unique-local addresses.
  * Added detection for private addresses embedded in IPv6 transition formats.
  * Sector identifier validation now examines all resolved addresses and fails closed for blank or unresolvable hosts.
  * Improved diagnostics identify the address and rule causing rejection.

* **Tests**
  * Added coverage for IPv4, IPv6, embedded-address formats, public addresses, and unresolvable hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->