### PR TITLE
fix: add download with retry for jans-cli-tui

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -722,6 +722,7 @@ jobs:
 
     - name: Resolve checkout ref
       id: resolve-ref
+      shell: bash
       env:
         WF_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         INPUT_TARGET_TAG: ${{ inputs.target_tag }}
@@ -958,6 +959,7 @@ jobs:
           egress-policy: audit
       - name: Resolve checkout ref
         id: resolve-ref
+        shell: bash
         env:
           WF_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           INPUT_TARGET_TAG: ${{ inputs.target_tag }}

--- a/.github/workflows/lint-flak8.yml
+++ b/.github/workflows/lint-flak8.yml
@@ -37,10 +37,10 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: 3.8
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/jans-cli-tui/setup.py
+++ b/jans-cli-tui/setup.py
@@ -6,10 +6,24 @@
 import codecs
 import os
 import re
+import time
 from setuptools import setup
 from setuptools import find_packages
 from setuptools.command.install import install
 from urllib.request import urlretrieve
+from urllib.error import URLError
+
+def _download_with_retry(url, dest, retries=5, delay=10):
+    for attempt in range(retries):
+        try:
+            urlretrieve(url, dest)
+            return
+        except (URLError, OSError) as e:
+            if attempt < retries - 1:
+                print("Download failed ({}), retrying in {}s...".format(e, delay))
+                time.sleep(delay)
+            else:
+                raise
 
 class PostInstallCommand(install):
     """Post-installation for installation mode."""
@@ -21,14 +35,14 @@ class PostInstallCommand(install):
 
         print("downloding", 'jans-config-api-swagger-auto.yaml')
 
-        urlretrieve(
+        _download_with_retry(
             'https://raw.githubusercontent.com/JanssenProject/jans/main/jans-config-api/docs/jans-config-api-swagger.yaml',
             os.path.join(yaml_dir, 'jans-config-api-swagger-auto.yaml')
             )
 
         for plugin_yaml_file in ('fido2-plugin-swagger.yaml', 'jans-link-plugin-swagger.yaml', 'scim-plugin-swagger.yaml', 'jans-admin-ui-plugin-swagger.yaml', 'lock-plugin-swagger.yaml', 'user-mgt-plugin-swagger.yaml'):
             print("downloding", plugin_yaml_file)
-            urlretrieve(
+            _download_with_retry(
                 'https://raw.githubusercontent.com/JanssenProject/jans/main/jans-config-api/plugins/docs/' + plugin_yaml_file,
                 os.path.join(yaml_dir, plugin_yaml_file)
                 )
@@ -39,7 +53,7 @@ class PostInstallCommand(install):
 
         scim_plugin_yaml_file = 'https://raw.githubusercontent.com/JanssenProject/jans/main/jans-scim/server/src/main/resources/jans-scim-openapi.yaml'
         print("downloding", os.path.basename(scim_plugin_yaml_file))
-        urlretrieve(
+        _download_with_retry(
             scim_plugin_yaml_file,
             os.path.join(scim_yaml_dir, os.path.basename(scim_plugin_yaml_file))
             )
@@ -50,7 +64,7 @@ class PostInstallCommand(install):
 
         auth_plugin_yaml_file = 'https://raw.githubusercontent.com/JanssenProject/jans/main/jans-auth-server/docs/swagger.yaml'
         print("downloding", os.path.basename(auth_plugin_yaml_file))
-        urlretrieve(
+        _download_with_retry(
             auth_plugin_yaml_file,
             os.path.join(auth_yaml_dir, os.path.basename(auth_plugin_yaml_file))
             )

--- a/jans-cli-tui/setup.py
+++ b/jans-cli-tui/setup.py
@@ -6,20 +6,21 @@
 import codecs
 import os
 import re
-import socket
 import time
 from setuptools import setup
 from setuptools import find_packages
 from setuptools.command.install import install
-from urllib.request import urlretrieve
+from urllib.request import urlopen
 from urllib.error import HTTPError, URLError
 
 def _download_with_retry(url, dest, retries=5, delay=10, timeout=60) -> None:
+    if retries <= 0:
+        raise ValueError(f"retries must be a positive integer, got {retries}")
     for attempt in range(retries):
-        prev_timeout = socket.getdefaulttimeout()
         try:
-            socket.setdefaulttimeout(timeout)
-            urlretrieve(url, dest)
+            with urlopen(url, timeout=timeout) as response:
+                with open(dest, 'wb') as f:
+                    f.write(response.read())
             return
         except HTTPError:
             raise
@@ -29,8 +30,6 @@ def _download_with_retry(url, dest, retries=5, delay=10, timeout=60) -> None:
                 time.sleep(delay)
             else:
                 raise
-        finally:
-            socket.setdefaulttimeout(prev_timeout)
 
 class PostInstallCommand(install):
     """Post-installation for installation mode."""

--- a/jans-cli-tui/setup.py
+++ b/jans-cli-tui/setup.py
@@ -6,24 +6,31 @@
 import codecs
 import os
 import re
+import socket
 import time
 from setuptools import setup
 from setuptools import find_packages
 from setuptools.command.install import install
 from urllib.request import urlretrieve
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
-def _download_with_retry(url, dest, retries=5, delay=10):
+def _download_with_retry(url, dest, retries=5, delay=10, timeout=60) -> None:
     for attempt in range(retries):
+        prev_timeout = socket.getdefaulttimeout()
         try:
+            socket.setdefaulttimeout(timeout)
             urlretrieve(url, dest)
             return
+        except HTTPError:
+            raise
         except (URLError, OSError) as e:
             if attempt < retries - 1:
-                print("Download failed ({}), retrying in {}s...".format(e, delay))
+                print(f"Download failed ({e}), retrying in {delay}s...")
                 time.sleep(delay)
             else:
                 raise
+        finally:
+            socket.setdefaulttimeout(prev_timeout)
 
 class PostInstallCommand(install):
     """Post-installation for installation mode."""


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14623, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build workflow reliability by standardizing how checkout reference values are written for key build jobs.
  * Strengthened CLI installation by downloading required YAML assets with retry logic for transient network issues, failing clearly after retries are exhausted.
* **Chores**
  * Updated the flake8 lint workflow to run Python 3.10 (instead of 3.8).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->