### PR TITLE
feat(jans-fido2): expose effective attestation-mode status endpoint

### DIFF
--- a/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2TrustResource.java
+++ b/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2TrustResource.java
@@ -1,0 +1,123 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.configapi.plugin.fido2.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.jans.configapi.core.rest.BaseResource;
+import io.jans.configapi.core.rest.ProtectedApi;
+import io.jans.configapi.plugin.fido2.service.Fido2TrustService;
+import io.jans.configapi.plugin.fido2.util.Constants;
+import io.jans.configapi.util.ApiAccessConstants;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.*;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+
+/**
+ * Read-only attestation and MDS diagnostics, surfaced through the Config API for the Admin UI.
+ * <p>
+ * GitHub Issue #14602
+ */
+@Path(Constants.TRUST)
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class Fido2TrustResource extends BaseResource {
+
+    private static final String ERR_MSG = "Exception while getting Fido2 trust data is - ";
+
+    @Inject
+    Logger logger;
+
+    @Inject
+    Fido2TrustService fido2TrustService;
+
+    /**
+     * Retrieve the attestation policy the FIDO2 server is actually applying.
+     *
+     * @return a Response containing a JsonNode with the effective attestation configuration
+     */
+    @Operation(summary = "Get effective Fido2 attestation configuration.", description = "Get effective Fido2 attestation configuration.", operationId = "get-fido2-trust-attestation-config", tags = {
+            "Fido2 - Trust" }, security = {
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_CONFIG_READ_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_CONFIG_WRITE_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_ADMIN_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { ApiAccessConstants.SUPER_ADMIN_READ_ACCESS }) })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = JsonNode.class), examples = @ExampleObject(name = "Response example", value = "example/fido2/trust/fido2-attestation-config.json"))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "InternalServerError") })
+    @GET
+    @Path(Constants.ATTESTATION_CONFIG)
+    @ProtectedApi(scopes = { Constants.FIDO2_CONFIG_READ_ACCESS }, groupScopes = {
+            Constants.FIDO2_CONFIG_WRITE_ACCESS }, superScopes = { Constants.FIDO2_ADMIN_ACCESS,
+                    ApiAccessConstants.SUPER_ADMIN_READ_ACCESS })
+    public Response getAttestationConfig() {
+        logger.info("Fido2 attestation trust configuration");
+        JsonNode jsonNode = null;
+        try {
+            jsonNode = fido2TrustService.getAttestationConfig(null);
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Fido2 attestation trust configuration - jsonNode:{}", jsonNode);
+            }
+
+        } catch (Exception ex) {
+            logger.error(ERR_MSG, ex);
+            throwInternalServerException(ex);
+        }
+        return Response.ok(jsonNode).build();
+    }
+
+    /**
+     * Retrieve the health of the metadata the FIDO2 server uses for attestation validation.
+     *
+     * @return a Response containing a JsonNode with the MDS health status
+     */
+    @Operation(summary = "Get Fido2 MDS health.", description = "Get Fido2 MDS health.", operationId = "get-fido2-trust-mds-health", tags = {
+            "Fido2 - Trust" }, security = {
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_CONFIG_READ_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_CONFIG_WRITE_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_ADMIN_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { ApiAccessConstants.SUPER_ADMIN_READ_ACCESS }) })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = JsonNode.class), examples = @ExampleObject(name = "Response example", value = "example/fido2/trust/fido2-mds-health.json"))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "InternalServerError") })
+    @GET
+    @Path(Constants.MDS_HEALTH)
+    @ProtectedApi(scopes = { Constants.FIDO2_CONFIG_READ_ACCESS }, groupScopes = {
+            Constants.FIDO2_CONFIG_WRITE_ACCESS }, superScopes = { Constants.FIDO2_ADMIN_ACCESS,
+                    ApiAccessConstants.SUPER_ADMIN_READ_ACCESS })
+    public Response getMdsHealth() {
+        logger.info("Fido2 MDS health");
+        JsonNode jsonNode = null;
+        try {
+            jsonNode = fido2TrustService.getMdsHealth(null);
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Fido2 MDS health - jsonNode:{}", jsonNode);
+            }
+
+        } catch (Exception ex) {
+            logger.error(ERR_MSG, ex);
+            throwInternalServerException(ex);
+        }
+        return Response.ok(jsonNode).build();
+    }
+}

