### PR TITLE
fix(docs): correct autodoc source metadata and heading level

### DIFF
--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -102,7 +102,7 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "URL for Pushed Authorisation Request (PAR) Endpoint")
     private String parEndpoint;
 
-    @DocProperty(description = "Boolean value to indicate whether to include requested claims in id_token (specified by 'claims' parameter at Authorization Endpoint). Default value is false to put minimize claims in token (for security).", defaultValue = "false")
+    @DocProperty(description = "Boolean value to indicate whether to include requested claims in id_token (specified by 'claims' parameter at Authorization Endpoint). Default value is false to minimize the claims in the id_token (for security).", defaultValue = "false")
     private Boolean includeRequestedClaimsInIdToken = false;
 
     @DocProperty(description = "Boolean value to indicate whether to allow client assertion 'aud' without strict server issuer match. Default value is false which means that server requires strict match.", defaultValue = "false")
@@ -1000,7 +1000,7 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Defines if Response body will be logged. Default value is false", defaultValue = "false")
     private Boolean httpLoggingResponseBodyContent = false;
 
-    @DocProperty(description = "Force Authentication Filter to process OPTIONS request", defaultValue = "true")
+    @DocProperty(description = "When true, skips authentication filter processing for OPTIONS requests (the filter returns early before client authentication)", defaultValue = "true")
     private Boolean skipAuthenticationFilterOptionsMethod = true;
 
     @DocProperty(description = "Lock message Pub configuration", defaultValue = "false")

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -102,7 +102,7 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "URL for Pushed Authorisation Request (PAR) Endpoint")
     private String parEndpoint;
 
-    @DocProperty(description = "Boolean value to indicate whether to include requested claims in id_token (specified by 'claims' parameter at Authorization Endpoint). Default value is false to put minimize claims in token (for security).")
+    @DocProperty(description = "Boolean value to indicate whether to include requested claims in id_token (specified by 'claims' parameter at Authorization Endpoint). Default value is false to put minimize claims in token (for security).", defaultValue = "false")
     private Boolean includeRequestedClaimsInIdToken = false;
 
     @DocProperty(description = "Boolean value to indicate whether to allow client assertion 'aud' without strict server issuer match. Default value is false which means that server requires strict match.", defaultValue = "false")
@@ -111,7 +111,7 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Boolean value to indicate of Pushed Authorisation Request(PAR)is required", defaultValue = "false")
     private Boolean requirePar = false;
 
-    @DocProperty(description = "Boolean value to indicate whether public client is allowed for Pushed Authorisation Request(PAR)", defaultValue = "false")
+    @DocProperty(description = "Boolean value indicating whether public clients are forbidden from using Pushed Authorization Requests (PAR); when true, public clients are not allowed to use PAR.", defaultValue = "false")
     private Boolean parForbidPublicClient = false;
 
     @DocProperty(description = "Boolean value to indicate whether to allow user identification by uid claim from assertion at Token Endpoint", defaultValue = "false")
@@ -195,7 +195,7 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Archived JWK lifetime in seconds")
     private int archivedJwkLifetimeInSeconds;
 
-    @DocProperty(description = "Boolean value to indicate whether to uppercase keys returns from /open-banking/v3.1/aisp/account-access-consents endpoint", defaultValue = "false")
+    @DocProperty(description = "Boolean value to indicate whether to uppercase keys returned from /open-banking/v3.1/aisp/account-access-consents endpoint", defaultValue = "false")
     private Boolean uppercaseResponseKeysInAccountAccessConsent = false;
 
     @DocProperty(description = "UMA Configuration endpoint URL")
@@ -294,19 +294,19 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT")
     private List<String> userInfoSigningAlgValuesSupported;
 
-    @DocProperty(description = "This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT")
+    @DocProperty(description = "This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT")
     private List<String> userInfoEncryptionAlgValuesSupported;
 
-    @DocProperty(description = "This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT")
+    @DocProperty(description = "This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT")
     private List<String> userInfoEncryptionEncValuesSupported;
 
     @DocProperty(description = "This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT")
     private List<String> introspectionSigningAlgValuesSupported;
 
-    @DocProperty(description = "This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT")
+    @DocProperty(description = "This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT")
     private List<String> introspectionEncryptionAlgValuesSupported;
 
-    @DocProperty(description = "This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT")
+    @DocProperty(description = "This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT")
     private List<String> introspectionEncryptionEncValuesSupported;
 
     @DocProperty(description = "This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the Logout Status JWT at Authorization Endpoint to encode the claims in a JWT")
@@ -315,10 +315,10 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT")
     private List<String> txTokenSigningAlgValuesSupported;
 
-    @DocProperty(description = "This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT")
+    @DocProperty(description = "This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT")
     private List<String> txTokenEncryptionAlgValuesSupported;
 
-    @DocProperty(description = "This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT")
+    @DocProperty(description = "This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT")
     private List<String> txTokenEncryptionEncValuesSupported;
 
     @DocProperty(description = "A list of the JWS signing algorithms (alg values) supported by the OP for the ID Token to encode the Claims in a JWT")
