### PR TITLE
fix(cedarling-java): don't use cached remote relese files

### DIFF
--- a/jans-cedarling/bindings/cedarling-java/pom.xml
+++ b/jans-cedarling/bindings/cedarling-java/pom.xml
@@ -202,10 +202,11 @@
                             <url>${cedarling.base.url}/libcedarling_uniffi-${cedarling.native.version}.so</url>
                             <outputDirectory>${cedarling.resources.dir}</outputDirectory>
                             <outputFileName>libcedarling_uniffi.so</outputFileName>
-                            <!-- Re-download only when the remote file changes -->
+                            <!-- Skip the whole execution when the file already exists -->
                             <overwrite>false</overwrite>
-                            <!-- Cache by URL hash so incremental builds skip the download -->
-                            <skipCache>false</skipCache>
+                            <!-- The nightly URL has volatile content: the plugin cache is
+                                 keyed by URL only and would serve stale artifacts forever -->
+                            <skipCache>true</skipCache>
                         </configuration>
                     </execution>
 
@@ -378,7 +379,9 @@
                                          mirroring: unzip -q … && rm -f … -->
                                     <unpack>true</unpack>
                                     <overwrite>false</overwrite>
-                                    <skipCache>false</skipCache>
+                                    <!-- Nightly URL, volatile content: never serve from the
+                                         URL-keyed plugin cache (it would stay stale forever) -->
+                                    <skipCache>true</skipCache>
                                 </configuration>
                             </execution>
                         </executions>

--- a/jans-cedarling/bindings/cedarling-java/pom.xml
+++ b/jans-cedarling/bindings/cedarling-java/pom.xml
@@ -209,24 +209,13 @@
                         </configuration>
                     </execution>
 
-                    <!-- Step 2: download the Kotlin-bindings zip and unpack it in-place
-                         (equivalent to: wget zip && unzip zip -d $KOTLIN_DIR && rm zip) -->
-                    <execution>
-                        <id>download-kotlin-bindings</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>${cedarling.base.url}/cedarling_uniffi-kotlin-${cedarling.native.version}.zip</url>
-                            <outputDirectory>${cedarling.kotlin.dir}</outputDirectory>
-                            <!-- unpack=true extracts the zip and does NOT keep the archive,
-                                 mirroring: unzip -q … && rm -f … -->
-                            <unpack>true</unpack>
-                            <overwrite>false</overwrite>
-                            <skipCache>false</skipCache>
-                        </configuration>
-                    </execution>
+                    <!-- Step 2 (Kotlin-bindings zip) lives in the
+                         download-kotlin-bindings profile below: with
+                         unpack=true the plugin re-extracts the cached zip on
+                         every build regardless of overwrite=false, which
+                         silently clobbers bindings regenerated locally via
+                         uniffi-bindgen.  The profile only activates when the
+                         generated file is absent (fresh checkout / CI). -->
 
                 </executions>
             </plugin>
@@ -345,4 +334,57 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+            ============================================================
+            Download the pre-built Kotlin bindings ONLY when the generated
+            file does not exist yet (fresh checkout, CI).  Once the file is
+            present - whether downloaded earlier or regenerated locally with
+              cargo run - -bin uniffi-bindgen generate
+                - -library ./target/release/libcedarling_uniffi.so
+                - -language kotlin
+                - -out-dir ./bindings/cedarling-java/src/main/kotlin/io/jans/cedarling
+            this profile stays inactive and the local file is never
+            overwritten.  Delete the file to force a fresh download.
+            ============================================================
+        -->
+        <profile>
+            <id>download-kotlin-bindings</id>
+            <activation>
+                <file>
+                    <missing>${basedir}/src/main/kotlin/io/jans/cedarling/uniffi/cedarling_uniffi/cedarling_uniffi.kt</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>1.9.0</version>
+                        <executions>
+                            <!-- Download the Kotlin-bindings zip and unpack it in-place
+                                 (equivalent to: wget zip && unzip zip -d $KOTLIN_DIR && rm zip) -->
+                            <execution>
+                                <id>download-kotlin-bindings</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>${cedarling.base.url}/cedarling_uniffi-kotlin-${cedarling.native.version}.zip</url>
+                                    <outputDirectory>${cedarling.kotlin.dir}</outputDirectory>
+                                    <!-- unpack=true extracts the zip and does NOT keep the archive,
+                                         mirroring: unzip -q … && rm -f … -->
+                                    <unpack>true</unpack>
+                                    <overwrite>false</overwrite>
+                                    <skipCache>false</skipCache>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
#14668
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14668

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented native library downloads from reusing stale cached content.
  * Automatically retrieves Kotlin bindings during build when they’re not present locally.
  * Ensures downloaded bindings are unpacked as part of the build for consistent availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->