--- a/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/service/Fido2TrustService.java
+++ b/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/service/Fido2TrustService.java
@@ -1,0 +1,104 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.configapi.plugin.fido2.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.jans.configapi.plugin.fido2.util.Constants;
+import io.jans.configapi.plugin.fido2.util.Fido2Util;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Proxies the read-only attestation and MDS diagnostics exposed by the FIDO2 server, so the Admin UI
+ * can render an attestation and MDS status panel through the Config API.
+ * <p>
+ * GitHub Issue #14602
+ */
+@Singleton
+public class Fido2TrustService {
+
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String FIDO2_TRUST_BASE_URL = "/jans-fido2/restv1/trust";
+
+    @Inject
+    Logger log;
+
+    @Inject
+    Fido2Util fido2Util;
+
+    public String getFido2TrustUrl() {
+        return fido2Util.getIssuer() + FIDO2_TRUST_BASE_URL;
+    }
+
+    public String getAttestationConfigUrl() {
+        return getFido2TrustUrl() + Constants.ATTESTATION_CONFIG;
+    }
+
+    public String getMdsHealthUrl() {
+        return getFido2TrustUrl() + Constants.MDS_HEALTH;
+    }
+
+    /**
+     * The attestation policy the FIDO2 server is applying.
+     *
+     * @param token bearer token to forward, may be null
+     * @return attestation trust configuration
+     */
+    public JsonNode getAttestationConfig(String token) throws JsonProcessingException {
+        log.info("Get Fido2 attestation trust configuration");
+
+        return getTrustData(this.getAttestationConfigUrl(), buildHeaders(token));
+    }
+
+    /**
+     * The state of the metadata the FIDO2 server uses for attestation validation.
+     *
+     * @param token bearer token to forward, may be null
+     * @return MDS health status
+     */
+    public JsonNode getMdsHealth(String token) throws JsonProcessingException {
+        log.info("Get Fido2 MDS health");
+
+        return getTrustData(this.getMdsHealthUrl(), buildHeaders(token));
+    }
+
+    private JsonNode getTrustData(String url, Map<String, String> headers) throws JsonProcessingException {
+        log.debug("Fido2 trust data: url:{}, headers:{}", url, headers);
+
+        if (StringUtils.isBlank(url)) {
+            throw new WebApplicationException("Error while getting Fido2 trust data",
+                    Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        }
+
+        JsonNode jsonNode = fido2Util.executeGetRequest(url, headers, null);
+        log.debug("Fido2 trust data: jsonNode:{}", jsonNode);
+
+        return jsonNode;
+    }
+
+    private Map<String, String> buildHeaders(String token) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        if (StringUtils.isNotBlank(token)) {
+            headers.put(AUTHORIZATION, token);
+        }
+        return headers;
+    }
+}

