### PR TITLE
feat(jans-lock): update lock ORM model

### DIFF
--- a/jans-auth-server/server/src/main/resources/log4j2.component.properties
+++ b/jans-auth-server/server/src/main/resources/log4j2.component.properties
@@ -1,1 +1,1 @@
-log4j2.configurationFile=log4j2.xml, log4j2-lock.xml
+log4j2.configurationFile=log4j2.xml, log4j2-lock.xml, log4j2-core-cedarling.xml

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -15690,21 +15690,21 @@ components:
           $ref: "#/components/schemas/AttributeValidation"
         tooltip:
           type: string
-        userCanView:
-          type: boolean
-        userCanEdit:
+        adminCanAccess:
           type: boolean
         adminCanView:
           type: boolean
         adminCanEdit:
           type: boolean
-        adminCanAccess:
-          type: boolean
         userCanAccess:
           type: boolean
-        selected:
+        userCanView:
+          type: boolean
+        userCanEdit:
           type: boolean
         whitePagesCanView:
+          type: boolean
+        selected:
           type: boolean
         baseDn:
           type: string
@@ -16660,6 +16660,8 @@ components:
         cimdMaxTtlMinutes:
           type: integer
           format: int32
+        authorizationResponseIssParameterSupported:
+          type: boolean
         fapi:
           type: boolean
         allResponseTypesSupported:
@@ -17557,10 +17559,10 @@ components:
           type: array
           items:
             type: object
-        value:
-          type: object
         displayValue:
           type: string
+        value:
+          type: object
     LocalizedString:
       type: object
       properties:

