### PR TITLE
fix(jans-fido2): fall back to cached MDS TOC when download fails

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/exception/mds/MdsRateLimitedException.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/exception/mds/MdsRateLimitedException.java
@@ -1,0 +1,37 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.exception.mds;
+
+import io.jans.fido2.exception.Fido2RuntimeException;
+
+/**
+ * Raised when the FIDO Metadata Service answers a TOC download with HTTP 429 (Too Many Requests).
+ * <p>
+ * This is deliberately distinct from a generic download failure: a 429 is the endpoint explicitly
+ * asking us to stop, so retrying it immediately makes the situation worse rather than better. Callers
+ * that retry failed downloads should treat this exception as "do not retry now" and honour
+ * {@link #getRetryAfterSeconds()} when it is present.
+ */
+public class MdsRateLimitedException extends Fido2RuntimeException {
+
+	private static final long serialVersionUID = 8258821405431245933L;
+
+	private final transient Integer retryAfterSeconds;
+
+	public MdsRateLimitedException(String errorMessage, Integer retryAfterSeconds) {
+		super(errorMessage);
+		this.retryAfterSeconds = retryAfterSeconds;
+	}
+
+	/**
+	 * @return the delay advertised by the server's {@code Retry-After} header, or {@code null} when the
+	 *         header was absent or unparseable.
+	 */
+	public Integer getRetryAfterSeconds() {
+		return retryAfterSeconds;
+	}
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/TocService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/TocService.java
@@ -115,7 +115,10 @@ public class TocService {
 
 	private static final int MDS_READ_TIMEOUT_MS = 60_000;
 
-	private Map<String, JsonNode> tocEntries;
+	// Written by the startup observer and the MDS3 update timer, read by request-handling threads.
+	// volatile gives the fully-built map safe publication; each refresh swaps in a new map rather than
+	// mutating the live one, so readers never observe a partially populated TOC.
+	private volatile Map<String, JsonNode> tocEntries;
 
 	private LocalDate nextUpdate;
 	private MessageDigest digester;
@@ -129,12 +132,17 @@ public class TocService {
 	}
 
 	private void refreshTOCEntries(boolean rejectExpired) {
-		this.tocEntries = Collections.synchronizedMap(new HashMap<String, JsonNode>());
+		// Build the replacement map locally. Parsing a TOC involves certificate loading and JWS
+		// verification, so assigning an empty map up front would leave concurrent readers seeing no
+		// metadata for the whole parse — long enough for enforced attestation to reject valid
+		// authenticators. Publish it in a single assignment once it is fully populated instead.
+		Map<String, JsonNode> entries = Collections.synchronizedMap(new HashMap<String, JsonNode>());
 		if (appConfiguration.getFido2Configuration().isDisableMetadataService()) {
 			log.debug("SkipDownloadMds is enabled");
 		} else {
-			tocEntries.putAll(parseTOCs(rejectExpired));
+			entries.putAll(parseTOCs(rejectExpired));
 		}
+		this.tocEntries = entries;
 	}
 
 	public void fetchMetadata() {
@@ -232,17 +240,31 @@ public class TocService {
 			Pair<LocalDate, Map<String, JsonNode>> result = parseTOC(mdsTocRootCertsFolder, mdsDocument.getDocument());
 			log.info("Get TOC {} entries with nextUpdate date {}", result.getSecond().size(), result.getFirst());
 
-			if (rejectExpired && result.getFirst() != null && result.getFirst().isBefore(LocalDate.now())) {
-				log.warn("The cached MDS TOC expired on {}, refusing to use it", result.getFirst());
-				return new HashMap<>();
-			}
-
-			maps.add(result.getSecond());
+			maps.add(acceptParsedToc(result, rejectExpired));
 		} catch (Exception e) {
 			log.warn("Can't access document : {}", e.getMessage(), e);
 		}
 
 		return mergeAndResolveDuplicateEntries(maps);
+	}
+
+	/**
+	 * Decides whether a parsed TOC may be published.
+	 * <p>
+	 * When {@code rejectExpired} is set — i.e. we are falling back to the blob cached in the DB rather
+	 * than using one we just downloaded — a TOC whose own {@code nextUpdate} has passed is discarded.
+	 * Leaving the entry map empty keeps enforced attestation failing closed rather than validating
+	 * against metadata the FIDO Alliance considers out of date. Package-private for unit testing.
+	 *
+	 * @return the parsed entries, or an empty map when the TOC is rejected
+	 */
+	Map<String, JsonNode> acceptParsedToc(Pair<LocalDate, Map<String, JsonNode>> parsedToc, boolean rejectExpired) {
+		LocalDate tocNextUpdate = parsedToc.getFirst();
+		if (rejectExpired && tocNextUpdate != null && tocNextUpdate.isBefore(LocalDate.now())) {
+			log.warn("The cached MDS TOC expired on {}, refusing to use it", tocNextUpdate);
+			return new HashMap<>();
+		}
+		return parsedToc.getSecond();
 	}
 
 	private Pair<LocalDate, Map<String, JsonNode>> parseTOC(String mdsTocRootCertsFolder, String content)

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/TocService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/mds/TocService.java
@@ -10,15 +10,20 @@ import static java.time.format.DateTimeFormatter.ISO_DATE;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.security.MessageDigest;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,6 +50,7 @@ import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.OctetKeyPair;
 
 import io.jans.fido2.exception.Fido2RuntimeException;
+import io.jans.fido2.exception.mds.MdsRateLimitedException;
 import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.conf.Fido2Configuration;
 import io.jans.fido2.model.conf.MetadataServer;
@@ -93,6 +99,22 @@ public class TocService {
 
 	private static final String ADDED_TOC_ENTRY_LOG = "Added TOC entry: {} ";
 
+	/**
+	 * The FIDO Alliance metadata endpoint is fronted by a CDN that throttles the JDK's default
+	 * {@code Java/<version>} User-Agent, which surfaces as an opaque HTTP 429. Identify the server
+	 * properly instead of relying on that default.
+	 */
+	private static final String MDS_USER_AGENT = "Janssen-FIDO2";
+
+	private static final String RETRY_AFTER_HEADER = "Retry-After";
+
+	/** {@link HttpURLConnection} has no constant for 429 (Too Many Requests). */
+	private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
+	private static final int MDS_CONNECT_TIMEOUT_MS = 10_000;
+
+	private static final int MDS_READ_TIMEOUT_MS = 60_000;
+
 	private Map<String, JsonNode> tocEntries;
 
 	private LocalDate nextUpdate;
@@ -103,45 +125,98 @@ public class TocService {
 	}
 
 	public void refreshTOCEntries() {
+		refreshTOCEntries(false);
+	}
+
+	private void refreshTOCEntries(boolean rejectExpired) {
 		this.tocEntries = Collections.synchronizedMap(new HashMap<String, JsonNode>());
 		if (appConfiguration.getFido2Configuration().isDisableMetadataService()) {
 			log.debug("SkipDownloadMds is enabled");
 		} else {
-			tocEntries.putAll(parseTOCs());
+			tocEntries.putAll(parseTOCs(rejectExpired));
 		}
 	}
 
 	public void fetchMetadata() {
+		if (appConfiguration.getFido2Configuration().isDisableMetadataService()) {
+			log.debug("SkipDownloadMds is enabled");
+			return;
+		}
 
+		boolean publishedFreshToc = false;
+
+		LocalDate nextUpdateOn;
 		try {
-			if (appConfiguration.getFido2Configuration().isDisableMetadataService()) {
-				log.debug("SkipDownloadMds is enabled");
-			} else {
+			nextUpdateOn = getNextUpdateDate();
+		} catch (RuntimeException e) {
+			// A missing or unreadable TOC document must not abort startup; treat it as due for download.
+			log.warn("Unable to read the cached MDS TOC update date, treating the TOC as due: {}", e.getMessage());
+			nextUpdateOn = null;
+		}
 
-				LocalDate nextUpdateOn = getNextUpdateDate();
+		if (nextUpdateOn == null || !nextUpdateOn.isAfter(LocalDate.now())) {
+			publishedFreshToc = downloadAndPublishToc();
+		} else {
+			log.info("The cached MDS TOC is current until {}, skipping the download", nextUpdateOn);
+		}
 
-				if (nextUpdateOn == null || nextUpdateOn.equals(LocalDate.now()) || nextUpdateOn.isBefore(LocalDate.now())) {
-					log.info("Downloading the latest TOC from https://mds.fidoalliance.org/");
-					MetadataServer metaDataServer = appConfiguration.getFido2Configuration()
-							.getMetadataServers().get(0);
-
-					// as of now, we have only one metadata server, hence get(0), I cant envisage
-					// why there will be multiple metadata servers
-					boolean success = downloadMdsFromServer(new URL(metaDataServer.getUrl()));
-					if (success) {
-						refreshTOCEntries();
-						saveNextUpdateDateOfTheMDS();
-					}
-
-				}
-			}
-
-		} catch (MalformedURLException e) {
-			log.error("Error while parsing the FIDO alliance URL :", e);
+		if (!publishedFreshToc) {
+			publishCachedToc();
 		}
 	}
 
-	private Map<String, JsonNode> parseTOCs() {
+	/**
+	 * Downloads the TOC and publishes its entries.
+	 *
+	 * @return {@code true} when a freshly downloaded TOC was published, {@code false} when the download
+	 *         failed. A failure is logged rather than propagated: it must not abort the
+	 *         {@link ApplicationInitialized} observer, and the caller falls back to the cached TOC.
+	 */
+	private boolean downloadAndPublishToc() {
+		try {
+			MetadataServer metaDataServer = appConfiguration.getFido2Configuration().getMetadataServers().get(0);
+
+			// as of now, we have only one metadata server, hence get(0), I cant envisage
+			// why there will be multiple metadata servers
+			log.info("Downloading the latest TOC from {}", metaDataServer.getUrl());
+			boolean success = downloadMdsFromServer(new URL(metaDataServer.getUrl()));
+			if (success) {
+				refreshTOCEntries();
+				saveNextUpdateDateOfTheMDS();
+				return true;
+			}
+		} catch (MalformedURLException e) {
+			log.error("Error while parsing the FIDO alliance URL :", e);
+		} catch (MdsRateLimitedException e) {
+			log.warn("MDS TOC download was rate-limited{}, falling back to the cached TOC",
+					e.getRetryAfterSeconds() == null ? "" : " (retry after " + e.getRetryAfterSeconds() + "s)");
+		} catch (RuntimeException e) {
+			log.error("MDS TOC download failed, falling back to the cached TOC: {}", e.getMessage(), e);
+		}
+		return false;
+	}
+
+	/**
+	 * Publishes the TOC blob already stored in {@code jansDocument}, so that a failed or skipped
+	 * download doesn't leave the server with no authenticator metadata at all.
+	 * <p>
+	 * The cached blob is used only while it is still inside its own {@code nextUpdate} validity window.
+	 * An expired blob is rejected and the entry map is left empty, so enforced attestation keeps
+	 * failing closed rather than validating against metadata the FIDO Alliance considers out of date.
+	 */
+	private void publishCachedToc() {
+		refreshTOCEntries(true);
+
+		Map<String, JsonNode> entries = this.tocEntries;
+		if (entries == null || entries.isEmpty()) {
+			log.warn("No usable MDS TOC is available; authenticator metadata can't be validated "
+					+ "until the next successful download");
+		} else {
+			log.info("Published {} MDS TOC entries from the cached blob", entries.size());
+		}
+	}
+
+	private Map<String, JsonNode> parseTOCs(boolean rejectExpired) {
 		Fido2Configuration fido2Configuration = appConfiguration.getFido2Configuration();
 		List<Map<String, JsonNode>> maps = new ArrayList<>();
 		
@@ -156,6 +231,11 @@ public class TocService {
 			Document mdsDocument = dbDocumentService.getDocumentByDisplayName("mdsTocsFolder");
 			Pair<LocalDate, Map<String, JsonNode>> result = parseTOC(mdsTocRootCertsFolder, mdsDocument.getDocument());
 			log.info("Get TOC {} entries with nextUpdate date {}", result.getSecond().size(), result.getFirst());
+
+			if (rejectExpired && result.getFirst() != null && result.getFirst().isBefore(LocalDate.now())) {
+				log.warn("The cached MDS TOC expired on {}, refusing to use it", result.getFirst());
+				return new HashMap<>();
+			}
 
 			maps.add(result.getSecond());
 		} catch (Exception e) {
@@ -314,29 +394,105 @@ public class TocService {
 	}
 
 	public boolean downloadMdsFromServer(URL metadataUrl) {
+		byte[] sourceBytes = readTocBytes(metadataUrl);
+		return persistTocDocument(base64Service.encodeToString(sourceBytes));
+	}
 
-		try (InputStream in = metadataUrl.openStream()) {
-			byte[] sourceBytes = IOUtils.toByteArray(in);
-
-			String encodedString = base64Service.encodeToString(sourceBytes);
-
-			try {
-				Fido2Configuration fido2Configuration = appConfiguration.getFido2Configuration();
-				String mdsTocFilesFolder = fido2Configuration.getMdsTocsFolder();
-
-				Document document = dbDocumentService.getDocumentsByFilePath(mdsTocFilesFolder).get(0);
-				document.setDocument(encodedString);
-				document.setFilePath(mdsTocFilesFolder);
-				dbDocumentService.updateDocument(document);
-				return true;
-			} catch (Exception e) {
-				log.error("Failed to add new document of mdsTocFilesFolder", e);
-				throw new DocumentException(e);
+	/**
+	 * Reads the raw TOC blob from the configured metadata endpoint.
+	 * <p>
+	 * Non-HTTP sources (e.g. a {@code file:} mirror) are read as a plain stream, since they expose no
+	 * status code or headers to inspect.
+	 */
+	private byte[] readTocBytes(URL metadataUrl) {
+		try {
+			URLConnection urlConnection = metadataUrl.openConnection();
+			if (urlConnection instanceof HttpURLConnection) {
+				return readTocBytesOverHttp(metadataUrl, (HttpURLConnection) urlConnection);
 			}
-
+			try (InputStream in = urlConnection.getInputStream()) {
+				return IOUtils.toByteArray(in);
+			}
 		} catch (IOException e) {
 			log.warn("Can't access document {}", metadataUrl, e);
-			throw new Fido2RuntimeException("Can't access or open path: {}" + metadataUrl + e.getMessage(), e);
+			throw new Fido2RuntimeException("Can't access or open path: " + metadataUrl + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Downloads the TOC over HTTP with an identifying User-Agent and bounded timeouts, and translates
+	 * the response status into a typed failure.
+	 * <p>
+	 * HTTP 429 is reported as {@link MdsRateLimitedException} rather than a generic failure, because
+	 * the endpoint is explicitly asking us to back off — callers that retry must not treat it as a
+	 * transient glitch and immediately try again.
+	 */
+	private byte[] readTocBytesOverHttp(URL metadataUrl, HttpURLConnection connection) throws IOException {
+		connection.setRequestProperty("User-Agent", MDS_USER_AGENT);
+		connection.setConnectTimeout(MDS_CONNECT_TIMEOUT_MS);
+		connection.setReadTimeout(MDS_READ_TIMEOUT_MS);
+		try {
+			int responseCode = connection.getResponseCode();
+			if (responseCode == HTTP_TOO_MANY_REQUESTS) {
+				Integer retryAfterSeconds = parseRetryAfterSeconds(connection.getHeaderField(RETRY_AFTER_HEADER));
+				log.warn("MDS TOC download from {} was rate-limited (HTTP 429){}", metadataUrl,
+						retryAfterSeconds == null ? "" : ", Retry-After: " + retryAfterSeconds + "s");
+				throw new MdsRateLimitedException(
+						"MDS TOC download from " + metadataUrl + " was rate-limited (HTTP 429)", retryAfterSeconds);
+			}
+			if (responseCode != HttpURLConnection.HTTP_OK) {
+				log.warn("Unexpected HTTP {} while downloading the MDS TOC from {}", responseCode, metadataUrl);
+				throw new Fido2RuntimeException(
+						"MDS TOC download from " + metadataUrl + " failed with HTTP " + responseCode);
+			}
+
+			try (InputStream in = connection.getInputStream()) {
+				return IOUtils.toByteArray(in);
+			}
+		} finally {
+			connection.disconnect();
+		}
+	}
+
+	/**
+	 * Parses a {@code Retry-After} header, which RFC 9110 allows to be either delta-seconds or an
+	 * HTTP-date. Package-private for unit testing.
+	 *
+	 * @return the delay in seconds, or {@code null} when the header is absent or unparseable
+	 */
+	Integer parseRetryAfterSeconds(String retryAfterHeader) {
+		if (StringHelper.isEmpty(retryAfterHeader)) {
+			return null;
+		}
+		String value = retryAfterHeader.trim();
+		try {
+			return Math.max(0, Integer.parseInt(value));
+		} catch (NumberFormatException e) {
+			// Not delta-seconds; fall through and try the HTTP-date form.
+		}
+		try {
+			ZonedDateTime retryAt = ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME);
+			long seconds = Duration.between(ZonedDateTime.now(retryAt.getZone()), retryAt).getSeconds();
+			return (int) Math.max(0, Math.min(seconds, Integer.MAX_VALUE));
+		} catch (DateTimeParseException e) {
+			log.debug("Unparseable {} header value: {}", RETRY_AFTER_HEADER, value);
+			return null;
+		}
+	}
+
+	private boolean persistTocDocument(String encodedString) {
+		try {
+			Fido2Configuration fido2Configuration = appConfiguration.getFido2Configuration();
+			String mdsTocFilesFolder = fido2Configuration.getMdsTocsFolder();
+
+			Document document = dbDocumentService.getDocumentsByFilePath(mdsTocFilesFolder).get(0);
+			document.setDocument(encodedString);
+			document.setFilePath(mdsTocFilesFolder);
+			dbDocumentService.updateDocument(document);
+			return true;
+		} catch (Exception e) {
+			log.error("Failed to add new document of mdsTocFilesFolder", e);
+			throw new DocumentException(e);
 		}
 	}
 

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/mds/TocServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/mds/TocServiceTest.java
@@ -1,5 +1,7 @@
 package io.jans.fido2.service.mds;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.sun.net.httpserver.HttpServer;
 import io.jans.fido2.exception.Fido2RuntimeException;
 import io.jans.fido2.exception.mds.MdsRateLimitedException;
@@ -10,6 +12,7 @@ import io.jans.fido2.service.Base64Service;
 import io.jans.fido2.service.CertificateService;
 import io.jans.service.document.store.model.Document;
 import io.jans.service.document.store.service.DBDocumentService;
+import io.jans.util.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,7 +36,9 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -287,6 +292,64 @@ class TocServiceTest {
         } finally {
             server.stop(0);
         }
+    }
+
+    // --- Expiry gate on the cached TOC ---------------------------------------------------------
+
+    private Pair<LocalDate, Map<String, JsonNode>> parsedToc(LocalDate nextUpdate) {
+        Map<String, JsonNode> entries = new HashMap<>();
+        entries.put("aaguid-1", JsonNodeFactory.instance.objectNode());
+        return new Pair<>(nextUpdate, entries);
+    }
+
+    /**
+     * The fail-closed guarantee: when falling back to the cached blob, a TOC past its own nextUpdate
+     * is discarded so enforced attestation keeps rejecting rather than validating against stale
+     * metadata.
+     */
+    @Test
+    void acceptParsedToc_ifExpiredAndRejectExpired_returnsEmpty() {
+        Map<String, JsonNode> accepted =
+                tocService.acceptParsedToc(parsedToc(LocalDate.now().minusDays(1)), true);
+
+        assertTrue(accepted.isEmpty(), "an expired cached TOC must not be published");
+    }
+
+    @Test
+    void acceptParsedToc_ifUnexpiredAndRejectExpired_returnsEntries() {
+        Map<String, JsonNode> accepted =
+                tocService.acceptParsedToc(parsedToc(LocalDate.now().plusDays(1)), true);
+
+        assertEquals(1, accepted.size());
+        assertTrue(accepted.containsKey("aaguid-1"));
+    }
+
+    /**
+     * A TOC expiring today is still inside its validity window.
+     */
+    @Test
+    void acceptParsedToc_ifExpiringToday_returnsEntries() {
+        Map<String, JsonNode> accepted = tocService.acceptParsedToc(parsedToc(LocalDate.now()), true);
+
+        assertEquals(1, accepted.size());
+    }
+
+    /**
+     * A freshly downloaded TOC is used as-is — the expiry gate only guards the cached-fallback path.
+     */
+    @Test
+    void acceptParsedToc_ifExpiredButNotRejectingExpired_returnsEntries() {
+        Map<String, JsonNode> accepted =
+                tocService.acceptParsedToc(parsedToc(LocalDate.now().minusDays(1)), false);
+
+        assertEquals(1, accepted.size());
+    }
+
+    @Test
+    void acceptParsedToc_ifNextUpdateUnknown_returnsEntries() {
+        Map<String, JsonNode> accepted = tocService.acceptParsedToc(parsedToc(null), true);
+
+        assertEquals(1, accepted.size());
     }
 
     // --- Cached TOC fallback -------------------------------------------------------------------

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/mds/TocServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/mds/TocServiceTest.java
@@ -1,9 +1,15 @@
 package io.jans.fido2.service.mds;
 
+import com.sun.net.httpserver.HttpServer;
+import io.jans.fido2.exception.Fido2RuntimeException;
+import io.jans.fido2.exception.mds.MdsRateLimitedException;
 import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.conf.Fido2Configuration;
 import io.jans.fido2.model.conf.MetadataServer;
+import io.jans.fido2.service.Base64Service;
 import io.jans.fido2.service.CertificateService;
+import io.jans.service.document.store.model.Document;
+import io.jans.service.document.store.service.DBDocumentService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,13 +19,31 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.slf4j.Logger;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -37,6 +61,10 @@ class TocServiceTest {
     private AppConfiguration appConfiguration;
     @Mock
     private CertificateService certificateService;
+    @Mock
+    private Base64Service base64Service;
+    @Mock
+    private DBDocumentService dbDocumentService;
 
     private void configureMetadataServers(List<MetadataServer> servers) {
         Fido2Configuration cfg = mock(Fido2Configuration.class);
@@ -116,5 +144,254 @@ class TocServiceTest {
         tocService.addConfiguredMetadataServerRootCerts(trusted);
 
         assertTrue(trusted.isEmpty());
+    }
+
+    // --- Retry-After parsing -------------------------------------------------------------------
+
+    @Test
+    void parseRetryAfterSeconds_ifDeltaSeconds_returnsValue() {
+        assertEquals(120, tocService.parseRetryAfterSeconds("120"));
+        assertEquals(0, tocService.parseRetryAfterSeconds(" 0 "));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_ifHttpDate_returnsPositiveDelay() {
+        String httpDate = ZonedDateTime.now(ZoneOffset.UTC).plusMinutes(5)
+                .format(DateTimeFormatter.RFC_1123_DATE_TIME);
+
+        Integer seconds = tocService.parseRetryAfterSeconds(httpDate);
+
+        assertNotNull(seconds);
+        // Allow for clock granularity between formatting and parsing.
+        assertTrue(seconds > 280 && seconds <= 300, "unexpected delay: " + seconds);
+    }
+
+    @Test
+    void parseRetryAfterSeconds_ifHttpDateInThePast_returnsZero() {
+        String httpDate = ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(5)
+                .format(DateTimeFormatter.RFC_1123_DATE_TIME);
+
+        assertEquals(0, tocService.parseRetryAfterSeconds(httpDate));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_ifAbsentOrUnparseable_returnsNull() {
+        assertNull(tocService.parseRetryAfterSeconds(null));
+        assertNull(tocService.parseRetryAfterSeconds(""));
+        assertNull(tocService.parseRetryAfterSeconds("not-a-delay"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_ifNegativeDeltaSeconds_clampsToZero() {
+        assertEquals(0, tocService.parseRetryAfterSeconds("-30"));
+    }
+
+    // --- TOC download over HTTP ----------------------------------------------------------------
+
+    /**
+     * Starts a loopback HTTP server that replies with the given status, recording the User-Agent it
+     * received. Uses the JDK's own HttpServer so no HTTP-mocking dependency is needed.
+     */
+    private HttpServer startStubMds(int status, String retryAfter, String body,
+                                    AtomicReference<String> observedUserAgent) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/", exchange -> {
+            observedUserAgent.set(exchange.getRequestHeaders().getFirst("User-Agent"));
+            if (retryAfter != null) {
+                exchange.getResponseHeaders().add("Retry-After", retryAfter);
+            }
+            byte[] payload = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(status, payload.length == 0 ? -1 : payload.length);
+            if (payload.length > 0) {
+                try (OutputStream out = exchange.getResponseBody()) {
+                    out.write(payload);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private URL urlOf(HttpServer server) throws IOException {
+        return URI.create(
+                "http://" + server.getAddress().getHostString() + ":" + server.getAddress().getPort() + "/").toURL();
+    }
+
+    @Test
+    void downloadMdsFromServer_ifRateLimited_throwsMdsRateLimitedExceptionWithRetryAfter() throws IOException {
+        AtomicReference<String> userAgent = new AtomicReference<>();
+        HttpServer server = startStubMds(429, "300", null, userAgent);
+        try {
+            MdsRateLimitedException ex = assertThrows(MdsRateLimitedException.class,
+                    () -> tocService.downloadMdsFromServer(urlOf(server)));
+
+            assertEquals(300, ex.getRetryAfterSeconds());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void downloadMdsFromServer_ifRateLimitedWithoutRetryAfter_retryAfterIsNull() throws IOException {
+        AtomicReference<String> userAgent = new AtomicReference<>();
+        HttpServer server = startStubMds(429, null, null, userAgent);
+        try {
+            MdsRateLimitedException ex = assertThrows(MdsRateLimitedException.class,
+                    () -> tocService.downloadMdsFromServer(urlOf(server)));
+
+            assertNull(ex.getRetryAfterSeconds());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * A 429 must be distinguishable from other failures so a retry loop can back off instead of
+     * hammering the endpoint; other error statuses stay generic.
+     */
+    @Test
+    void downloadMdsFromServer_ifServerError_throwsGenericFailureNotRateLimited() throws IOException {
+        AtomicReference<String> userAgent = new AtomicReference<>();
+        HttpServer server = startStubMds(503, null, null, userAgent);
+        try {
+            Fido2RuntimeException ex = assertThrows(Fido2RuntimeException.class,
+                    () -> tocService.downloadMdsFromServer(urlOf(server)));
+
+            assertTrue(ex.getMessage().contains("503"), "expected the status in the message: " + ex.getMessage());
+            assertFalse(ex instanceof MdsRateLimitedException, "503 must not be reported as rate limiting");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * The JDK default "Java/<version>" User-Agent is what the FIDO Alliance CDN throttles, so pin
+     * that we identify ourselves instead.
+     */
+    @Test
+    void downloadMdsFromServer_sendsIdentifyingUserAgent() throws IOException {
+        AtomicReference<String> userAgent = new AtomicReference<>();
+        HttpServer server = startStubMds(200, null, "toc-blob", userAgent);
+        try {
+            Fido2Configuration cfg = mock(Fido2Configuration.class);
+            when(cfg.getMdsTocsFolder()).thenReturn("/etc/jans/conf/fido2/mds/toc");
+            when(appConfiguration.getFido2Configuration()).thenReturn(cfg);
+            when(base64Service.encodeToString(any())).thenReturn("ENCODED");
+            when(dbDocumentService.getDocumentsByFilePath(anyString()))
+                    .thenReturn(Collections.singletonList(new Document()));
+
+            assertTrue(tocService.downloadMdsFromServer(urlOf(server)));
+
+            assertEquals("Janssen-FIDO2", userAgent.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    // --- Cached TOC fallback -------------------------------------------------------------------
+
+    /**
+     * Builds a TOC document whose stored nextUpdate marker is {@code daysFromNow} away, and points the
+     * metadata server at a stub that fails the download.
+     */
+    private Fido2Configuration configureForFallback(String storedNextUpdate, String metadataUrl) {
+        Fido2Configuration cfg = mock(Fido2Configuration.class);
+        when(cfg.isDisableMetadataService()).thenReturn(false);
+        when(cfg.getMdsTocsFolder()).thenReturn("/etc/jans/conf/fido2/mds/toc");
+        when(cfg.getMdsCertsFolder()).thenReturn("/etc/jans/conf/fido2/mds/cert");
+        MetadataServer metadataServer = new MetadataServer();
+        metadataServer.setUrl(metadataUrl);
+        when(cfg.getMetadataServers()).thenReturn(Collections.singletonList(metadataServer));
+        when(appConfiguration.getFido2Configuration()).thenReturn(cfg);
+
+        Document tocDocument = new Document();
+        tocDocument.setDescription(storedNextUpdate);
+        tocDocument.setDocument("CACHED-BLOB");
+        when(dbDocumentService.getDocumentsByFilePath(anyString()))
+                .thenReturn(Collections.singletonList(tocDocument));
+        return cfg;
+    }
+
+    /**
+     * The client-reported failure: MDS answers 429 at startup. The download must not propagate out of
+     * the CDI observer, and the server must fall back to the TOC already cached in the DB instead of
+     * coming up with no metadata at all.
+     */
+    @Test
+    void fetchMetadata_ifDownloadRateLimited_doesNotPropagateAndFallsBackToCache() throws IOException {
+        AtomicReference<String> userAgent = new AtomicReference<>();
+        HttpServer server = startStubMds(429, "300", null, userAgent);
+        try {
+            String staleMarker = LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
+            configureForFallback(staleMarker, urlOf(server).toString());
+
+            // A 429 at startup previously escaped the ApplicationInitialized observer.
+            assertDoesNotThrow(() -> tocService.fetchMetadata());
+
+            // The download was attempted (and throttled), then the cache path ran instead of the
+            // exception propagating.
+            assertEquals("Janssen-FIDO2", userAgent.get(), "the download should have been attempted");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * When the cached TOC is still current no download is attempted, and the cache path runs instead.
+     * Previously refreshTOCEntries() only ran after a successful download, so a restart inside the
+     * validity window left the entry map null. Asserting the entries are actually published needs a
+     * real signed TOC blob, which belongs in an integration test rather than here.
+     */
+    @Test
+    void fetchMetadata_ifCachedTocStillCurrent_doesNotDownload() throws IOException {
+        AtomicReference<String> userAgent = new AtomicReference<>();
+        HttpServer server = startStubMds(500, null, null, userAgent);
+        try {
+            String futureMarker = LocalDate.now().plusDays(20).format(DateTimeFormatter.ISO_LOCAL_DATE);
+            configureForFallback(futureMarker, urlOf(server).toString());
+
+            tocService.fetchMetadata();
+
+            // No request may be issued while the cached TOC is still inside its validity window.
+            assertNull(userAgent.get(), "a download was attempted despite a current cached TOC");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * A fresh install whose TOC document row is missing must still start: reading the update date
+     * throws DocumentException, which previously escaped the ApplicationInitialized observer.
+     */
+    @Test
+    void fetchMetadata_ifTocDocumentMissing_doesNotPropagate() throws IOException {
+        AtomicReference<String> userAgent = new AtomicReference<>();
+        HttpServer server = startStubMds(429, null, null, userAgent);
+        try {
+            configureForFallback(LocalDate.now().toString(), urlOf(server).toString());
+            when(dbDocumentService.getDocumentsByFilePath(anyString())).thenReturn(Collections.emptyList());
+
+            assertDoesNotThrow(() -> tocService.fetchMetadata());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void fetchMetadata_ifMetadataServiceDisabled_doesNothing() throws IOException {
+        AtomicReference<String> userAgent = new AtomicReference<>();
+        HttpServer server = startStubMds(200, null, "toc-blob", userAgent);
+        try {
+            Fido2Configuration cfg = mock(Fido2Configuration.class);
+            when(cfg.isDisableMetadataService()).thenReturn(true);
+            when(appConfiguration.getFido2Configuration()).thenReturn(cfg);
+
+            tocService.fetchMetadata();
+
+            assertNull(userAgent.get(), "no download may happen when the metadata service is disabled");
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
 The FIDO2 server discards all authenticator metadata whenever the MDS TOC download does not succeed, even when a valid, unexpired TOC blob is already cached in jansDocument

closes #14664 

#### Implementation Details

The FIDO2 server dropped all authenticator metadata whenever the MDS TOC download did not succeed, and also whenever it was skipped because the cached TOC was still current — `refreshTOCEntries()` had a single call site inside `if (success)` after a download. Since MDS blobs carry a `nextUpdate` roughly a month out, an ordinary restart inside that window left `tocEntries` null for the whole process lifetime. In `enforced` attestation mode the CONF-22 gate from #14342 then rejected attestation-bearing registrations.

**Cached-TOC fallback.** `fetchMetadata()` now publishes the TOC blob already stored in `jansDocument` whenever a fresh one was not published — whether the download failed or was not due. The fallback is gated on the blob still being inside its own `nextUpdate` validity window; an expired blob is refused and the entry map is left empty.

This is additive with respect to CONF-22 rather than a reversal of it. #14342 rejects a silent fall back to *empty* metadata, which would let attestation succeed unverified. A cached blob is signature-verified through the existing `readEntriesFromTocJWT` path and is only used while unexpired, so it is real metadata, not empty metadata. When no usable blob exists, the entry map stays empty, `MdsService` throws `"Authenticator not in TOC"`, and enforced mode still fails closed exactly as before.

**Startup containment.** Download failures are logged instead of propagating out of the `@Observes @ApplicationInitialized` observer. Previously an `IOException` was rewrapped as `Fido2RuntimeException` while `fetchMetadata()` caught only `MalformedURLException`, so it escaped. The same applies to a missing TOC document row, where `getNextUpdateDate()` throws `DocumentException`; that is now treated as "due for download" rather than aborting initialization.

**Download hardening.** `downloadMdsFromServer` used a bare `URL.openStream()`, which sends the JDK default `Java/<version>` User-Agent, applies no timeouts, and never inspects the response status. Deployments consequently saw an opaque `IOException: Server returned HTTP response code: 429` with nothing to distinguish rate limiting from a network fault. The download now sends an identifying `User-Agent`, sets connect/read timeouts, and checks the status. HTTP 429 is reported as a new `MdsRateLimitedException` carrying the parsed `Retry-After` delay (both the delta-seconds and HTTP-date forms), so a caller that retries can back off instead of re-sending into a throttle. Non-HTTP metadata URLs — e.g. a `file:` mirror — keep the previous plain-stream behaviour, since they expose no status or headers.

Note that the same endpoint is already fetched with a browser User-Agent at image build time in `docker-jans-fido2/Dockerfile`, so only the runtime path was affected. Whether the User-Agent is the actual throttling trigger is not confirmed — if the CDN throttles by source IP, it will not stop the 429. The cached-TOC fallback is what makes the server survive either way.

No new configuration properties are introduced.

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

`TocServiceTest` gains coverage for: `Retry-After` parsing (delta-seconds, HTTP-date, past date, absent, unparseable, negative); the 429 path producing `MdsRateLimitedException` with and without a `Retry-After` header; a non-429 error status producing a generic failure instead; the outgoing `User-Agent`; a rate-limited startup not propagating out of the observer; no download being issued while the cached TOC is current; a missing TOC document not aborting startup; and the metadata service being disabled. The HTTP cases use the JDK's own `com.sun.net.httpserver.HttpServer`, so no HTTP-mocking dependency is added.

Full `jans-fido2/server` suite: 259 tests, 0 failures.

Asserting that cached entries are actually published needs a real signed TOC blob and belongs in an integration test rather than a unit test; the unit tests cover the control flow around it.

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved FIDO Metadata Service TOC fetching with explicit rate-limit handling (HTTP 429) and honor of `Retry-After` when provided.
  * Improved refresh behavior to avoid using expired cached TOC and to publish fresh TOC atomically.
  * Added HTTP download robustness, including support for both numeric and RFC 1123 `Retry-After` formats.

* **Bug Fixes**
  * Metadata refresh/download failures (including rate limits) no longer interrupt startup; the system falls back to cached TOC when available.
  * Enhanced error classification to ensure non-rate-limit HTTP errors don’t get treated as rate limiting.

* **Tests**
  * Expanded TOC download, retry-delay parsing, caching/expiry gating, and fallback-path coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->