### PR TITLE
feat(jans-core): remove jans-auth-client dependecy in

### DIFF
--- a/jans-config-api/server/src/main/java/io/jans/configapi/service/cedar/CedarlingProtectionService.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/service/cedar/CedarlingProtectionService.java
@@ -9,15 +9,12 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 import io.jans.as.client.OpenIdConfigurationClient;
 import io.jans.as.client.OpenIdConfigurationResponse;
@@ -43,19 +40,14 @@ import jakarta.ws.rs.core.Response;
 @ApplicationScoped
 public class CedarlingProtectionService extends io.jans.core.cedarling.service.CedarlingProtectionService {
 
-    public static final int JWKS_CACHE_LIFETIME = 60;
-
     private OpenIdConfigurationResponse oidcConfig;
-
+    
     private ObjectMapper mapper;
-
-    private Cache<String, Map<?, ?>> jwksCache;
-
+    
     @PostConstruct
     private void init() {
         try {
             mapper = new ObjectMapper();
-            jwksCache = CacheBuilder.newBuilder().expireAfterWrite(JWKS_CACHE_LIFETIME, TimeUnit.MINUTES).build();
             oidcConfig = getOpenIdConfiguration();
         } catch (Exception e) {
             log.error(e.getMessage(), e);
@@ -64,10 +56,6 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
 
     public Response processAuthorization(String bearerToken, ResourceInfo resourceInfo) {
         try {
-            if (oidcConfig == null) {
-                return simpleResponse(FORBIDDEN, "Loaded OpenID configuration is invalid!");
-            }
-
             boolean authFound = StringUtils.isNotEmpty(bearerToken);
             log.info("Authorization header {} found", authFound ? "" : "not");
             
@@ -111,18 +99,9 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
                         "HMAC algorithm not allowed for token signature. Please use an algorithm in the EC, ED, or RSA family for signing");
             }
                 
-            String jwksUri = oidcConfig.getJwksUri();
-            Map<?, ?> jwks = getJwks(jwksUri);
-            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
+            Map<?, ?> jwks = mapper.readValue(new URL(oidcConfig.getJwksUri()), Map.class);
+            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(), 
                     jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
-
-            if (!valid) {
-                // Cached JWKS can be stale after key rotation, refresh once and retry
-                jwksCache.invalidate(jwksUri);
-                jwks = getJwks(jwksUri);
-                valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
-                        jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
-            }
 
             if (valid) {
                 return isValid(bearerToken, resourceInfo);
@@ -134,13 +113,6 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
             log.error(e.getMessage(), e);
             return simpleResponse(INTERNAL_SERVER_ERROR, e.getMessage());
         }
-    }
-
-    private Map<?, ?> getJwks(String jwksUri) throws Exception {
-        return jwksCache.get(jwksUri, () -> {
-            log.debug("Loading JWKS from {}", jwksUri);
-            return mapper.readValue(new URL(jwksUri), Map.class);
-        });
     }
 
     private Jwt tokenAsJwt(String token) {

--- a/jans-config-api/server/src/main/java/io/jans/configapi/service/cedar/CedarlingProtectionService.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/service/cedar/CedarlingProtectionService.java
@@ -9,12 +9,15 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 import io.jans.as.client.OpenIdConfigurationClient;
 import io.jans.as.client.OpenIdConfigurationResponse;
@@ -40,14 +43,19 @@ import jakarta.ws.rs.core.Response;
 @ApplicationScoped
 public class CedarlingProtectionService extends io.jans.core.cedarling.service.CedarlingProtectionService {
 
+    public static final int JWKS_CACHE_LIFETIME = 60;
+
     private OpenIdConfigurationResponse oidcConfig;
-    
+
     private ObjectMapper mapper;
-    
+
+    private Cache<String, Map<?, ?>> jwksCache;
+
     @PostConstruct
     private void init() {
         try {
             mapper = new ObjectMapper();
+            jwksCache = CacheBuilder.newBuilder().expireAfterWrite(JWKS_CACHE_LIFETIME, TimeUnit.MINUTES).build();
             oidcConfig = getOpenIdConfiguration();
         } catch (Exception e) {
             log.error(e.getMessage(), e);
@@ -56,6 +64,10 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
 
     public Response processAuthorization(String bearerToken, ResourceInfo resourceInfo) {
         try {
+            if (oidcConfig == null) {
+                return simpleResponse(FORBIDDEN, "Loaded OpenID configuration is invalid!");
+            }
+
             boolean authFound = StringUtils.isNotEmpty(bearerToken);
             log.info("Authorization header {} found", authFound ? "" : "not");
             
@@ -99,9 +111,18 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
                         "HMAC algorithm not allowed for token signature. Please use an algorithm in the EC, ED, or RSA family for signing");
             }
                 
-            Map<?, ?> jwks = mapper.readValue(new URL(oidcConfig.getJwksUri()), Map.class);
-            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(), 
+            String jwksUri = oidcConfig.getJwksUri();
+            Map<?, ?> jwks = getJwks(jwksUri);
+            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
                     jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
+
+            if (!valid) {
+                // Cached JWKS can be stale after key rotation, refresh once and retry
+                jwksCache.invalidate(jwksUri);
+                jwks = getJwks(jwksUri);
+                valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
+                        jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
+            }
 
             if (valid) {
                 return isValid(bearerToken, resourceInfo);
@@ -113,6 +134,13 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
             log.error(e.getMessage(), e);
             return simpleResponse(INTERNAL_SERVER_ERROR, e.getMessage());
         }
+    }
+
+    private Map<?, ?> getJwks(String jwksUri) throws Exception {
+        return jwksCache.get(jwksUri, () -> {
+            log.debug("Loading JWKS from {}", jwksUri);
+            return mapper.readValue(new URL(jwksUri), Map.class);
+        });
     }
 
     private Jwt tokenAsJwt(String token) {

--- a/jans-config-api/server/src/main/java/io/jans/configapi/service/cedar/CedarlingProtectionService.java
+++ b/jans-config-api/server/src/main/java/io/jans/configapi/service/cedar/CedarlingProtectionService.java
@@ -1,0 +1,151 @@
+package io.jans.configapi.service.cedar;
+
+import static io.jans.core.cedarling.service.CedarlingProtection.simpleResponse;
+import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jans.as.client.OpenIdConfigurationClient;
+import io.jans.as.client.OpenIdConfigurationResponse;
+import io.jans.as.model.crypto.AuthCryptoProvider;
+import io.jans.as.model.crypto.signature.AlgorithmFamily;
+import io.jans.as.model.crypto.signature.SignatureAlgorithm;
+import io.jans.as.model.exception.InvalidJwtException;
+import io.jans.as.model.jwt.Jwt;
+import io.jans.as.model.jwt.JwtClaimName;
+import io.jans.as.model.jwt.JwtClaims;
+import io.jans.core.cedarling.model.CedarlingPermission;
+import io.jans.util.StringHelper;
+import io.jans.util.exception.InvalidConfigurationException;
+import io.jans.util.exception.MissingResourceException;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author Yuriy Movchan Date: 10/08/2022
+ */
+@ApplicationScoped
+public class CedarlingProtectionService extends io.jans.core.cedarling.service.CedarlingProtectionService {
+
+    private OpenIdConfigurationResponse oidcConfig;
+    
+    private ObjectMapper mapper;
+    
+    @PostConstruct
+    private void init() {
+        try {
+            mapper = new ObjectMapper();
+            oidcConfig = getOpenIdConfiguration();
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    public Response processAuthorization(String bearerToken, ResourceInfo resourceInfo) {
+        try {
+            boolean authFound = StringUtils.isNotEmpty(bearerToken);
+            log.info("Authorization header {} found", authFound ? "" : "not");
+            
+            if (!authFound) {
+                log.info("Request is missing authorization header");
+                // See section 3.12 RFC 7644
+                return simpleResponse(UNAUTHORIZED, "No authorization header found");
+            }
+            
+            bearerToken = bearerToken.replaceFirst("Bearer\\s+","");
+            log.debug("Validating token {}", bearerToken);
+
+            List<CedarlingPermission> requestedPermissions = getRequestedOperations(resourceInfo);
+            if (requestedPermissions.isEmpty()) {
+                return simpleResponse(INTERNAL_SERVER_ERROR, "Access to operation is not correct");
+            }
+
+            Jwt jwt = tokenAsJwt(bearerToken);
+            if (jwt == null) {
+                return simpleResponse(FORBIDDEN, "Provided token isn't JWT encoded");
+            }
+
+            // Process the JWT: validate isuer, expiration and signature
+            JwtClaims claims = jwt.getClaims();
+
+            if (!oidcConfig.getIssuer().equals(claims.getClaimAsString(JwtClaimName.ISSUER))) {
+                return simpleResponse(FORBIDDEN, "Invalid token issuer");
+            }
+
+            int exp = Optional.ofNullable(claims.getClaimAsInteger(JwtClaimName.EXPIRATION_TIME)).orElse(0);
+            if (1000L * exp < System.currentTimeMillis()) {
+                return simpleResponse(FORBIDDEN, "Expired token");
+            }
+
+            AuthCryptoProvider cryptoProvider = new AuthCryptoProvider(null, null, null, true);
+            SignatureAlgorithm signatureAlg = jwt.getHeader().getSignatureAlgorithm();
+            
+            if (AlgorithmFamily.HMAC.equals(signatureAlg.getFamily())) {
+                // It is "expensive" to get the associated client secret
+                return simpleResponse(INTERNAL_SERVER_ERROR,
+                        "HMAC algorithm not allowed for token signature. Please use an algorithm in the EC, ED, or RSA family for signing");
+            }
+                
+            Map<?, ?> jwks = mapper.readValue(new URL(oidcConfig.getJwksUri()), Map.class);
+            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(), 
+                    jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
+
+            if (valid) {
+                return isValid(bearerToken, resourceInfo);
+            }
+
+            // See section 3.12 RFC 7644
+            return simpleResponse(FORBIDDEN, "Invalid token signature");
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return simpleResponse(INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+    private Jwt tokenAsJwt(String token) {
+        Jwt jwt = null;
+        try {
+            jwt = Jwt.parse(token);
+            if (log.isTraceEnabled()) {
+            	log.trace("This looks like a JWT token");
+            }
+        } catch (InvalidJwtException e) {
+            log.trace("Not a JWT token");
+        }
+        
+        return jwt;
+    }
+
+	private OpenIdConfigurationResponse getOpenIdConfiguration() {
+		String openIdIssuer = openIDConnectConfig.getIssuer();
+		if (StringHelper.isEmpty(openIdIssuer)) {
+			throw new InvalidConfigurationException("OpenIdIssuer Url is invalid");
+		}
+
+		String openIdIssuerEndpoint = openIdIssuer + "/.well-known/openid-configuration";
+
+		OpenIdConfigurationClient client = new OpenIdConfigurationClient(openIdIssuerEndpoint);
+		OpenIdConfigurationResponse openIdConfigurationResponse = client.execOpenIdConfiguration();
+
+		if ((openIdConfigurationResponse == null) || (openIdConfigurationResponse.getStatus() != HttpStatus.SC_OK)) {
+			throw new MissingResourceException("Failed to load OpenID configuration!");
+		}
+
+		log.info("Successfully loaded OpenID configuration");
+
+		return openIdConfigurationResponse;
+	}
+}

--- a/jans-core/cedarling/pom.xml
+++ b/jans-core/cedarling/pom.xml
@@ -90,10 +90,6 @@
 		</dependency>
 		<dependency>
 			<groupId>io.jans</groupId>
-			<artifactId>jans-auth-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.jans</groupId>
 			<artifactId>cedarling-java</artifactId>
 		</dependency>
 

--- a/jans-core/cedarling/src/main/java/io/jans/core/cedarling/service/CedarlingProtectionService.java
+++ b/jans-core/cedarling/src/main/java/io/jans/core/cedarling/service/CedarlingProtectionService.java
@@ -1,140 +1,54 @@
 package io.jans.core.cedarling.service;
 
+import static io.jans.core.cedarling.service.CedarlingProtection.simpleResponse;
 import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpStatus;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.jans.as.client.OpenIdConfigurationClient;
-import io.jans.as.client.OpenIdConfigurationResponse;
-import io.jans.as.model.crypto.AuthCryptoProvider;
-import io.jans.as.model.crypto.signature.AlgorithmFamily;
-import io.jans.as.model.crypto.signature.SignatureAlgorithm;
-import io.jans.as.model.exception.InvalidJwtException;
-import io.jans.as.model.jwt.Jwt;
-import io.jans.as.model.jwt.JwtClaimName;
-import io.jans.as.model.jwt.JwtClaims;
 import io.jans.core.cedarling.model.CedarlingPermission;
 import io.jans.core.cedarling.model.OpenIDConnectConfig;
 import io.jans.core.cedarling.service.security.api.ProtectedCedarlingApi;
-
-
-import io.jans.util.StringHelper;
-import io.jans.util.exception.InvalidConfigurationException;
-import io.jans.util.exception.MissingResourceException;
-import jakarta.annotation.PostConstruct;
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Response;
 
-import static io.jans.core.cedarling.service.CedarlingProtection.simpleResponse;
-
-@ApplicationScoped
-public class CedarlingProtectionService implements CedarlingProtection {
+/**
+ * @author Yuriy Movchan Date: 10/08/2022
+ */
+public abstract class CedarlingProtectionService implements CedarlingProtection {
 
 	@Inject
-    private Logger log;
+    protected Logger log;
 
     @Inject
-    private OpenIDConnectConfig openIDConnectConfig;
+    protected OpenIDConnectConfig openIDConnectConfig;
     
     @Inject
-    private CedarlingAuthorizationService authorizationService;
+    protected CedarlingAuthorizationService authorizationService;
+    
+    protected ObjectMapper mapper;
 
-    private OpenIdConfigurationResponse oidcConfig;
+    public abstract Response processAuthorization(String bearerToken, ResourceInfo resourceInfo);
     
-    private ObjectMapper mapper;
-    
-    @PostConstruct
-    private void init() {
-        try {
-            mapper = new ObjectMapper();
-            oidcConfig = getOpenIdConfiguration();
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
+    protected Response isValid(String bearerToken, ResourceInfo resourceInfo) {
+        List<CedarlingPermission> requestedPermissions = getRequestedOperations(resourceInfo);
+        log.info("Check access to requested opearations: {}", requestedPermissions);
+        if (requestedPermissions.isEmpty()) {
+            return simpleResponse(INTERNAL_SERVER_ERROR, "Access to operation is not correct");
         }
-    }
 
-    public Response processAuthorization(String bearerToken, ResourceInfo resourceInfo) {
-        try {
-            boolean authFound = StringUtils.isNotEmpty(bearerToken);
-            log.info("Authorization header {} found", authFound ? "" : "not");
-            
-            if (!authFound) {
-                log.info("Request is missing authorization header");
-                // See section 3.12 RFC 7644
-                return simpleResponse(UNAUTHORIZED, "No authorization header found");
-            }
-            
-            bearerToken = bearerToken.replaceFirst("Bearer\\s+","");
-            log.debug("Validating token {}", bearerToken);
-
-            List<CedarlingPermission> requestedPermissions = getRequestedOperations(resourceInfo);
-            log.info("Check access to requested opearations: {}", requestedPermissions);
-            if (requestedPermissions.isEmpty()) {
-	            return simpleResponse(INTERNAL_SERVER_ERROR, "Access to operation is not correct");
-            }
-
-            Jwt jwt = tokenAsJwt(bearerToken);
-            if (jwt == null) {
-                return simpleResponse(FORBIDDEN, "Provided token isn't JWT encoded");
-            }
-
-            // Process the JWT: validate isuer, expiration and signature
-            JwtClaims claims = jwt.getClaims();
-
-            if (!oidcConfig.getIssuer().equals(claims.getClaimAsString(JwtClaimName.ISSUER))) {
-                return simpleResponse(FORBIDDEN, "Invalid token issuer");
-            }
-
-            int exp = Optional.ofNullable(claims.getClaimAsInteger(JwtClaimName.EXPIRATION_TIME)).orElse(0);
-            if (1000L * exp < System.currentTimeMillis()) {
-                return simpleResponse(FORBIDDEN, "Expired token");
-            }
-
-            AuthCryptoProvider cryptoProvider = new AuthCryptoProvider(null, null, null, true);
-            SignatureAlgorithm signatureAlg = jwt.getHeader().getSignatureAlgorithm();
-            
-            if (AlgorithmFamily.HMAC.equals(signatureAlg.getFamily())) {
-                // It is "expensive" to get the associated client secret
-                return simpleResponse(INTERNAL_SERVER_ERROR,
-                        "HMAC algorithm not allowed for token signature. Please use an algorithm in the EC, ED, or RSA family for signing");
-            }
-                
-            Map<?, ?> jwks = mapper.readValue(new URL(oidcConfig.getJwksUri()), Map.class);
-            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(), 
-                    jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
-
-            if (valid) {
-                isValid(bearerToken, requestedPermissions);
-            }
- 
-            // See section 3.12 RFC 7644
-            return simpleResponse(FORBIDDEN, "Invalid token signature or insufficient scopes");
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return simpleResponse(INTERNAL_SERVER_ERROR, e.getMessage());
-        }
-    }
-    
-    private Response isValid(String bearerToken, List<CedarlingPermission> requestedPermissions) {
         boolean authorized = true;
         Map<String, String> tokens = getCedarlingTokens(bearerToken);
         for (CedarlingPermission requestedPermission : requestedPermissions) {
@@ -149,22 +63,8 @@ public class CedarlingProtectionService implements CedarlingProtection {
         if (authorized) {
             return null;
         }
-        
-        return null;
-    }
 
-    private Jwt tokenAsJwt(String token) {
-        Jwt jwt = null;
-        try {
-            jwt = Jwt.parse(token);
-            if (log.isTraceEnabled()) {
-            	log.trace("This looks like a JWT token");
-            }
-        } catch (InvalidJwtException e) {
-            log.trace("Not a JWT token");
-        }
-        
-        return jwt;
+        return simpleResponse(FORBIDDEN, "Insufficient permissions to access requested operations");
     }
 
 	private Map<String, String> getCedarlingTokens(String accessToken) {
@@ -199,7 +99,7 @@ public class CedarlingProtectionService implements CedarlingProtection {
 	    return new HashMap<>();
 	}
 
-    private List<CedarlingPermission> getRequestedOperations(ResourceInfo resourceInfo) {
+    protected List<CedarlingPermission> getRequestedOperations(ResourceInfo resourceInfo) {
         List<CedarlingPermission> cedarlingPermissions = new ArrayList<>();
         addCedarlingPermission(cedarlingPermissions, getOperationFromAnnotation(resourceInfo.getResourceClass()));
         addCedarlingPermission(cedarlingPermissions, getOperationFromAnnotation(resourceInfo.getResourceMethod()));
@@ -243,23 +143,4 @@ public class CedarlingProtectionService implements CedarlingProtection {
         return Optional.ofNullable(elem.getAnnotation(cls));
     }
 
-	private OpenIdConfigurationResponse getOpenIdConfiguration() {
-		String openIdIssuer = openIDConnectConfig.getIssuer();
-		if (StringHelper.isEmpty(openIdIssuer)) {
-			throw new InvalidConfigurationException("OpenIdIssuer Url is invalid");
-		}
-
-		String openIdIssuerEndpoint = openIdIssuer + "/.well-known/openid-configuration";
-
-		OpenIdConfigurationClient client = new OpenIdConfigurationClient(openIdIssuerEndpoint);
-		OpenIdConfigurationResponse openIdConfigurationResponse = client.execOpenIdConfiguration();
-
-		if ((openIdConfigurationResponse == null) || (openIdConfigurationResponse.getStatus() != HttpStatus.SC_OK)) {
-			throw new MissingResourceException("Failed to load OpenID configuration!");
-		}
-
-		log.info("Successfully loaded OpenID configuration");
-
-		return openIdConfigurationResponse;
-	}
 }

--- a/jans-core/cedarling/src/main/java/io/jans/core/cedarling/service/CedarlingProtectionService.java
+++ b/jans-core/cedarling/src/main/java/io/jans/core/cedarling/service/CedarlingProtectionService.java
@@ -37,6 +37,8 @@ public abstract class CedarlingProtectionService implements CedarlingProtection 
     
     @Inject
     protected CedarlingAuthorizationService authorizationService;
+    
+    protected ObjectMapper mapper;
 
     public abstract Response processAuthorization(String bearerToken, ResourceInfo resourceInfo);
     

--- a/jans-core/cedarling/src/main/java/io/jans/core/cedarling/service/CedarlingProtectionService.java
+++ b/jans-core/cedarling/src/main/java/io/jans/core/cedarling/service/CedarlingProtectionService.java
@@ -37,8 +37,6 @@ public abstract class CedarlingProtectionService implements CedarlingProtection 
     
     @Inject
     protected CedarlingAuthorizationService authorizationService;
-    
-    protected ObjectMapper mapper;
 
     public abstract Response processAuthorization(String bearerToken, ResourceInfo resourceInfo);
     

--- a/jans-core/cedarling/src/test/java/io/jans/core/cedarling/service/CedarlingProtectionServiceTest.java
+++ b/jans-core/cedarling/src/test/java/io/jans/core/cedarling/service/CedarlingProtectionServiceTest.java
@@ -12,67 +12,45 @@ import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Field;
-import java.net.URL;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.jans.as.client.OpenIdConfigurationResponse;
-import io.jans.as.model.crypto.AuthCryptoProvider;
-import io.jans.as.model.crypto.signature.SignatureAlgorithm;
-import io.jans.as.model.exception.InvalidJwtException;
-import io.jans.as.model.jwt.Jwt;
-import io.jans.as.model.jwt.JwtClaimName;
-import io.jans.as.model.jwt.JwtClaims;
-import io.jans.as.model.jwt.JwtHeader;
-import io.jans.core.cedarling.model.CedarlingConfiguration;
 import io.jans.core.cedarling.service.security.api.ProtectedCedarlingApi;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Response;
 
 /**
- * Unit tests for {@link CedarlingProtectionService#processAuthorization}.
+ * Unit tests for the abstract {@link CedarlingProtectionService} base class, exercised through the test-only
+ * {@link DummyCedarlingProtectionService} subclass.
  *
- * <p>The method under test implements a multi-step authorization filter:
+ * <p>The base class implements the transport-agnostic part of the authorization filter:
  * <ol>
- *   <li>Presence check – bearer token must be present.</li>
  *   <li>Permission resolution – at least one {@code @ProtectedCedarlingApi} annotation
  *       must be found on the JAX-RS resource class, method, or its interfaces.</li>
- *   <li>JWT validation – token must be parseable as a JWT.</li>
- *   <li>Issuer check – JWT {@code iss} claim must match the OIDC discovery document.</li>
- *   <li>Expiry check – JWT {@code exp} claim must be in the future.</li>
- *   <li>Algorithm check – HMAC-family algorithms are rejected.</li>
- *   <li>Signature verification – cryptographic signature must be valid.</li>
  *   <li>Cedarling policy evaluation – the Cedarling engine must grant access
  *       for every declared permission.</li>
  * </ol>
+ *
+ * <p>JWT validation (issuer, expiry, signature) is a concern of production subclasses (e.g. the Lock Server one) and
+ * is tested there. {@link DummyCedarlingProtectionService} only adds the bearer-token presence check and delegates
+ * straight to {@link CedarlingProtectionService#isValid}.
  *
  * <p>A {@code null} return value from {@code processAuthorization} means
  * "pass-through" – the JAX-RS filter will allow the request to continue.
@@ -84,21 +62,16 @@ class CedarlingProtectionServiceTest {
 
     // ─── Constants ──────────────────────────────────────────────────────────────
 
-    private static final String TEST_ISSUER   = "https://idp.example.com";
-    private static final String TEST_JWKS_URI = "https://idp.example.com/jwks";
     /** Minimal three-part placeholder used wherever a JWT string is required. */
-    private static final String DUMMY_JWT     = "header.payload.signature";
+    private static final String DUMMY_JWT = "header.payload.signature";
 
     // ─── Mocks & SUT ────────────────────────────────────────────────────────────
 
     @Mock private Logger                        log;
-    @Mock private CedarlingConfiguration        cedarConf;
     @Mock private CedarlingAuthorizationService authorizationService;
-    /** Injected as a mock so that JWKS HTTP calls can be stubbed without networking. */
-    @Mock private ObjectMapper                  mapper;
 
     @InjectMocks
-    private CedarlingProtectionService service;
+    private DummyCedarlingProtectionService service;
 
     // ─── JAX-RS Resource Fixtures ───────────────────────────────────────────────
 
@@ -154,25 +127,6 @@ class CedarlingProtectionServiceTest {
         public void multiMethod() { /* no-op */ }
     }
 
-    // ─── Setup ──────────────────────────────────────────────────────────────────
-
-    /**
-     * Injects the fields that are normally initialised in the {@code @PostConstruct}
-     * lifecycle method.  We bypass the real {@code init()} to avoid network calls
-     * during unit tests.
-     */
-    @BeforeEach
-    void setUp() throws Exception {
-        // Inject the mocked ObjectMapper (avoids real HTTP for JWKS fetches)
-        injectField("mapper", mapper);
-
-        // Build a minimal OpenID configuration stub
-        OpenIdConfigurationResponse oidcConfig = mock(OpenIdConfigurationResponse.class);
-        lenient().when(oidcConfig.getIssuer()).thenReturn(TEST_ISSUER);
-        lenient().when(oidcConfig.getJwksUri()).thenReturn(TEST_JWKS_URI);
-        injectField("oidcConfig", oidcConfig);
-    }
-
     // ===========================================================================
     // 1. Missing / blank bearer token → 401 Unauthorized
     // ===========================================================================
@@ -221,185 +175,7 @@ class CedarlingProtectionServiceTest {
     }
 
     // ===========================================================================
-    // 3. Token is not a valid JWT → 403 Forbidden
-    // ===========================================================================
-
-    @Nested
-    @DisplayName("JWT parsing")
-    class JwtParsingTests {
-
-        @Test
-        @DisplayName("plain text token (not JWT-encoded) returns 403")
-        void plainTextToken_returns403() {
-            // Jwt.parse() will throw InvalidJwtException for a non-JWT string,
-            // causing tokenAsJwt() to return null.
-            Response response = service.processAuthorization(
-                    "Bearer i-am-not-a-jwt",
-                    mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-            assertStatus(FORBIDDEN, response);
-            assertTrue(
-                    response.getEntity().toString().contains("JWT"),
-                    "Response body should mention JWT");
-        }
-
-        @Test
-        @DisplayName("random base64 string that looks like JWT parts returns 403")
-        void malformedBase64Token_returns403() {
-            Response response = service.processAuthorization(
-                    "Bearer aaa.bbb.ccc",
-                    mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-            assertStatus(FORBIDDEN, response);
-        }
-    }
-
-    // ===========================================================================
-    // 4. JWT issuer mismatch → 403 Forbidden
-    // ===========================================================================
-
-    @Nested
-    @DisplayName("JWT issuer validation")
-    class IssuerValidationTests {
-
-        @Test
-        @DisplayName("JWT with wrong issuer returns 403")
-        void wrongIssuer_returns403() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
-                Jwt jwt = buildMockJwt("https://untrusted-idp.example.com", futureEpoch(), SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-                assertStatus(FORBIDDEN, response);
-                assertTrue(
-                        response.getEntity().toString().contains("issuer"),
-                        "Response body should mention 'issuer'");
-            }
-        }
-    }
-
-    // ===========================================================================
-    // 5. Expired JWT → 403 Forbidden
-    // ===========================================================================
-
-    @Nested
-    @DisplayName("JWT expiry validation")
-    class ExpiryValidationTests {
-
-        @Test
-        @DisplayName("expired JWT returns 403")
-        void expiredJwt_returns403() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
-                Jwt jwt = buildMockJwt(TEST_ISSUER, pastEpoch(), SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-                assertStatus(FORBIDDEN, response);
-                assertTrue(
-                        response.getEntity().toString().contains("Expired"),
-                        "Response body should mention expiry");
-            }
-        }
-
-        @Test
-        @DisplayName("JWT with exp claim absent (defaults to epoch 0) returns 403")
-        void missingExpClaim_returns403() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
-                // When getClaimAsInteger returns null, the service defaults to 0
-                // (epoch 0 = 1970-01-01), so the token is immediately expired.
-                Jwt jwt = buildMockJwtNullExp(TEST_ISSUER, SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-                assertStatus(FORBIDDEN, response);
-            }
-        }
-    }
-
-    // ===========================================================================
-    // 6. HMAC-family algorithm → 500 Internal Server Error
-    // ===========================================================================
-
-    @Nested
-    @DisplayName("Signing algorithm validation")
-    class AlgorithmValidationTests {
-
-        @Test
-        @DisplayName("HS256 (HMAC) algorithm returns 500 with HMAC message")
-        void hmacAlgorithmHS256_returns500() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
-                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.HS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-                assertStatus(INTERNAL_SERVER_ERROR, response);
-                assertTrue(
-                        response.getEntity().toString().contains("HMAC"),
-                        "Response body should explain that HMAC is not allowed");
-            }
-        }
-
-        @Test
-        @DisplayName("HS384 (HMAC) algorithm also returns 500")
-        void hmacAlgorithmHS384_returns500() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
-                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.HS384);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-                assertStatus(INTERNAL_SERVER_ERROR, response);
-            }
-        }
-    }
-
-    // ===========================================================================
-    // 7. Signature verification fails → 403 Forbidden
-    // ===========================================================================
-
-    @Nested
-    @DisplayName("JWT signature verification")
-    class SignatureVerificationTests {
-
-        @Test
-        @DisplayName("invalid signature returns 403")
-        void invalidSignature_returns403() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
-                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
-                         AuthCryptoProvider.class,
-                         (mock, ctx) -> when(
-                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
-                                 .thenReturn(false))) {
-
-                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
-
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-                assertStatus(FORBIDDEN, response);
-            }
-        }
-    }
-
-    // ===========================================================================
-    // 8. Cedarling authorization decisions
+    // 3. Cedarling authorization decisions
     // ===========================================================================
 
     @Nested
@@ -407,51 +183,54 @@ class CedarlingProtectionServiceTest {
     class CedarlingAuthorizationTests {
 
         @Test
-        @DisplayName("valid JWT + Cedarling grants access → null (pass-through)")
-        void validJwtAndCedarlingGrants_returnsNull() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
-                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
-                         AuthCryptoProvider.class,
-                         (mock, ctx) -> when(
-                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
-                                 .thenReturn(true))) {
+        @DisplayName("Cedarling grants access → null (pass-through)")
+        void cedarlingGrants_returnsNull() {
+            when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                    .thenReturn(true);
 
-                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
-                when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
-                        .thenReturn(true);
+            Response response = service.processAuthorization(
+                    "Bearer " + DUMMY_JWT,
+                    mockResourceInfo(SecuredResource.class, "securedMethod"));
 
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-                assertStatus(FORBIDDEN, response);
-            }
+            assertNull(response, "Granted access must pass through (null response)");
         }
 
         @Test
-        @DisplayName("valid JWT + Cedarling denies access → 403")
-        void validJwtAndCedarlingDenies_returns403() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
-                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
-                         AuthCryptoProvider.class,
-                         (mock, ctx) -> when(
-                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
-                                 .thenReturn(true))) {
+        @DisplayName("Cedarling denies access → 403")
+        void cedarlingDenies_returns403() {
+            when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                    .thenReturn(false);
 
-                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
-                when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
-                        .thenReturn(false);
+            Response response = service.processAuthorization(
+                    "Bearer " + DUMMY_JWT,
+                    mockResourceInfo(SecuredResource.class, "securedMethod"));
 
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+            assertStatus(FORBIDDEN, response);
+        }
 
-                assertStatus(FORBIDDEN, response);
-            }
+        /**
+         * The bearer token must reach Cedarling with the {@code Bearer } prefix stripped —
+         * Cedarling itself performs the (test-disabled) JWT validation and the scope-based
+         * decision, so the token cannot simply be ignored.
+         */
+        @Test
+        @DisplayName("bearer token is forwarded to Cedarling without the 'Bearer ' prefix")
+        void bearerToken_forwardedToCedarling() {
+            when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                    .thenReturn(true);
+
+            service.processAuthorization(
+                    "Bearer " + DUMMY_JWT,
+                    mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<String, String>> tokensCaptor = ArgumentCaptor.forClass(Map.class);
+            verify(authorizationService).authorize(tokensCaptor.capture(), anyString(), anyMap(), anyMap());
+
+            assertEquals(
+                    DUMMY_JWT,
+                    tokensCaptor.getValue().get(CedarlingAuthorizationService.CEDARLING_JANS_ACCESS_TOKEN),
+                    "Raw token (without 'Bearer ' prefix) must be passed to Cedarling");
         }
 
         /**
@@ -461,64 +240,41 @@ class CedarlingProtectionServiceTest {
          */
         @Test
         @DisplayName("first permission denied short-circuits remaining checks")
-        void multiplePermissions_firstDenied_doesNotCheckRemainder() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
-                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
-                         AuthCryptoProvider.class,
-                         (mock, ctx) -> when(
-                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
-                                 .thenReturn(true))) {
+        void multiplePermissions_firstDenied_doesNotCheckRemainder() {
+            // First call is denied; second should never be reached
+            when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                    .thenReturn(false);
 
-                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
+            Response response = service.processAuthorization(
+                    "Bearer " + DUMMY_JWT,
+                    mockResourceInfo(MultiPermissionResource.class, "multiMethod"));
 
-                // First call is denied; second should never be reached
-                when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
-                        .thenReturn(false);
-
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(MultiPermissionResource.class, "multiMethod"));
-
-                assertStatus(FORBIDDEN, response);
-                // MultiPermissionResource has 2 permissions; the service must stop after
-                // the first denied result — so authorize() is called exactly once.
-                verify(authorizationService, times(1))
-                        .authorize(anyMap(), anyString(), anyMap(), anyMap());
-            }
+            assertStatus(FORBIDDEN, response);
+            // MultiPermissionResource has 2 permissions; the service must stop after
+            // the first denied result — so authorize() is called exactly once.
+            verify(authorizationService, times(1))
+                    .authorize(anyMap(), anyString(), anyMap(), anyMap());
         }
 
         @Test
         @DisplayName("both permissions granted returns null")
-        void multiplePermissions_allGranted_returnsNull() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
-                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
-                         AuthCryptoProvider.class,
-                         (mock, ctx) -> when(
-                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
-                                 .thenReturn(true))) {
+        void multiplePermissions_allGranted_returnsNull() {
+            when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                    .thenReturn(true);
 
-                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
-                when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
-                        .thenReturn(true);
+            Response response = service.processAuthorization(
+                    "Bearer " + DUMMY_JWT,
+                    mockResourceInfo(MultiPermissionResource.class, "multiMethod"));
 
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(MultiPermissionResource.class, "multiMethod"));
-
-                assertStatus(FORBIDDEN, response);
-                // Exactly 2 permissions → authorize() called twice
-                verify(authorizationService, times(2))
-                        .authorize(anyMap(), anyString(), anyMap(), anyMap());
-            }
+            assertNull(response, "Granted access must pass through (null response)");
+            // Exactly 2 permissions → authorize() called twice
+            verify(authorizationService, times(2))
+                    .authorize(anyMap(), anyString(), anyMap(), anyMap());
         }
     }
 
     // ===========================================================================
-    // 9. Unexpected runtime exception → 500 Internal Server Error
+    // 4. Unexpected runtime exception → 500 Internal Server Error
     // ===========================================================================
 
     @Nested
@@ -527,58 +283,25 @@ class CedarlingProtectionServiceTest {
 
         @Test
         @DisplayName("unexpected exception returns 500 with exception message")
-        void unexpectedException_returns500() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
-                jwtStatic.when(() -> Jwt.parse(anyString()))
-                         .thenThrow(new RuntimeException("Unexpected adapter failure"));
+        void unexpectedException_returns500() {
+            when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                    .thenThrow(new RuntimeException("Unexpected adapter failure"));
 
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+            Response response = service.processAuthorization(
+                    "Bearer " + DUMMY_JWT,
+                    mockResourceInfo(SecuredResource.class, "securedMethod"));
 
-                assertStatus(INTERNAL_SERVER_ERROR, response);
-                assertEquals(
-                        "Unexpected adapter failure",
-                        response.getEntity().toString(),
-                        "Exception message must be surfaced in the response body");
-            }
-        }
-
-        @Test
-        @DisplayName("JWKS fetch failure returns 500")
-        void jwksFetchFailure_returns500() throws Exception {
-            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
-                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
-                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
-
-                // Simulate an I/O error when fetching the JWKS endpoint
-                when(mapper.readValue(any(URL.class), eq(Map.class)))
-                        .thenThrow(new java.io.IOException("Connection refused"));
-
-                Response response = service.processAuthorization(
-                        "Bearer " + DUMMY_JWT,
-                        mockResourceInfo(SecuredResource.class, "securedMethod"));
-
-                assertStatus(INTERNAL_SERVER_ERROR, response);
-            }
+            assertStatus(INTERNAL_SERVER_ERROR, response);
+            assertEquals(
+                    "Unexpected adapter failure",
+                    response.getEntity().toString(),
+                    "Exception message must be surfaced in the response body");
         }
     }
 
     // ===========================================================================
     // Helper methods
     // ===========================================================================
-
-    /**
-     * Injects a value into a private field of the service under test using reflection.
-     *
-     * @param fieldName the exact name of the private field
-     * @param value     the value to inject
-     */
-    private void injectField(String fieldName, Object value) throws Exception {
-        Field field = CedarlingProtectionService.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(service, value);
-    }
 
     /**
      * Creates a {@link ResourceInfo} mock that returns the specified class and method.
@@ -612,82 +335,5 @@ class CedarlingProtectionServiceTest {
                 actual.getStatus(),
                 String.format("Expected HTTP %d (%s) but got %d",
                         expected.getStatusCode(), expected, actual.getStatus()));
-    }
-
-    /**
-     * Builds a fully mocked {@link Jwt} with the specified issuer, expiry, and
-     * signing algorithm.  All fields needed by the service under test are stubbed.
-     *
-     * @param issuer    value for the {@code iss} JWT claim
-     * @param expEpoch  value for the {@code exp} JWT claim (epoch seconds)
-     * @param algorithm signing algorithm to report via the JWT header
-     * @return a mocked {@link Jwt}
-     * @throws InvalidJwtException 
-     */
-    private static Jwt buildMockJwt(String issuer, int expEpoch, SignatureAlgorithm algorithm) throws InvalidJwtException {
-        Jwt jwt = mock(Jwt.class);
-
-        // Stub JWT header
-        JwtHeader header = mock(JwtHeader.class);
-        lenient().when(header.getSignatureAlgorithm()).thenReturn(algorithm);
-        lenient().when(header.getKeyId()).thenReturn("test-key-id");
-        lenient().when(jwt.getHeader()).thenReturn(header);
-
-        // Stub JWT claims
-        JwtClaims claims = mock(JwtClaims.class);
-        lenient().when(claims.getClaimAsString(JwtClaimName.ISSUER)).thenReturn(issuer);
-        lenient().when(claims.getClaimAsInteger(JwtClaimName.EXPIRATION_TIME)).thenReturn(expEpoch);
-        lenient().when(jwt.getClaims()).thenReturn(claims);
-
-        // Stub signing material (needed for signature verification)
-        lenient().when(jwt.getSigningInput()).thenReturn("signing.input");
-        lenient().when(jwt.getEncodedSignature()).thenReturn("encoded-signature");
-
-        return jwt;
-    }
-
-    /**
-     * Same as {@link #buildMockJwt} but returns {@code null} for the {@code exp}
-     * claim, which the service defaults to epoch 0 (i.e. immediately expired).
-     *
-     * @param issuer    value for the {@code iss} JWT claim
-     * @param algorithm signing algorithm to report via the JWT header
-     * @return a mocked {@link Jwt} with a null {@code exp} claim
-     * @throws InvalidJwtException 
-     */
-    private static Jwt buildMockJwtNullExp(String issuer, SignatureAlgorithm algorithm) throws InvalidJwtException {
-        Jwt jwt = mock(Jwt.class);
-
-        JwtHeader header = mock(JwtHeader.class);
-        lenient().when(header.getSignatureAlgorithm()).thenReturn(algorithm);
-        lenient().when(header.getKeyId()).thenReturn("test-key-id");
-        lenient().when(jwt.getHeader()).thenReturn(header);
-
-        JwtClaims claims = mock(JwtClaims.class);
-        lenient().when(claims.getClaimAsString(JwtClaimName.ISSUER)).thenReturn(issuer);
-        // null triggers Optional.orElse(0) in the service → token is expired
-        lenient().when(claims.getClaimAsInteger(JwtClaimName.EXPIRATION_TIME)).thenReturn(null);
-        lenient().when(jwt.getClaims()).thenReturn(claims);
-
-        lenient().when(jwt.getSigningInput()).thenReturn("signing.input");
-        lenient().when(jwt.getEncodedSignature()).thenReturn("encoded-signature");
-
-        return jwt;
-    }
-
-    /**
-     * Returns an {@code exp} value (epoch seconds) 1 hour in the future.
-     * Tokens with this value are not yet expired.
-     */
-    private static int futureEpoch() {
-        return (int) (System.currentTimeMillis() / 1000) + 3600;
-    }
-
-    /**
-     * Returns an {@code exp} value (epoch seconds) 1 hour in the past.
-     * Tokens with this value are expired.
-     */
-    private static int pastEpoch() {
-        return (int) (System.currentTimeMillis() / 1000) - 3600;
     }
 }

--- a/jans-core/cedarling/src/test/java/io/jans/core/cedarling/service/DummyCedarlingProtectionService.java
+++ b/jans-core/cedarling/src/test/java/io/jans/core/cedarling/service/DummyCedarlingProtectionService.java
@@ -1,0 +1,53 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+package io.jans.core.cedarling.service;
+
+import static io.jans.core.cedarling.service.CedarlingProtection.simpleResponse;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Test-only {@link CedarlingProtectionService} implementation.
+ *
+ * <p>
+ * Production subclasses (e.g. the Lock Server one) validate the bearer token as a JWT (issuer, expiration, signature against the OIDC provider's JWKS) before
+ * asking Cedarling for an authorization decision. Tests have no OIDC provider available and initialise Cedarling with {@code jwtStatusValidation(false)} /
+ * {@code jwtSigValidation(false)}, so this implementation skips the JWT validation step entirely.
+ *
+ * <p>
+ * The bearer token itself is <strong>not</strong> ignored: it is still passed to {@link #isValid(String, ResourceInfo)} and therefore to Cedarling, which
+ * makes the real scope-based ALLOW/DENY decision from the token's claims.
+ *
+ * @author Author Date: 12/05/2026
+ */
+public class DummyCedarlingProtectionService extends CedarlingProtectionService {
+
+    @Override
+    public Response processAuthorization(String bearerToken, ResourceInfo resourceInfo) {
+        try {
+            boolean authFound = (bearerToken != null) && !bearerToken.isEmpty();
+            log.info("Authorization header {} found", authFound ? "" : "not");
+
+            if (!authFound) {
+                log.info("Request is missing authorization header");
+                // See section 3.12 RFC 7644
+                return simpleResponse(UNAUTHORIZED, "No authorization header found");
+            }
+
+            bearerToken = bearerToken.replaceFirst("Bearer\\s+", "");
+            log.debug("Skipping JWT validation, authorizing token {} via Cedarling", bearerToken);
+
+            return isValid(bearerToken, resourceInfo);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return simpleResponse(INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+}

--- a/jans-core/pom.xml
+++ b/jans-core/pom.xml
@@ -49,7 +49,6 @@
 		<module>util</module>
 		<module>model</module>
 		<module>cache</module>
-		<module>cedarling</module>
 		<module>message</module>
 		<module>document-store</module>
 		<module>standalone</module>
@@ -62,6 +61,7 @@
 		<module>exception-extension-cdi</module>
 		<module>script</module>
 		<module>service</module>
+		<module>cedarling</module>
 		<module>server</module>
 		<module>radius</module>
 		<module>demo-cdi</module>

--- a/jans-lock/lock-server/service/pom.xml
+++ b/jans-lock/lock-server/service/pom.xml
@@ -134,11 +134,6 @@
 
 		<dependency>
 			<groupId>io.jans</groupId>
-			<artifactId>jans-lock-cedarling</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>io.jans</groupId>
 			<artifactId>jans-core-model</artifactId>
 		</dependency>
 

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/CedarlingProtectionService.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/CedarlingProtectionService.java
@@ -1,0 +1,151 @@
+package io.jans.lock.service;
+
+import static io.jans.core.cedarling.service.CedarlingProtection.simpleResponse;
+import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jans.as.client.OpenIdConfigurationClient;
+import io.jans.as.client.OpenIdConfigurationResponse;
+import io.jans.as.model.crypto.AuthCryptoProvider;
+import io.jans.as.model.crypto.signature.AlgorithmFamily;
+import io.jans.as.model.crypto.signature.SignatureAlgorithm;
+import io.jans.as.model.exception.InvalidJwtException;
+import io.jans.as.model.jwt.Jwt;
+import io.jans.as.model.jwt.JwtClaimName;
+import io.jans.as.model.jwt.JwtClaims;
+import io.jans.core.cedarling.model.CedarlingPermission;
+import io.jans.util.StringHelper;
+import io.jans.util.exception.InvalidConfigurationException;
+import io.jans.util.exception.MissingResourceException;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author Yuriy Movchan Date: 10/08/2022
+ */
+@ApplicationScoped
+public class CedarlingProtectionService extends io.jans.core.cedarling.service.CedarlingProtectionService {
+
+    private OpenIdConfigurationResponse oidcConfig;
+    
+    private ObjectMapper mapper;
+    
+    @PostConstruct
+    private void init() {
+        try {
+            mapper = new ObjectMapper();
+            oidcConfig = getOpenIdConfiguration();
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    public Response processAuthorization(String bearerToken, ResourceInfo resourceInfo) {
+        try {
+            boolean authFound = StringUtils.isNotEmpty(bearerToken);
+            log.info("Authorization header {} found", authFound ? "" : "not");
+            
+            if (!authFound) {
+                log.info("Request is missing authorization header");
+                // See section 3.12 RFC 7644
+                return simpleResponse(UNAUTHORIZED, "No authorization header found");
+            }
+            
+            bearerToken = bearerToken.replaceFirst("Bearer\\s+","");
+            log.debug("Validating token {}", bearerToken);
+
+            List<CedarlingPermission> requestedPermissions = getRequestedOperations(resourceInfo);
+            if (requestedPermissions.isEmpty()) {
+                return simpleResponse(INTERNAL_SERVER_ERROR, "Access to operation is not correct");
+            }
+
+            Jwt jwt = tokenAsJwt(bearerToken);
+            if (jwt == null) {
+                return simpleResponse(FORBIDDEN, "Provided token isn't JWT encoded");
+            }
+
+            // Process the JWT: validate isuer, expiration and signature
+            JwtClaims claims = jwt.getClaims();
+
+            if (!oidcConfig.getIssuer().equals(claims.getClaimAsString(JwtClaimName.ISSUER))) {
+                return simpleResponse(FORBIDDEN, "Invalid token issuer");
+            }
+
+            int exp = Optional.ofNullable(claims.getClaimAsInteger(JwtClaimName.EXPIRATION_TIME)).orElse(0);
+            if (1000L * exp < System.currentTimeMillis()) {
+                return simpleResponse(FORBIDDEN, "Expired token");
+            }
+
+            AuthCryptoProvider cryptoProvider = new AuthCryptoProvider(null, null, null, true);
+            SignatureAlgorithm signatureAlg = jwt.getHeader().getSignatureAlgorithm();
+            
+            if (AlgorithmFamily.HMAC.equals(signatureAlg.getFamily())) {
+                // It is "expensive" to get the associated client secret
+                return simpleResponse(INTERNAL_SERVER_ERROR,
+                        "HMAC algorithm not allowed for token signature. Please use an algorithm in the EC, ED, or RSA family for signing");
+            }
+                
+            Map<?, ?> jwks = mapper.readValue(new URL(oidcConfig.getJwksUri()), Map.class);
+            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(), 
+                    jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
+
+            if (valid) {
+                return isValid(bearerToken, resourceInfo);
+            }
+
+            // See section 3.12 RFC 7644
+            return simpleResponse(FORBIDDEN, "Invalid token signature");
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return simpleResponse(INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+    private Jwt tokenAsJwt(String token) {
+        Jwt jwt = null;
+        try {
+            jwt = Jwt.parse(token);
+            if (log.isTraceEnabled()) {
+            	log.trace("This looks like a JWT token");
+            }
+        } catch (InvalidJwtException e) {
+            log.trace("Not a JWT token");
+        }
+        
+        return jwt;
+    }
+
+	private OpenIdConfigurationResponse getOpenIdConfiguration() {
+		String openIdIssuer = openIDConnectConfig.getIssuer();
+		if (StringHelper.isEmpty(openIdIssuer)) {
+			throw new InvalidConfigurationException("OpenIdIssuer Url is invalid");
+		}
+
+		String openIdIssuerEndpoint = openIdIssuer + "/.well-known/openid-configuration";
+
+		OpenIdConfigurationClient client = new OpenIdConfigurationClient(openIdIssuerEndpoint);
+		OpenIdConfigurationResponse openIdConfigurationResponse = client.execOpenIdConfiguration();
+
+		if ((openIdConfigurationResponse == null) || (openIdConfigurationResponse.getStatus() != HttpStatus.SC_OK)) {
+			throw new MissingResourceException("Failed to load OpenID configuration!");
+		}
+
+		log.info("Successfully loaded OpenID configuration");
+
+		return openIdConfigurationResponse;
+	}
+}

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/CedarlingProtectionService.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/CedarlingProtectionService.java
@@ -9,15 +9,12 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 import io.jans.as.client.OpenIdConfigurationClient;
 import io.jans.as.client.OpenIdConfigurationResponse;
@@ -43,19 +40,14 @@ import jakarta.ws.rs.core.Response;
 @ApplicationScoped
 public class CedarlingProtectionService extends io.jans.core.cedarling.service.CedarlingProtectionService {
 
-    public static final int JWKS_CACHE_LIFETIME = 60;
-
     private OpenIdConfigurationResponse oidcConfig;
-
+    
     private ObjectMapper mapper;
-
-    private Cache<String, Map<?, ?>> jwksCache;
-
+    
     @PostConstruct
     private void init() {
         try {
             mapper = new ObjectMapper();
-            jwksCache = CacheBuilder.newBuilder().expireAfterWrite(JWKS_CACHE_LIFETIME, TimeUnit.MINUTES).build();
             oidcConfig = getOpenIdConfiguration();
         } catch (Exception e) {
             log.error(e.getMessage(), e);
@@ -64,10 +56,6 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
 
     public Response processAuthorization(String bearerToken, ResourceInfo resourceInfo) {
         try {
-            if (oidcConfig == null) {
-                return simpleResponse(FORBIDDEN, "Loaded OpenID configuration is invalid!");
-            }
-
             boolean authFound = StringUtils.isNotEmpty(bearerToken);
             log.info("Authorization header {} found", authFound ? "" : "not");
             
@@ -111,18 +99,9 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
                         "HMAC algorithm not allowed for token signature. Please use an algorithm in the EC, ED, or RSA family for signing");
             }
                 
-            String jwksUri = oidcConfig.getJwksUri();
-            Map<?, ?> jwks = getJwks(jwksUri);
-            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
+            Map<?, ?> jwks = mapper.readValue(new URL(oidcConfig.getJwksUri()), Map.class);
+            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(), 
                     jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
-
-            if (!valid) {
-                // Cached JWKS can be stale after key rotation, refresh once and retry
-                jwksCache.invalidate(jwksUri);
-                jwks = getJwks(jwksUri);
-                valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
-                        jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
-            }
 
             if (valid) {
                 return isValid(bearerToken, resourceInfo);
@@ -134,13 +113,6 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
             log.error(e.getMessage(), e);
             return simpleResponse(INTERNAL_SERVER_ERROR, e.getMessage());
         }
-    }
-
-    private Map<?, ?> getJwks(String jwksUri) throws Exception {
-        return jwksCache.get(jwksUri, () -> {
-            log.debug("Loading JWKS from {}", jwksUri);
-            return mapper.readValue(new URL(jwksUri), Map.class);
-        });
     }
 
     private Jwt tokenAsJwt(String token) {

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/CedarlingProtectionService.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/CedarlingProtectionService.java
@@ -9,12 +9,15 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 
 import io.jans.as.client.OpenIdConfigurationClient;
 import io.jans.as.client.OpenIdConfigurationResponse;
@@ -40,14 +43,19 @@ import jakarta.ws.rs.core.Response;
 @ApplicationScoped
 public class CedarlingProtectionService extends io.jans.core.cedarling.service.CedarlingProtectionService {
 
+    public static final int JWKS_CACHE_LIFETIME = 60;
+
     private OpenIdConfigurationResponse oidcConfig;
-    
+
     private ObjectMapper mapper;
-    
+
+    private Cache<String, Map<?, ?>> jwksCache;
+
     @PostConstruct
     private void init() {
         try {
             mapper = new ObjectMapper();
+            jwksCache = CacheBuilder.newBuilder().expireAfterWrite(JWKS_CACHE_LIFETIME, TimeUnit.MINUTES).build();
             oidcConfig = getOpenIdConfiguration();
         } catch (Exception e) {
             log.error(e.getMessage(), e);
@@ -56,6 +64,10 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
 
     public Response processAuthorization(String bearerToken, ResourceInfo resourceInfo) {
         try {
+            if (oidcConfig == null) {
+                return simpleResponse(FORBIDDEN, "Loaded OpenID configuration is invalid!");
+            }
+
             boolean authFound = StringUtils.isNotEmpty(bearerToken);
             log.info("Authorization header {} found", authFound ? "" : "not");
             
@@ -99,9 +111,18 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
                         "HMAC algorithm not allowed for token signature. Please use an algorithm in the EC, ED, or RSA family for signing");
             }
                 
-            Map<?, ?> jwks = mapper.readValue(new URL(oidcConfig.getJwksUri()), Map.class);
-            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(), 
+            String jwksUri = oidcConfig.getJwksUri();
+            Map<?, ?> jwks = getJwks(jwksUri);
+            boolean valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
                     jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
+
+            if (!valid) {
+                // Cached JWKS can be stale after key rotation, refresh once and retry
+                jwksCache.invalidate(jwksUri);
+                jwks = getJwks(jwksUri);
+                valid = cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(),
+                        jwt.getHeader().getKeyId(), new JSONObject(jwks), null, signatureAlg);
+            }
 
             if (valid) {
                 return isValid(bearerToken, resourceInfo);
@@ -113,6 +134,13 @@ public class CedarlingProtectionService extends io.jans.core.cedarling.service.C
             log.error(e.getMessage(), e);
             return simpleResponse(INTERNAL_SERVER_ERROR, e.getMessage());
         }
+    }
+
+    private Map<?, ?> getJwks(String jwksUri) throws Exception {
+        return jwksCache.get(jwksUri, () -> {
+            log.debug("Loading JWKS from {}", jwksUri);
+            return mapper.readValue(new URL(jwksUri), Map.class);
+        });
     }
 
     private Jwt tokenAsJwt(String token) {

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/grpc/security/GrpcAuthorizationInterceptor.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/grpc/security/GrpcAuthorizationInterceptor.java
@@ -23,7 +23,7 @@ import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.jans.core.cedarling.model.AuditActionType;
 import io.jans.core.cedarling.model.AuditLogEntry;
-import io.jans.lock.cedarling.service.CedarlingProtection;
+import io.jans.core.cedarling.service.CedarlingProtection;
 import io.jans.lock.model.config.AppConfiguration;
 import io.jans.lock.model.config.LockProtectionMode;
 import io.jans.lock.service.app.audit.ApplicationAuditLogger;

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/policy/LockPolicyStoreFileProvider.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/policy/LockPolicyStoreFileProvider.java
@@ -20,7 +20,7 @@ import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 
-import io.jans.lock.cedarling.service.policy.PolicyStoreFileProvider;
+import io.jans.core.cedarling.service.policy.PolicyStoreFileProvider;
 import io.jans.lock.model.config.AppConfiguration;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/audit/AuditRestWebService.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/audit/AuditRestWebService.java
@@ -16,7 +16,7 @@
 
 package io.jans.lock.service.ws.rs.audit;
 
-import io.jans.lock.cedarling.service.security.api.ProtectedCedarlingApi;
+import io.jans.core.cedarling.service.security.api.ProtectedCedarlingApi;
 import io.jans.lock.model.audit.HealthEntry;
 import io.jans.lock.model.audit.LogEntry;
 import io.jans.lock.model.audit.TelemetryEntry;

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/policy/PolicyRestWebService.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/policy/PolicyRestWebService.java
@@ -1,6 +1,6 @@
 package io.jans.lock.service.ws.rs.policy;
 
-import io.jans.lock.cedarling.service.security.api.ProtectedCedarlingApi;
+import io.jans.core.cedarling.service.security.api.ProtectedCedarlingApi;
 import io.jans.lock.model.core.LockApiError;
 import io.jans.lock.util.ApiAccessConstants;
 import io.jans.service.security.api.ProtectedApi;

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/policy/PolicyRestWebServiceImpl.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/policy/PolicyRestWebServiceImpl.java
@@ -8,8 +8,8 @@ import org.slf4j.Logger;
 
 import io.jans.core.cedarling.model.AuditActionType;
 import io.jans.core.cedarling.model.AuditLogEntry;
-import io.jans.lock.cedarling.service.policy.PolicyDownloadService;
-import io.jans.lock.cedarling.service.policy.PolicyDownloadService.LoadedPolicySource;
+import io.jans.core.cedarling.service.policy.PolicyDownloadService;
+import io.jans.core.cedarling.service.policy.PolicyDownloadService.LoadedPolicySource;
 import io.jans.lock.model.error.CommonErrorResponseType;
 import io.jans.lock.model.error.ErrorResponseFactory;
 import io.jans.lock.service.app.audit.ApplicationAuditLogger;

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/stat/StatRestWebService.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/stat/StatRestWebService.java
@@ -1,6 +1,6 @@
 package io.jans.lock.service.ws.rs.stat;
 
-import io.jans.lock.cedarling.service.security.api.ProtectedCedarlingApi;
+import io.jans.core.cedarling.service.security.api.ProtectedCedarlingApi;
 import io.jans.lock.model.core.LockApiError;
 import io.jans.lock.model.stat.FlatStatResponse;
 import io.jans.lock.util.ApiAccessConstants;

--- a/jans-lock/lock-server/service/src/test/java/io/jans/lock/cedarling/service/CedarlingProtectionServiceTest.java
+++ b/jans-lock/lock-server/service/src/test/java/io/jans/lock/cedarling/service/CedarlingProtectionServiceTest.java
@@ -1,0 +1,695 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.lock.cedarling.service;
+
+import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jans.as.client.OpenIdConfigurationResponse;
+import io.jans.as.model.crypto.AuthCryptoProvider;
+import io.jans.as.model.crypto.signature.SignatureAlgorithm;
+import io.jans.as.model.exception.InvalidJwtException;
+import io.jans.as.model.jwt.Jwt;
+import io.jans.as.model.jwt.JwtClaimName;
+import io.jans.as.model.jwt.JwtClaims;
+import io.jans.as.model.jwt.JwtHeader;
+import io.jans.core.cedarling.model.CedarlingConfiguration;
+import io.jans.core.cedarling.service.CedarlingAuthorizationService;
+import io.jans.core.cedarling.service.security.api.ProtectedCedarlingApi;
+import io.jans.lock.service.CedarlingProtectionService;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Unit tests for {@link CedarlingProtectionService#processAuthorization}.
+ *
+ * <p>The method under test implements a multi-step authorization filter:
+ * <ol>
+ *   <li>Presence check – bearer token must be present.</li>
+ *   <li>Permission resolution – at least one {@code @ProtectedCedarlingApi} annotation
+ *       must be found on the JAX-RS resource class, method, or its interfaces.</li>
+ *   <li>JWT validation – token must be parseable as a JWT.</li>
+ *   <li>Issuer check – JWT {@code iss} claim must match the OIDC discovery document.</li>
+ *   <li>Expiry check – JWT {@code exp} claim must be in the future.</li>
+ *   <li>Algorithm check – HMAC-family algorithms are rejected.</li>
+ *   <li>Signature verification – cryptographic signature must be valid.</li>
+ *   <li>Cedarling policy evaluation – the Cedarling engine must grant access
+ *       for every declared permission.</li>
+ * </ol>
+ *
+ * <p>A {@code null} return value from {@code processAuthorization} means
+ * "pass-through" – the JAX-RS filter will allow the request to continue.
+ *
+ * @author Author Date: 12/05/2026
+ */
+@ExtendWith(MockitoExtension.class)
+class CedarlingProtectionServiceTest {
+
+    // ─── Constants ──────────────────────────────────────────────────────────────
+
+    private static final String TEST_ISSUER   = "https://idp.example.com";
+    private static final String TEST_JWKS_URI = "https://idp.example.com/jwks";
+    /** Minimal three-part placeholder used wherever a JWT string is required. */
+    private static final String DUMMY_JWT     = "header.payload.signature";
+
+    // ─── Mocks & SUT ────────────────────────────────────────────────────────────
+
+    @Mock private Logger                        log;
+    @Mock private CedarlingConfiguration        cedarConf;
+    @Mock private CedarlingAuthorizationService authorizationService;
+    /** Injected as a mock so that JWKS HTTP calls can be stubbed without networking. */
+    @Mock private ObjectMapper                  mapper;
+
+    @InjectMocks
+    private CedarlingProtectionService service;
+
+    // ─── JAX-RS Resource Fixtures ───────────────────────────────────────────────
+
+    /**
+     * A plain resource class that carries no {@code @ProtectedCedarlingApi}
+     * annotation and implements no interfaces.  Used to simulate "empty
+     * permissions" scenarios.
+     */
+    static class PlainResource {
+        public void plainMethod() { /* no-op */ }
+    }
+
+    /**
+     * An interface-level {@code @ProtectedCedarlingApi} annotation.
+     * The service resolves permissions by walking the resource class's
+     * interface hierarchy, so placing the annotation here is the most
+     * common real-world pattern.
+     */
+    @ProtectedCedarlingApi(
+            action   = "Jans::Action::\"POST\"",
+            resource = "Jans::HTTP_Request",
+            id       = "lock_audit_log_write",
+            path     = "/audit/log/bulk"
+    )
+    interface SecuredInterface {
+        void securedMethod();
+    }
+
+    /** Resource class that inherits its permission from {@link SecuredInterface}. */
+    static class SecuredResource implements SecuredInterface {
+        @Override
+        public void securedMethod() { /* no-op */ }
+    }
+
+    /**
+     * A resource class that has a {@code @ProtectedCedarlingApi} on the class
+     * itself AND on the method, producing two permissions.  Used to verify
+     * short-circuit behaviour when the first permission is denied.
+     */
+    @ProtectedCedarlingApi(
+            action   = "Jans::Action::\"POST\"",
+            resource = "Jans::HTTP_Request",
+            id       = "lock_audit_health_write",
+            path     = "/audit/health/bulk"
+    )
+    static class MultiPermissionResource {
+        @ProtectedCedarlingApi(
+                action   = "Jans::Action::\"POST\"",
+                resource = "Jans::HTTP_Request",
+                id       = "lock_audit_log_write",
+                path     = "/audit/log/bulk"
+        )
+        public void multiMethod() { /* no-op */ }
+    }
+
+    // ─── Setup ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Injects the fields that are normally initialised in the {@code @PostConstruct}
+     * lifecycle method.  We bypass the real {@code init()} to avoid network calls
+     * during unit tests.
+     */
+    @BeforeEach
+    void setUp() throws Exception {
+        // Inject the mocked ObjectMapper (avoids real HTTP for JWKS fetches)
+        injectField("mapper", mapper);
+
+        // Build a minimal OpenID configuration stub
+        OpenIdConfigurationResponse oidcConfig = mock(OpenIdConfigurationResponse.class);
+        lenient().when(oidcConfig.getIssuer()).thenReturn(TEST_ISSUER);
+        lenient().when(oidcConfig.getJwksUri()).thenReturn(TEST_JWKS_URI);
+        injectField("oidcConfig", oidcConfig);
+    }
+
+    // ===========================================================================
+    // 1. Missing / blank bearer token → 401 Unauthorized
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Bearer token presence check")
+    class BearerTokenPresenceTests {
+
+        @Test
+        @DisplayName("null token returns 401")
+        void nullToken_returns401() {
+            Response response = service.processAuthorization(null, mock(ResourceInfo.class));
+
+            assertStatus(UNAUTHORIZED, response);
+        }
+
+        @Test
+        @DisplayName("empty string token returns 401")
+        void emptyToken_returns401() {
+            Response response = service.processAuthorization("", mock(ResourceInfo.class));
+
+            assertStatus(UNAUTHORIZED, response);
+        }
+    }
+
+    // ===========================================================================
+    // 2. No @ProtectedCedarlingApi annotation resolved → 500 Internal Server Error
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Permission annotation resolution")
+    class PermissionResolutionTests {
+
+        @Test
+        @DisplayName("resource with no annotation on class, method, or interfaces returns 500")
+        void noAnnotation_returns500() {
+            // PlainResource has no @ProtectedCedarlingApi and no interfaces,
+            // so the permissions list stays empty.
+            Response response = service.processAuthorization(
+                    "Bearer some-token-value",
+                    mockResourceInfo(PlainResource.class, "plainMethod"));
+
+            assertStatus(INTERNAL_SERVER_ERROR, response);
+            assertNotNull(response.getEntity(), "Error detail should be present in response body");
+        }
+    }
+
+    // ===========================================================================
+    // 3. Token is not a valid JWT → 403 Forbidden
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("JWT parsing")
+    class JwtParsingTests {
+
+        @Test
+        @DisplayName("plain text token (not JWT-encoded) returns 403")
+        void plainTextToken_returns403() {
+            // Jwt.parse() will throw InvalidJwtException for a non-JWT string,
+            // causing tokenAsJwt() to return null.
+            Response response = service.processAuthorization(
+                    "Bearer i-am-not-a-jwt",
+                    mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+            assertStatus(FORBIDDEN, response);
+            assertTrue(
+                    response.getEntity().toString().contains("JWT"),
+                    "Response body should mention JWT");
+        }
+
+        @Test
+        @DisplayName("random base64 string that looks like JWT parts returns 403")
+        void malformedBase64Token_returns403() {
+            Response response = service.processAuthorization(
+                    "Bearer aaa.bbb.ccc",
+                    mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+            assertStatus(FORBIDDEN, response);
+        }
+    }
+
+    // ===========================================================================
+    // 4. JWT issuer mismatch → 403 Forbidden
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("JWT issuer validation")
+    class IssuerValidationTests {
+
+        @Test
+        @DisplayName("JWT with wrong issuer returns 403")
+        void wrongIssuer_returns403() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
+                Jwt jwt = buildMockJwt("https://untrusted-idp.example.com", futureEpoch(), SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(FORBIDDEN, response);
+                assertTrue(
+                        response.getEntity().toString().contains("issuer"),
+                        "Response body should mention 'issuer'");
+            }
+        }
+    }
+
+    // ===========================================================================
+    // 5. Expired JWT → 403 Forbidden
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("JWT expiry validation")
+    class ExpiryValidationTests {
+
+        @Test
+        @DisplayName("expired JWT returns 403")
+        void expiredJwt_returns403() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
+                Jwt jwt = buildMockJwt(TEST_ISSUER, pastEpoch(), SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(FORBIDDEN, response);
+                assertTrue(
+                        response.getEntity().toString().contains("Expired"),
+                        "Response body should mention expiry");
+            }
+        }
+
+        @Test
+        @DisplayName("JWT with exp claim absent (defaults to epoch 0) returns 403")
+        void missingExpClaim_returns403() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
+                // When getClaimAsInteger returns null, the service defaults to 0
+                // (epoch 0 = 1970-01-01), so the token is immediately expired.
+                Jwt jwt = buildMockJwtNullExp(TEST_ISSUER, SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(FORBIDDEN, response);
+            }
+        }
+    }
+
+    // ===========================================================================
+    // 6. HMAC-family algorithm → 500 Internal Server Error
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Signing algorithm validation")
+    class AlgorithmValidationTests {
+
+        @Test
+        @DisplayName("HS256 (HMAC) algorithm returns 500 with HMAC message")
+        void hmacAlgorithmHS256_returns500() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
+                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.HS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(INTERNAL_SERVER_ERROR, response);
+                assertTrue(
+                        response.getEntity().toString().contains("HMAC"),
+                        "Response body should explain that HMAC is not allowed");
+            }
+        }
+
+        @Test
+        @DisplayName("HS384 (HMAC) algorithm also returns 500")
+        void hmacAlgorithmHS384_returns500() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
+                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.HS384);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(INTERNAL_SERVER_ERROR, response);
+            }
+        }
+    }
+
+    // ===========================================================================
+    // 7. Signature verification fails → 403 Forbidden
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("JWT signature verification")
+    class SignatureVerificationTests {
+
+        @Test
+        @DisplayName("invalid signature returns 403")
+        void invalidSignature_returns403() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
+                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
+                         AuthCryptoProvider.class,
+                         (mock, ctx) -> when(
+                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
+                                 .thenReturn(false))) {
+
+                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(FORBIDDEN, response);
+            }
+        }
+    }
+
+    // ===========================================================================
+    // 8. Cedarling authorization decisions
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Cedarling policy evaluation")
+    class CedarlingAuthorizationTests {
+
+        @Test
+        @DisplayName("valid JWT + Cedarling grants access → null (pass-through)")
+        void validJwtAndCedarlingGrants_returnsNull() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
+                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
+                         AuthCryptoProvider.class,
+                         (mock, ctx) -> when(
+                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
+                                 .thenReturn(true))) {
+
+                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
+                when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                        .thenReturn(true);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertNull(response, "Granted access must pass through (null response)");
+            }
+        }
+
+        @Test
+        @DisplayName("valid JWT + Cedarling denies access → 403")
+        void validJwtAndCedarlingDenies_returns403() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
+                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
+                         AuthCryptoProvider.class,
+                         (mock, ctx) -> when(
+                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
+                                 .thenReturn(true))) {
+
+                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
+                when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                        .thenReturn(false);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(FORBIDDEN, response);
+            }
+        }
+
+        /**
+         * When a resource has multiple permissions (class-level + method-level) and the
+         * first call to {@code authorizationService.authorize()} returns {@code false},
+         * the service must short-circuit and not evaluate further permissions.
+         */
+        @Test
+        @DisplayName("first permission denied short-circuits remaining checks")
+        void multiplePermissions_firstDenied_doesNotCheckRemainder() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
+                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
+                         AuthCryptoProvider.class,
+                         (mock, ctx) -> when(
+                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
+                                 .thenReturn(true))) {
+
+                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
+
+                // First call is denied; second should never be reached
+                when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                        .thenReturn(false);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(MultiPermissionResource.class, "multiMethod"));
+
+                assertStatus(FORBIDDEN, response);
+                // MultiPermissionResource has 2 permissions; the service must stop after
+                // the first denied result — so authorize() is called exactly once.
+                verify(authorizationService, times(1))
+                        .authorize(anyMap(), anyString(), anyMap(), anyMap());
+            }
+        }
+
+        @Test
+        @DisplayName("both permissions granted returns null")
+        void multiplePermissions_allGranted_returnsNull() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class);
+                 MockedConstruction<AuthCryptoProvider> cryptoMock = mockConstruction(
+                         AuthCryptoProvider.class,
+                         (mock, ctx) -> when(
+                                 mock.verifySignature(any(), any(), any(), any(), any(), any()))
+                                 .thenReturn(true))) {
+
+                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+                when(mapper.readValue(any(URL.class), eq(Map.class))).thenReturn(Map.of());
+                when(authorizationService.authorize(anyMap(), anyString(), anyMap(), anyMap()))
+                        .thenReturn(true);
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(MultiPermissionResource.class, "multiMethod"));
+
+                assertNull(response, "Granted access must pass through (null response)");
+                // Exactly 2 permissions → authorize() called twice
+                verify(authorizationService, times(2))
+                        .authorize(anyMap(), anyString(), anyMap(), anyMap());
+            }
+        }
+    }
+
+    // ===========================================================================
+    // 9. Unexpected runtime exception → 500 Internal Server Error
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Exception handling")
+    class ExceptionHandlingTests {
+
+        @Test
+        @DisplayName("unexpected exception returns 500 with exception message")
+        void unexpectedException_returns500() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
+                jwtStatic.when(() -> Jwt.parse(anyString()))
+                         .thenThrow(new RuntimeException("Unexpected adapter failure"));
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(INTERNAL_SERVER_ERROR, response);
+                assertEquals(
+                        "Unexpected adapter failure",
+                        response.getEntity().toString(),
+                        "Exception message must be surfaced in the response body");
+            }
+        }
+
+        @Test
+        @DisplayName("JWKS fetch failure returns 500")
+        void jwksFetchFailure_returns500() throws Exception {
+            try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
+                Jwt jwt = buildMockJwt(TEST_ISSUER, futureEpoch(), SignatureAlgorithm.RS256);
+                jwtStatic.when(() -> Jwt.parse(anyString())).thenReturn(jwt);
+
+                // Simulate an I/O error when fetching the JWKS endpoint
+                when(mapper.readValue(any(URL.class), eq(Map.class)))
+                        .thenThrow(new java.io.IOException("Connection refused"));
+
+                Response response = service.processAuthorization(
+                        "Bearer " + DUMMY_JWT,
+                        mockResourceInfo(SecuredResource.class, "securedMethod"));
+
+                assertStatus(INTERNAL_SERVER_ERROR, response);
+            }
+        }
+    }
+
+    // ===========================================================================
+    // Helper methods
+    // ===========================================================================
+
+    /**
+     * Injects a value into a private field of the service under test using reflection.
+     *
+     * @param fieldName the exact name of the private field
+     * @param value     the value to inject
+     */
+    private void injectField(String fieldName, Object value) throws Exception {
+        Field field = CedarlingProtectionService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    /**
+     * Creates a {@link ResourceInfo} mock that returns the specified class and method.
+     *
+     * @param resourceClass the JAX-RS resource class to return
+     * @param methodName    the public method name to return
+     * @return a configured {@link ResourceInfo} mock
+     */
+    @SuppressWarnings("unchecked")
+    private static ResourceInfo mockResourceInfo(Class<?> resourceClass, String methodName) {
+        ResourceInfo ri = mock(ResourceInfo.class);
+        try {
+            when(ri.getResourceClass()).thenReturn((Class) resourceClass);
+            when(ri.getResourceMethod()).thenReturn(resourceClass.getMethod(methodName));
+        } catch (NoSuchMethodException e) {
+            fail("Test fixture error – method not found: " + resourceClass.getSimpleName() + "#" + methodName);
+        }
+        return ri;
+    }
+
+    /**
+     * Asserts that the {@link Response} has the expected HTTP status code.
+     *
+     * @param expected expected status
+     * @param actual   actual response (must not be null)
+     */
+    private static void assertStatus(Response.Status expected, Response actual) {
+        assertNotNull(actual, "Expected a response but got null (pass-through)");
+        assertEquals(
+                expected.getStatusCode(),
+                actual.getStatus(),
+                String.format("Expected HTTP %d (%s) but got %d",
+                        expected.getStatusCode(), expected, actual.getStatus()));
+    }
+
+    /**
+     * Builds a fully mocked {@link Jwt} with the specified issuer, expiry, and
+     * signing algorithm.  All fields needed by the service under test are stubbed.
+     *
+     * @param issuer    value for the {@code iss} JWT claim
+     * @param expEpoch  value for the {@code exp} JWT claim (epoch seconds)
+     * @param algorithm signing algorithm to report via the JWT header
+     * @return a mocked {@link Jwt}
+     * @throws InvalidJwtException 
+     */
+    private static Jwt buildMockJwt(String issuer, int expEpoch, SignatureAlgorithm algorithm) throws InvalidJwtException {
+        Jwt jwt = mock(Jwt.class);
+
+        // Stub JWT header
+        JwtHeader header = mock(JwtHeader.class);
+        lenient().when(header.getSignatureAlgorithm()).thenReturn(algorithm);
+        lenient().when(header.getKeyId()).thenReturn("test-key-id");
+        lenient().when(jwt.getHeader()).thenReturn(header);
+
+        // Stub JWT claims
+        JwtClaims claims = mock(JwtClaims.class);
+        lenient().when(claims.getClaimAsString(JwtClaimName.ISSUER)).thenReturn(issuer);
+        lenient().when(claims.getClaimAsInteger(JwtClaimName.EXPIRATION_TIME)).thenReturn(expEpoch);
+        lenient().when(jwt.getClaims()).thenReturn(claims);
+
+        // Stub signing material (needed for signature verification)
+        lenient().when(jwt.getSigningInput()).thenReturn("signing.input");
+        lenient().when(jwt.getEncodedSignature()).thenReturn("encoded-signature");
+
+        return jwt;
+    }
+
+    /**
+     * Same as {@link #buildMockJwt} but returns {@code null} for the {@code exp}
+     * claim, which the service defaults to epoch 0 (i.e. immediately expired).
+     *
+     * @param issuer    value for the {@code iss} JWT claim
+     * @param algorithm signing algorithm to report via the JWT header
+     * @return a mocked {@link Jwt} with a null {@code exp} claim
+     * @throws InvalidJwtException 
+     */
+    private static Jwt buildMockJwtNullExp(String issuer, SignatureAlgorithm algorithm) throws InvalidJwtException {
+        Jwt jwt = mock(Jwt.class);
+
+        JwtHeader header = mock(JwtHeader.class);
+        lenient().when(header.getSignatureAlgorithm()).thenReturn(algorithm);
+        lenient().when(header.getKeyId()).thenReturn("test-key-id");
+        lenient().when(jwt.getHeader()).thenReturn(header);
+
+        JwtClaims claims = mock(JwtClaims.class);
+        lenient().when(claims.getClaimAsString(JwtClaimName.ISSUER)).thenReturn(issuer);
+        // null triggers Optional.orElse(0) in the service → token is expired
+        lenient().when(claims.getClaimAsInteger(JwtClaimName.EXPIRATION_TIME)).thenReturn(null);
+        lenient().when(jwt.getClaims()).thenReturn(claims);
+
+        lenient().when(jwt.getSigningInput()).thenReturn("signing.input");
+        lenient().when(jwt.getEncodedSignature()).thenReturn("encoded-signature");
+
+        return jwt;
+    }
+
+    /**
+     * Returns an {@code exp} value (epoch seconds) 1 hour in the future.
+     * Tokens with this value are not yet expired.
+     */
+    private static int futureEpoch() {
+        return (int) (System.currentTimeMillis() / 1000) + 3600;
+    }
+
+    /**
+     * Returns an {@code exp} value (epoch seconds) 1 hour in the past.
+     * Tokens with this value are expired.
+     */
+    private static int pastEpoch() {
+        return (int) (System.currentTimeMillis() / 1000) - 3600;
+    }
+}


### PR DESCRIPTION
jans-core-cedarling

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
#14611
  
closes #14611

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cedarling-based authorization protection for Config API and Lock service endpoints.
  * Bearer tokens are validated against OpenID Connect issuer, expiration, and signing keys before access is granted.
  * Requests now enforce permissions declared for protected operations.

* **Bug Fixes**
  * Standardized Cedarling authorization components across core services.
  * Improved handling of missing credentials, invalid tokens, insufficient permissions, and authorization errors.

* **Tests**
  * Expanded coverage for token validation, policy decisions, permission checks, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->