### PR TITLE
feat(jans-fido2): Jans fido2 attestation rejection diagnostics

### DIFF
--- a/docs/janssen-server/fido/attestation-rejection-diagnostics.md
+++ b/docs/janssen-server/fido/attestation-rejection-diagnostics.md
@@ -1,0 +1,93 @@
+---
+tags:
+  - administration
+  - fido2
+  - attestation
+  - diagnostics
+---
+
+# Attestation Rejection Diagnostics
+
+When attestation rejects a registration, the reason reaches the end user as a generic failure and is
+recorded in metrics as the raw exception message. An unknown AAGUID, an untrusted root certificate and
+an authenticator blocked by an MDS status report all look alike, so rejections cannot be counted by
+cause.
+
+The FIDO2 server records a stable diagnostic code against the metrics entry instead, and exposes an
+endpoint that groups rejections by that code.
+
+!!! note
+    Nothing about rejection behaviour changes — only the reason that gets recorded. The response
+    returned to the client is unchanged: `ErrorResponseFactory` still returns
+    `{"status": "failed", "errorMessage": "…"}`, and the codes never appear in the client body.
+
+## Rejection analytics
+
+=== "FIDO2 server"
+
+    ```
+    GET /jans-fido2/restv1/metrics/analytics/attestation-rejections?startTime=&endTime=
+    ```
+
+=== "Config API (fido2 plugin)"
+
+    ```
+    GET /fido2/metrics/analytics/attestation-rejections?start_date=&end_date=
+    ```
+
+    Served under the Config API base path. Requires one of the
+    `https://jans.io/oauth/config/fido2-metrics.readonly`,
+    `https://jans.io/oauth/config/fido2.write`,
+    `https://jans.io/oauth/config/fido2.admin`,
+    `https://jans.io/oauth/config/read-all` or
+    `https://jans.io/oauth/config/write-all` scopes.
+
+```json
+{
+    "totalRejections": 18,
+    "registrationAttempts": 150,
+    "rejectionRate": 0.12,
+    "reasonCodes": {
+        "JFS_AAGUID_NOT_IN_MDS": 14,
+        "JFS_ROOT_CERT_NOT_TRUSTED": 3,
+        "JFS_AUTHENTICATOR_STATUS_UNACCEPTABLE": 1
+    }
+}
+```
+
+## Diagnostic codes
+
+| Code | Cause | What to check |
+| --- | --- | --- |
+| `JFS_AAGUID_NOT_IN_MDS` | The authenticator's AAGUID is not in the loaded metadata | Whether metadata loaded at all; [Vendor Metadata](./vendor-metadata.md) to supply it locally |
+| `JFS_AUTHENTICATOR_STATUS_UNACCEPTABLE` | An MDS status report marks the authenticator as unacceptable | The authenticator's status in the FIDO metadata |
+| `JFS_ROOT_CERT_NOT_TRUSTED` | The attestation certificate chain did not verify to a trusted root | Configured root certificates for that vendor |
+| `JFS_ATTESTATION_FORMAT_NOT_PERMITTED` | The attestation statement format is not accepted | The attestation format the authenticator uses |
+| `JFS_MDS_UNAVAILABLE` | Metadata was required but could not be fetched or loaded | Server logs for the last metadata refresh |
+
+A failure that is not trust related keeps its original message, and the original message is still
+written to the log whenever a code is substituted, so no detail is lost.
+
+## How the codes are stored
+
+Codes are written into the existing `errorReason` field of the metrics entry, with `errorCategory` set
+to `ATTESTATION_TRUST`. No new store is introduced, so rejections also appear in the general
+[`analytics/errors`](./passkey-telemetry.md) breakdown under that category.
+
+Because `errorReason` normally holds prose, a client that displays it should treat a value prefixed
+`JFS_` as a code to map rather than a sentence to show.
+
+## Reading the rejection rate
+
+`rejectionRate` is `totalRejections` divided by `registrationAttempts` over the same range.
+
+An attempt and the rejection that follows it are separate records with their own timestamps, so a
+narrow range can contain one without the other. Rather than publish a misleading number, the endpoint
+reports:
+
+- the computed rate, when there are attempts in range and rejections do not exceed them;
+- `1.0` plus a `rejectionRateNote`, when rejections exceed attempts because some attempts fall before
+  the range;
+- `null` plus a `rejectionRateNote`, when no attempts were recorded in range at all.
+
+Widening the range resolves both boundary cases.

--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -35,6 +35,7 @@ within your organization.
 | Are registrations and sign-ins actually succeeding? | aggregation `summary`, `analytics/errors` |
 | How many users start a passkey flow but drop off? | `analytics/errors` (`dropOffRate`) |
 | Why are users failing — cancels, timeouts, bad credentials? | `analytics/errors` (`errorCategories`, `topErrors`) |
+| Why is attestation rejecting authenticators? | `analytics/attestation-rejections` (counts per trust diagnostic code) |
 | Which platforms, browsers, and authenticator types are in use? | `analytics/devices` |
 | Is passkey latency healthy, or getting worse? | `analytics/performance` |
 | How does this month compare to last? | `analytics/comparison` |
@@ -171,7 +172,7 @@ parameters, and response schemas, use the Swagger spec:
 |---|---|
 | Raw entries | `entries`, `entries/user/{userId}`, `entries/operation/{operationType}` |
 | Aggregations | `aggregations/{type}`, `aggregations/{type}/summary` |