@@ -516,7 +516,7 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "The acr mappings. When AS meets key-value in map, it tries to replace 'key' with 'value' as very first thing and use that 'value' in further processing.")
     private Map<String, String> acrMappings;
 
-    @DocProperty(description = "The acr mapping to consent script name. When AS meets acr it tries to match consent script name and invoke it during authorization. This takes higher precedence then client consent script configuration.")
+    @DocProperty(description = "The acr mapping to consent script name. When AS meets acr it tries to match consent script name and invoke it during authorization. This takes higher precedence than client consent script configuration.")
     private Map<String, String> acrToConsentScriptNameMapping;
 
     @DocProperty(description = "The acr mapping to agama consent flow name. When AS meets acr it tries to match agama consent name and set it into session attributes under 'consent_flow' name. This makes it available for main Agama Consent script, so it knows which flow to invoke.")
@@ -528,7 +528,7 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Boolean value specifying whether to enable client authentication filters")
     private Boolean clientAuthenticationFiltersEnabled;
 
-    @DocProperty(description = "Boolean value specifying whether to add Authorization Code Flow with Refresh grant during client registratio")
+    @DocProperty(description = "Boolean value specifying whether to add Authorization Code Flow with Refresh grant during client registration")
     private Boolean clientRegDefaultToCodeFlowWithRefresh;
 
     @DocProperty(description = "Boolean value specifying whether to Grant types and Response types can be auto fixed")