--- a/jans-config-api/server/src/main/resources/example/fido2/trust/fido2-attestation-config.json
+++ b/jans-config-api/server/src/main/resources/example/fido2/trust/fido2-attestation-config.json
@@ -1,0 +1,13 @@
+{
+    "attestationMode": "monitor",
+    "attestationModeRecognized": true,
+    "unattestedAuthenticatorsAllowed": true,
+    "enterpriseAttestation": false,
+    "metadataServiceDisabled": false,
+    "appleRootCaPresent": true,
+    "enabledFidoAlgorithms": [
+        "RS256",
+        "ES256"
+    ],
+    "hints": []
+}

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/trust/AttestationTrustConfig.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/trust/AttestationTrustConfig.java
@@ -1,0 +1,134 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.model.trust;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Read-only view of the attestation policy the server is actually enforcing. Lets an administrator see
+ * whether a strict mode is the reason certain authenticators are being rejected, instead of that
+ * surfacing to end users as a generic registration failure.
+ *
+ * @author Janssen Project
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AttestationTrustConfig {
+
+    private String attestationMode;
+
+    private boolean attestationModeRecognized;
+
+    private boolean unattestedAuthenticatorsAllowed;
+
+    private boolean enterpriseAttestation;
+
+    private boolean metadataServiceDisabled;
+
+    private boolean appleRootCaPresent;
+
+    private List<String> enabledFidoAlgorithms = new ArrayList<>();
+
+    private List<String> hints = new ArrayList<>();
+
+    /**
+     * The configured attestation mode, verbatim. Reported as configured rather than normalized so an
+     * administrator can see a typo for what it is.
+     */
+    public String getAttestationMode() {
+        return attestationMode;
+    }
+
+    public void setAttestationMode(String attestationMode) {
+        this.attestationMode = attestationMode;
+    }
+
+    /**
+     * Whether the configured value matches one of the supported modes (disabled / monitor / enforced).
+     * When false the server falls back to lenient behaviour, which is otherwise invisible.
+     */
+    public boolean isAttestationModeRecognized() {
+        return attestationModeRecognized;
+    }
+
+    public void setAttestationModeRecognized(boolean attestationModeRecognized) {
+        this.attestationModeRecognized = attestationModeRecognized;
+    }
+
+    /**
+     * Whether an authenticator that fails attestation validation is still accepted. True for every mode
+     * except {@code enforced} — only that mode applies the stricter MDS trust rules.
+     */
+    public boolean isUnattestedAuthenticatorsAllowed() {
+        return unattestedAuthenticatorsAllowed;
+    }
+
+    public void setUnattestedAuthenticatorsAllowed(boolean unattestedAuthenticatorsAllowed) {
+        this.unattestedAuthenticatorsAllowed = unattestedAuthenticatorsAllowed;
+    }
+
+    public boolean isEnterpriseAttestation() {
+        return enterpriseAttestation;
+    }
+
+    public void setEnterpriseAttestation(boolean enterpriseAttestation) {
+        this.enterpriseAttestation = enterpriseAttestation;
+    }
+
+    /**
+     * When true, MDS download and validation are switched off and attestation cannot be validated
+     * against FIDO metadata.
+     */
+    public boolean isMetadataServiceDisabled() {
+        return metadataServiceDisabled;
+    }
+
+    public void setMetadataServiceDisabled(boolean metadataServiceDisabled) {
+        this.metadataServiceDisabled = metadataServiceDisabled;
+    }
+
+    /**
+     * Whether the Apple WebAuthn root CA was loaded at startup. When false, Apple anonymous attestation
+     * cannot be validated.
+     */
+    public boolean isAppleRootCaPresent() {
+        return appleRootCaPresent;
+    }
+
+    public void setAppleRootCaPresent(boolean appleRootCaPresent) {
+        this.appleRootCaPresent = appleRootCaPresent;
+    }
+
+    public List<String> getEnabledFidoAlgorithms() {
+        return enabledFidoAlgorithms;
+    }
+
+    public void setEnabledFidoAlgorithms(List<String> enabledFidoAlgorithms) {
+        this.enabledFidoAlgorithms = enabledFidoAlgorithms;
+    }
+
+    public List<String> getHints() {
+        return hints;
+    }
+
+    public void setHints(List<String> hints) {
+        this.hints = hints;
+    }
+
+    @Override
+    public String toString() {
+        return "AttestationTrustConfig [attestationMode=" + attestationMode + ", attestationModeRecognized="
+                + attestationModeRecognized + ", unattestedAuthenticatorsAllowed=" + unattestedAuthenticatorsAllowed
+                + ", enterpriseAttestation=" + enterpriseAttestation + ", metadataServiceDisabled="
+                + metadataServiceDisabled + ", appleRootCaPresent=" + appleRootCaPresent + ", enabledFidoAlgorithms="
+                + enabledFidoAlgorithms + ", hints=" + hints + "]";
+    }
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/trust/TrustStatusService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/trust/TrustStatusService.java
@@ -1,0 +1,153 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.trust;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.AttestationMode;
+import io.jans.fido2.model.conf.Fido2Configuration;
+import io.jans.fido2.model.conf.MetadataServer;
+import io.jans.fido2.model.trust.AttestationTrustConfig;
+import io.jans.fido2.model.trust.MdsHealth;
+import io.jans.fido2.model.trust.MdsHealthStatus;
+import io.jans.fido2.model.trust.MetadataServerStatus;
+import io.jans.fido2.service.mds.AttestationCertificateService;
+import io.jans.fido2.service.mds.TocService;
+import io.jans.util.StringHelper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Assembles the read-only attestation and MDS status reported by the trust endpoints.
+ * <p>
+ * This service only reads state that the attestation and metadata services already hold; it never
+ * changes attestation behaviour, triggers a metadata download, or touches the document store.
+ *
+ * @author Janssen Project
+ */
+@ApplicationScoped
+public class TrustStatusService {
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private AppConfiguration appConfiguration;
+
+    @Inject
+    private TocService tocService;
+
+    @Inject
+    private AttestationCertificateService attestationCertificateService;
+
+    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    /**
+     * The attestation policy the server is actually applying.
+     */
+    public AttestationTrustConfig getAttestationTrustConfig() {
+        AttestationTrustConfig trustConfig = new AttestationTrustConfig();
+        Fido2Configuration fido2Configuration = appConfiguration.getFido2Configuration();
+        if (fido2Configuration == null) {
+            log.warn("Fido2 configuration is not available; reporting empty attestation trust config");
+            return trustConfig;
+        }
+
+        String configuredMode = fido2Configuration.getAttestationMode();
+        trustConfig.setAttestationMode(configuredMode);
+        trustConfig.setAttestationModeRecognized(AttestationMode.getByValue(configuredMode) != null);
+        // Only "enforced" applies the stricter MDS trust rules (AttestationCertificateService
+        // .isAttestationEnforced) — "disabled" and "monitor" both stay lenient, so anything other than
+        // enforced still accepts an authenticator that fails attestation validation.
+        trustConfig.setUnattestedAuthenticatorsAllowed(!isAttestationEnforced(configuredMode));
+        trustConfig.setEnterpriseAttestation(fido2Configuration.isEnterpriseAttestation());
+        trustConfig.setMetadataServiceDisabled(fido2Configuration.isDisableMetadataService());
+        trustConfig.setAppleRootCaPresent(attestationCertificateService.isAppleRootCaPresent());
+        trustConfig.setEnabledFidoAlgorithms(fido2Configuration.getEnabledFidoAlgorithms());
+        trustConfig.setHints(fido2Configuration.getHints());
+
+        return trustConfig;
+    }
+
+    /**
+     * The state of the metadata used for attestation validation.
+     */
+    public MdsHealth getMdsHealth() {
+        MdsHealth health = new MdsHealth();
+        health.setTimestamp(LocalDateTime.now(ZoneOffset.UTC).format(ISO_FORMATTER));
+
+        Fido2Configuration fido2Configuration = appConfiguration.getFido2Configuration();
+        if (fido2Configuration == null) {
+            log.warn("Fido2 configuration is not available; reporting MDS as DOWN");
+            health.setStatus(MdsHealthStatus.DOWN);
+            health.setBlobExpired(true);
+            health.setLastRefreshError("Fido2 configuration is not available");
+            return health;
+        }
+
+        boolean metadataServiceDisabled = fido2Configuration.isDisableMetadataService();
+        health.setMetadataServiceDisabled(metadataServiceDisabled);
+        health.setMetadataServers(toMetadataServerStatus(fido2Configuration.getMetadataServers()));
+
+        LocalDate nextUpdate = tocService.getLoadedTocNextUpdate();
+        if (nextUpdate != null) {
+            health.setNextUpdate(nextUpdate.toString());
+        }
+        // Matches the rule fetchMetadata() uses to decide a re-download is due: absent, today, or past.
+        health.setBlobExpired(nextUpdate == null || !nextUpdate.isAfter(LocalDate.now()));
+
+        health.setTocEntryCount(tocService.getTocEntryCount());
+        health.setLastRefreshError(tocService.getLastRefreshError());
+
+        LocalDateTime lastSuccessfulRefresh = tocService.getLastSuccessfulRefresh();
+        if (lastSuccessfulRefresh != null) {
+            health.setLastSuccessfulRefresh(lastSuccessfulRefresh.format(ISO_FORMATTER));
+        }
+
+        health.setStatus(resolveStatus(health, metadataServiceDisabled));
+
+        return health;
+    }
+
+    /**
+     * Disabled is a deliberate configuration choice, not a failure, so it must not be reported as DOWN.
+     */
+    private MdsHealthStatus resolveStatus(MdsHealth health, boolean metadataServiceDisabled) {
+        if (metadataServiceDisabled) {
+            return MdsHealthStatus.DISABLED;
+        }
+        if (health.getLastRefreshError() != null || health.getTocEntryCount() == 0 || health.isBlobExpired()) {
+            return MdsHealthStatus.DOWN;
+        }
+        return MdsHealthStatus.UP;
+    }
+
+    private boolean isAttestationEnforced(String configuredMode) {
+        return AttestationMode.ENFORCED.getValue().equalsIgnoreCase(configuredMode);
+    }
+
+    private List<MetadataServerStatus> toMetadataServerStatus(List<MetadataServer> metadataServers) {
+        List<MetadataServerStatus> statuses = new ArrayList<>();
+        if (metadataServers == null) {
+            return statuses;
+        }
+        for (MetadataServer metadataServer : metadataServers) {
+            // Report only whether a trust anchor is configured — never the certificate itself.
+            statuses.add(new MetadataServerStatus(metadataServer.getUrl(),
+                    StringHelper.isNotEmpty(metadataServer.getRootCert())));
+        }
+        return statuses;
+    }
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/Fido2TrustController.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/Fido2TrustController.java
@@ -1,0 +1,116 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.ws.rs.controller;
+
+import org.slf4j.Logger;
+
+import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.model.trust.MdsHealth;
+import io.jans.fido2.model.trust.MdsHealthStatus;
+import io.jans.fido2.service.DataMapperService;
+import io.jans.fido2.service.trust.TrustStatusService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * REST API controller exposing attestation-mode and MDS health diagnostics.
+ * <p>
+ * Read-only: these endpoints surface configuration and metadata state that already exists in the
+ * server, so an administrator can see why enrollments are failing instead of that appearing to end
+ * users as a generic registration failure. Nothing here changes attestation behaviour.
+ * <p>
+ * SECURITY NOTE: as with the metrics endpoints, authentication and authorization are expected to be
+ * enforced at the infrastructure level (API gateway, OAuth interceptor, or reverse proxy) or via the
+ * Config API fido2 plugin, which applies the fido2 configuration scopes.
+ * <p>
+ * GitHub Issue #14602
+ *
+ * @author Janssen Project
+ */
+@ApplicationScoped
+@Path("/trust")
+public class Fido2TrustController {
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private TrustStatusService trustStatusService;
+
+    @Inject
+    private DataMapperService dataMapperService;
+
+    @Inject
+    private ErrorResponseFactory errorResponseFactory;
+
+    /**
+     * Effective attestation configuration: the mode in force, whether unattested authenticators are
+     * still accepted, and whether the trust anchors attestation depends on are present.
+     *
+     * @return attestation trust configuration
+     */
+    @GET
+    @Path("/attestation/config")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAttestationConfig() {
+        return processRequest(
+                () -> Response.ok(dataMapperService.writeValueAsString(trustStatusService.getAttestationTrustConfig()))
+                        .build());
+    }
+
+    /**
+     * MDS health: blob validity, loaded entry count, and the outcome of the last refresh. Returns 503
+     * when the metadata is expired, empty, or failed to load, so it can be wired to a monitor directly.
+     * A metadata service that is disabled by configuration is reported as DISABLED with HTTP 200 — that
+     * is a deliberate choice, not a failure.
+     *
+     * @return MDS health status
+     */
+    @GET
+    @Path("/mds/health")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getMdsHealth() {
+        return processRequest(() -> {
+            MdsHealth health = trustStatusService.getMdsHealth();
+            String entity = dataMapperService.writeValueAsString(health);
+
+            Response.ResponseBuilder responseBuilder = MdsHealthStatus.DOWN == health.getStatus()
+                    ? Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(entity)
+                    : Response.ok(entity);
+
+            return responseBuilder.build();
+        });
+    }
+
+    private Response processRequest(RequestProcessor processor) {
+        try {
+            return processor.process();
+        } catch (WebApplicationException e) {
+            // Already carries the right status code.
+            throw e;
+        } catch (Exception e) {
+            // Log the detail, return a generic message — the response must not leak internal paths or
+            // connection details.
+            log.error("Error processing trust status request: {}", e.getMessage(), e);
+            throw errorResponseFactory.unknownError("Failed to read trust status");
+        }
+    }
+
+    /**
+     * Functional interface for request processing; throws Exception to accommodate the checked
+     * exceptions raised while serializing the response.
+     */
+    private interface RequestProcessor {
+        Response process() throws Exception;
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/trust/TrustStatusServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/trust/TrustStatusServiceTest.java
@@ -1,0 +1,196 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.trust;
+
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
+import io.jans.fido2.model.conf.MetadataServer;
+import io.jans.fido2.model.trust.AttestationTrustConfig;
+import io.jans.fido2.model.trust.MdsHealth;
+import io.jans.fido2.model.trust.MdsHealthStatus;
+import io.jans.fido2.service.mds.AttestationCertificateService;
+import io.jans.fido2.service.mds.TocService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TrustStatusServiceTest {
+
+    @InjectMocks
+    private TrustStatusService trustStatusService;
+
+    @Mock
+    private Logger log;
+    @Mock
+    private AppConfiguration appConfiguration;
+    @Mock
+    private TocService tocService;
+    @Mock
+    private AttestationCertificateService attestationCertificateService;
+
+    private Fido2Configuration configure(String attestationMode, boolean metadataServiceDisabled) {
+        Fido2Configuration cfg = mock(Fido2Configuration.class);
+        when(cfg.getAttestationMode()).thenReturn(attestationMode);
+        when(cfg.isDisableMetadataService()).thenReturn(metadataServiceDisabled);
+        when(appConfiguration.getFido2Configuration()).thenReturn(cfg);
+        return cfg;
+    }
+
+    private void configureLoadedMetadata(LocalDate nextUpdate, int entryCount, String refreshError) {
+        when(tocService.getLoadedTocNextUpdate()).thenReturn(nextUpdate);
+        when(tocService.getTocEntryCount()).thenReturn(entryCount);
+        when(tocService.getLastRefreshError()).thenReturn(refreshError);
+        when(tocService.getLastSuccessfulRefresh()).thenReturn(LocalDateTime.of(2026, 7, 27, 4, 15, 22));
+    }
+
+    // ---------- attestation trust config ----------
+
+    @Test
+    void getAttestationTrustConfig_ifEnforced_disallowsUnattested() {
+        configure("enforced", false);
+        when(attestationCertificateService.isAppleRootCaPresent()).thenReturn(true);
+
+        AttestationTrustConfig config = trustStatusService.getAttestationTrustConfig();
+
+        assertEquals("enforced", config.getAttestationMode());
+        assertTrue(config.isAttestationModeRecognized());
+        assertFalse(config.isUnattestedAuthenticatorsAllowed());
+        assertTrue(config.isAppleRootCaPresent());
+    }
+
+    @Test
+    void getAttestationTrustConfig_ifMonitor_stillAllowsUnattested() {
+        configure("monitor", false);
+
+        AttestationTrustConfig config = trustStatusService.getAttestationTrustConfig();
+
+        // Only "enforced" applies the stricter trust rules — monitor is lenient, which is exactly the
+        // thing administrators get wrong about the default.
+        assertTrue(config.isAttestationModeRecognized());
+        assertTrue(config.isUnattestedAuthenticatorsAllowed());
+    }
+
+    @Test
+    void getAttestationTrustConfig_ifModeUnrecognized_reportsRawValueAndLenientBehaviour() {
+        configure("Enforce", false);
+
+        AttestationTrustConfig config = trustStatusService.getAttestationTrustConfig();
+
+        // A typo silently makes the server lenient; report it rather than normalising it away.
+        assertEquals("Enforce", config.getAttestationMode());
+        assertFalse(config.isAttestationModeRecognized());
+        assertTrue(config.isUnattestedAuthenticatorsAllowed());
+    }
+
+    @Test
+    void getAttestationTrustConfig_ifNoFido2Configuration_returnsEmptyConfig() {
+        when(appConfiguration.getFido2Configuration()).thenReturn(null);
+
+        AttestationTrustConfig config = trustStatusService.getAttestationTrustConfig();
+
+        assertNotNull(config);
+        assertNull(config.getAttestationMode());
+    }
+
+    // ---------- MDS health ----------
+
+    @Test
+    void getMdsHealth_ifMetadataServiceDisabled_reportsDisabledNotDown() {
+        configure("monitor", true);
+
+        MdsHealth health = trustStatusService.getMdsHealth();
+
+        assertEquals(MdsHealthStatus.DISABLED, health.getStatus());
+        assertTrue(health.isMetadataServiceDisabled());
+        assertNotNull(health.getTimestamp());
+    }
+
+    @Test
+    void getMdsHealth_ifBlobLoadedAndValid_reportsUp() {
+        configure("monitor", false);
+        configureLoadedMetadata(LocalDate.now().plusDays(30), 1284, null);
+
+        MdsHealth health = trustStatusService.getMdsHealth();
+
+        assertEquals(MdsHealthStatus.UP, health.getStatus());
+        assertEquals(1284, health.getTocEntryCount());
+        assertFalse(health.isBlobExpired());
+        assertNotNull(health.getLastSuccessfulRefresh());
+        assertNull(health.getLastRefreshError());
+    }
+
+    @Test
+    void getMdsHealth_ifLastRefreshFailed_reportsDown() {
+        configure("monitor", false);
+        configureLoadedMetadata(LocalDate.now().plusDays(30), 1284, "Can't parse MDS TOC document: boom");
+
+        MdsHealth health = trustStatusService.getMdsHealth();
+
+        assertEquals(MdsHealthStatus.DOWN, health.getStatus());
+        assertNotNull(health.getLastRefreshError());
+    }
+
+    @Test
+    void getMdsHealth_ifBlobExpired_reportsDown() {
+        configure("monitor", false);
+        configureLoadedMetadata(LocalDate.now().minusDays(1), 1284, null);
+
+        MdsHealth health = trustStatusService.getMdsHealth();
+
+        assertEquals(MdsHealthStatus.DOWN, health.getStatus());
+        assertTrue(health.isBlobExpired());
+    }
+
+    @Test
+    void getMdsHealth_ifNoBlobLoaded_reportsDownAndExpired() {
+        configure("monitor", false);
+        configureLoadedMetadata(null, 0, null);
+
+        MdsHealth health = trustStatusService.getMdsHealth();
+
+        assertEquals(MdsHealthStatus.DOWN, health.getStatus());
+        assertTrue(health.isBlobExpired());
+        assertNull(health.getNextUpdate());
+    }
+
+    @Test
+    void getMdsHealth_metadataServers_reportRootCertPresenceOnly() {
+        Fido2Configuration cfg = configure("monitor", false);
+        MetadataServer server = new MetadataServer();
+        server.setUrl("https://mds.fidoalliance.org/");
+        server.setRootCert("BASE64-DER-CERT");
+        when(cfg.getMetadataServers()).thenReturn(Collections.singletonList(server));
+        configureLoadedMetadata(LocalDate.now().plusDays(30), 10, null);
+
+        MdsHealth health = trustStatusService.getMdsHealth();
+
+        assertEquals(1, health.getMetadataServers().size());
+        assertEquals("https://mds.fidoalliance.org/", health.getMetadataServers().get(0).getUrl());
+        // The certificate itself must never leave the server.
+        assertTrue(health.getMetadataServers().get(0).isRootCertConfigured());
+        assertFalse(health.toString().contains("BASE64-DER-CERT"));
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/ws/rs/controller/Fido2TrustControllerTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/ws/rs/controller/Fido2TrustControllerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.ws.rs.controller;
+
+import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.model.trust.AttestationTrustConfig;
+import io.jans.fido2.model.trust.MdsHealth;
+import io.jans.fido2.model.trust.MdsHealthStatus;
+import io.jans.fido2.service.DataMapperService;
+import io.jans.fido2.service.trust.TrustStatusService;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class Fido2TrustControllerTest {
+
+    @InjectMocks
+    private Fido2TrustController fido2TrustController;
+
+    @Mock
+    private Logger log;
+    @Mock
+    private TrustStatusService trustStatusService;
+    @Mock
+    private DataMapperService dataMapperService;
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    private MdsHealth healthWithStatus(MdsHealthStatus status) {
+        MdsHealth health = new MdsHealth();
+        health.setStatus(status);
+        return health;
+    }
+
+    @Test
+    void getAttestationConfig_returnsOk() throws Exception {
+        when(trustStatusService.getAttestationTrustConfig()).thenReturn(new AttestationTrustConfig());
+        when(dataMapperService.writeValueAsString(any())).thenReturn("{}");
+
+        Response response = fido2TrustController.getAttestationConfig();
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void getMdsHealth_ifUp_returnsOk() throws Exception {
+        when(trustStatusService.getMdsHealth()).thenReturn(healthWithStatus(MdsHealthStatus.UP));
+        when(dataMapperService.writeValueAsString(any())).thenReturn("{}");
+
+        Response response = fido2TrustController.getMdsHealth();
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void getMdsHealth_ifDisabled_returnsOk() throws Exception {
+        when(trustStatusService.getMdsHealth()).thenReturn(healthWithStatus(MdsHealthStatus.DISABLED));
+        when(dataMapperService.writeValueAsString(any())).thenReturn("{}");
+
+        Response response = fido2TrustController.getMdsHealth();
+
+        // Disabled is a configuration choice, not an outage — it must not page anyone.
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void getMdsHealth_ifDown_returnsServiceUnavailable() throws Exception {
+        when(trustStatusService.getMdsHealth()).thenReturn(healthWithStatus(MdsHealthStatus.DOWN));
+        when(dataMapperService.writeValueAsString(any())).thenReturn("{}");
+
+        Response response = fido2TrustController.getMdsHealth();
+
+        assertEquals(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void getMdsHealth_ifServiceFails_raisesSanitizedError() {
+        when(trustStatusService.getMdsHealth()).thenThrow(new IllegalStateException("jdbc://secret-host/db"));
+        when(errorResponseFactory.unknownError(anyString()))
+                .thenReturn(new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR));
+
+        assertThrows(WebApplicationException.class, () -> fido2TrustController.getMdsHealth());
+
+        // The internal detail goes to the log, never into the response.
+        org.mockito.Mockito.verify(errorResponseFactory).unknownError("Failed to read trust status");
+    }
+}


### PR DESCRIPTION

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
MDS health is invisible. TocService.refreshTOCEntries() downloads and refreshes metadata unless disableMetadataService is set, but there is no surfaced last-refresh time, blob validity, loaded entry count, or load error. Failures are caught and written to the log, then discarded — nothing retains them. A stale or failed MDS load is a common cause of "a previously valid authenticator is suddenly rejected", and today the only way to diagnose it is to grep server logs.

closes #https://github.com/JanssenProject/jans/issues/14639

Part of [#14602](https://github.com/JanssenProject/jans/issues/14602), deliverable (a). MDS health (#<B>) and rejection
diagnostics (#<C>) follow in separate PRs.

#### Implementation Details

`GET /jans-fido2/restv1/trust/attestation/config`, mirrored in the Config API
fido2 plugin. Read-only — it surfaces configuration the server already holds and changes no attestation behaviour.

Two decisions worth review attention:

**`unattestedAuthenticatorsAllowed` is `mode != enforced`, not `mode == disabled`.** `AttestationCertificateService.isAttestationEnforced()` applies the stricter MDS trust rules only for `enforced`; `disabled` and
`monitor` are both lenient. Since `monitor` is the default, an authenticator that fails attestation validation is still registered — surfacing that is the point of the endpoint. There is a test pinning it.

**The mode is reported verbatim with an `attestationModeRecognized` flag.** `Fido2Configuration.attestationMode` is a raw `String`; a typo such as `Enforce` silently leaves the server lenient, so the response reveals it rather than normalising it away.

`AttestationCertificateService` gains an `isAppleRootCaPresent()` accessor — the field is already populated at startup, and a missing Apple root CA is currently only a log warning. Note that #14602 groups this signal under MDS health; it is exposed here instead, since it is a property of the attestation trust anchors rather than of the metadata blob.

Date fields are pre-formatted strings: the FIDO2 `DataMapperService` uses a plain `ObjectMapper` with no JSR-310 module registered.

**Two changes that are not part of the feature:**

1. `jansFido2Swagger.yaml` had trailing tab characters on two pre-existing  lines that made the spec fail to parse in any strict  
   YAML loader. Fixedhere because it is the same file as the feature additions; whitespace only.
3. `plugins/fido2-plugin/pom.xml` declares `jans-config-api-common` explicitly (separate commit) — the plugin imports 
    `ApiAccessConstants` and  `ApiConstants` directly.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**
