### PR TITLE
feat(cloud-native): add allowedDomain config for jans-config-api

### DIFF
--- a/docker-jans-all-in-one/Dockerfile
+++ b/docker-jans-all-in-one/Dockerfile
@@ -59,7 +59,7 @@ RUN apk update \
 # Assets sync
 # ===========
 
-ARG JANS_SOURCE_VERSION=1ff62d742f45c46a780e0653eb4b5ba09f3439fa
+ARG JANS_SOURCE_VERSION=a85b887912dd857cea4f0e7f7febc06182da6035
 ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -80,7 +80,7 @@ RUN mkdir -p /etc/jans/conf \
     /usr/share/java \
     /opt/jans/bin
 
-ARG JANS_SOURCE_VERSION=1ff62d742f45c46a780e0653eb4b5ba09f3439fa
+ARG JANS_SOURCE_VERSION=a85b887912dd857cea4f0e7f7febc06182da6035
 ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 ARG JANS_CONFIG_API_RESOURCES=jans-config-api/server/src/main/resources

--- a/docker-jans-config-api/scripts/upgrade.py
+++ b/docker-jans-config-api/scripts/upgrade.py
@@ -174,10 +174,6 @@ def _transform_api_dynamic_config(conf):
         conf["auditLogConf"]["auditLogDateFormat"] = audit_log_date_fmt
         should_update = True
 
-    if "authOpenidRevokeUrl" in conf:
-        conf.pop("authOpenidRevokeUrl", None)
-        should_update = True
-
     if "allowedDomain" not in conf["agamaConfiguration"]:
         conf["agamaConfiguration"]["allowedDomain"] = ["github.com"]
         should_update = True

--- a/docker-jans-config-api/scripts/upgrade.py
+++ b/docker-jans-config-api/scripts/upgrade.py
@@ -174,6 +174,14 @@ def _transform_api_dynamic_config(conf):
         conf["auditLogConf"]["auditLogDateFormat"] = audit_log_date_fmt
         should_update = True
 
+    if "authOpenidRevokeUrl" in conf:
+        conf.pop("authOpenidRevokeUrl", None)
+        should_update = True
+
+    if "allowedDomain" not in conf["agamaConfiguration"]:
+        conf["agamaConfiguration"]["allowedDomain"] = ["github.com"]
+        should_update = True
+
     # finalized conf and flag to determine update process
     return conf, should_update
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14654 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration upgrades by adding a default `allowedDomain` for Agama configuration when it’s missing.
  * Ensured upgraded configuration changes are persisted automatically.
* **Chores**
  * Updated the bundled Jans monorepo revision used during Docker image builds (for the all-in-one and config API images).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->