### PR TITLE
fix(jans-cli-tui): only one of one time use or rotate can be checked for SSA

### DIFF
--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/ssa.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/ssa.py
@@ -468,11 +468,13 @@ class SSA(DialogUtils):
                 max_height=3
                 )
 
+        one_time_use = bool(data.get('one_time_use', False))
+        rotate_ssa = bool(data.get('rotate_ssa', False)) and not one_time_use
 
         self.one_time_use_checkbox = self.app.getTitledCheckBox(
                                 _("One Time Use"),
                                 name='one_time_use',
-                                checked=data.get('one_time_use', False),
+                                checked=one_time_use,
                                 style=cli_style.check_box,
                                 on_selection_changed=self.check_one_time_rotate
                             )
@@ -480,7 +482,7 @@ class SSA(DialogUtils):
         self.rotate_checkbox = self.app.getTitledCheckBox(
                                 _("Rotate SSA"),
                                 name='rotate_ssa',
-                                checked=data.get('rotate_ssa', False),
+                                checked=rotate_ssa,
                                 style=cli_style.check_box,
                                 on_selection_changed=self.check_one_time_rotate
                             )

--- a/jans-cli-tui/cli_tui/plugins/010_auth_server/ssa.py
+++ b/jans-cli-tui/cli_tui/plugins/010_auth_server/ssa.py
@@ -351,6 +351,19 @@ class SSA(DialogUtils):
 
         self.app.show_jans_dialog(dialog)
 
+
+    def check_one_time_rotate(self, me):
+
+        if me.window.jans_name == 'one_time_use':
+            check_widget = self.rotate_checkbox
+        else:
+            check_widget = self.one_time_use_checkbox
+
+        if me.checked and check_widget.me.checked:
+            check_widget.me.checked = False
+
+
+
     def edit_ssa_dialog(self, data=None):
 
         # check if SSA flag is enabled
@@ -455,6 +468,24 @@ class SSA(DialogUtils):
                 max_height=3
                 )
 
+
+        self.one_time_use_checkbox = self.app.getTitledCheckBox(
+                                _("One Time Use"),
+                                name='one_time_use',
+                                checked=data.get('one_time_use', False),
+                                style=cli_style.check_box,
+                                on_selection_changed=self.check_one_time_rotate
+                            )
+
+        self.rotate_checkbox = self.app.getTitledCheckBox(
+                                _("Rotate SSA"),
+                                name='rotate_ssa',
+                                checked=data.get('rotate_ssa', False),
+                                style=cli_style.check_box,
+                                on_selection_changed=self.check_one_time_rotate
+                            )
+
+
         body_widgets = [
 
                 self.app.getTitledText(
@@ -511,19 +542,8 @@ class SSA(DialogUtils):
                             height=5, width=D(),
                             ),
 
-                self.app.getTitledCheckBox(
-                            _("One Time Use"),
-                            name='one_time_use',
-                            checked=data.get('one_time_use', False),
-                            style=cli_style.check_box
-                            ),
-
-                self.app.getTitledCheckBox(
-                            _("Rotate SSA"),
-                            name='rotate_ssa',
-                            checked=data.get('rotate_ssa', False),
-                            style=cli_style.check_box
-                            ),
+                            self.one_time_use_checkbox,
+                            self.rotate_checkbox,
 
                 VSplit([
                     Label(expiration_label + ': ', width=len(expiration_label)+2, style=cli_style.titled_text),


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14625

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSA configuration checkboxes so “One Time Use” and “Rotate SSA” cannot be selected simultaneously.
  * Selecting one option automatically clears the other when necessary.
  * Updated the edit dialog’s checkbox controls to ensure consistent mutual exclusivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->