### PR TITLE
fix(docs): skip server-fips when generating swagger specs

### DIFF
--- a/automation/docs/generate-swagger-specs.sh
+++ b/automation/docs/generate-swagger-specs.sh
@@ -6,5 +6,7 @@ MAIN_DIRECTORY_LOCATION=$1
 SETTINGS="$MAIN_DIRECTORY_LOCATION"/.github/maven-settings.xml
 echo "Generate Swagger yaml SPEC"
 
-# Compile jans-config-api to generate new Swagger SPECs from API annotations
-mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-config-api/pom.xml -DskipTests clean compile
+# Compile jans-config-api to generate new Swagger SPECs from API annotations.
+# Exclude server-fips: it emits no swagger and its build-configapi-fips-war antrun
+# (bound to process-sources) needs a packaged war that 'compile' never produces.
+mvn -q -s "$SETTINGS" -f "$MAIN_DIRECTORY_LOCATION"/jans-config-api/pom.xml -pl '!server-fips' -DskipTests clean compile


### PR DESCRIPTION
## Problem

In the nightly docs run, the swagger step failed:

```
maven-antrun (build-configapi-fips-war) on jans-config-api-server-fips:
.../jans-config-api/server/target/jans-config-api does not exist
```

`generate-swagger-specs.sh` compiled the whole `jans-config-api` aggregator. Its `server-fips` module has a `build-configapi-fips-war` antrun bound to `process-sources` (so it runs during `compile`) that copies an exploded war produced only at `package` — so it fails. (The step is `|| echo`-tolerant so it didn't fail the job, but it left the swagger specs stale.)

## Fix

`server-fips` emits no swagger (`jans-config-api-swagger.yaml` comes from the `server` module; plugins emit their own). Exclude it: `-pl '!server-fips'`. `server` + `plugins` still build and produce all swagger specs.

## Note

Companion to the model-only build applied to property-doc generation in #14717 — same root cause (aggregator `compile` triggering a fips war-assembly antrun), same shape of fix.

## Validation

- `bash -n` passes. Reactor build needs GitHub Packages auth; authoritative check is a docs `workflow_dispatch` (target `nightly`).
Closes #14727, 