-| Analytics | `analytics/adoption`, `analytics/performance`, `analytics/devices`, `analytics/errors`, `analytics/trends/{type}`, `analytics/comparison/{type}` |
+| Analytics | `analytics/adoption`, `analytics/performance`, `analytics/devices`, `analytics/errors`, `analytics/attestation-rejections`, `analytics/trends/{type}`, `analytics/comparison/{type}` |
 | Utility | `config`, `health` |
 
 `{type}` is one of `HOURLY`, `DAILY`, `WEEKLY`, `MONTHLY`; `{operationType}` is

--- a/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
@@ -132,6 +132,68 @@ paths:
         - https://jans.io/oauth/config/read-all
       - oauth2:
         - https://jans.io/oauth/config/write-all
+  /fido2/metrics/analytics/attestation-rejections:
+    get:
+      tags:
+      - Fido2 - Metrics
+      summary: Get Fido2 attestation rejection analysis by time range.
+      description: Get Fido2 attestation rejection analysis by time range.
+      operationId: get-fido2-metrics-attestation-rejections
+      parameters:
+      - name: start_date
+        in: query
+        description: "Start date/time for the log entries report. Accepted format\
+          \ dd-MM-yyyy or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example,\
+          \ 31-12-2025 and 2025-12-31T23:59:59Z."
+        required: true
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: "End date/time for the log entries. Accepted format dd-MM-yyyy\
+          \ or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example, 31-12-2025\
+          \ and 2025-12-31T23:59:59Z."
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonNode"
+              examples:
+                Response example:
+                  description: Response example
+                  value: |
+                    {
+                        "totalRejections": 18,
+                        "registrationAttempts": 150,
+                        "rejectionRate": 0.12,
+                        "reasonCodes": {
+                            "JFS_AAGUID_NOT_IN_MDS": 14,
+                            "JFS_ROOT_CERT_NOT_TRUSTED": 3,
+                            "JFS_AUTHENTICATOR_STATUS_UNACCEPTABLE": 1
+                        }
+                    }
+        "400":
+          description: Bad Request
+        "401":
+          description: Unauthorized
+        "500":
+          description: InternalServerError
+      security:
+      - oauth2:
+        - https://jans.io/oauth/config/fido2-metrics.readonly
+      - oauth2:
+        - https://jans.io/oauth/config/fido2.write
+      - oauth2:
+        - https://jans.io/oauth/config/fido2.admin
+      - oauth2:
+        - https://jans.io/oauth/config/read-all
+      - oauth2:
+        - https://jans.io/oauth/config/write-all
   /fido2/metrics/analytics/devices:
     get:
       tags:

