### PR TITLE
docs: add GDPR cookie consent banner for Scarf and Reo.dev analytics

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -24,13 +24,40 @@
 
 {% block scripts %}
 {{ super() }}
-{% if config.extra.enable_scarf_pixel | default(false) %}
-<img referrerpolicy="no-referrer-when-downgrade"
-     src="https://static.scarf.sh/a.png?x-pxid=2c347abc-a9b4-4c4b-bdc9-2682edbcc0c9"
-     width="0" height="0"/>
-{% endif %}
-{% if config.extra.enable_reo_flag | default(false) %}
-  <script src="{{ base_url }}/assets/js/reo.js" defer></script>
+{% if config.extra.enable_scarf_pixel | default(false) or config.extra.enable_reo_flag | default(false) %}
+{#- Analytics (Scarf pixel + Reo.dev) load only after the visitor grants
+    consent via the cookie banner, for GDPR compliance. -#}
+<script>
+  (function () {
+    function loadAnalytics() {
+      var consent = __md_get("__consent");
+      if (!(consent && consent.analytics)) return;
+      {% if config.extra.enable_scarf_pixel | default(false) %}
+      if (!document.getElementById("__scarf_pixel")) {
+        var img = document.createElement("img");
+        img.id = "__scarf_pixel";
+        img.referrerPolicy = "no-referrer-when-downgrade";
+        img.src = "https://static.scarf.sh/a.png?x-pxid=2c347abc-a9b4-4c4b-bdc9-2682edbcc0c9";
+        img.width = 0;
+        img.height = 0;
+        document.body.appendChild(img);
+      }
+      {% endif %}
+      {% if config.extra.enable_reo_flag | default(false) %}
+      if (!document.getElementById("__reo_loader")) {
+        var s = document.createElement("script");
+        s.id = "__reo_loader";
+        s.src = "{{ base_url }}/assets/js/reo.js";
+        s.defer = true;
+        document.head.appendChild(s);
+      }
+      {% endif %}
+    }
+    loadAnalytics();
+    /* Re-check when the visitor updates their choice in the consent banner. */
+    document.addEventListener("consent", loadAnalytics);
+  })();
+</script>
 {% endif %}
 <script src="https://help.gluu.org/widget/503f7c06-6e04-4f3d-abe0-61da60db5a23" defer async></script>
 {% endblock %}
@@ -40,10 +67,10 @@
   {{ super() }}
 {% endblock %}
 
-<!-- Linux Foundation Footer Badge -->
-<div class="linux-foundation-footer">
-  <a href="https://www.linuxfoundation.org/projects" target="_blank" rel="noopener noreferrer" class="foundation-badge-bottom">
-    <img src="{{ base_url }}/assets/logo/linux_foundation.svg" alt="Linux Foundation" class="linux-foundation-logo-bottom">
-    <span class="foundation-text-bottom">A Linux Foundation Project</span>
-  </a>
-</div>
+{% block footer %}
+  {{ super() }}
+  <!-- Cookie settings link: reopens the consent banner so choices can be changed -->
+  <div class="cookie-settings-footer">
+    <a href="#__consent">Change cookie settings</a>
+  </div>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,23 @@ extra:
   enable_scarf_pixel: false
   enable_reo_flag: false
   generator: false
+  consent:
+    title: Cookie consent
+    description: >-
+      This site uses Scarf and Reo.dev to measure documentation traffic and to
+      understand which content is most useful, so we can improve the docs. These
+      analytics cookies are only set with your consent. Essential cookies needed
+      for the site to function are always active. For details on how your data is
+      handled, see the
+      <a href="https://www.linuxfoundation.org/legal/privacy-policy" target="_blank" rel="noopener noreferrer">Linux Foundation Privacy Policy</a>.
+    actions:
+      - accept
+      - reject
+      - manage
+    cookies:
+      analytics:
+        name: Scarf &amp; Reo.dev analytics
+        checked: false
   social:
   - icon: fontawesome/brands/github
     link: https://github.com/JanssenProject/jans


### PR DESCRIPTION
## Summary

docs.jans.io loads a **Scarf** tracking pixel and the **Reo.dev** script to measure documentation traffic. Under GDPR these analytics cookies/trackers require prior, informed consent. This PR adds a cookie consent banner and defers the trackers until the visitor opts in.

## Changes

- **`mkdocs.yml`** — enable the Material for MkDocs `extra.consent` banner with an `analytics` cookie group (unchecked by default) covering Scarf and Reo.dev. Description links to the Linux Foundation Privacy Policy. Actions: accept / reject / manage.
- **`docs/overrides/main.html`** — the Scarf pixel and Reo.dev loader no longer render unconditionally. They are injected via JS only when `__md_get("__consent").analytics` is true, and re-evaluated on the Material `consent` event so a later opt-in takes effect without a reload. Both feature flags (`enable_scarf_pixel`, `enable_reo_flag`) still gate whether the code is emitted at all.
- Added a **"Change cookie settings"** footer link (`#__consent`) so visitors can withdraw or change consent at any time.

## Behavior

- First visit: banner shown, no analytics loaded until a choice is made.
- Reject / no choice: Scarf and Reo.dev never load.
- Accept: trackers load; choice persists and is revocable via the footer link.

## Testing

Built the site locally with `mkdocs build`; verified the banner renders, the footer link appears, and with the analytics flags enabled the Scarf/Reo code is emitted only inside the consent gate (no always-on tags). Screenshot of the rendered banner below.

<img width="800" alt="cookie consent banner" src="about:blank">
Closes #14683, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cookie consent controls for analytics, including accept, reject, and manage options.
  * Analytics services now load only after users grant consent.
  * Added a footer link to reopen cookie settings.
  * Added configurable consent messaging and a privacy-policy link.

* **Changes**
  * Removed the Linux Foundation footer badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->