### PR TITLE
fix(docs): build only annotated module for doc generation

### DIFF
--- a/automation/docs/generate-autogenerated-docs.sh
+++ b/automation/docs/generate-autogenerated-docs.sh
@@ -19,14 +19,14 @@ done
 # Compile jans-core to pick-up any changes in annotation processors
 mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-core/pom.xml -DskipTests clean compile install
 
-# Compile modules where classes that use these annotations exist.
-# This will generate markdown files under target/classes directory in respective module
-# Compilation would also generate Swagger SPEC in any module which uses appropriate annotations and undergoes any change
-mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-auth-server/pom.xml clean compile
-mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-fido2/pom.xml clean compile
-mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-scim/pom.xml clean compile
-mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-config-api/pom.xml -DskipTests clean compile
-mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-lock/pom.xml -DskipTests clean compile
+# Compile only the module holding the annotated classes (-pl ... -am). Building the
+# full aggregators also runs server/server-fips war-assembly steps that need a package
+# phase and fail under 'compile'; the doc processors only need the model/common module.
+mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-auth-server/pom.xml -pl model -am clean compile
+mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-fido2/pom.xml -pl model -am clean compile
+mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-scim/pom.xml -pl model -am clean compile
+mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-config-api/pom.xml -pl common -am -DskipTests clean compile
+mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-lock/pom.xml -pl lock-server/model -am -DskipTests clean compile
 
 # Move markdown files generated in respective modules by @DocFeatureFlag and @DocProperty annotations
 mv -f "$MAIN_DIRECTORY_LOCATION"/jans-auth-server/model/target/classes/janssenauthserver-properties.md "$PROPERTIES_DIR"


### PR DESCRIPTION
## Problem

Nightly docs run [31058365986](https://github.com/JanssenProject/jans/actions/runs/31058365986) failed in *Generate docs*:

```
maven-antrun-plugin:3.2.0:run (build-oxauth-fips-war) on jans-fido2-server-fips:
An Ant BuildException ... jans-fido2/server/target/fido2-server does not exist.
```

## Root cause

Good news first: the auth fix (#14709) worked — the build got past the `jans-bom` 401, through `jans-core`, and into `jans-fido2`. This is a **new, latent** failure now exposed.

The generate script compiled the whole aggregators (`mvn -f jans-fido2/pom.xml clean compile`), which includes `server` / `server-fips`. `server-fips`'s `build-oxauth-fips-war` antrun copies the exploded war from `server/target/fido2-server`, produced only at the `package` phase — so it fails under `compile`. Doc generation never needed those modules: the `@DocProperty`/`@DocFeatureFlag` classes live only in `model` (`common` for config-api, `lock-server/model` for lock).

## Fix

Restrict each build to the annotated module with `-pl <module> -am`, so `server`/`server-fips`/`client`/`plugins` never build. The compiler processor config is inherited from the aggregator `pluginManagement`, so `-pl model` still runs the processors. Also faster.

## Validation

- `bash -n` passes.
- Reactor build needs GitHub Packages auth; can't run locally. Authoritative check: docs `workflow_dispatch` (target `nightly`).

## Follow-up (not blocking)

`generate-swagger-specs.sh` still builds the full `jans-config-api` aggregator and may hit the same class of war-assembly issue — but that step is `|| echo`-tolerant, so it degrades to a stale swagger spec without failing the job. Will address separately if it surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated documentation generation by compiling only the required modules and dependencies.
  * Prevented unnecessary web archive assembly during the documentation build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->