### PR TITLE
feat(jans-linux-setup): fallback to env var in case downloading fails

### DIFF
--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -21,7 +21,7 @@ import random
 
 from pathlib import Path
 from collections import OrderedDict
-
+from urllib.error import HTTPError, URLError
 
 # disable ssl certificate check
 ssl._create_default_https_context = ssl._create_unverified_context
@@ -387,15 +387,21 @@ def download(url, dst, verbose=False, headers=None):
     download_ok = False
     while download_tries < 4:
         try:
-            urllib.request.urlretrieve(url, dst)
+            dst_tmp_fn = dst + '~' + os.urandom(4).hex()
+            urllib.request.urlretrieve(url, dst_tmp_fn)
+            shutil.move(dst_tmp_fn, dst)
             mylog("Download size: {} bytes".format(os.path.getsize(dst)))
             time.sleep(0.1)
             download_ok = True
-        except:
+        except (HTTPError, URLError, OSError):
             retry_sec = random.randint(1,4)
             mylog(f"Error downloading {url}. Download will be re-tried once more in {retry_sec} seconds.")
             download_tries += 1
-            time.sleep(retry_sec)
+            if download_tries >=3:
+                time.sleep(retry_sec)
+        except Exception as e:
+            mylog("Can't contuinue {e}")
+            sys.exit(2)
         else:
             break
 

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -382,15 +382,15 @@ def download(url, dst, verbose=False, headers=None):
     opener.addheaders = headers
     urllib.request.install_opener(opener)
 
-    mylog(f"Downloading {url} to {dst}")
+    dst_tmp_fn = dst + '~' + os.urandom(8).hex()
+    mylog(f"Downloading {url} to {dst_tmp_fn}")
     download_tries = 1
     download_ok = False
+
     while download_tries < 4:
         try:
-            dst_tmp_fn = dst + '~' + os.urandom(4).hex()
             urllib.request.urlretrieve(url, dst_tmp_fn)
-            shutil.move(dst_tmp_fn, dst)
-            mylog("Download size: {} bytes".format(os.path.getsize(dst)))
+            mylog(f"Download size: {os.path.getsize(dst_tmp_fn)} bytes")
             time.sleep(0.1)
             download_ok = True
         except (HTTPError, URLError, OSError):
@@ -400,10 +400,14 @@ def download(url, dst, verbose=False, headers=None):
             if download_tries >=3:
                 time.sleep(retry_sec)
         except Exception as e:
-            mylog("Can't contuinue {e}")
+            mylog(f"Can't contuinue {e}")
             sys.exit(2)
         else:
             break
+
+    if download_ok and os.path.exists(dst_tmp_fn):
+        mylog(f"Moving file {dst_tmp_fn} to {dst}")
+        shutil.move(dst_tmp_fn, dst)
 
     if not download_ok:
         env_var = re.sub(r'[^_a-zA-Z0-9]', '_', fn)

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -382,15 +382,15 @@ def download(url, dst, verbose=False, headers=None):
     opener.addheaders = headers
     urllib.request.install_opener(opener)
 
-    dst_tmp_fn = dst + '~' + os.urandom(8).hex()
-    mylog(f"Downloading {url} to {dst_tmp_fn}")
+    mylog(f"Downloading {url} to {dst}")
     download_tries = 1
     download_ok = False
-
+    dst_tmp_fn = dst + '~' + os.urandom(4).hex()
     while download_tries < 4:
         try:
             urllib.request.urlretrieve(url, dst_tmp_fn)
-            mylog(f"Download size: {os.path.getsize(dst_tmp_fn)} bytes")
+            shutil.move(dst_tmp_fn, dst)
+            mylog(f"Download size: {os.path.getsize(dst)} bytes")
             time.sleep(0.1)
             download_ok = True
         except (HTTPError, URLError, OSError):
@@ -400,14 +400,14 @@ def download(url, dst, verbose=False, headers=None):
             if download_tries >=3:
                 time.sleep(retry_sec)
         except Exception as e:
-            mylog(f"Can't contuinue {e}")
+            mylog("Can't contuinue {e}")
             sys.exit(2)
         else:
             break
-
-    if download_ok and os.path.exists(dst_tmp_fn):
-        mylog(f"Moving file {dst_tmp_fn} to {dst}")
-        shutil.move(dst_tmp_fn, dst)
+        finally:
+            if os.path.exists(dst_tmp_fn):
+                mylog(f"Removing file {dst_tmp_fn}")
+                os.remove(dst_tmp_fn)
 
     if not download_ok:
         env_var = re.sub(r'[^_a-zA-Z0-9]', '_', fn)

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -17,7 +17,6 @@ import multiprocessing
 import ssl
 import tempfile
 import urllib.request
-import random
 import secrets
 
 from pathlib import Path

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -21,7 +21,7 @@ import random
 
 from pathlib import Path
 from collections import OrderedDict
-from urllib.error import HTTPError, URLError
+from urllib.error import URLError
 
 # disable ssl certificate check
 ssl._create_default_https_context = ssl._create_unverified_context
@@ -393,11 +393,11 @@ def download(url, dst, verbose=False, headers=None):
             mylog(f"Download size: {os.path.getsize(dst)} bytes")
             time.sleep(0.1)
             download_ok = True
-        except (HTTPError, URLError, OSError):
+        except URLError:
             retry_sec = random.randint(1,4)
             mylog(f"Error downloading {url}. Download will be re-tried once more in {retry_sec} seconds.")
             download_tries += 1
