### PR TITLE
fix(config-api): add jans-doc to annotation processor path

### DIFF
--- a/jans-config-api/common/pom.xml
+++ b/jans-config-api/common/pom.xml
@@ -54,6 +54,16 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
+					<!-- Parent sets annotationProcessorPaths (mapstruct), so processors are
+					     discovered only from that path; jans-doc must be added for the named
+					     processors to resolve. -->
+					<annotationProcessorPaths>
+						<path>
+							<groupId>io.jans</groupId>
+							<artifactId>jans-doc</artifactId>
+							<version>${project.version}</version>
+						</path>
+					</annotationProcessorPaths>
 					<annotationProcessors>
 						<annotationProcessor>
 							io.jans.doc.annotation.DocPropertyProcessor


### PR DESCRIPTION
## Problem

After #14697 merged, the nightly reactor build failed compiling `jans-config-api-common`:

```
[ERROR] error: Annotation processor 'io.jans.doc.annotation.DocPropertyProcessor' not found
```

## Root cause

The config-api parent (`jans-config-api/pom.xml`) configures `maven-compiler-plugin` with `annotationProcessorPaths` (mapstruct). Once `annotationProcessorPaths` is set, javac discovers annotation processors **only** from that path — not from the project classpath/dependencies. #14697 added `<annotationProcessors>` naming `DocPropertyProcessor`/`DocFeatureFlagProcessor` and `jans-doc` as a dependency, but did not add `jans-doc` to the processor path, so the named processors could not be resolved.

(jans-auth-server / jans-scim / jans-lock are unaffected because their parents define no `annotationProcessorPaths`, so javac falls back to the classpath where the `jans-doc` dependency lives.)

## Fix

Add `jans-doc` to `annotationProcessorPaths` in `jans-config-api-common`. `common` uses no MapStruct (0 usages), so naming only the doc processors is safe.

## Validation

- POM is well-formed XML.
- Full reactor compile requires GitHub Packages auth and could not be run locally; the authoritative check is the `build-test` reactor build. Recommend a `build-test` `workflow_dispatch` (target `nightly`, config-api) before the next scheduled nightly.
Closes #14704, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure documentation annotation processing runs correctly during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->