@@ -1000,7 +1000,7 @@ public class AppConfiguration implements Configuration {
     @DocProperty(description = "Defines if Response body will be logged. Default value is false", defaultValue = "false")
     private Boolean httpLoggingResponseBodyContent = false;
 
-    @DocProperty(description = "Force Authentication Filtker to process OPTIONS request", defaultValue = "true")
+    @DocProperty(description = "Force Authentication Filter to process OPTIONS request", defaultValue = "true")
     private Boolean skipAuthenticationFilterOptionsMethod = true;
 
     @DocProperty(description = "Lock message Pub configuration", defaultValue = "false")
@@ -1010,7 +1010,7 @@ public class AppConfiguration implements Configuration {
     private ConnectionServiceConfiguration connectionServiceConfiguration;
 
     // Client ID Metadata Document (CIMD) Configuration
-    @DocProperty(description = "Allowed URL schemes for CIMD client_id (default: https only)")
+    @DocProperty(description = "Allowed URL schemes for CIMD client_id (default: https only)", defaultValue = "[\"https\"]")
     private List<String> cimdSchemeAllowlist;
 
     @DocProperty(description = "Allowed domains for CIMD client_id URLs")

--- a/jans-config-api/common/src/main/java/io/jans/configapi/model/configuration/ApiAppConfiguration.java
+++ b/jans-config-api/common/src/main/java/io/jans/configapi/model/configuration/ApiAppConfiguration.java
@@ -20,7 +20,7 @@ public class ApiAppConfiguration implements Configuration {
     @Schema(description = "OAuth authentication enable/disable flag. Default value `true`.")
     private boolean configOauthEnabled;
 
-    @DocProperty(description = "Protection mode for the Lock server (OAuth or Cedarling)")
+    @DocProperty(description = "Protection mode for the Lock server (OAuth or Cedarling)", defaultValue = "oauth")
     @Schema(description = "Protection mode for the Lock server (OAuth or Cedarling)")
     private LockProtectionMode protectionMode = LockProtectionMode.OAUTH;
 

--- a/jans-core/cedarling/src/main/java/io/jans/core/cedarling/model/CedarlingConfiguration.java
+++ b/jans-core/cedarling/src/main/java/io/jans/core/cedarling/model/CedarlingConfiguration.java
@@ -41,8 +41,8 @@ public class CedarlingConfiguration implements Configuration {
 	@Schema(description = "External policy store URI")
 	private String externalPolicyStoreUri;
 	
-    @DocProperty(description = "maximum number of enteries in policy store file")
-    @Schema(description = "maximum number of enteries in policy store file")
+    @DocProperty(description = "maximum number of entries in policy store file")
+    @Schema(description = "maximum number of entries in policy store file")
     private int maxEntries = 0;
 
 	public boolean isEnabled() {

--- a/jans-core/doc/src/main/java/io/jans/doc/annotation/DocFeatureFlagProcessor.java
+++ b/jans-core/doc/src/main/java/io/jans/doc/annotation/DocFeatureFlagProcessor.java
@@ -96,7 +96,7 @@ public class DocFeatureFlagProcessor extends AbstractProcessor {
     }
 
     private static void addToDetails(StringBuilder propDetails, Element jansElement, DocFeatureFlag featureFlagAnnotation) {
-        propDetails.append("### "+ jansElement.getSimpleName()+"\n\n");
+        propDetails.append("## "+ jansElement.getSimpleName()+"\n\n");
         propDetails.append("- Description: "+ featureFlagAnnotation.description()+"\n\n");
         propDetails.append("- Required: "+ (featureFlagAnnotation.isRequired()?"Yes":"No")+"\n\n");
         propDetails.append("- Default value: "+ featureFlagAnnotation.defaultValue()+"\n\n");

--- a/jans-core/doc/src/main/java/io/jans/doc/annotation/DocPropertyProcessor.java
+++ b/jans-core/doc/src/main/java/io/jans/doc/annotation/DocPropertyProcessor.java
@@ -104,7 +104,7 @@ public class DocPropertyProcessor extends AbstractProcessor {
     }
 
     private static void addToDetails(StringBuilder propDetails, Element jansProperty, DocProperty propertyAnnotation) {
-        propDetails.append("### "+ jansProperty.getSimpleName()+"\n\n");
+        propDetails.append("## "+ jansProperty.getSimpleName()+"\n\n");
         propDetails.append("- Description: "+ propertyAnnotation.description()+"\n\n");
         propDetails.append("- Required: "+ (propertyAnnotation.isRequired()?"Yes":"No")+"\n\n");
         propDetails.append("- Default value: "+ propertyAnnotation.defaultValue()+"\n\n");

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
@@ -45,7 +45,7 @@ public class Fido2Configuration {
 	private List<RequestedParty> requestedParties = new ArrayList<>();
 	@DocProperty(description = "String value to provide source of URLs with external metadata")
 	private List<MetadataServer> metadataServers = new ArrayList<>();
-	@DocProperty(description = "Boolean value indicating whether the MDS download should be omitted")
+	@DocProperty(description = "Boolean value indicating whether the MDS download should be omitted", defaultValue = "false")
 	private boolean disableMetadataService = false;
 	@DocProperty(description = "Number of times the MDS TOC download is retried at server startup when the TOC blob is missing (a missing TOC prevents attestation validation)", defaultValue = "3")
 	private int mdsDownloadStartupRetries = 3;
@@ -53,9 +53,9 @@ public class Fido2Configuration {
 	private int mdsDownloadStartupRetryInterval = 30;
 	@DocProperty(description = "Hints to the RP - security-key, client-device, hybrid")
 	private List<String> hints = new ArrayList<>();
-	@DocProperty(description = "If authenticators have been enabled for use in a specific protected envt (enterprise authenticators)")
+	@DocProperty(description = "If authenticators have been enabled for use in a specific protected envt (enterprise authenticators)", defaultValue = "false")
 	private boolean enterpriseAttestation = false;
-	@DocProperty(description = "String value indicating whether MDS validation should be omitted during attestation")
+	@DocProperty(description = "String value indicating whether MDS validation should be omitted during attestation", defaultValue = "monitor")
 	private String attestationMode = "monitor";
 
 	public String getAuthenticatorCertsFolder() {


### PR DESCRIPTION
Addresses CodeRabbit findings on the auto-generated docs PR (#14729). Since those pages are generated, the fixes are applied at the **source** (annotations + generator); CI regenerates the pages.

## Fixed

**Generator** (heading hierarchy — covers all cited pages)
- `DocPropertyProcessor`/`DocFeatureFlagProcessor` now emit detail sections as `##` instead of `###`, so the level doesn't skip under the `#` title.

**Typos** (`@DocProperty`/`@Schema`)
- `keys returns`→`returned`, `precedence then`→`than`, `registratio`→`registration`, `Filtker`→`Filter` (auth); `enteries`→`entries` (cedarling → lock-plugin swagger).

**Semantics**
- Auth `JWS encryption algorithms`→`JWE encryption algorithms` (UserInfo/Introspection/Transaction-Token encryption alg+enc — 6 entries; signing entries correctly stay JWS).
- `parForbidPublicClient`: description had reversed meaning — corrected to "true forbids public clients from using PAR".

**Missing `defaultValue`** (added to match the field initializer — the code's actual default)
- auth `cimdSchemeAllowlist`=`["https"]` (getter falls back to `List.of("https")`), `includeRequestedClaimsInIdToken`=`false`; fido2 `attestationMode`=`monitor`, `disableMetadataService`=`false`, `enterpriseAttestation`=`false`; config-api `protectionMode`=`oauth`.

## Skipped (with reason)

- **config-api `disableExternalLoggerConfiguration` → false**: model field default is `true` and the annotation already says `true`. CodeRabbit's `false` comes from `upgrade.py` (a deployment override), not the model — documenting the model default is correct.
- **fido2 `requestedParties` → `rp`**: the persisted key is `rp` (`@JsonProperty`), but the generator keys sections off the field name. Reading `@JsonProperty` is a generator-wide change affecting every aliased property across all modules — out of scope for a minimal fix.
- **status-list numeric defaults (2/100/RS256)**: couldn't precisely identify the exact set of cited properties, and their descriptions already state the defaults; adding `defaultValue` to an unclear set would be an imprecise, broad change.

## Validation

- String/annotation edits only — no structural Java changes. Regenerated pages come from CI (docs `workflow_dispatch`).
Closes #14732, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified configuration property descriptions and corrected terminology.
  - Added documented defaults for protection mode, metadata service, enterprise attestation, requested claims, and CIMD scheme restrictions.
  - Clarified PAR public-client behavior.
  - Improved generated documentation structure with clearer heading levels.
  - Corrected a spelling error in configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->