--- a/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2MetricsResource.java
+++ b/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2MetricsResource.java
@@ -586,6 +586,50 @@ public class Fido2MetricsResource extends BaseResource {
      * @return a Response containing a JsonNode with the matching entries
      * 
      */
+    @Operation(summary = "Get Fido2 attestation rejection analysis by time range.", description = "Get Fido2 attestation rejection analysis by time range.", operationId = "get-fido2-metrics-attestation-rejections", tags = {
+            "Fido2 - Metrics" }, security = {
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_METRICS_READ_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_CONFIG_WRITE_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_ADMIN_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { ApiAccessConstants.SUPER_ADMIN_READ_ACCESS }),
+                    @SecurityRequirement(name = "oauth2", scopes = { ApiAccessConstants.SUPER_ADMIN_WRITE_ACCESS }) })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = JsonNode.class), examples = @ExampleObject(name = "Response example", value = "example/fido2/metrics/fido2-metrics-attestation-rejections.json"))),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "InternalServerError") })
+    @GET
+    @Path("/analytics/attestation-rejections")
+    @ProtectedApi(scopes = { Constants.FIDO2_METRICS_READ_ACCESS }, groupScopes = {
+            Constants.FIDO2_CONFIG_WRITE_ACCESS }, superScopes = { Constants.FIDO2_ADMIN_ACCESS,
+                    ApiAccessConstants.SUPER_ADMIN_READ_ACCESS, ApiAccessConstants.SUPER_ADMIN_WRITE_ACCESS })
+    public Response getAttestationRejectionAnalysis(
+            @Parameter(description = "Start date/time for the log entries report. Accepted format dd-MM-yyyy or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example, 31-12-2025 and 2025-12-31T23:59:59Z.", schema = @Schema(type = "string")) @QueryParam(value = "start_date") @NotNull(message="The attribute 'Start Date Time' is required for this operation")  String startDate,
+            @Parameter(description = "End date/time for the log entries. Accepted format dd-MM-yyyy or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example, 31-12-2025 and 2025-12-31T23:59:59Z.", schema = @Schema(type = "string")) @QueryParam(value = "end_date") @NotNull(message="The attribute 'End Date Time' is required for this operation") String endDate) {
+
+        if (logger.isInfoEnabled()) {
+            logger.info(DATE_PARAM, escapeLog(startDate), escapeLog(endDate));
+        }
+        JsonNode jsonNode = null;
+        try {
+
+            // validate Date
+            validateDate(startDate, endDate, formatter);
+
+            jsonNode = fido2MetricsService.getAttestationRejectionAnalysis(null, parseDate(startDate), parseDate(endDate));
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Fido2AttestationRejectionAnalysis  - jsonNode:{}", jsonNode);
+            }
+        } catch (WebApplicationException wex) {
+            throw wex;
+        } catch (Exception ex) {
+            logger.error(ERR_MSG, ex);
+            throwInternalServerException(ex);
+        }
+        return Response.ok(jsonNode).build();
+    }
+
     @Operation(summary = "Get Fido2 error analysis metrics by time range.", description = "Get Fido2 error analysis metrics by time range.", operationId = "get-fido2-metrics-analytics-errors", tags = {
             "Fido2 - Metrics" }, security = {
                     @SecurityRequirement(name = "oauth2", scopes = { Constants.FIDO2_METRICS_READ_ACCESS }),

--- a/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2MetricsResource.java
+++ b/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2MetricsResource.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -607,27 +608,44 @@ public class Fido2MetricsResource extends BaseResource {
             @Parameter(description = "Start date/time for the log entries report. Accepted format dd-MM-yyyy or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example, 31-12-2025 and 2025-12-31T23:59:59Z.", schema = @Schema(type = "string")) @QueryParam(value = "start_date") @NotNull(message="The attribute 'Start Date Time' is required for this operation")  String startDate,
             @Parameter(description = "End date/time for the log entries. Accepted format dd-MM-yyyy or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example, 31-12-2025 and 2025-12-31T23:59:59Z.", schema = @Schema(type = "string")) @QueryParam(value = "end_date") @NotNull(message="The attribute 'End Date Time' is required for this operation") String endDate) {
 
+        return dateRangedAnalytics(startDate, endDate, "Fido2AttestationRejectionAnalysis",
+                fido2MetricsService::getAttestationRejectionAnalysis);
+    }
+
+    /**
+     * Validates a date range, runs a date-ranged analytics call, and wraps the result.
+     * <p>
+     * The validate / parse / delegate / translate-failure sequence is identical for every analytics
+     * endpoint, so it lives here once rather than being restated per endpoint.
+     */
+    private Response dateRangedAnalytics(String startDate, String endDate, String debugLabel,
+            DateRangedAnalytics call) {
         if (logger.isInfoEnabled()) {
             logger.info(DATE_PARAM, escapeLog(startDate), escapeLog(endDate));
         }
         JsonNode jsonNode = null;
         try {
-
-            // validate Date
             validateDate(startDate, endDate, formatter);
 
-            jsonNode = fido2MetricsService.getAttestationRejectionAnalysis(null, parseDate(startDate), parseDate(endDate));
+            jsonNode = call.execute(null, parseDate(startDate), parseDate(endDate));
 
             if (logger.isDebugEnabled()) {
-                logger.debug("Fido2AttestationRejectionAnalysis  - jsonNode:{}", jsonNode);
+                logger.debug("{} - jsonNode:{}", debugLabel, jsonNode);
             }
         } catch (WebApplicationException wex) {
+            // Already carries the right status code.
             throw wex;
         } catch (Exception ex) {
             logger.error(ERR_MSG, ex);
             throwInternalServerException(ex);
         }
         return Response.ok(jsonNode).build();
+    }
+
+    /** An analytics lookup over a time range, as exposed by {@link Fido2MetricsService}. */
+    @FunctionalInterface
+    private interface DateRangedAnalytics {
+        JsonNode execute(String token, LocalDateTime startTime, LocalDateTime endTime) throws Exception;
     }
 
     @Operation(summary = "Get Fido2 error analysis metrics by time range.", description = "Get Fido2 error analysis metrics by time range.", operationId = "get-fido2-metrics-analytics-errors", tags = {
@@ -935,7 +953,11 @@ public class Fido2MetricsResource extends BaseResource {
         // 2024-02-13T10:30:00+01:00)
         try {
             ZonedDateTime zdt = ZonedDateTime.parse(trimmed, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-            return zdt.toLocalDateTime();
+            // Normalise to UTC before dropping the zone. The FIDO2 server stores and compares metrics
+            // timestamps as UTC, so calling toLocalDateTime() directly would forward the wall-clock
+            // reading and silently shift the requested range by the caller's offset - a request for
+            // 2026-01-01T00:00:00+02:00 would be treated as 2026-01-01T00:00:00 UTC, two hours out.
+            return zdt.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
         } catch (DateTimeParseException ignored) {
             // continue
         }

--- a/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2MetricsResource.java
+++ b/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2MetricsResource.java
@@ -645,7 +645,8 @@ public class Fido2MetricsResource extends BaseResource {
     /** An analytics lookup over a time range, as exposed by {@link Fido2MetricsService}. */
     @FunctionalInterface
     private interface DateRangedAnalytics {
-        JsonNode execute(String token, LocalDateTime startTime, LocalDateTime endTime) throws Exception;
+        JsonNode execute(String token, LocalDateTime startTime, LocalDateTime endTime)
+                throws JsonProcessingException;
     }
 
     @Operation(summary = "Get Fido2 error analysis metrics by time range.", description = "Get Fido2 error analysis metrics by time range.", operationId = "get-fido2-metrics-analytics-errors", tags = {

--- a/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/service/Fido2MetricsService.java
+++ b/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/service/Fido2MetricsService.java
@@ -76,6 +76,10 @@ public class Fido2MetricsService {
         return getFido2MetricsUrl() + "/analytics/errors";
     }
 
+    public String getAttestationRejectionsUrl() {
+        return getFido2MetricsUrl() + "/analytics/attestation-rejections";
+    }
+
     public String getTrendAnalysisUrl() {
         return getFido2MetricsUrl() + "/analytics/trends";
     }
@@ -266,6 +270,18 @@ public class Fido2MetricsService {
     public JsonNode getErrorAnalysis(String token, LocalDateTime startTime, LocalDateTime endTime)
             throws JsonProcessingException {
         return getAnalyticsMetrics(token, this.getErrorAnalysisUrl(), startTime, endTime);
+    }
+
+    /**
+     * Get attestation rejections grouped by trust-related diagnostic code
+     *
+     * @param startTime Start time in ISO format
+     * @param endTime   End time in ISO format
+     * @return Attestation rejection analysis
+     */
+    public JsonNode getAttestationRejectionAnalysis(String token, LocalDateTime startTime, LocalDateTime endTime)
+            throws JsonProcessingException {
+        return getAnalyticsMetrics(token, this.getAttestationRejectionsUrl(), startTime, endTime);
     }
 
     /**

--- a/jans-config-api/server/src/main/resources/example/fido2/metrics/fido2-metrics-attestation-rejections.json
+++ b/jans-config-api/server/src/main/resources/example/fido2/metrics/fido2-metrics-attestation-rejections.json
@@ -1,0 +1,10 @@
+{
+    "totalRejections": 18,
+    "registrationAttempts": 150,
+    "rejectionRate": 0.12,
+    "reasonCodes": {
+        "JFS_AAGUID_NOT_IN_MDS": 14,
+        "JFS_ROOT_CERT_NOT_TRUSTED": 3,
+        "JFS_AUTHENTICATOR_STATUS_UNACCEPTABLE": 1
+    }
+}

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -1436,8 +1436,19 @@ components:
         rejectionRate:
           type: number
           format: double
+          nullable: true
           example: 0.12
-          description: Rejections divided by registration attempts; 0.0 when there were no attempts.
+          description: >-
+            Rejections divided by registration attempts. Null when no registration attempts fall in the
+            range, since the rate cannot be computed - a zero would misreport real rejections as a clean
+            record. Capped at 1.0 when rejections exceed attempts, which happens when an attempt was
+            recorded just before the range and its rejection inside it. Both cases carry
+            rejectionRateNote.
+        rejectionRateNote:
+          type: string
+          description: >-
+            Present only when rejectionRate is null or capped, explaining why and how to get an exact
+            figure. Absent when the rate is directly computable.
         reasonCodes:
           type: object
           additionalProperties:

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -882,6 +882,42 @@ paths:
           $ref: '#/components/responses/AccessDenied'
         500:
           $ref: '#/components/responses/InternalServerError'
+  /jans-fido2/restv1/metrics/analytics/attestation-rejections:
+    get:
+      tags:
+        - FIDO2 Metrics
+      summary: Attestation rejection analysis by time range
+      description: >-
+        Breaks down attestation rejections by trust-related diagnostic code. Reads the same metrics
+        store as /analytics/errors - the codes are written into the existing errorReason and
+        errorCategory fields, so no new metrics store is introduced.
+      operationId: get-metrics-attestation-rejections
+      parameters:
+        - name: startTime
+          in: query
+          required: true
+          description: Start of the range, ISO local date-time (UTC).
+          schema:
+            type: string
+        - name: endTime
+          in: query
+          required: true
+          description: End of the range, ISO local date-time (UTC).
+          schema:
+            type: string
+      responses:
+        200:
+          description: Attestation rejection breakdown.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttestationRejectionAnalysis'
+        400:
+          $ref: '#/components/responses/InvalidRequest'
+        403:
+          $ref: '#/components/responses/AccessDenied'
+        500:
+          $ref: '#/components/responses/InternalServerError'
   /jans-fido2/restv1/metrics/analytics/trends/{aggregationType}:
     get:
       tags:
@@ -1113,10 +1149,19 @@ components:
           description: Parsed device details (browser, os, deviceType). Present when deviceInfoCollection is enabled.
         errorReason:
           type: string
-          description: Human-readable error message. Present only when status is FAILURE.
+          description: >-
+            Error detail. Present only when status is FAILURE. Normally a human-readable message, with
+            one exception: when errorCategory is ATTESTATION_TRUST this field carries a stable
+            diagnostic code rather than prose - an identifier prefixed "JFS_", such as
+            JFS_AAGUID_NOT_IN_MDS. Clients that display this value should treat a "JFS_"-prefixed value
+            as a code to map, not a sentence to show. See /metrics/analytics/attestation-rejections.
         errorCategory:
           type: string
-          description: Categorized error type (e.g. USER_CANCELLED, TIMEOUT, INVALID_CREDENTIAL). Present only when status is FAILURE.
+          description: >-
+            Categorized error type (e.g. USER_CANCELLED, TIMEOUT, INVALID_CREDENTIAL). Present only when
+            status is FAILURE. The value ATTESTATION_TRUST marks a rejection caused by attestation trust
+            evaluation, and is the one category under which errorReason holds a "JFS_" diagnostic code
+            instead of a human-readable message.
         sessionId:
           type: string
           description: Session identifier linking this operation to a user session.
@@ -1378,3 +1423,29 @@ components:
         serviceAvailable:
           type: boolean
           description: True if metrics backend (e.g. DB) is reachable.
+    AttestationRejectionAnalysis:
+      type: object
+      description: Attestation rejections grouped by trust-related diagnostic code for the requested range.
+      properties:
+        totalRejections:
+          type: integer
+          description: Attestation rejections in range - entries whose error category is ATTESTATION_TRUST.
+        registrationAttempts:
+          type: integer
+          description: Registration attempts in range, the denominator for rejectionRate.
+        rejectionRate:
+          type: number
+          format: double
+          example: 0.12
+          description: Rejections divided by registration attempts; 0.0 when there were no attempts.
+        reasonCodes:
+          type: object
+          additionalProperties:
+            type: integer
+          example:
+            JFS_AAGUID_NOT_IN_MDS: 14
+            JFS_ROOT_CERT_NOT_TRUSTED: 3
+            JFS_AUTHENTICATOR_STATUS_UNACCEPTABLE: 1
+          description: >-
+            Count per internal diagnostic code, read from Fido2MetricsEntry.errorReason. These codes are
+            internal: the FIDO response envelope returned to the client is unchanged.

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/trust/AttestationTrustDiagnostic.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/trust/AttestationTrustDiagnostic.java
@@ -1,0 +1,90 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.model.trust;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Internal diagnostic codes for attestation rejections caused by trust or metadata problems.
+ * <p>
+ * These are written into the existing {@code Fido2MetricsEntry.errorReason} field, with
+ * {@link #CATEGORY} as the error category, so an operator can tell an unknown AAGUID from an untrusted
+ * root instead of reading free-text exception messages. They are internal: the public FIDO response
+ * envelope is unchanged and these codes never reach the client body.
+ * <p>
+ * Each constant carries the message markers of the failure site it maps to, so the mapping stays
+ * traceable to the code that raises it.
+ *
+ * @author Janssen Project
+ */
+public enum AttestationTrustDiagnostic {
+
+    /** {@code MdsService}: "Authenticator not in TOC aaguid …". */
+    JFS_AAGUID_NOT_IN_MDS("not in toc"),
+
+    /**
+     * {@code MdsService}: "Authenticator … status undesirable …" and
+     * {@code CertificateVerifier.verifyStatusAcceptable}: "… due to status: …".
+     */
+    JFS_AUTHENTICATOR_STATUS_UNACCEPTABLE("status undesirable", "due to status:"),
+
+    /** {@code CertificateVerifier.verifyAttestationCertificates}: "Problem with certificate …". */
+    JFS_ROOT_CERT_NOT_TRUSTED("problem with certificate"),
+
+    /** The attestation statement format is not one the server accepts. */
+    JFS_ATTESTATION_FORMAT_NOT_PERMITTED("unsupported attestation", "attestation format"),
+
+    /** Metadata was required to validate the authenticator but could not be fetched or loaded. */
+    JFS_MDS_UNAVAILABLE("mds unavailable", "metadata service");
+
+    /** Value written to {@code Fido2MetricsEntry.errorCategory} for every code in this enum. */
+    public static final String CATEGORY = "ATTESTATION_TRUST";
+
+    /** Shared prefix, used to recognise a diagnostic code without matching the enum itself. */
+    public static final String CODE_PREFIX = "JFS_";
+
+    private final List<String> messageMarkers;
+
+    AttestationTrustDiagnostic(String... messageMarkers) {
+        this.messageMarkers = Collections.unmodifiableList(Arrays.asList(messageMarkers));
+    }
+
+    public List<String> getMessageMarkers() {
+        return messageMarkers;
+    }
+
+    /**
+     * Classify a failure message as a trust diagnostic.
+     *
+     * @param errorMessage the message of the exception that failed the registration; may be null
+     * @return the matching code name, or {@code null} when the failure is not trust related — in which
+     *         case the caller keeps the original message, so nothing is lost for non-trust failures
+     */
+    public static String resolveCode(String errorMessage) {
+        if (errorMessage == null || errorMessage.isEmpty()) {
+            return null;
+        }
+        String normalized = errorMessage.toLowerCase();
+        for (AttestationTrustDiagnostic diagnostic : values()) {
+            for (String marker : diagnostic.messageMarkers) {
+                if (normalized.contains(marker)) {
+                    return diagnostic.name();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether a recorded {@code errorReason} is one of these diagnostic codes.
+     */
+    public static boolean isDiagnosticCode(String errorReason) {
+        return errorReason != null && errorReason.startsWith(CODE_PREFIX);
+    }
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -48,6 +48,10 @@ public class Fido2MetricsService {
     @Named(ApplicationFactory.PERSISTENCE_ENTRY_MANAGER_NAME)
     private PersistenceEntryManager persistenceEntryManager;
 
+    /** Response keys for the attestation-rejection analysis. */
+    private static final String REJECTION_RATE = "rejectionRate";
+    private static final String REJECTION_RATE_NOTE = "rejectionRateNote";
+
     private static final String METRICS_ENTRY_BASE_DN = "ou=fido2-metrics,o=jans";
     private static final String METRICS_AGGREGATION_BASE_DN = "ou=fido2-aggregations,o=jans";
 
@@ -585,17 +589,17 @@ public class Fido2MetricsService {
         // at all). Neither is a rate an administrator can act on, so report one only when the
         // denominator can carry it, and say why when it cannot.
         if (registrationAttempts <= 0) {
-            analysis.put("rejectionRate", null);
-            analysis.put("rejectionRateNote", totalRejections > 0
+            analysis.put(REJECTION_RATE, null);
+            analysis.put(REJECTION_RATE_NOTE, totalRejections > 0
                     ? "No registration attempts recorded in this range, so the rate cannot be computed. "
                             + "Widen the range, or check whether these rejections predate attempt tracking."
                     : "No registration attempts recorded in this range.");
         } else if (totalRejections > registrationAttempts) {
-            analysis.put("rejectionRate", 1.0);
-            analysis.put("rejectionRateNote", "Some rejections belong to attempts recorded before this "
+            analysis.put(REJECTION_RATE, 1.0);
+            analysis.put(REJECTION_RATE_NOTE, "Some rejections belong to attempts recorded before this "
                     + "range, so the rate is capped at 1.0. Widen the range for an exact figure.");
         } else {
-            analysis.put("rejectionRate", (double) totalRejections / registrationAttempts);
+            analysis.put(REJECTION_RATE, (double) totalRejections / registrationAttempts);
         }
 
         return analysis;

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -11,6 +11,7 @@ import io.jans.fido2.model.metric.Fido2MetricsAggregation;
 import io.jans.fido2.model.metric.Fido2MetricsConstants;
 import io.jans.fido2.model.metric.Fido2MetricsData;
 import io.jans.fido2.model.metric.Fido2MetricsEntry;
+import io.jans.fido2.model.trust.AttestationTrustDiagnostic;
 import io.jans.as.common.service.common.ApplicationFactory;
 import io.jans.orm.PersistenceEntryManager;
 import io.jans.orm.search.filter.Filter;
@@ -539,6 +540,62 @@ public class Fido2MetricsService {
                 analysis.put(Fido2MetricsConstants.COMPLETION_RATE, 0.0);
                 analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, 0.0);
             }
+        }
+
+        return analysis;
+    }
+
+    /**
+     * Break down attestation rejections by trust-related diagnostic code for a time range.
+     * <p>
+     * Reads the same metrics store as {@link #getErrorAnalysis}; rejections are the entries whose
+     * error category is {@link AttestationTrustDiagnostic#CATEGORY}. The rejection rate is expressed
+     * against registration attempts in the range, since a rejection is always a registration failure.
+     *
+     * @param startTime range start
+     * @param endTime   range end
+     * @return counts per reason code plus the totals needed to interpret them
+     */
+    public Map<String, Object> getAttestationRejectionAnalysis(LocalDateTime startTime, LocalDateTime endTime) {
+        List<Fido2MetricsEntry> entries = getMetricsEntries(startTime, endTime);
+
+        Map<String, Long> reasonCodes = entries.stream()
+            .filter(e -> AttestationTrustDiagnostic.CATEGORY.equals(e.getErrorCategory()))
+            .filter(e -> e.getErrorReason() != null)
+            .collect(Collectors.groupingBy(
+                Fido2MetricsEntry::getErrorReason,
+                Collectors.counting()
+            ));
+
+        long totalRejections = reasonCodes.values().stream().mapToLong(Long::longValue).sum();
+
+        long registrationAttempts = entries.stream()
+            .filter(e -> Fido2MetricsConstants.REGISTRATION.equals(e.getOperationType()))
+            .filter(e -> Fido2MetricsConstants.ATTEMPT.equals(e.getStatus()))
+            .count();
+
+        Map<String, Object> analysis = new HashMap<>();
+        analysis.put("totalRejections", totalRejections);
+        analysis.put("registrationAttempts", registrationAttempts);
+        analysis.put("reasonCodes", reasonCodes);
+
+        // A rejection and the attempt it belongs to are separate records with their own timestamps, so
+        // a range can hold one without the other. A bare ratio would then publish a rate above 1.0
+        // (attempt recorded just before the range) or 0.0 against real rejections (no attempts recorded
+        // at all). Neither is a rate an administrator can act on, so report one only when the
+        // denominator can carry it, and say why when it cannot.
+        if (registrationAttempts <= 0) {
+            analysis.put("rejectionRate", null);
+            analysis.put("rejectionRateNote", totalRejections > 0
+                    ? "No registration attempts recorded in this range, so the rate cannot be computed. "
+                            + "Widen the range, or check whether these rejections predate attempt tracking."
+                    : "No registration attempts recorded in this range.");
+        } else if (totalRejections > registrationAttempts) {
+            analysis.put("rejectionRate", 1.0);
+            analysis.put("rejectionRateNote", "Some rejections belong to attempts recorded before this "
+                    + "range, so the rate is capped at 1.0. Widen the range for an exact figure.");
+        } else {
+            analysis.put("rejectionRate", (double) totalRejections / registrationAttempts);
         }
 
         return analysis;

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
@@ -21,6 +21,7 @@ import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.conf.AttestationMode;
 import io.jans.fido2.model.conf.RequestedParty;
 import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.model.trust.AttestationTrustDiagnostic;
 import io.jans.fido2.service.Base64Service;
 import io.jans.fido2.service.ChallengeGenerator;
 import io.jans.fido2.service.DataMapperService;
@@ -616,12 +617,24 @@ public class AttestationService {
 	}
 	
 	/**
-	 * Record registration failure metrics
+	 * Record registration failure metrics.
+	 * <p>
+	 * Trust and metadata failures are recorded under an internal diagnostic code rather than the raw
+	 * exception message, so rejections can be counted by cause. Any other failure keeps its message
+	 * unchanged. This only affects what is written to metrics — the response returned to the client is
+	 * untouched.
 	 */
-	private void recordRegistrationFailureMetrics(String username, HttpServletRequest httpRequest, 
+	private void recordRegistrationFailureMetrics(String username, HttpServletRequest httpRequest,
 												  long startTime, Exception error, String authenticatorType) {
 		try {
-			String errorReason = error.getMessage() != null ? error.getMessage() : "Unknown error";
+			String message = error.getMessage() != null ? error.getMessage() : "Unknown error";
+			String diagnosticCode = AttestationTrustDiagnostic.resolveCode(message);
+			String errorReason = message;
+			if (diagnosticCode != null) {
+				errorReason = diagnosticCode;
+				// The original message stays in the log so no detail is lost by the substitution.
+				log.debug("Attestation rejected with diagnostic {}: {}", diagnosticCode, message);
+			}
 			metricService.recordPasskeyRegistrationFailure(username, httpRequest, startTime, errorReason, authenticatorType);
 		} catch (Exception metricsException) {
 			log.debug("Failed to record registration failure metrics", metricsException);

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/shared/MetricService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/shared/MetricService.java
@@ -15,6 +15,7 @@ import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.metric.Fido2MetricsData;
 import io.jans.fido2.model.metric.Fido2MetricType;
 import io.jans.fido2.model.metric.UserMetricsUpdateRequest;
+import io.jans.fido2.model.trust.AttestationTrustDiagnostic;
 import io.jans.fido2.service.util.DeviceInfoExtractor;
 import io.jans.model.ApplicationType;
 import io.jans.as.common.service.common.ApplicationFactory;
@@ -331,7 +332,12 @@ public class MetricService extends io.jans.service.metric.MetricService {
 
         if (event.errorReason != null) {
             metricsData.setErrorReason(event.errorReason);
-            if (appConfiguration.isFido2ErrorCategorization()) {
+            // A trust diagnostic code is not an inferred category - it is the value the attestation
+            // path deliberately recorded, and the attestation-rejections endpoint selects on it. Gating
+            // it on fido2ErrorCategorization would leave that endpoint silently empty whenever this
+            // unrelated toggle is off, so only the keyword-based bucketing stays behind the flag.
+            boolean trustDiagnostic = AttestationTrustDiagnostic.isDiagnosticCode(event.errorReason);
+            if (trustDiagnostic || appConfiguration.isFido2ErrorCategorization()) {
                 metricsData.setErrorCategory(categorizeError(event.errorReason));
             }
         }
@@ -569,7 +575,13 @@ public class MetricService extends io.jans.service.metric.MetricService {
         if (errorReason == null) {
             return UNKNOWN_ERROR;
         }
-        
+
+        // Checked before the keyword matching below, which would otherwise mis-bucket codes that happen
+        // to contain a keyword (e.g. JFS_MDS_METADATA_EXPIRED reads as "expired" -> TIMEOUT).
+        if (AttestationTrustDiagnostic.isDiagnosticCode(errorReason)) {
+            return AttestationTrustDiagnostic.CATEGORY;
+        }
+
         String lowerError = errorReason.toLowerCase();
         
         if (lowerError.contains("timeout") || lowerError.contains("expired")) {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/Fido2MetricsController.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/Fido2MetricsController.java
@@ -316,6 +316,31 @@ public class Fido2MetricsController {
     }
 
     /**
+     * Attestation rejections broken down by trust-related diagnostic code
+     *
+     * @param startTime Start time in ISO format
+     * @param endTime End time in ISO format
+     * @return Rejection counts per reason code
+     */
+    @GET
+    @Path("/analytics/attestation-rejections")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAttestationRejectionAnalysis(
+            @QueryParam("startTime") String startTime,
+            @QueryParam("endTime") String endTime) {
+        return processRequest(() -> {
+            checkMetricsEnabled();
+
+            LocalDateTime start = parseDateTime(startTime, Fido2MetricsConstants.PARAM_START_TIME);
+            LocalDateTime end = parseDateTime(endTime, Fido2MetricsConstants.PARAM_END_TIME);
+            validateTimeRange(start, end);
+
+            Map<String, Object> rejections = metricsService.getAttestationRejectionAnalysis(start, end);
+            return Response.ok(dataMapperService.writeValueAsString(rejections)).build();
+        });
+    }
+
+    /**
      * Get trend analysis for metrics over time
      * 
      * @param aggregationType Aggregation type for trend analysis

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/trust/AttestationTrustDiagnosticTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/trust/AttestationTrustDiagnosticTest.java
@@ -1,0 +1,91 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.trust;
+
+import io.jans.fido2.model.trust.AttestationTrustDiagnostic;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AttestationTrustDiagnosticTest {
+
+    // The expected inputs are the messages the failure sites actually raise, not invented strings.
+
+    @Test
+    void resolveCode_ifAuthenticatorNotInToc_returnsAaguidNotInMds() {
+        // MdsService: "Authenticator not in TOC aaguid " + aaguid
+        assertEquals("JFS_AAGUID_NOT_IN_MDS",
+                AttestationTrustDiagnostic.resolveCode("Authenticator not in TOC aaguid 83c44309"));
+    }
+
+    @Test
+    void resolveCode_ifStatusUndesirable_returnsStatusUnacceptable() {
+        // MdsService: "Authenticator " + aaguid + "status undesirable " + status
+        assertEquals("JFS_AUTHENTICATOR_STATUS_UNACCEPTABLE",
+                AttestationTrustDiagnostic.resolveCode("Authenticator 83c44309 status undesirable REVOKED"));
+    }
+
+    @Test
+    void resolveCode_ifStatusReportRejection_returnsStatusUnacceptable() {
+        // CertificateVerifier.verifyStatusAcceptable: "Ignore entry AAGUID: %s due to status: %s"
+        assertEquals("JFS_AUTHENTICATOR_STATUS_UNACCEPTABLE",
+                AttestationTrustDiagnostic.resolveCode("Ignore entry AAGUID: 83c44309 due to status: USER_VERIFICATION_BYPASS"));
+    }
+
+    @Test
+    void resolveCode_ifCertificateChainProblem_returnsRootCertNotTrusted() {
+        // CertificateVerifier.verifyAttestationCertificates: "Problem with certificate: ..."
+        assertEquals("JFS_ROOT_CERT_NOT_TRUSTED",
+                AttestationTrustDiagnostic.resolveCode("Problem with certificate: unable to find valid certification path"));
+    }
+
+    @Test
+    void resolveCode_ifAttestationFormatNotAccepted_returnsFormatNotPermitted() {
+        // Both markers the enum declares for this code, so a change to either is caught.
+        assertEquals("JFS_ATTESTATION_FORMAT_NOT_PERMITTED",
+                AttestationTrustDiagnostic.resolveCode("Unsupported attestation format tpm"));
+        assertEquals("JFS_ATTESTATION_FORMAT_NOT_PERMITTED",
+                AttestationTrustDiagnostic.resolveCode("This attestation format is not permitted"));
+    }
+
+    @Test
+    void resolveCode_ifMetadataUnavailable_returnsMdsUnavailable() {
+        assertEquals("JFS_MDS_UNAVAILABLE",
+                AttestationTrustDiagnostic.resolveCode("MDS unavailable, no TOC entries loaded"));
+        assertEquals("JFS_MDS_UNAVAILABLE",
+                AttestationTrustDiagnostic.resolveCode("The metadata service could not be reached"));
+    }
+
+    @Test
+    void resolveCode_ifNotTrustRelated_returnsNull() {
+        // A non-trust failure must keep its original message, so nothing is lost for other errors.
+        assertNull(AttestationTrustDiagnostic.resolveCode("Challenge is not valid"));
+        assertNull(AttestationTrustDiagnostic.resolveCode(""));
+        assertNull(AttestationTrustDiagnostic.resolveCode(null));
+    }
+
+    @Test
+    void isDiagnosticCode_recognisesOnlyPrefixedCodes() {
+        assertTrue(AttestationTrustDiagnostic.isDiagnosticCode("JFS_AAGUID_NOT_IN_MDS"));
+        assertFalse(AttestationTrustDiagnostic.isDiagnosticCode("Problem with certificate"));
+        assertFalse(AttestationTrustDiagnostic.isDiagnosticCode(null));
+    }
+
+    @Test
+    void everyCodeUsesTheSharedPrefix() {
+        // The category lookup in MetricService keys off this prefix.
+        for (AttestationTrustDiagnostic diagnostic : AttestationTrustDiagnostic.values()) {
+            assertTrue(diagnostic.name().startsWith(AttestationTrustDiagnostic.CODE_PREFIX),
+                    diagnostic.name() + " must start with " + AttestationTrustDiagnostic.CODE_PREFIX);
+            assertFalse(diagnostic.getMessageMarkers().isEmpty(),
+                    diagnostic.name() + " must declare at least one message marker");
+        }
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -243,6 +243,7 @@ nav:
       - Vendor Metadata: janssen-server/fido/vendor-metadata.md
       - Conditional UI and Fallback: janssen-server/fido/conditional-ui-and-fallback.md
       - Passkey Telemetry: janssen-server/fido/passkey-telemetry.md
+      - Attestation Rejection Diagnostics: janssen-server/fido/attestation-rejection-diagnostics.md
     - SAML:
       - Shibboleth IDP:
         - janssen-server/shibboleth-idp/README.md


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  The status endpoints tell an administrator what the trust configuration is, but not why individual registrations are being rejected. There is no categorization of attestation rejection causes: an unknown AAGUID, expired metadata, an attestation format not permitted by the mode, and an untrusted root certificate are indistinguishable from each other and from any other registration failure. The metrics subsystem already has the fields for this — Fido2MetricsEntry carries errorReason and errorCategory — but nothing populates them with trust-specific values, and there is no endpoint to aggregate them.
  
closes #14641 

#### Implementation Details
  
**This is the only one of the three PRs that touches attestation code paths.** No rejection behaviour changes; only the reason gets recorded.

Rejections were previously recorded as the raw exception message, so an unknown AAGUID, an untrusted root, and an unacceptable authenticator status were indistinguishable in metrics. `AttestationTrustDiagnostic` introduces internal
codes written into the existing `errorReason` field with `errorCategory` set to `ATTESTATION_TRUST` — additive, no new store.

**The codes map to messages the failure sites actually raise** (`MdsService`, `CertificateVerifier`), and each enum constant carries those markers in its definition so the mapping stays traceable to the code that raises it. A failure that is not trust related keeps its original message, and the original message is still logged whenever a code is substituted, so no detail is lost.

`categorizeError()` checks the `JFS_` prefix **before** its existing keyword matching — otherwise a code containing a keyword would be mis-bucketed (e.g. `JFS_MDS_METADATA_EXPIRED` reads as "expired" → `TIMEOUT`).

`GET /metrics/analytics/attestation-rejections` sits alongside `/analytics/errors` and reads the same store.

**Two deviations from the issue as filed, both deliberate:**

1. **No `topAaguids`.** `Fido2MetricsEntry` has no AAGUID field, so it cannot be computed without a persisted-model 
   change. The response returns `registrationAttempts` instead, which is what makes `rejectionRate`  interpretable. Adding an 
   AAGUID dimension is a reasonable follow-up.
3. **5 codes, not 7.** `JFS_MDS_METADATA_EXPIRED` and `JFS_APPLE_ROOT_CA_MISSING` have no emitting site in the current 
    code — nothing rejects on blob expiry during attestation, and the Apple processor fails on a missing `x5c` rather  than a   
    missing root CA. Shipping codes that can never fire would be worse than omitting them; they can be added when a site 
    exists.

The public FIDO response envelope is unchanged: `ErrorResponseFactory` still returns `{status:"failed", errorMessage:"…"}` and codes reach metrics and structured logs only, never the client body.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added attestation-rejection analytics with date-range filtering, totals, registration attempts, rejection rates, and diagnostic-code breakdowns.
- Added standardized diagnostics for common attestation trust and metadata failures while preserving existing client-facing responses.
- Added API documentation and example responses for the new metrics endpoint.

## Documentation
- Added guidance on diagnostic codes, analytics fields, storage behavior, and rejection-rate calculations.
- Updated FIDO2 and passkey documentation navigation and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->