### PR TITLE
fix(ci): upload SLSA provenance to releases via PAT

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -2253,11 +2253,8 @@ jobs:
       compile-generator: true
       provenance-name: cedarling-pg.intoto.jsonl
 
-  # Attach the SLSA provenance (.intoto.jsonl) to the release ourselves. The SLSA generator's own
-  # upload uses the ambient GITHUB_TOKEN, which the REST API rejects with "Resource not accessible
-  # by integration" when updating a published (non-prerelease) release. Uploading with the release
-  # PAT — as every other asset in this workflow does — sidesteps that, so the generators run with
-  # upload-assets: false and only produce the signed provenance as a run artifact.
+  # SLSA's own upload uses GITHUB_TOKEN, which can't update a published release; attach the
+  # provenance with the release PAT instead (generators run with upload-assets: false).
   upload-provenance-assets:
     name: Upload SLSA provenance to release
     needs:
@@ -2279,12 +2276,21 @@ jobs:
     steps:
       - name: Resolve release tag
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_TAG: ${{ inputs.target_tag }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "tag=${{ inputs.target_tag }}" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            TAG="$TARGET_TAG"
           else
-            echo "tag=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+            TAG="$HEAD_BRANCH"
           fi
+          if [[ -z "$TAG" || "$TAG" == *$'\n'* || "$TAG" == *$'\r'* ]]; then
+            echo "::error::Invalid release tag: empty or contains a line break"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Download provenance artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
@@ -2294,6 +2300,7 @@ jobs:
       - name: Upload provenance to release
         env:
           GH_TOKEN: ${{ secrets.MOAUTO2_WORKFLOW_TOKEN || secrets.MOAUTO_WORKFLOW_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           shopt -s nullglob
           files=(provenance/*.intoto.jsonl)
@@ -2301,5 +2308,4 @@ jobs:
             echo "No provenance artifacts found; nothing to upload."
             exit 0
           fi
-          gh release upload "${{ steps.tag.outputs.tag }}" "${files[@]}" --clobber \
-            --repo "${{ github.repository }}"
+          gh release upload "$TAG" "${files[@]}" --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1653,7 +1653,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-binary-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-binary-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: binary.intoto.jsonl
@@ -1703,7 +1703,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-python-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-python-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: python.intoto.jsonl
@@ -1752,7 +1752,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-wasm-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-wasm-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: wasm.intoto.jsonl
@@ -1802,7 +1802,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-cedarling-python-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-cedarling-python-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: cedarling-python.intoto.jsonl
@@ -1852,7 +1852,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-cedarling-go-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-cedarling-go-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: cedarling-go.intoto.jsonl
@@ -1902,7 +1902,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-cedarling-krakend-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-cedarling-krakend-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: cedarling-krakend.intoto.jsonl
@@ -1982,7 +1982,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-cedarling-uniffi-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-cedarling-uniffi-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: cedarling-uniffi.intoto.jsonl
@@ -1998,7 +1998,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-cedarling-uniffi-ios-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-cedarling-uniffi-ios-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: cedarling-uniffi-ios.intoto.jsonl
@@ -2047,7 +2047,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-demo-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-demo-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: demo.intoto.jsonl
@@ -2248,7 +2248,58 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-cedarling-pg-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-cedarling-pg-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: cedarling-pg.intoto.jsonl
+
+  # Attach the SLSA provenance (.intoto.jsonl) to the release ourselves. The SLSA generator's own
+  # upload uses the ambient GITHUB_TOKEN, which the REST API rejects with "Resource not accessible
+  # by integration" when updating a published (non-prerelease) release. Uploading with the release
+  # PAT — as every other asset in this workflow does — sidesteps that, so the generators run with
+  # upload-assets: false and only produce the signed provenance as a run artifact.
+  upload-provenance-assets:
+    name: Upload SLSA provenance to release
+    needs:
+      - provenance-binary
+      - provenance-python
+      - provenance-wasm
+      - provenance-cedarling-python
+      - provenance-cedarling-go
+      - provenance-cedarling-krakend
+      - provenance-cedarling-uniffi
+      - provenance-cedarling-uniffi-ios
+      - provenance-demo
+      - provenance-cedarling-pg
+    if: |
+      always() &&
+      github.repository == 'JanssenProject/jans' &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'nightly' || startsWith(github.event.workflow_run.head_branch, 'v'))) || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "tag=${{ inputs.target_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Download provenance artifacts
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          pattern: '*.intoto.jsonl'
+          path: provenance
+          merge-multiple: true
+      - name: Upload provenance to release
+        env:
+          GH_TOKEN: ${{ secrets.MOAUTO2_WORKFLOW_TOKEN || secrets.MOAUTO_WORKFLOW_TOKEN }}
+        run: |
+          shopt -s nullglob
+          files=(provenance/*.intoto.jsonl)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No provenance artifacts found; nothing to upload."
+            exit 0
+          fi
+          gh release upload "${{ steps.tag.outputs.tag }}" "${files[@]}" --clobber \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -441,7 +441,34 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.collect-maven-digests.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
       upload-tag-name: "${{ needs.collect-maven-digests.outputs.tag }}"
       compile-generator: true
       provenance-name: maven-artifacts.intoto.jsonl
+
+  # Attach the SLSA provenance (.intoto.jsonl) to the release ourselves. The SLSA generator's own
+  # upload uses the ambient GITHUB_TOKEN, which the REST API rejects with "Resource not accessible
+  # by integration" when updating a published (non-prerelease) release such as vX.Y.Z. Uploading
+  # with the release PAT — as every other asset in this workflow does — sidesteps that, so the
+  # generator runs with upload-assets: false and only produces the signed provenance as an artifact.
+  upload-maven-provenance:
+    name: Upload SLSA provenance to release
+    needs: [collect-maven-digests, provenance-maven]
+    if: |
+      always() &&
+      github.repository == 'JanssenProject/jans' &&
+      needs.collect-maven-digests.outputs.tag != '' &&
+      needs.provenance-maven.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download provenance artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: maven-artifacts.intoto.jsonl
+          path: provenance
+      - name: Upload provenance to release
+        env:
+          GH_TOKEN: ${{ secrets.MOAUTO2_WORKFLOW_TOKEN || secrets.MOAUTO_WORKFLOW_TOKEN }}
+          TAG: ${{ needs.collect-maven-digests.outputs.tag }}
+        run: |
+          gh release upload "${TAG}" provenance/*.intoto.jsonl --repo "${{ github.repository }}" --clobber

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -446,11 +446,8 @@ jobs:
       compile-generator: true
       provenance-name: maven-artifacts.intoto.jsonl
 
-  # Attach the SLSA provenance (.intoto.jsonl) to the release ourselves. The SLSA generator's own
-  # upload uses the ambient GITHUB_TOKEN, which the REST API rejects with "Resource not accessible
-  # by integration" when updating a published (non-prerelease) release such as vX.Y.Z. Uploading
-  # with the release PAT — as every other asset in this workflow does — sidesteps that, so the
-  # generator runs with upload-assets: false and only produces the signed provenance as an artifact.
+  # SLSA's own upload uses GITHUB_TOKEN, which can't update a published release; attach the
+  # provenance with the release PAT instead (generator runs with upload-assets: false).
   upload-maven-provenance:
     name: Upload SLSA provenance to release
     needs: [collect-maven-digests, provenance-maven]


### PR DESCRIPTION
## Problem

Uploading SLSA provenance to the **v2.3.0** release failed:

```
Found release v2.3.0 (with id=362364124)
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v2.3.0: HttpError: Resource not accessible by integration - update-a-release
Error: Resource not accessible by integration
```

The SLSA generator's built-in upload (`upload-assets: true`) attaches provenance using the ambient `GITHUB_TOKEN`. GitHub rejects that token's `update-a-release` call on a **published, non-prerelease** tag (`vX.Y.Z`) with *"Resource not accessible by integration"*. It still works on the mutable `nightly` prerelease, which is why nightly and the 2.2.0 release were unaffected.

Verified during diagnosis: no branch/tag rulesets, no legacy tag protection, release is not immutable — the only differentiator is `prerelease: false`. PAT-uploaded assets (the WARs/jars already on v2.3.0) prove the PAT can write; only the `GITHUB_TOKEN` step fails.

### Cascade

In `build-test.yml` this failed the `provenance-maven` job → failed the whole **Janssen Build & Publish** run → the downstream **build-packages** workflow (which gates on that workflow succeeding) was skipped entirely. That is why v2.3.0 is missing ~93 assets (all provenance + all binary/wasm/wheel/cedarling/demo packages).

## Fix

Both `build-packages.yml` and `build-test.yml`:

- Run the SLSA generators with `upload-assets: false`. They still generate, sign, log to Rekor, and expose the `.intoto.jsonl` as a run artifact.
- A follow-up job downloads those artifacts and attaches them to the release with `gh release upload --clobber` using `MOAUTO2_WORKFLOW_TOKEN || MOAUTO_WORKFLOW_TOKEN` — the same PAT mechanism every other asset in these workflows already uses. Immune to the `GITHUB_TOKEN` published-release restriction.

## Notes

- No change to what provenance is generated or how it is signed — only the release-attach step's identity changes.
- There is a separate in-flight branch (`ci/nightly-split-upload-token`) refactoring release-upload tokens; it does not touch the SLSA provenance jobs, so no overlap with this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability for signed provenance files.
  * Prevented failures when updating assets on already-published, non-prerelease releases.
  * Added handling for cases where no provenance artifacts are available.
  * Added validation to ensure provenance files are attached to the correct release.

* **Release Process**
  * Provenance files are now generated first and attached to releases in a dedicated follow-up step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->