--- a/jans-linux-setup/jans_setup/schema/jans_schema.json
+++ b/jans-linux-setup/jans_setup/schema/jans_schema.json
@@ -3948,73 +3948,36 @@
       "x_origin": "Jans created attribute"
     },
     {
-      "desc": "jansDownloadSize",
-      "equality": "integerMatch",
-      "names": [
-        "jansDownloadSize"
-      ],
-      "oid": "jansAttr",
-      "syntax": "1.3.6.1.4.1.1466.115.121.1.27",
-      "x_origin": "Jans created attribute"
-    },
-    {
-      "desc": "jansFailedLoadCounter",
-      "equality": "integerMatch",
-      "names": [
-        "jansFailedLoadCounter"
-      ],
-      "oid": "jansAttr",
-      "syntax": "1.3.6.1.4.1.1466.115.121.1.27",
-      "x_origin": "Jans created attribute"
-    },
-    {
-      "desc": "jansSuccessLoadCounter",
-      "equality": "integerMatch",
-      "names": [
-        "jansSuccessLoadCounter"
-      ],
-      "oid": "jansAttr",
-      "syntax": "1.3.6.1.4.1.1466.115.121.1.27",
-      "x_origin": "Jans created attribute"
-    },
-    {
-      "desc": "Evaluation time in ns",
-      "equality": "integerMatch",
-      "names": [
-        "evaluationTimeNs"
-      ],
-      "oid": "jansAttr",
-      "ordering": "integerOrderingMatch",
-      "syntax": "1.3.6.1.4.1.1466.115.121.1.27",
-      "x_origin": "Jans created attribute"
-    },
-    {
-      "desc": "Average time in ns",
-      "equality": "integerMatch",
-      "names": [
-        "averageTimeNs"
-      ],
-      "oid": "jansAttr",
-      "ordering": "integerOrderingMatch",
-      "syntax": "1.3.6.1.4.1.1466.115.121.1.27",
-      "x_origin": "Jans created attribute"
-    },
-    {
-      "desc": "memoryUsage",
+      "desc": "Error stats details",
       "equality": "caseIgnoreMatch",
       "names": [
-        "memoryUsage"
+        "errorCounters"
       ],
+      "json": true,
+      "rdbm_json_column": true,
       "oid": "jansAttr",
       "substr": "caseIgnoreSubstringsMatch",
       "syntax": "1.3.6.1.4.1.1466.115.121.1.15",
       "x_origin": "Jans created attribute"
     },
     {
-      "desc": "requestCounter",
+      "desc": "Operational stats details",
+      "equality": "caseIgnoreMatch",
+      "names": [
+        "operationalStats"
+      ],
+      "json": true,
+      "rdbm_json_column": true,
+      "oid": "jansAttr",
+      "substr": "caseIgnoreSubstringsMatch",
+      "syntax": "1.3.6.1.4.1.1466.115.121.1.15",
+      "x_origin": "Jans created attribute"
+    },
+    {
+      "desc": "intervalSecs",
       "equality": "integerMatch",
       "names": [
-        "requestCounter"
+        "intervalSecs"
       ],
       "oid": "jansAttr",
       "syntax": "1.3.6.1.4.1.1466.115.121.1.27",
@@ -6098,18 +6061,13 @@
       "may": [
         "inum",
         "creationDate",
-        "eventTime",
         "jansService",
         "jansNodeName",
         "jansStatus",
-        "jansDownloadSize",
-        "jansSuccessLoadCounter",
-        "jansFailedLoadCounter",
-        "evaluationTimeNs",
-        "averageTimeNs",
-        "memoryUsage",
-        "requestCounter",
-        "policyStats"
+        "policyStats",
+        "errorCounters",
+        "operationalStats",
+        "intervalSecs"
       ],
       "must": [
         "objectclass"

--- a/jans-lock/lock-server.yaml
+++ b/jans-lock/lock-server.yaml
@@ -515,29 +515,33 @@ components:
           type: string
         inum:
           type: string
-        creationDate:
+        creation_date:
           type: string
           description: Creation date of the entry
           format: date-time
-          example: 2026-07-24T15:33:06.875Z
-        eventTime:
+          example: 2024-04-21T17:25:43-05:00
+        event_time:
           type: string
           description: Time when the event occurred
           format: date-time
-          example: 2026-07-24T15:33:06.875Z
+          example: 2024-04-21T18:25:43-05:00
         service:
           type: string
           description: Service name
-          example: Lock Server
-        nodeName:
+          example: jans-auth
+        node_name:
           type: string
           description: Node name or identifier
-          example: 04bbe9ef-a853-417c-a2b8-5328b62936e2
+          example: "1"
         status:
           type: string
           description: Health status
-          example: running
-        engineStatus:
+          example: ok
+          enum:
+          - ok
+          - warning
+          - error
+        engine_status:
           type: object
           additionalProperties:
             type: string
@@ -551,29 +555,29 @@ components:
           type: string
         inum:
           type: string
-        creationDate:
+        creation_date:
           type: string
           description: Creation date of the entry
           format: date-time
-          example: 2026-07-24T15:33:02.937Z
-        eventTime:
+          example: 2024-04-21T18:25:43-05:00
+        event_time:
           type: string
           description: Time when the event occurred
           format: date-time
-          example: 2026-07-24T15:33:02.937Z
+          example: 2024-04-21T18:25:43-05:00
         service:
           type: string
           description: Service name
-          example: Lock Server
-        nodeName:
+          example: jans-auth
+        node_name:
           type: string
           description: Node name or identifier
-          example: 04bbe9ef-a853-417c-a2b8-5328b62936e2
-        eventType:
+          example: "1"
+        event_type:
           type: string
           description: Type of event
-          example: Decision
-        severityLevel:
+          example: registration
+        severity_level:
           type: string
           description: Severity level
           example: warning
@@ -585,23 +589,23 @@ components:
         action:
           type: string
           description: Action performed
-          example: Jans::Action::"POST"
-        decisionResult:
+          example: ACTION_NAME_3
+        decision_result:
           type: string
           description: Decision result
-          example: ALLOW
+          example: allow
           enum:
-          - ALLOW
-          - DENY
-        requestedResource:
+          - allow
+          - deny
+        requested_resource:
           type: string
-          description: Requested resource identifier
-          example: Jans::HTTP_Request::"lock_audit_log_write"
-        principalId:
+          description: Requested resource as JSON string
+          example: "{\"t1\":\"value1\",\"t2\":\"value2\"}"
+        principal_id:
           type: string
           description: Principal (user) identifier
           example: ACC0001
-        clientId:
+        client_id:
           type: string
           description: Client identifier
           example: CLI001
@@ -609,7 +613,7 @@ components:
           type: string
           description: JWT ID - unique identifier for the token
           example: 550e8400-e29b-41d4-a716-446655440000
-        contextInformation:
+        context_information:
           type: object
           additionalProperties:
             type: string
@@ -625,38 +629,47 @@ components:
           type: string
         inum:
           type: string
-        creationDate:
+        creation_date:
           type: string
           description: Creation date of the entry
           format: date-time
-          example: 2026-07-24T15:33:06.872Z
+          example: 2024-04-21T18:25:43-05:00
+        event_time:
+          type: string
+          description: Time when the event occurred
+          format: date-time
+          example: 2024-04-21T18:25:43-05:00
         service:
           type: string
           description: Service name
-          example: Lock Server
-        nodeName:
+          example: jans-auth
+        node_name:
           type: string
           description: Node name or identifier
-          example: 04bbe9ef-a853-417c-a2b8-5328b62936e2
+          example: "1"
         status:
           type: string
           description: Service status
-          example: running
-        policyStats:
+          example: ok
+          enum:
+          - ok
+          - warning
+          - error
+        policy_stats:
           type: object
           additionalProperties:
             type: integer
             description: Per-policy evaluation counters as key-value pairs
             format: int64
           description: Per-policy evaluation counters as key-value pairs
-        errorCounters:
+        error_counters:
           type: object
           additionalProperties:
             type: integer
             description: Error counters broken down by error type
             format: int64
           description: Error counters broken down by error type
-        operationalStats:
+        operational_stats:
           type: object
           additionalProperties:
             type: integer
@@ -665,11 +678,11 @@ components:
             format: int64
           description: "Operational statistics (requests, decisions, eval times) as\
             \ key-value pairs"
-        intervalSecs:
+        interval_secs:
           type: integer
           description: Telemetry collection interval in seconds
           format: int64
-          example: 5
+          example: 60
       description: Telemetry audit entry
     FlatStatResponse:
       type: object

--- a/jans-lock/lock-server.yaml
+++ b/jans-lock/lock-server.yaml
@@ -515,33 +515,29 @@ components:
           type: string
         inum:
           type: string
-        creation_date:
+        creationDate:
           type: string
           description: Creation date of the entry
           format: date-time
-          example: 2024-04-21T17:25:43-05:00
-        event_time:
+          example: 2026-07-24T15:33:06.875Z
+        eventTime:
           type: string
           description: Time when the event occurred
           format: date-time
-          example: 2024-04-21T18:25:43-05:00
+          example: 2026-07-24T15:33:06.875Z
         service:
           type: string
           description: Service name
-          example: jans-auth
-        node_name:
+          example: Lock Server
+        nodeName:
           type: string
           description: Node name or identifier
-          example: "1"
+          example: 04bbe9ef-a853-417c-a2b8-5328b62936e2
         status:
           type: string
           description: Health status
-          example: ok
-          enum:
-          - ok
-          - warning
-          - error
-        engine_status:
+          example: running
+        engineStatus:
           type: object
           additionalProperties:
             type: string
@@ -555,29 +551,29 @@ components:
           type: string
         inum:
           type: string
-        creation_date:
+        creationDate:
           type: string
           description: Creation date of the entry
           format: date-time
-          example: 2024-04-21T18:25:43-05:00
-        event_time:
+          example: 2026-07-24T15:33:02.937Z
+        eventTime:
           type: string
           description: Time when the event occurred
           format: date-time
-          example: 2024-04-21T18:25:43-05:00
+          example: 2026-07-24T15:33:02.937Z
         service:
           type: string
           description: Service name
-          example: jans-auth
-        node_name:
+          example: Lock Server
+        nodeName:
           type: string
           description: Node name or identifier
-          example: "1"
-        event_type:
+          example: 04bbe9ef-a853-417c-a2b8-5328b62936e2
+        eventType:
           type: string
           description: Type of event
-          example: registration
-        severity_level:
+          example: Decision
+        severityLevel:
           type: string
           description: Severity level
           example: warning
@@ -589,23 +585,23 @@ components:
         action:
           type: string
           description: Action performed
-          example: ACTION_NAME_3
-        decision_result:
+          example: Jans::Action::"POST"
+        decisionResult:
           type: string
           description: Decision result
-          example: allow
+          example: ALLOW
           enum:
-          - allow
-          - deny
-        requested_resource:
+          - ALLOW
+          - DENY
+        requestedResource:
           type: string
-          description: Requested resource as JSON string
-          example: "{\"t1\":\"value1\",\"t2\":\"value2\"}"
-        principal_id:
+          description: Requested resource identifier
+          example: Jans::HTTP_Request::"lock_audit_log_write"
+        principalId:
           type: string
           description: Principal (user) identifier
           example: ACC0001
-        client_id:
+        clientId:
           type: string
           description: Client identifier
           example: CLI001
@@ -613,7 +609,7 @@ components:
           type: string
           description: JWT ID - unique identifier for the token
           example: 550e8400-e29b-41d4-a716-446655440000
-        context_information:
+        contextInformation:
           type: object
           additionalProperties:
             type: string
@@ -629,47 +625,38 @@ components:
           type: string
         inum:
           type: string
-        creation_date:
+        creationDate:
           type: string
           description: Creation date of the entry
           format: date-time
-          example: 2024-04-21T18:25:43-05:00
-        event_time:
-          type: string
-          description: Time when the event occurred
-          format: date-time
-          example: 2024-04-21T18:25:43-05:00
+          example: 2026-07-24T15:33:06.872Z
         service:
           type: string
           description: Service name
-          example: jans-auth
-        node_name:
+          example: Lock Server
+        nodeName:
           type: string
           description: Node name or identifier
-          example: "1"
+          example: 04bbe9ef-a853-417c-a2b8-5328b62936e2
         status:
           type: string
           description: Service status
-          example: ok
-          enum:
-          - ok
-          - warning
-          - error
-        policy_stats:
+          example: running
+        policyStats:
           type: object
           additionalProperties:
             type: integer
             description: Per-policy evaluation counters as key-value pairs
             format: int64
           description: Per-policy evaluation counters as key-value pairs
-        error_counters:
+        errorCounters:
           type: object
           additionalProperties:
             type: integer
             description: Error counters broken down by error type
             format: int64
           description: Error counters broken down by error type
-        operational_stats:
+        operationalStats:
           type: object
           additionalProperties:
             type: integer
@@ -678,11 +665,11 @@ components:
             format: int64
           description: "Operational statistics (requests, decisions, eval times) as\
             \ key-value pairs"
-        interval_secs:
+        intervalSecs:
           type: integer
           description: Telemetry collection interval in seconds
           format: int64
-          example: 60
+          example: 5
       description: Telemetry audit entry
     FlatStatResponse:
       type: object

--- a/jans-lock/lock-server/model/src/main/java/io/jans/lock/model/audit/HealthEntry.java
+++ b/jans-lock/lock-server/model/src/main/java/io/jans/lock/model/audit/HealthEntry.java
@@ -40,35 +40,35 @@ public class HealthEntry extends BaseEntry implements Serializable {
 	@AttributeName(name = "inum", ignoreDuringUpdate = true)
 	private String inum;
 
-	@JsonProperty("creation_date")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
-	@Schema(description = "Creation date of the entry", example = "2024-04-21T17:25:43-05:00")
+	@JsonProperty("creationDate")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
+	@Schema(description = "Creation date of the entry", example = "2026-07-24T15:33:06.875Z")
 	@AttributeName(name = "creationDate")
 	private Date creationDate;
 
-	@JsonProperty("event_time")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
-	@Schema(description = "Time when the event occurred", example = "2024-04-21T18:25:43-05:00")
+	@JsonProperty("eventTime")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
+	@Schema(description = "Time when the event occurred", example = "2026-07-24T15:33:06.875Z")
 	@AttributeName(name = "eventTime")
 	private Date eventTime;
 
 	@JsonProperty("service")
-	@Schema(description = "Service name", example = "jans-auth")
+	@Schema(description = "Service name", example = "Lock Server")
 	@AttributeName(name = "jansService")
 	private String service;
 
-	@JsonProperty("node_name")
-	@Schema(description = "Node name or identifier", example = "1")
+	@JsonProperty("nodeName")
+	@Schema(description = "Node name or identifier", example = "04bbe9ef-a853-417c-a2b8-5328b62936e2")
 	@AttributeName(name = "jansNodeName")
 	private String nodeName;
 
 	@JsonProperty("status")
-	@Schema(description = "Health status", example = "ok", allowableValues = { "ok", "warning", "error" })
+	@Schema(description = "Health status", example = "running")
 	@AttributeName(name = "jansStatus")
 	private String status;
 
-	// Details: cedarEngineStatus, cedarPolicyStatus, tokenDataStatus. etc..
-	@JsonProperty("engine_status")
+	// Details: policy_load, core, etc..
+	@JsonProperty("engineStatus")
 	@JsonObject
 	@AttributeName(name = "engineStatus")
 	private Map<String, String> engineStatus;

--- a/jans-lock/lock-server/model/src/main/java/io/jans/lock/model/audit/LogEntry.java
+++ b/jans-lock/lock-server/model/src/main/java/io/jans/lock/model/audit/LogEntry.java
@@ -34,59 +34,59 @@ public class LogEntry extends BaseEntry implements Serializable {
     @AttributeName(name = "inum", ignoreDuringUpdate = true)
     private String inum;
 
-    @JsonProperty("creation_date")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
-    @Schema(description = "Creation date of the entry", example = "2024-04-21T18:25:43-05:00")
+    @JsonProperty("creationDate")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
+    @Schema(description = "Creation date of the entry", example = "2026-07-24T15:33:02.937Z")
     @AttributeName(name = "creationDate")
     private Date creationDate;
 
-    @JsonProperty("event_time")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
-    @Schema(description = "Time when the event occurred", example = "2024-04-21T18:25:43-05:00")
+    @JsonProperty("eventTime")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
+    @Schema(description = "Time when the event occurred", example = "2026-07-24T15:33:02.937Z")
     @AttributeName(name = "eventTime")
     private Date eventTime;
 
     @JsonProperty("service")
-    @Schema(description = "Service name", example = "jans-auth")
+    @Schema(description = "Service name", example = "Lock Server")
     @AttributeName(name = "jansService")
     private String service;
 
-    @JsonProperty("node_name")
-    @Schema(description = "Node name or identifier", example = "1")
+    @JsonProperty("nodeName")
+    @Schema(description = "Node name or identifier", example = "04bbe9ef-a853-417c-a2b8-5328b62936e2")
     @AttributeName(name = "jansNodeName")
     private String nodeName;
 
-    @JsonProperty("event_type")
-    @Schema(description = "Type of event", example = "registration")
+    @JsonProperty("eventType")
+    @Schema(description = "Type of event", example = "Decision")
     @AttributeName(name = "eventType")
     private String eventType;
 
-    @JsonProperty("severity_level")
+    @JsonProperty("severityLevel")
     @Schema(description = "Severity level", example = "warning", allowableValues = {"info", "warning", "error", "critical"})
     @AttributeName(name = "severityLevel")
     private String severityLevel;
 
     @JsonProperty("action")
-    @Schema(description = "Action performed", example = "ACTION_NAME_3")
+    @Schema(description = "Action performed", example = "Jans::Action::\"POST\"")
     @AttributeName(name = "actionName")
     private String action;
 
-    @JsonProperty("decision_result")
-    @Schema(description = "Decision result", example = "allow", allowableValues = {"allow", "deny"})
+    @JsonProperty("decisionResult")
+    @Schema(description = "Decision result", example = "ALLOW", allowableValues = {"ALLOW", "DENY"})
     @AttributeName(name = "decisionResult")
     private String decisionResult;
 
-    @JsonProperty("requested_resource")
-    @Schema(description = "Requested resource as JSON string", example = "{\"t1\":\"value1\",\"t2\":\"value2\"}")
+    @JsonProperty("requestedResource")
+    @Schema(description = "Requested resource identifier", example = "Jans::HTTP_Request::\"lock_audit_log_write\"")
     @AttributeName(name = "requestedResource")
     private String requestedResource;
 
-    @JsonProperty("principal_id")
+    @JsonProperty("principalId")
     @Schema(description = "Principal (user) identifier", example = "ACC0001")
     @AttributeName(name = "principalId")
     private String principalId;
 
-    @JsonProperty("client_id")
+    @JsonProperty("clientId")
     @Schema(description = "Client identifier", example = "CLI001")
     @AttributeName(name = "clientId")
     private String clientId;
@@ -96,7 +96,7 @@ public class LogEntry extends BaseEntry implements Serializable {
     @AttributeName(name = "jti")
     private String jti;
 
-    @JsonProperty("context_information")
+    @JsonProperty("contextInformation")
     @Schema(description = "Additional context information as key-value pairs")
     @JsonObject
     @AttributeName(name = "contextInformation")

--- a/jans-lock/lock-server/model/src/main/java/io/jans/lock/model/audit/TelemetryEntry.java
+++ b/jans-lock/lock-server/model/src/main/java/io/jans/lock/model/audit/TelemetryEntry.java
@@ -30,7 +30,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 @Schema(description = "Telemetry audit entry")
 @JsonIgnoreProperties(ignoreUnknown = true)
-@DataEntry(sortByName = "eventTime")
+@DataEntry(sortByName = "creationDate")
 @ObjectClass(value = "jansTelemetryEntry")
 public class TelemetryEntry extends BaseEntry implements Serializable {
 
@@ -40,53 +40,47 @@ public class TelemetryEntry extends BaseEntry implements Serializable {
 	@AttributeName(name = "inum", ignoreDuringUpdate = true)
 	private String inum;
 
-	@JsonProperty("creation_date")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
-	@Schema(description = "Creation date of the entry", example = "2024-04-21T18:25:43-05:00")
+	@JsonProperty("creationDate")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
+	@Schema(description = "Creation date of the entry", example = "2026-07-24T15:33:06.872Z")
 	@AttributeName(name = "creationDate")
 	private Date creationDate;
 
-	@JsonProperty("event_time")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
-	@Schema(description = "Time when the event occurred", example = "2024-04-21T18:25:43-05:00")
-	@AttributeName(name = "eventTime")
-	private Date eventTime;
-
 	@JsonProperty("service")
-	@Schema(description = "Service name", example = "jans-auth")
+	@Schema(description = "Service name", example = "Lock Server")
 	@AttributeName(name = "jansService")
 	private String service;
 
-	@JsonProperty("node_name")
-	@Schema(description = "Node name or identifier", example = "1")
+	@JsonProperty("nodeName")
+	@Schema(description = "Node name or identifier", example = "04bbe9ef-a853-417c-a2b8-5328b62936e2")
 	@AttributeName(name = "jansNodeName")
 	private String nodeName;
 
 	@JsonProperty("status")
-	@Schema(description = "Service status", example = "ok", allowableValues = { "ok", "warning", "error" })
+	@Schema(description = "Service status", example = "running")
 	@AttributeName(name = "jansStatus")
 	private String status;
 
-	@JsonProperty("policy_stats")
+	@JsonProperty("policyStats")
 	@Schema(description = "Per-policy evaluation counters as key-value pairs")
 	@JsonObject
 	@AttributeName(name = "policyStats")
 	private Map<String, Long> policyStats;
 
-	@JsonProperty("error_counters")
+	@JsonProperty("errorCounters")
 	@Schema(description = "Error counters broken down by error type")
 	@JsonObject
 	@AttributeName(name = "errorCounters")
 	private Map<String, Long> errorCounters;
 
-	@JsonProperty("operational_stats")
+	@JsonProperty("operationalStats")
 	@Schema(description = "Operational statistics (requests, decisions, eval times) as key-value pairs")
 	@JsonObject
 	@AttributeName(name = "operationalStats")
 	private Map<String, Long> operationalStats;
 
-	@JsonProperty("interval_secs")
-	@Schema(description = "Telemetry collection interval in seconds", example = "60")
+	@JsonProperty("intervalSecs")
+	@Schema(description = "Telemetry collection interval in seconds", example = "5")
 	@AttributeName(name = "intervalSecs")
 	private Long intervalSecs;
 
@@ -104,14 +98,6 @@ public class TelemetryEntry extends BaseEntry implements Serializable {
 
 	public void setCreationDate(Date creationDate) {
 		this.creationDate = creationDate;
-	}
-
-	public Date getEventTime() {
-		return eventTime;
-	}
-
-	public void setEventTime(Date eventTime) {
-		this.eventTime = eventTime;
 	}
 
 	public String getService() {
@@ -177,7 +163,7 @@ public class TelemetryEntry extends BaseEntry implements Serializable {
 		if (o == null || getClass() != o.getClass())
 			return false;
 		TelemetryEntry that = (TelemetryEntry) o;
-		return Objects.equals(creationDate, that.creationDate) && Objects.equals(eventTime, that.eventTime)
+		return Objects.equals(creationDate, that.creationDate)
 				&& Objects.equals(service, that.service) && Objects.equals(nodeName, that.nodeName)
 				&& Objects.equals(status, that.status) && Objects.equals(intervalSecs, that.intervalSecs)
 				&& Objects.equals(policyStats, that.policyStats)
@@ -187,13 +173,13 @@ public class TelemetryEntry extends BaseEntry implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(creationDate, eventTime, service, nodeName, status, intervalSecs,
+		return Objects.hash(creationDate, service, nodeName, status, intervalSecs,
 				policyStats, errorCounters, operationalStats);
 	}
 
 	@Override
 	public String toString() {
-		return "TelemetryEntry{" + "creationDate='" + creationDate + '\'' + ", eventTime='" + eventTime + '\''
+		return "TelemetryEntry{" + "creationDate='" + creationDate + '\''
 				+ ", service='" + service + '\'' + ", nodeName='" + nodeName + '\'' + ", status='" + status + '\''
 				+ ", intervalSecs=" + intervalSecs + ", policyStats=" + policyStats
 				+ ", errorCounters=" + errorCounters + ", operationalStats=" + operationalStats + '}';

--- a/jans-lock/lock-server/server/src/main/resources/log4j2.component.properties
+++ b/jans-lock/lock-server/server/src/main/resources/log4j2.component.properties
@@ -1,1 +1,1 @@
-log4j2.configurationFile=log4j2.xml, log4j2-lock.xml, log4j2-lock-cedarling.xml
+log4j2.configurationFile=log4j2.xml, log4j2-lock.xml, log4j2-core-cedarling.xml

--- a/jans-lock/lock-server/server/src/main/resources/log4j2.xml
+++ b/jans-lock/lock-server/server/src/main/resources/log4j2.xml
@@ -48,7 +48,6 @@
 
     <Loggers>
         <Root level="INFO">
-			<AppenderRef ref="JANS_LOCK_FILE" />
 			<AppenderRef ref="Console" />
         </Root>
 

--- a/jans-lock/lock-server/server/src/test/manual/automatic_audit_enpoints_tests.sh
+++ b/jans-lock/lock-server/server/src/test/manual/automatic_audit_enpoints_tests.sh
@@ -20,19 +20,19 @@ INVALID_TOKEN="this-is-definitely-not-a-valid-token"
 
 # Log
 SINGLE_LOG_JSON_REST='{
-    "creation_date": "2024-04-21T18:25:43-05:00",
-    "event_time":   "2024-04-21T18:25:43-05:00",
+    "creationDate": "2024-04-21T18:25:43-05:00",
+    "eventTime":   "2024-04-21T18:25:43-05:00",
     "service":      "jans-auth",
-    "node_name":    "node-1",
-    "event_type":   "registration",
-    "severity_level": "warning",
+    "nodeName":    "node-1",
+    "eventType":   "registration",
+    "severityLevel": "warning",
     "action":       "LOGIN_ATTEMPT",
-    "decision_result": "allow",
-    "requested_resource": "{\"res\":\"/api/user\",\"method\":\"POST\"}",
-    "principal_id": "ACC-000123",
-    "client_id":    "CLI-001",
+    "decisionResult": "allow",
+    "requestedResource": "{\"res\":\"/api/user\",\"method\":\"POST\"}",
+    "principalId": "ACC-000123",
+    "clientId":    "CLI-001",
     "jti":          "test-jti-123456",
-    "context_information": {
+    "contextInformation": {
       "ip": "192.168.1.77",
       "user_agent": "Mozilla/5.0 (test)"
     }
@@ -40,31 +40,31 @@ SINGLE_LOG_JSON_REST='{
 
 BULK_LOG_JSON_REST='[
    {
-      "creation_date": "2024-04-21T18:25:43-05:00",
-      "event_time":   "2024-04-21T18:25:43-05:00",
+      "creationDate": "2024-04-21T18:25:43-05:00",
+      "eventTime":   "2024-04-21T18:25:43-05:00",
       "service":      "jans-auth",
-      "node_name":    "node-1",
-      "event_type":   "registration",
-      "severity_level": "warning",
+      "nodeName":    "node-1",
+      "eventType":   "registration",
+      "severityLevel": "warning",
       "action":       "LOGIN_ATTEMPT",
-      "decision_result": "deny",
-      "requested_resource": "{\"res\":\"/api/admin\"}",
-      "principal_id": "ACC-000123",
-      "client_id":    "CLI-001",
-      "context_information": {"ip": "10.0.0.5"}
+      "decisionResult": "deny",
+      "requestedResource": "{\"res\":\"/api/admin\"}",
+      "principalId": "ACC-000123",
+      "clientId":    "CLI-001",
+      "contextInformation": {"ip": "10.0.0.5"}
     },
     {
-      "creation_date": "2024-06-15T14:10:22Z",
-      "event_time":   "2024-06-15T14:10:22Z",
+      "creationDate": "2024-06-15T14:10:22Z",
+      "eventTime":   "2024-06-15T14:10:22Z",
       "service":      "jans-auth",
-      "node_name":    "node-2",
-      "event_type":   "transaction",
-      "severity_level": "info",
+      "nodeName":    "node-2",
+      "eventType":   "transaction",
+      "severityLevel": "info",
       "action":       "PAYMENT",
-      "decision_result": "allow",
-      "requested_resource": "{\"amount\":99.99}",
-      "principal_id": "ACC-000123",
-      "client_id":    "CLI-001"
+      "decisionResult": "allow",
+      "requestedResource": "{\"amount\":99.99}",
+      "principalId": "ACC-000123",
+      "clientId":    "CLI-001"
     }
 ]'
 
@@ -74,7 +74,11 @@ SINGLE_HEALTH_JSON_REST='{
   "eventTime":    "2024-04-21T18:25:43-05:00",
   "service":      "jans-auth",
   "nodeName":     "node-1",
-  "status":       "ok"
+  "status":       "ok",
+  "engineStatus": {
+    "cedarling": "up",
+    "policy_store": "loaded"
+  }
 }'
 
 BULK_HEALTH_JSON_REST='[
@@ -83,14 +87,21 @@ BULK_HEALTH_JSON_REST='[
     "eventTime":    "2024-04-21T18:25:43-05:00",
     "service":      "jans-auth",
     "nodeName":     "node-1",
-    "status":       "ok"
+    "status":       "ok",
+    "engineStatus": {
+      "cedarling": "up",
+      "policy_store": "loaded"
+    }
   },
   {
     "creationDate": "2024-04-21T17:30:00-05:00",
     "eventTime":    "2024-04-21T18:30:00-05:00",
     "service":      "jans-lock",
     "nodeName":     "node-2",
-    "status":       "degraded"
+    "status":       "degraded",
+    "engineStatus": {
+      "cedarling": "down"
+    }
   }
 ]'
 
@@ -289,6 +300,7 @@ check_grpc_success "grpcurl -insecure --proto audit.proto -H 'authorization: bea
 echo -e "\n── Telemetry ─────────────────────────────────────────"
 check_http_success "curl -k -H 'Authorization: Bearer $WRITE_TELEMETRY_TOKEN' -H 'Content-Type: application/json' -d @- '${HOST}/jans-lock/api/v1/audit/telemetry' <<< '$SINGLE_TELEMETRY_JSON_REST'" "REST → single telemetry entry"
 check_http_success "curl -k -H 'Authorization: Bearer $WRITE_TELEMETRY_TOKEN' -H 'Content-Type: application/json' -d @- '${HOST}/jans-lock/api/v1/audit/telemetry/bulk' <<< '$BULK_TELEMETRY_JSON_REST'" "REST → bulk telemetry entries"
+
 check_grpc_success "grpcurl -insecure --proto audit.proto -H 'authorization: bearer $WRITE_TELEMETRY_TOKEN' -d '$SINGLE_TELEMETRY_GRPC' $GRPC_ADDR io.jans.lock.audit.AuditService/ProcessTelemetry" "gRPC → ProcessTelemetry"
 check_grpc_success "grpcurl -insecure --proto audit.proto -H 'authorization: bearer $WRITE_TELEMETRY_TOKEN' -d '$BULK_TELEMETRY_GRPC'  $GRPC_ADDR io.jans.lock.audit.AuditService/ProcessBulkTelemetry" "gRPC → ProcessBulkTelemetry"
 
@@ -349,4 +361,3 @@ check_grpc_should_fail "grpcurl -insecure --proto audit.proto -H 'authorization:
 echo -e "\n┌──────────────────────────────┐"
 echo   "│         TESTS PASSED         │"
 echo   "└──────────────────────────────┘"
-

--- a/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/audit/AuditRestWebServiceImpl.java
+++ b/jans-lock/lock-server/service/src/main/java/io/jans/lock/service/ws/rs/audit/AuditRestWebServiceImpl.java
@@ -357,9 +357,9 @@ public class AuditRestWebServiceImpl extends BaseResource implements AuditRestWe
 
 		if (logEntry.getDecisionResult() != null) {
 			String decisionResult = logEntry.getDecisionResult();
-			if (LOG_DECISION_RESULT_ALLOW.equals(decisionResult)) {
+			if (LOG_DECISION_RESULT_ALLOW.equalsIgnoreCase(decisionResult)) {
 				statService.reportAllow(LOG_DECISION_RESULT);
-			} else if (LOG_DECISION_RESULT_DENY.equals(decisionResult)) {
+			} else if (LOG_DECISION_RESULT_DENY.equalsIgnoreCase(decisionResult)) {
 				statService.reportDeny(LOG_DECISION_RESULT);
 			}
 		}

--- a/jans-lock/lock-server/service/src/main/resources/log4j2-lock.xml
+++ b/jans-lock/lock-server/service/src/main/resources/log4j2-lock.xml
@@ -10,15 +10,6 @@
 			<DefaultRolloverStrategy max="30" />
 		</RollingFile>
 
-		<RollingFile name="JANS_LOCK_CEDARLING_FILE" fileName="${sys:log.base}/logs/jans-lock-cedarling.log" filePattern="${sys:log.base}/logs/jans-lock-cedarling-%d{yyyy-MM-dd}-%i.log">
-			<PatternLayout pattern="%d{dd-MM-yyyy HH:mm:ss.SSS} %-5p [%t] %C{4} %F:%L- %m%n" />
-
-			<Policies>
-				<SizeBasedTriggeringPolicy size="5 MB" />
-			</Policies>
-			<DefaultRolloverStrategy max="30" />
-		</RollingFile>
-
 		<RollingFile name="JANS_LOCK_APP_AUDIT_FILE" fileName="${sys:log.base}/logs/jans-lock_audit.log" filePattern="${sys:log.base}/logs/jans-lock_audit-%d{yyyy-MM-dd}-%i.log">
 			<PatternLayout pattern="%d %-5p [%t] [%C{6}] (%F:%L) - %m%n" />
 
@@ -33,10 +24,6 @@
     <Loggers>
 		<Logger name="io.jans.lock" level="${log4j.default.log.level}">
 			<AppenderRef ref="JANS_LOCK_FILE" />
-		</Logger>
-
-		<Logger name="io.jans.core.cedarling" level="${log4j.default.log.level}">
-			<AppenderRef ref="JANS_LOCK_CEDARLING_FILE" />
 		</Logger>
 
 		<Logger name="io.jans.core.cedarling.service.app.audit" level="${log4j.default.log.level}" additivity="false">

--- a/jans-lock/lock-server/service/src/test/java/io/jans/lock/cedarling/service/CedarlingProtectionServiceTest.java
+++ b/jans-lock/lock-server/service/src/test/java/io/jans/lock/cedarling/service/CedarlingProtectionServiceTest.java
@@ -43,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
 
 import io.jans.as.client.OpenIdConfigurationResponse;
 import io.jans.as.model.crypto.AuthCryptoProvider;
@@ -167,6 +168,9 @@ class CedarlingProtectionServiceTest {
     void setUp() throws Exception {
         // Inject the mocked ObjectMapper (avoids real HTTP for JWKS fetches)
         injectField("mapper", mapper);
+
+        // Real (empty) JWKS cache — normally created in @PostConstruct init()
+        injectField("jwksCache", CacheBuilder.newBuilder().build());
 
         // Build a minimal OpenID configuration stub
         OpenIdConfigurationResponse oidcConfig = mock(OpenIdConfigurationResponse.class);
@@ -528,7 +532,7 @@ class CedarlingProtectionServiceTest {
     class ExceptionHandlingTests {
 
         @Test
-        @DisplayName("unexpected exception returns 500 with exception message")
+        @DisplayName("unexpected exception returns 500 with generic message")
         void unexpectedException_returns500() throws Exception {
             try (MockedStatic<Jwt> jwtStatic = mockStatic(Jwt.class)) {
                 jwtStatic.when(() -> Jwt.parse(anyString()))
@@ -539,10 +543,11 @@ class CedarlingProtectionServiceTest {
                         mockResourceInfo(SecuredResource.class, "securedMethod"));
 
                 assertStatus(INTERNAL_SERVER_ERROR, response);
+                // The service deliberately hides internal error details from the caller
                 assertEquals(
-                        "Unexpected adapter failure",
+                        "Failed to validate token",
                         response.getEntity().toString(),
-                        "Exception message must be surfaced in the response body");
+                        "Internal exception details must not leak into the response body");
             }
         }
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
#14627
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14627

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated audit health/log/telemetry API payloads to consistent camelCase field names.
  * Standardized audit timestamps to UTC-formatted strings.
  * Improved telemetry with structured policy/error/operational/interval statistics; telemetry no longer includes eventTime.
  * Updated telemetry LDAP schema to match the new structured statistics model.
* **Bug Fixes**
  * Audit decision statistics now treat allow/deny values case-insensitively.
  * Runtime token-validation failures now return a generic error message.
* **Documentation / Tests**
  * Refreshed REST↔gRPC audit test payloads to camelCase.
* **Chores / Configuration**
  * Updated Log4j2 configuration files and added Swagger schema field `authorizationResponseIssParameterSupported`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->