-            if download_tries >=3:
+            if download_tries < 4:
                 time.sleep(retry_sec)
         except Exception as e:
             mylog("Can't contuinue {e}")
@@ -410,7 +410,7 @@ def download(url, dst, verbose=False, headers=None):
                 os.remove(dst_tmp_fn)
 
     if not download_ok:
-        env_var = re.sub(r'[^_a-zA-Z0-9]', '_', fn)
+        env_var = re.sub(r'[^\w]', '_', fn)
         if env_var[0].isnumeric():
             env_var = '_' + env_var
         mylog(f"Unable to download {url}, looking for environmental variable {env_var} for fallback")

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -397,7 +397,7 @@ def download(url, dst, verbose=False, headers=None):
             download_tries += 1
             if download_tries < 4:
                 retry_sec = 1.0 + (secrets.randbelow(3000) / 1000.0)
-                mylog(f"Error downloading {url}. Download will be re-tried once more in {retry_sec} seconds.")
+                mylog(f"Error downloading {url}. Download will be re-tried in {retry_sec} seconds.")
                 time.sleep(retry_sec)
         except Exception as e:
             mylog("Can't contuinue {e}")

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -395,10 +395,10 @@ def download(url, dst, verbose=False, headers=None):
             time.sleep(0.1)
             download_ok = True
         except URLError:
-            retry_sec = 1.0 + (secrets.randbelow(3000) / 1000.0)
-            mylog(f"Error downloading {url}. Download will be re-tried once more in {retry_sec} seconds.")
             download_tries += 1
             if download_tries < 4:
+                retry_sec = 1.0 + (secrets.randbelow(3000) / 1000.0)
+                mylog(f"Error downloading {url}. Download will be re-tried once more in {retry_sec} seconds.")
                 time.sleep(retry_sec)
         except Exception as e:
             mylog("Can't contuinue {e}")

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -18,6 +18,7 @@ import ssl
 import tempfile
 import urllib.request
 import random
+import secrets
 
 from pathlib import Path
 from collections import OrderedDict
@@ -394,7 +395,7 @@ def download(url, dst, verbose=False, headers=None):
             time.sleep(0.1)
             download_ok = True
         except URLError:
-            retry_sec = random.randint(1,4)
+            retry_sec = 1.0 + (secrets.randbelow(3000) / 1000.0)
             mylog(f"Error downloading {url}. Download will be re-tried once more in {retry_sec} seconds.")
             download_tries += 1
             if download_tries < 4:
@@ -410,7 +411,7 @@ def download(url, dst, verbose=False, headers=None):
                 os.remove(dst_tmp_fn)
 
     if not download_ok:
-        env_var = re.sub(r'[^\w]', '_', fn)
+        env_var = re.sub(r'[^\w]', '_', fn, re.ASCII)
         if env_var[0].isnumeric():
             env_var = '_' + env_var
         mylog(f"Unable to download {url}, looking for environmental variable {env_var} for fallback")

--- a/jans-linux-setup/jans_setup/setup_app/utils/base.py
+++ b/jans-linux-setup/jans_setup/setup_app/utils/base.py
@@ -17,6 +17,7 @@ import multiprocessing
 import ssl
 import tempfile
 import urllib.request
+import random
 
 from pathlib import Path
 from collections import OrderedDict
@@ -381,19 +382,41 @@ def download(url, dst, verbose=False, headers=None):
     opener.addheaders = headers
     urllib.request.install_opener(opener)
 
-    mylog("Downloading {} to {}".format(url, dst))
+    mylog(f"Downloading {url} to {dst}")
     download_tries = 1
+    download_ok = False
     while download_tries < 4:
         try:
             urllib.request.urlretrieve(url, dst)
             mylog("Download size: {} bytes".format(os.path.getsize(dst)))
             time.sleep(0.1)
+            download_ok = True
         except:
-             mylog("Error downloading {}. Download will be re-tried once more".format(url))
-             download_tries += 1
-             time.sleep(1)
+            retry_sec = random.randint(1,4)
+            mylog(f"Error downloading {url}. Download will be re-tried once more in {retry_sec} seconds.")
+            download_tries += 1
+            time.sleep(retry_sec)
         else:
             break
+
+    if not download_ok:
+        env_var = re.sub(r'[^_a-zA-Z0-9]', '_', fn)
+        if env_var[0].isnumeric():
+            env_var = '_' + env_var
+        mylog(f"Unable to download {url}, looking for environmental variable {env_var} for fallback")
+        src = os.environ.get(env_var)
+        if src and os.path.isfile(src):
+            if os.path.exists(dst) and os.path.samefile(src, dst):
+                mylog(f"Fallback source {src} already matches destination {dst}. Passing")
+                return
+
+            mylog(f"Copying {src} to {dst}")
+            shutil.copy(src, dst)
+        elif os.path.exists(dst):
+            mylog(f"File {dst} was already exist, Continuing with old file...")
+        else:
+            mylog(f"File {dst} is not available for this time. Exiting ...")
+            sys.exit(2)
 
     urllib.request.install_opener(None)
 


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14631

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability by staging downloads in a temporary file and only moving them into place after success, preventing incomplete/corrupt destination files.
  * Added up to three additional retry attempts for transient network errors, using randomized backoff delays.
  * Introduced a fallback mechanism to use a locally provided file when remote download repeatedly fails.
  * Standardized failure behavior when no fallback is available, ensuring consistent termination on unrecoverable errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->