### PR TITLE
fix(jans-fido2): record failed and abandoned assertion ceremonies

### DIFF
--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -75,13 +75,17 @@ Two kinds of data are produced:
 
 !!! note "ATTEMPT vs. completion"
     Each operation produces a separate `ATTEMPT` entry when the user starts and a
-    `SUCCESS`/`FAILURE`/`ABANDONED` entry when it resolves. An `ATTEMPT` with no matching
-    completion means the user **dropped off** — which is what `dropOffRate` measures.
+    `SUCCESS`/`FAILURE`/`ABANDONED` entry when it resolves. An `ATTEMPT` with no matching entry is
+    either a ceremony **still in flight** or one the user **dropped off** from — the two are not
+    distinguishable at query time, which is why `dropOffRate`, computed as that residual, is an
+    inference rather than a count.
 
 ### The three outcomes of an authentication ceremony
 
-Every assertion ceremony resolves to exactly one of three server-observable outcomes, recorded
-both as the `jansStatus` of its `jansFido2AuthnEntry` row and as a metrics entry status:
+With `recordAbandonedAssertions` enabled (the default), every assertion ceremony resolves to one of
+three server-observable outcomes, recorded both as the `jansStatus` of its `jansFido2AuthnEntry` row
+and as a metrics entry status. With it disabled, a lapsed ceremony stays `pending` and is deleted by
+normal cleanup, as it was before:
 
 | Outcome | `jansStatus` | Metric status | Meaning |
 |---|---|---|---|

--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -33,7 +33,7 @@ within your organization.
 |---|---|
 | Is adoption growing? How many users are new vs. returning? | `analytics/adoption`, `analytics/trends` |
 | Are registrations and sign-ins actually succeeding? | aggregation `summary`, `analytics/errors` |
-| How many users start a passkey flow but drop off? | `analytics/errors` (`dropOffRate`) |
+| How many users start a passkey flow but drop off? | `analytics/errors` (`dropOffRate`, `abandonmentRate`) |
 | Why are users failing — cancels, timeouts, bad credentials? | `analytics/errors` (`errorCategories`, `topErrors`) |
 | Why are authenticators being rejected at registration? | `analytics/attestation-rejections` (`reasonCodes`, `topRejectedAaguids`) |
 | Which platforms, browsers, and authenticator types are in use? | `analytics/devices` |
@@ -75,8 +75,47 @@ Two kinds of data are produced:
 
 !!! note "ATTEMPT vs. completion"
     Each operation produces a separate `ATTEMPT` entry when the user starts and a
-    `SUCCESS`/`FAILURE` entry when it completes. An `ATTEMPT` with no matching completion
-    means the user **dropped off** — which is exactly what `dropOffRate` measures.
+    `SUCCESS`/`FAILURE`/`ABANDONED` entry when it resolves. An `ATTEMPT` with no matching
+    completion means the user **dropped off** — which is what `dropOffRate` measures.
+
+### The three outcomes of an authentication ceremony
+
+Every assertion ceremony resolves to exactly one of three server-observable outcomes, recorded
+both as the `jansStatus` of its `jansFido2AuthnEntry` row and as a metrics entry status:
+
+| Outcome | `jansStatus` | Metric status | Meaning |
+|---|---|---|---|
+| Verified success | `authenticated` | `SUCCESS` | An assertion was posted and passed verification |
+| Verified failure | `failed` | `FAILURE` | An assertion was posted and the server rejected it — bad signature, stale challenge, unknown credential, RP ID mismatch |
+| Abandonment | `abandoned` | `ABANDONED` | The ceremony window elapsed and nothing was ever posted back |
+
+Abandonment is detected by a sweep that runs every `abandonedRequestSweepInterval` seconds and
+relabels ceremonies still marked `pending` past `unfinishedRequestExpiration`. Abandoned rows are
+retained for `abandonedRequestExpiration` — deliberately much shorter than
+`authenticationHistoryExpiration`, because conditional-UI ceremonies start on virtually every login
+page load and abandonment is therefore the highest-volume outcome by far. Set
+`recordAbandonedAssertions` to `false` to disable the sweep.
+
+`abandonmentRate` and `dropOffRate` answer different questions and are reported side by side.
+`dropOffRate` is inferred as the residual of attempts minus completions, so it also absorbs
+ceremonies still in flight when the query runs; `abandonmentRate` counts ceremonies actually
+observed to have lapsed. In multi-node deployments the sweep is not coordinated across nodes, so
+`abandonmentRate` is approximate — an exact count is available by querying `jansStatus = 'abandoned'`
+directly within the retention window.
+
+!!! warning "A failed fingerprint is never a `FAILURE`"
+    With platform authenticators such as Touch ID, Face ID or Windows Hello, user verification
+    happens **inside the authenticator**. A wrong fingerprint causes the operating system to retry
+    locally and eventually fall back to the device passcode; the authenticator only emits an
+    assertion once verification has already succeeded. None of those failed attempts reach the
+    browser, let alone this server.
+
+    Consequently **the count of failed biometric attempts is not obtainable by any relying party**,
+    and "the user failed their fingerprint" can never be recorded as an authentication failure. A
+    user who fights with Touch ID and gives up is indistinguishable, at the protocol level, from one
+    who cancelled immediately — both surface as `NotAllowedError` in the browser and as an
+    `abandoned` ceremony here. A `FAILURE` means the server rejected an assertion it received, which
+    in practice means a protocol-level problem rather than a user who could not verify.
 
 ### Request context on raw entries
 
@@ -207,6 +246,9 @@ is given below.
 - **authentication success rate** above ~0.90 (sign-in is usually higher, since no key generation is involved).
 - A high **`dropOffRate`** or high **`USER_CANCELLED`** count usually points at UX friction
   in the passkey prompt.
+- A high **`abandonmentRate`** points at the same friction but is the firmer signal, since it counts
+  ceremonies observed to have lapsed rather than inferring them. Remember that it cannot separate a
+  deliberate cancel from repeated biometric failures — see the warning above.
 - During rollout, expect a high **`adoptionRate`** (many new users); as the base matures it
   falls and **`returningUsers`** dominates — that's the healthy direction.
 - Rising **average durations** (`analytics/performance`) is an early warning of

--- a/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
@@ -298,7 +298,8 @@ paths:
                   description: Response example
                   value: "{\n    \"errorCategories\": {},\n    \"failureRate\": 0.75,\n\
                     \    \"successRate\": 0.25,\n\t\"completionRate\": 0.48,\n\t\"\
-                    dropOffRate\": 0.52,\n    \"topErrors\": {}\n}\n"
+                    dropOffRate\": 0.52,\n\t\"abandonedOperations\": 37,\n\t\"abandonmentRate\"\
+                    : 0.31,\n    \"topErrors\": {}\n}\n"
         "400":
           description: Bad Request
         "401":

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -1393,7 +1393,13 @@ components:
           description: Ratio of started operations that completed (success or failure). Equals successRate + failureRate (0.0–1.0).
         dropOffRate:
           type: number
-          description: Ratio of started operations that did not complete (user dropped off). Equals 1 - completionRate (0.0–1.0).
+          description: Ratio of started operations that did not complete (user dropped off). Equals 1 - completionRate (0.0–1.0). Inferred as a residual, so it also absorbs ceremonies still in flight at the edge of the query window.
+        abandonedOperations:
+          type: integer
+          description: Count of authentication ceremonies observed to have lapsed without ever being completed. Unlike dropOffRate this is counted from ceremonies actually relabelled as abandoned, not inferred. Approximate in multi-node deployments, where a ceremony may be counted more than once.
+        abandonmentRate:
+          type: number
+          description: Ratio of started operations observed to have been abandoned (0.0–1.0). Based on ATTEMPT count as denominator. Reported alongside dropOffRate, not instead of it.
     MetricsTrends:
       type: object
       description: Trend analysis over time with data points, growth rate, direction, and insights.

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -1187,7 +1187,8 @@ components:
             - SUCCESS
             - FAILURE
             - ATTEMPT
-          description: ATTEMPT (started), SUCCESS (completed), or FAILURE (completed with error).
+            - ABANDONED
+          description: ATTEMPT (started), SUCCESS (completed), FAILURE (completed with error), or ABANDONED (authentication ceremony started but never completed). ABANDONED is not a completion and is excluded from the attempt total that failures are derived from.
         durationMs:
           type: integer
           description: Operation duration in milliseconds.

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
@@ -36,6 +36,13 @@ public class Fido2Configuration {
 	@DocProperty(description = "Expiration time in seconds for approved authentication requests")
 	private int authenticationHistoryExpiration = 15 * 24 * 3600; // 15 days
 
+	@DocProperty(description = "Boolean value indicating whether assertion ceremonies that lapse without being completed are relabelled as abandoned instead of being deleted unlabelled", defaultValue = "true")
+	private boolean recordAbandonedAssertions = true;
+	@DocProperty(description = "Expiration time in seconds for abandoned assertion ceremonies. Kept much shorter than authenticationHistoryExpiration because conditional-UI ceremonies start on nearly every login page load, making abandonment the highest-volume outcome", defaultValue = "86400")
+	private int abandonedRequestExpiration = 24 * 3600; // 1 day
+	@DocProperty(description = "Interval in seconds between sweeps for lapsed assertion ceremonies. Must stay below unfinishedRequestExpiration so a ceremony cannot lapse and be deleted between two sweeps", defaultValue = "30")
+	private int abandonedRequestSweepInterval = 30;
+
 	@DocProperty(description = "Authenticators metadata in json format")
 	private String serverMetadataFolder;
 	@DocProperty(description = "List of Requested Credential Types")
@@ -57,6 +64,30 @@ public class Fido2Configuration {
 	private boolean enterpriseAttestation = false;
 	@DocProperty(description = "String value indicating whether MDS validation should be omitted during attestation", defaultValue = "monitor")
 	private String attestationMode = "monitor";
+
+	public boolean isRecordAbandonedAssertions() {
+		return recordAbandonedAssertions;
+	}
+
+	public void setRecordAbandonedAssertions(boolean recordAbandonedAssertions) {
+		this.recordAbandonedAssertions = recordAbandonedAssertions;
+	}
+
+	public int getAbandonedRequestExpiration() {
+		return abandonedRequestExpiration;
+	}
+
+	public void setAbandonedRequestExpiration(int abandonedRequestExpiration) {
+		this.abandonedRequestExpiration = abandonedRequestExpiration;
+	}
+
+	public int getAbandonedRequestSweepInterval() {
+		return abandonedRequestSweepInterval;
+	}
+
+	public void setAbandonedRequestSweepInterval(int abandonedRequestSweepInterval) {
+		this.abandonedRequestSweepInterval = abandonedRequestSweepInterval;
+	}
 
 	public String getAuthenticatorCertsFolder() {
 		return authenticatorCertsFolder;

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricType.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricType.java
@@ -41,6 +41,9 @@ public enum Fido2MetricType implements MetricTypeDeclaration {
             CounterMetricData.class, CounterMetricEntry.class),
     FIDO2_AUTHENTICATION_DURATION("fido2_authentication_duration", "Passkey authentication completion time",
             TimerMetricData.class, TimerMetricEntry.class),
+    FIDO2_AUTHENTICATION_ABANDONED("fido2_authentication_abandoned",
+            "Count passkey authentications started but never completed", CounterMetricData.class,
+            CounterMetricEntry.class),
 
     // FIDO2/Passkey Fallback Metrics
     FIDO2_FALLBACK_EVENT("fido2_fallback_event", "Count passkey fallback events to other methods",

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricsConstants.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricsConstants.java
@@ -44,6 +44,8 @@ public final class Fido2MetricsConstants {
     public static final String SUCCESS = "SUCCESS";
     public static final String FAILURE = "FAILURE";
     public static final String ATTEMPT = "ATTEMPT";
+    /** A ceremony that was started and never completed — neither verified nor rejected. */
+    public static final String ABANDONED = "ABANDONED";
 
     /** Key under which an attestation rejection records the AAGUID it concerns, in additionalData. */
     public static final String AAGUID = "aaguid";
@@ -105,6 +107,9 @@ public final class Fido2MetricsConstants {
     public static final String FALLBACK_EVENTS = "fallbackEvents";
     public static final String DEVICE_TYPES = "deviceTypes";
     public static final String ERROR_COUNTS = "errorCounts";
+    /** Ceremonies observed to have lapsed, as opposed to the residual that {@link #DROP_OFF_RATE} infers. */
+    public static final String ABANDONED_OPERATIONS = "abandonedOperations";
+    public static final String ABANDONMENT_RATE = "abandonmentRate";
     public static final String PERFORMANCE_METRICS = "performanceMetrics";
     public static final String TOTAL_OPERATIONS = "totalOperations";
     

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyEvent.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyEvent.java
@@ -1,0 +1,17 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.app;
+
+/**
+ * Fires the sweep for assertion ceremonies that lapsed without ever being completed.
+ * <p>
+ * Deliberately separate from {@code CleanerEvent}: the sweep has to run on its own, shorter cadence
+ * so that it can claim a lapsed ceremony before the cleaner deletes it.
+ */
+public interface AbandonedCeremonyEvent {
+
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyPolicy.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyPolicy.java
@@ -1,0 +1,78 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.app;
+
+import io.jans.fido2.model.conf.Fido2Configuration;
+
+/**
+ * Resolves the timing the abandonment sweep depends on.
+ * <p>
+ * The sweep and the code that writes pending ceremonies have to agree on two derived values, and they
+ * live in different classes. Deriving both here keeps the invariant in one place: a pending ceremony
+ * must survive long enough for at least one sweep to claim it after its window elapses, but no longer
+ * than necessary.
+ *
+ * @author Janssen Project
+ */
+public final class AbandonedCeremonyPolicy {
+
+	private static final int MINIMUM_INTERVAL = 1;
+
+	private AbandonedCeremonyPolicy() {
+	}
+
+	/**
+	 * The interval the sweep actually runs at.
+	 * <p>
+	 * A configured interval at or above {@code unfinishedRequestExpiration} is not usable: a ceremony
+	 * could lapse and be deleted entirely between two passes. Such a value is capped rather than
+	 * honoured, because silently sweeping too slowly loses data while running more often does not.
+	 *
+	 * @return a positive interval in seconds, strictly below the ceremony window whenever that window
+	 *         itself leaves room for one
+	 */
+	public static int effectiveSweepInterval(Fido2Configuration fido2Configuration) {
+		int unfinishedRequestExpiration = fido2Configuration.getUnfinishedRequestExpiration();
+		int configured = fido2Configuration.getAbandonedRequestSweepInterval();
+
+		// Half the window guarantees a pass inside it while staying strictly below it. Never below
+		// MINIMUM_INTERVAL, so a nonsensically short window still yields a runnable schedule.
+		int maximumUsable = Math.max(MINIMUM_INTERVAL, unfinishedRequestExpiration / 2);
+
+		if (configured < MINIMUM_INTERVAL || configured > maximumUsable) {
+			return maximumUsable;
+		}
+		return configured;
+	}
+
+	/**
+	 * True when the configured interval had to be overridden, so the caller can say so once at startup
+	 * rather than on every pass.
+	 */
+	public static boolean isSweepIntervalOverridden(Fido2Configuration fido2Configuration) {
+		return fido2Configuration.getAbandonedRequestSweepInterval() != effectiveSweepInterval(fido2Configuration);
+	}
+
+	/**
+	 * How long a {@code pending} ceremony is retained.
+	 * <p>
+	 * The row has to outlive its own ceremony window, otherwise it becomes eligible for deletion at the
+	 * same instant the sweep becomes eligible to claim it and abandonment goes unrecorded. Two sweep
+	 * intervals of grace guarantees a pass falls inside it. This does not widen the window in which an
+	 * assertion is accepted — that is enforced against the ceremony's issue time when it is verified.
+	 * <p>
+	 * With the sweep disabled the retention is exactly what it always was, so nothing changes for a
+	 * deployment that has opted out.
+	 */
+	public static int pendingCeremonyRetention(Fido2Configuration fido2Configuration) {
+		int unfinishedRequestExpiration = fido2Configuration.getUnfinishedRequestExpiration();
+		if (!fido2Configuration.isRecordAbandonedAssertions()) {
+			return unfinishedRequestExpiration;
+		}
+		return unfinishedRequestExpiration + (2 * effectiveSweepInterval(fido2Configuration));
+	}
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyTimer.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyTimer.java
@@ -1,0 +1,225 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.app;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.service.persist.AuthenticationPersistenceService;
+import io.jans.fido2.service.shared.MetricService;
+import io.jans.orm.model.fido2.Fido2AuthenticationData;
+import io.jans.orm.model.fido2.Fido2AuthenticationEntry;
+import io.jans.orm.model.fido2.Fido2AuthenticationStatus;
+import io.jans.service.cdi.async.Asynchronous;
+import io.jans.service.cdi.event.Scheduled;
+import io.jans.service.timer.event.TimerEvent;
+import io.jans.service.timer.schedule.TimerSchedule;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+/**
+ * Relabels assertion ceremonies that lapsed without ever being completed.
+ * <p>
+ * A ceremony is written as {@code pending} when the options are issued and flipped to
+ * {@code authenticated} when the assertion is verified. If the user cancels, closes the sheet, or
+ * simply gives up, nothing is ever posted back — so without this sweep the row stays {@code pending}
+ * until the cleaner deletes it, and an abandoned ceremony is indistinguishable first from one still
+ * in flight and then from one that never happened at all.
+ * <p>
+ * The sweep is deliberately <em>not</em> coordinated across nodes, so abandonment is counted at least
+ * once rather than exactly once. Two locking approaches were examined and rejected: the metrics
+ * aggregation scheduler's cluster lock is only initialised behind that scheduler's own enabled check,
+ * so with aggregation disabled it silently reports success on every node; and a dedicated cluster
+ * node type would allocate an index into a base DN that other components already populate. What
+ * bounds the error is the transition itself — it only fires from {@code pending}, so a row another
+ * node has already claimed is not matched again and the stored value converges regardless of who
+ * writes it. Only the emitted metric can duplicate, and only for a batch two nodes read before either
+ * writes it back; single-node deployments are exact.
+ *
+ * @author Janssen Project
+ */
+@ApplicationScoped
+@Named
+public class AbandonedCeremonyTimer {
+
+	/**
+	 * Ceilings one sweep. Abandonment is the highest-volume outcome — conditional-UI ceremonies start
+	 * on virtually every login page load — so a backlog is bounded per pass rather than read at once.
+	 */
+	public static final int BATCH_SIZE = 1000;
+
+	private static final int MINIMUM_INTERVAL = 1;
+
+	@Inject
+	private Logger log;
+
+	@Inject
+	private AppConfiguration appConfiguration;
+
+	@Inject
+	private AuthenticationPersistenceService authenticationPersistenceService;
+
+	@Inject
+	private MetricService metricService;
+
+	@Inject
+	private Event<TimerEvent> timerEvent;
+
+	private AtomicBoolean isActive;
+
+	public void initTimer() {
+		if (!isSweepEnabled()) {
+			log.info("Abandoned assertion ceremony sweep is disabled, skipping timer initialization");
+			return;
+		}
+
+		log.info("Initializing Abandoned Ceremony Timer");
+		this.isActive = new AtomicBoolean(false);
+
+		int interval = resolveSweepInterval();
+		timerEvent.fire(new TimerEvent(new TimerSchedule(interval, interval), new AbandonedCeremonyEvent() {
+		}, Scheduled.Literal.INSTANCE));
+
+		log.info("Initialized Abandoned Ceremony Timer with interval {}s", interval);
+	}
+
+	@Asynchronous
+	public void process(@Observes @Scheduled AbandonedCeremonyEvent abandonedCeremonyEvent) {
+		if (this.isActive == null || this.isActive.get()) {
+			return;
+		}
+
+		if (!this.isActive.compareAndSet(false, true)) {
+			return;
+		}
+
+		try {
+			processImpl();
+		} finally {
+			this.isActive.set(false);
+		}
+	}
+
+	/**
+	 * Claims every ceremony whose window has elapsed. Package-visible so a test can drive one pass
+	 * without standing up the timer.
+	 */
+	void processImpl() {
+		try {
+			// Re-read on every pass: the configuration is reloadable, and a sweep that kept a stale
+			// window would relabel ceremonies that are still legitimately open.
+			if (!isSweepEnabled()) {
+				return;
+			}
+
+			Date lapsedBefore = lapsedBefore();
+			int abandoned = 0;
+			for (String baseDn : authenticationPersistenceService.getCeremonyBaseDns()) {
+				abandoned += sweep(baseDn, lapsedBefore);
+			}
+
+			if (abandoned > 0) {
+				log.debug("Marked {} lapsed assertion ceremonies as abandoned", abandoned);
+			}
+		} catch (Exception e) {
+			log.error("Failed to sweep abandoned assertion ceremonies.", e);
+		}
+	}
+
+	private int sweep(String baseDn, Date lapsedBefore) {
+		List<Fido2AuthenticationEntry> lapsed;
+		try {
+			lapsed = authenticationPersistenceService.findLapsedPendingCeremonies(baseDn, lapsedBefore, BATCH_SIZE);
+		} catch (Exception e) {
+			// One unreadable subtree must not stop the other from being swept.
+			log.warn("Failed to read lapsed assertion ceremonies from {}: {}", baseDn, e.getMessage());
+			return 0;
+		}
+
+		int abandoned = 0;
+		for (Fido2AuthenticationEntry entry : lapsed) {
+			if (markAbandoned(entry)) {
+				abandoned++;
+			}
+		}
+		return abandoned;
+	}
+
+	/**
+	 * @return true when this pass is the one that claimed the ceremony
+	 */
+	private boolean markAbandoned(Fido2AuthenticationEntry entry) {
+		try {
+			Fido2AuthenticationData authenticationData = entry.getAuthenticationData();
+			if (authenticationData == null
+					|| authenticationData.getStatus() != Fido2AuthenticationStatus.pending) {
+				// Claimed by another node between the read above and now.
+				return false;
+			}
+
+			authenticationData.setStatus(Fido2AuthenticationStatus.abandoned);
+			entry.setExpiration(appConfiguration.getFido2Configuration().getAbandonedRequestExpiration());
+			authenticationPersistenceService.update(entry);
+
+			recordAbandonment(entry, authenticationData);
+			return true;
+		} catch (Exception e) {
+			// A single unwritable row must not abort the batch.
+			log.warn("Failed to mark assertion ceremony {} as abandoned: {}", entry.getId(), e.getMessage());
+			return false;
+		}
+	}
+
+	private void recordAbandonment(Fido2AuthenticationEntry entry, Fido2AuthenticationData authenticationData) {
+		try {
+			Date creationDate = entry.getCreationDate();
+			long ceremonyStartTime = creationDate != null ? creationDate.getTime() : System.currentTimeMillis();
+			metricService.recordPasskeyAuthenticationAbandoned(authenticationData.getUsername(), ceremonyStartTime);
+		} catch (Exception e) {
+			// The row is already labelled; losing the metric must not undo or retry that.
+			log.debug("Failed to record abandonment metric: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * Ceremonies issued at or before this instant have outlived their window.
+	 */
+	private Date lapsedBefore() {
+		Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+		calendar.add(Calendar.SECOND, -appConfiguration.getFido2Configuration().getUnfinishedRequestExpiration());
+		return calendar.getTime();
+	}
+
+	private boolean isSweepEnabled() {
+		return appConfiguration.getFido2Configuration() != null
+				&& appConfiguration.getFido2Configuration().isRecordAbandonedAssertions();
+	}
+
+	/**
+	 * The sweep has to run at least as often as ceremonies lapse, or a ceremony could be deleted
+	 * between two passes and never be labelled.
+	 */
+	private int resolveSweepInterval() {
+		int configured = appConfiguration.getFido2Configuration().getAbandonedRequestSweepInterval();
+		if (configured < MINIMUM_INTERVAL) {
+			log.warn("abandonedRequestSweepInterval {} is not a usable interval, falling back to {}s", configured,
+					MINIMUM_INTERVAL);
+			return MINIMUM_INTERVAL;
+		}
+		return configured;
+	}
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyTimer.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyTimer.java
@@ -62,8 +62,6 @@ public class AbandonedCeremonyTimer {
 	 */
 	public static final int BATCH_SIZE = 1000;
 
-	private static final int MINIMUM_INTERVAL = 1;
-
 	@Inject
 	private Logger log;
 
@@ -82,19 +80,25 @@ public class AbandonedCeremonyTimer {
 	private AtomicBoolean isActive;
 
 	public void initTimer() {
-		if (!isSweepEnabled()) {
-			log.info("Abandoned assertion ceremony sweep is disabled, skipping timer initialization");
-			return;
-		}
-
 		log.info("Initializing Abandoned Ceremony Timer");
 		this.isActive = new AtomicBoolean(false);
 
-		int interval = resolveSweepInterval();
+		// Scheduled regardless of whether recording is currently enabled. The configuration is
+		// reloadable, and a timer that was never scheduled could not observe it being switched on —
+		// which would make the property restart-only. Each pass re-checks and does nothing while off.
+		int interval = AbandonedCeremonyPolicy.effectiveSweepInterval(appConfiguration.getFido2Configuration());
+		if (AbandonedCeremonyPolicy.isSweepIntervalOverridden(appConfiguration.getFido2Configuration())) {
+			log.warn(
+					"abandonedRequestSweepInterval {} is not usable with unfinishedRequestExpiration {}; sweeping every {}s instead, otherwise a ceremony could lapse and be deleted between two passes",
+					appConfiguration.getFido2Configuration().getAbandonedRequestSweepInterval(),
+					appConfiguration.getFido2Configuration().getUnfinishedRequestExpiration(), interval);
+		}
+
 		timerEvent.fire(new TimerEvent(new TimerSchedule(interval, interval), new AbandonedCeremonyEvent() {
 		}, Scheduled.Literal.INSTANCE));
 
-		log.info("Initialized Abandoned Ceremony Timer with interval {}s", interval);
+		log.info("Initialized Abandoned Ceremony Timer with interval {}s (recording enabled: {})", interval,
+				isSweepEnabled());
 	}
 
 	@Asynchronous
@@ -207,19 +211,5 @@ public class AbandonedCeremonyTimer {
 	private boolean isSweepEnabled() {
 		return appConfiguration.getFido2Configuration() != null
 				&& appConfiguration.getFido2Configuration().isRecordAbandonedAssertions();
-	}
-
-	/**
-	 * The sweep has to run at least as often as ceremonies lapse, or a ceremony could be deleted
-	 * between two passes and never be labelled.
-	 */
-	private int resolveSweepInterval() {
-		int configured = appConfiguration.getFido2Configuration().getAbandonedRequestSweepInterval();
-		if (configured < MINIMUM_INTERVAL) {
-			log.warn("abandonedRequestSweepInterval {} is not a usable interval, falling back to {}s", configured,
-					MINIMUM_INTERVAL);
-			return MINIMUM_INTERVAL;
-		}
-		return configured;
 	}
 }

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyTimer.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyTimer.java
@@ -164,6 +164,16 @@ public class AbandonedCeremonyTimer {
 	}
 
 	/**
+	 * Claims one ceremony.
+	 * <p>
+	 * The status is re-checked on the loaded entry rather than transitioned conditionally in the
+	 * store, because {@code PersistenceEntryManager} exposes only an unconditional merge. What keeps
+	 * that from mattering is that the sweep and a live verification operate on disjoint ceremonies:
+	 * this only selects ceremonies already past {@code unfinishedRequestExpiration}, and a ceremony
+	 * past that point is rejected by {@code AssertionService.verify} rather than completed. So a sweep
+	 * cannot overwrite an outcome a concurrent verification is about to write — the verification would
+	 * have to have resolved before the ceremony lapsed, in which case the status check below sees it.
+	 *
 	 * @return true when this pass is the one that claimed the ceremony
 	 */
 	private boolean markAbandoned(Fido2AuthenticationEntry entry) {
@@ -171,7 +181,8 @@ public class AbandonedCeremonyTimer {
 			Fido2AuthenticationData authenticationData = entry.getAuthenticationData();
 			if (authenticationData == null
 					|| authenticationData.getStatus() != Fido2AuthenticationStatus.pending) {
-				// Claimed by another node between the read above and now.
+				// Already resolved — by a verification that landed before the ceremony lapsed, or by
+				// another node's sweep between the read above and now.
 				return false;
 			}
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AppInitializer.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AppInitializer.java
@@ -97,6 +97,9 @@ public class AppInitializer {
 	private CleanerTimer cleanerTimer;
 
 	@Inject
+	private AbandonedCeremonyTimer abandonedCeremonyTimer;
+
+	@Inject
 	private QuartzSchedulerManager quartzSchedulerManager;
 
 	@Inject
@@ -190,6 +193,13 @@ public class AppInitializer {
 			log.error("Failed to initialize cleaner timer: {}", e.getMessage(), e);
 		}
 		
+		try {
+			abandonedCeremonyTimer.initTimer();
+			log.info("Abandoned ceremony timer initialized");
+		} catch (Exception e) {
+			log.error("Failed to initialize abandoned ceremony timer: {}", e.getMessage(), e);
+		}
+
 		try {
 			mds3UpdateTimer.initTimer();
 			log.info("MDS3 update timer initialized");

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -665,6 +665,23 @@ public class Fido2MetricsService {
     /**
      * Calculate aggregation for a specific time period
      */
+    private static long countByStatus(List<Fido2MetricsEntry> entries, String operationType, String status) {
+        return entries.stream()
+                .filter(e -> operationType.equals(e.getOperationType()) && status.equals(e.getStatus()))
+                .count();
+    }
+
+    /**
+     * The denominator a success rate is computed against.
+     * <p>
+     * Normally the ATTEMPT count, which is what every operation writes when it starts. Data recorded
+     * before ATTEMPT entries existed has none, so the completions are used instead rather than
+     * reporting no rate at all for it.
+     */
+    private static long rateDenominator(long attempts, long successes, long failures) {
+        return attempts > 0 ? attempts : successes + failures;
+    }
+
     private Fido2MetricsAggregation calculateAggregation(String aggregationType, String period, LocalDateTime startTime, LocalDateTime endTime) {
         try {
             // Get all entries for the time period
@@ -681,54 +698,47 @@ public class Fido2MetricsService {
             Fido2MetricsAggregation aggregation = new Fido2MetricsAggregation(aggregationType, period, startDate, endDate);
             Map<String, Object> metricsData = new HashMap<>();
 
-            // Calculate registration metrics
-            long registrationAttempts = entries.stream()
-                .filter(e -> Fido2MetricsConstants.REGISTRATION.equals(e.getOperationType()))
-                .count();
-            
-            long registrationSuccesses = entries.stream()
-                .filter(e -> Fido2MetricsConstants.REGISTRATION.equals(e.getOperationType()) && 
-                           Fido2MetricsConstants.SUCCESS.equals(e.getStatus()))
-                .count();
-            
-            long registrationFailures = registrationAttempts - registrationSuccesses;
-            
+            // Each status is counted directly rather than deriving failures from an operation total.
+            // That total includes the ATTEMPT entry every operation writes when it starts, so deriving
+            // failures from it reported one failure for every success: a completed operation produces
+            // two entries, and total minus successes counted the ATTEMPT as a failure.
+            long registrationAttempts = countByStatus(entries, Fido2MetricsConstants.REGISTRATION,
+                    Fido2MetricsConstants.ATTEMPT);
+            long registrationSuccesses = countByStatus(entries, Fido2MetricsConstants.REGISTRATION,
+                    Fido2MetricsConstants.SUCCESS);
+            long registrationFailures = countByStatus(entries, Fido2MetricsConstants.REGISTRATION,
+                    Fido2MetricsConstants.FAILURE);
+
             metricsData.put(Fido2MetricsConstants.REGISTRATION_ATTEMPTS, registrationAttempts);
             metricsData.put(Fido2MetricsConstants.REGISTRATION_SUCCESSES, registrationSuccesses);
             metricsData.put(Fido2MetricsConstants.REGISTRATION_FAILURES, registrationFailures);
-            
-            if (registrationAttempts > 0) {
-                metricsData.put(Fido2MetricsConstants.REGISTRATION_SUCCESS_RATE, (double) registrationSuccesses / registrationAttempts);
+
+            long registrationDenominator = rateDenominator(registrationAttempts, registrationSuccesses,
+                    registrationFailures);
+            if (registrationDenominator > 0) {
+                metricsData.put(Fido2MetricsConstants.REGISTRATION_SUCCESS_RATE, (double) registrationSuccesses / registrationDenominator);
             }
 
-            // Calculate authentication metrics. Abandonment is excluded from the attempt total that
-            // failures are derived from: a ceremony that was never completed is neither a success nor a
-            // server-rejected failure, and counting it here would silently report every abandonment as
-            // an authentication failure. It is reported on its own below instead.
-            long authenticationAbandonments = entries.stream()
-                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()) &&
-                           Fido2MetricsConstants.ABANDONED.equals(e.getStatus()))
-                .count();
-
-            long authenticationAttempts = entries.stream()
-                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()) &&
-                           !Fido2MetricsConstants.ABANDONED.equals(e.getStatus()))
-                .count();
-
-            long authenticationSuccesses = entries.stream()
-                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()) &&
-                           Fido2MetricsConstants.SUCCESS.equals(e.getStatus()))
-                .count();
-
-            long authenticationFailures = authenticationAttempts - authenticationSuccesses;
+            // Counted the same way, with abandonment kept out of successes and failures alike: a
+            // ceremony that was never completed is neither verified nor server-rejected.
+            long authenticationAttempts = countByStatus(entries, Fido2MetricsConstants.AUTHENTICATION,
+                    Fido2MetricsConstants.ATTEMPT);
+            long authenticationSuccesses = countByStatus(entries, Fido2MetricsConstants.AUTHENTICATION,
+                    Fido2MetricsConstants.SUCCESS);
+            long authenticationFailures = countByStatus(entries, Fido2MetricsConstants.AUTHENTICATION,
+                    Fido2MetricsConstants.FAILURE);
+            long authenticationAbandonments = countByStatus(entries, Fido2MetricsConstants.AUTHENTICATION,
+                    Fido2MetricsConstants.ABANDONED);
 
             metricsData.put(Fido2MetricsConstants.AUTHENTICATION_ATTEMPTS, authenticationAttempts);
             metricsData.put(Fido2MetricsConstants.AUTHENTICATION_SUCCESSES, authenticationSuccesses);
             metricsData.put(Fido2MetricsConstants.AUTHENTICATION_FAILURES, authenticationFailures);
             metricsData.put(Fido2MetricsConstants.ABANDONED_OPERATIONS, authenticationAbandonments);
 
-            if (authenticationAttempts > 0) {
-                metricsData.put(Fido2MetricsConstants.AUTHENTICATION_SUCCESS_RATE, (double) authenticationSuccesses / authenticationAttempts);
+            long authenticationDenominator = rateDenominator(authenticationAttempts, authenticationSuccesses,
+                    authenticationFailures);
+            if (authenticationDenominator > 0) {
+                metricsData.put(Fido2MetricsConstants.AUTHENTICATION_SUCCESS_RATE, (double) authenticationSuccesses / authenticationDenominator);
             }
 
             // Calculate fallback events

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -498,10 +498,12 @@ public class Fido2MetricsService {
             ));
         analysis.put("topErrors", topErrors);
 
-        // Single-pass tally of status counts (ATTEMPT = started, SUCCESS/FAILURE = completed)
+        // Single-pass tally of status counts (ATTEMPT = started, SUCCESS/FAILURE = completed,
+        // ABANDONED = observed to have lapsed without ever completing)
         long totalStarted = 0;
         long successfulOperations = 0;
         long failedOperations = 0;
+        long abandonedOperations = 0;
         for (Fido2MetricsEntry e : entries) {
             String status = e.getStatus();
             if (Fido2MetricsConstants.ATTEMPT.equals(status)) {
@@ -510,8 +512,16 @@ public class Fido2MetricsService {
                 successfulOperations++;
             } else if (Fido2MetricsConstants.FAILURE.equals(status)) {
                 failedOperations++;
+            } else if (Fido2MetricsConstants.ABANDONED.equals(status)) {
+                abandonedOperations++;
             }
         }
+
+        // Reported alongside dropOffRate rather than replacing it: dropOffRate is inferred as the
+        // residual of attempts minus completions, so it also absorbs ceremonies still in flight at the
+        // edge of the query window, whereas this counts ceremonies actually observed to have lapsed.
+        // Approximate in multi-node deployments, where a ceremony can be counted more than once.
+        analysis.put(Fido2MetricsConstants.ABANDONED_OPERATIONS, abandonedOperations);
 
         if (totalStarted > 0) {
             // Normal case: rates as proportion of started operations (ATTEMPT count)
@@ -531,6 +541,8 @@ public class Fido2MetricsService {
             analysis.put(Fido2MetricsConstants.FAILURE_RATE, failureRate);
             analysis.put(Fido2MetricsConstants.COMPLETION_RATE, completionRate);
             analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, dropOffRate);
+            analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE,
+                    Math.min(1.0, (double) abandonedOperations / totalStarted));
         } else {
             // Fallback when no ATTEMPT entries (e.g. legacy data): use completed-only denominator
             long totalCompleted = successfulOperations + failedOperations;
@@ -541,12 +553,15 @@ public class Fido2MetricsService {
                 analysis.put(Fido2MetricsConstants.FAILURE_RATE, failureRate);
                 analysis.put(Fido2MetricsConstants.COMPLETION_RATE, 1.0);
                 analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, 0.0);
+                // No ATTEMPT entries to divide by, so the rate is not computable from this data.
+                analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE, 0.0);
             } else {
                 // Empty dataset: emit rate keys with defaults so response shape is stable for clients
                 analysis.put(Fido2MetricsConstants.SUCCESS_RATE, 0.0);
                 analysis.put(Fido2MetricsConstants.FAILURE_RATE, 0.0);
                 analysis.put(Fido2MetricsConstants.COMPLETION_RATE, 0.0);
                 analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, 0.0);
+                analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE, 0.0);
             }
         }
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -541,6 +541,8 @@ public class Fido2MetricsService {
             analysis.put(Fido2MetricsConstants.FAILURE_RATE, failureRate);
             analysis.put(Fido2MetricsConstants.COMPLETION_RATE, completionRate);
             analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, dropOffRate);
+            // Clamped for data recorded before conditional-UI ceremonies were counted as attempts:
+            // those produce an abandonment with no matching ATTEMPT, which can push the ratio past 1.
             analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE,
                     Math.min(1.0, (double) abandonedOperations / totalStarted));
         } else {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -701,22 +701,32 @@ public class Fido2MetricsService {
                 metricsData.put(Fido2MetricsConstants.REGISTRATION_SUCCESS_RATE, (double) registrationSuccesses / registrationAttempts);
             }
 
-            // Calculate authentication metrics
-            long authenticationAttempts = entries.stream()
-                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()))
+            // Calculate authentication metrics. Abandonment is excluded from the attempt total that
+            // failures are derived from: a ceremony that was never completed is neither a success nor a
+            // server-rejected failure, and counting it here would silently report every abandonment as
+            // an authentication failure. It is reported on its own below instead.
+            long authenticationAbandonments = entries.stream()
+                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()) &&
+                           Fido2MetricsConstants.ABANDONED.equals(e.getStatus()))
                 .count();
-            
+
+            long authenticationAttempts = entries.stream()
+                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()) &&
+                           !Fido2MetricsConstants.ABANDONED.equals(e.getStatus()))
+                .count();
+
             long authenticationSuccesses = entries.stream()
-                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()) && 
+                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()) &&
                            Fido2MetricsConstants.SUCCESS.equals(e.getStatus()))
                 .count();
-            
+
             long authenticationFailures = authenticationAttempts - authenticationSuccesses;
-            
+
             metricsData.put(Fido2MetricsConstants.AUTHENTICATION_ATTEMPTS, authenticationAttempts);
             metricsData.put(Fido2MetricsConstants.AUTHENTICATION_SUCCESSES, authenticationSuccesses);
             metricsData.put(Fido2MetricsConstants.AUTHENTICATION_FAILURES, authenticationFailures);
-            
+            metricsData.put(Fido2MetricsConstants.ABANDONED_OPERATIONS, authenticationAbandonments);
+
             if (authenticationAttempts > 0) {
                 metricsData.put(Fido2MetricsConstants.AUTHENTICATION_SUCCESS_RATE, (double) authenticationSuccesses / authenticationAttempts);
             }

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
@@ -35,6 +35,7 @@ import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.error.ErrorResponseFactory;
 import io.jans.fido2.model.metric.Fido2MetricsConstants;
 import io.jans.fido2.service.ChallengeGenerator;
+import io.jans.fido2.service.app.AbandonedCeremonyPolicy;
 import io.jans.fido2.service.external.ExternalFido2Service;
 import io.jans.fido2.service.external.context.ExternalFido2Context;
 import io.jans.fido2.service.shared.MetricService;
@@ -380,14 +381,16 @@ public class AssertionService {
 		// ceremonies legitimately have none, and are resolved by the registration lookup instead.
 		username = authenticationData.getUsername();
 
-		verifyCeremonyIsStillOpen(authenticationEntity);
-
 		// FIDO2 conformance: explicitly compare the clientData challenge to the issued challenge
 		// instead of relying solely on the DB lookup above.
 		String issuedChallenge = authenticationData.getChallenge();
 		if (issuedChallenge == null || !issuedChallenge.equals(challenge)) {
 			throw errorResponseFactory.invalidRequest("Challenge in clientData does not match the issued challenge");
 		}
+
+		// Ordered after the conformance challenge comparison so that a mismatched challenge is still
+		// reported as such rather than being masked by the state of whichever ceremony it resolved to.
+		verifyCeremonyIsStillOpen(authenticationEntity, authenticationData);
 
 		log.debug("Fido2AuthenticationData: {}", authenticationData);
 		// Verify domain
@@ -491,43 +494,41 @@ public class AssertionService {
 		}
 	}
 
-	/**
-	 * How long a {@code pending} ceremony is retained.
-	 * <p>
-	 * The row has to outlive its own ceremony window, otherwise it is deleted at the same instant the
-	 * sweep becomes eligible to claim it and abandonment goes unrecorded. The grace is derived from
-	 * the sweep cadence so a pass is guaranteed to fall inside it. It does not widen the window in
-	 * which an assertion is accepted — {@link #verifyCeremonyIsStillOpen} enforces that directly.
-	 * <p>
-	 * With the sweep disabled the retention is exactly what it always was, so nothing changes for a
-	 * deployment that has opted out.
-	 */
 	private int pendingCeremonyRetention() {
-		int unfinishedRequestExpiration = appConfiguration.getFido2Configuration().getUnfinishedRequestExpiration();
-		if (!appConfiguration.getFido2Configuration().isRecordAbandonedAssertions()) {
-			return unfinishedRequestExpiration;
-		}
-		int sweepInterval = Math.max(appConfiguration.getFido2Configuration().getAbandonedRequestSweepInterval(), 1);
-		return unfinishedRequestExpiration + (2 * sweepInterval);
+		return AbandonedCeremonyPolicy.pendingCeremonyRetention(appConfiguration.getFido2Configuration());
 	}
 
 	/**
-	 * Rejects a ceremony that has outlived its window.
+	 * Rejects a ceremony that is no longer open to being completed.
 	 * <p>
-	 * Checked against the issue time rather than inferred from the row still existing. Previously the
-	 * window was only enforced as a side effect of the cleaner having run, so a ceremony could outlive
-	 * its stated window by up to one clean interval; now that pending rows are deliberately retained
-	 * past it, enforcing it here is what keeps the grace from becoming extra time to authenticate.
+	 * Two conditions close a ceremony, and both have to be checked here rather than inferred:
+	 * <ul>
+	 * <li><b>It already reached a terminal status.</b> A challenge is single-use. Without this, a retry
+	 * after a rejected assertion could carry the row from {@code failed} back to {@code authenticated}
+	 * while leaving the stale error reason on it, and a replay could repeat the completion side effects
+	 * — updating the signature counter and the session — on a ceremony that was already resolved.</li>
+	 * <li><b>It outlived its window.</b> Previously the window was only enforced as a side effect of the
+	 * cleaner having removed the row, so a ceremony could outlive its stated window by up to one clean
+	 * interval. Now that pending rows are deliberately retained past it so the sweep can claim them,
+	 * enforcing it against the issue time is what stops that grace becoming extra time to authenticate.</li>
+	 * </ul>
 	 */
-	private void verifyCeremonyIsStillOpen(Fido2AuthenticationEntry authenticationEntity) {
+	private void verifyCeremonyIsStillOpen(Fido2AuthenticationEntry authenticationEntity,
+			Fido2AuthenticationData authenticationData) {
+		if (authenticationData.getStatus() != Fido2AuthenticationStatus.pending) {
+			throw errorResponseFactory.invalidRequest("Assertion ceremony is no longer open");
+		}
+
 		Date issuedAt = authenticationEntity.getCreationDate();
 		if (issuedAt == null) {
 			return;
 		}
 
 		int unfinishedRequestExpiration = appConfiguration.getFido2Configuration().getUnfinishedRequestExpiration();
-		long elapsedSeconds = (System.currentTimeMillis() - issuedAt.getTime()) / 1000;
-		if (elapsedSeconds > unfinishedRequestExpiration) {
+		// Compared in milliseconds: truncating to whole seconds would accept a ceremony up to a second
+		// past the configured window.
+		long elapsedMillis = System.currentTimeMillis() - issuedAt.getTime();
+		if (elapsedMillis > unfinishedRequestExpiration * 1000L) {
 			throw errorResponseFactory.invalidRequest("Assertion ceremony has expired");
 		}
 	}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
@@ -252,6 +252,9 @@ public class AssertionService {
 			log.debug("Generate assertion options: {}", CommonUtilService.toJsonNode(assertionOptionsGenerate));
 		}
 
+		// Start timing for metrics collection
+		long startTime = System.currentTimeMillis();
+
 		// Create result object
 		AsserOptGenerateResponse asserOptGenerateResponse = new AsserOptGenerateResponse();
 
@@ -305,6 +308,17 @@ public class AssertionService {
 		authenticationEntity.setExpiration(pendingCeremonyRetention());
 
 		authenticationPersistenceService.save(authenticationEntity);
+
+		// Record metrics for authentication attempt. A conditional-UI ceremony is an authentication
+		// attempt like any other; without this it was absent from the attempt count while still being
+		// able to produce a terminal outcome, so any rate computed against attempts was overstated for
+		// deployments that use conditional UI. The username is deliberately null — no user is known at
+		// this point, which is the defining property of a usernameless ceremony.
+		try {
+			metricService.recordPasskeyAuthenticationAttempt(null, httpRequest, startTime);
+		} catch (Exception e) {
+			log.debug("Failed to record authentication attempt metrics", e);
+		}
 
 		return asserOptGenerateResponse;
 	}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 
 import io.jans.fido2.exception.Fido2CompromisedDevice;
@@ -55,6 +56,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 
 /**
@@ -66,6 +68,9 @@ import jakarta.ws.rs.core.Context;
 
 @ApplicationScoped
 public class AssertionService {
+
+	/** Reads the {@code {status, errorMessage}} envelope off a rejection. Stateless and thread-safe. */
+	private static final ObjectMapper ERROR_ENVELOPE_MAPPER = new ObjectMapper();
 
 	@Inject
 	private Logger log;
@@ -314,6 +319,10 @@ public class AssertionService {
 		long startTime = System.currentTimeMillis();
 		String username = null;
 		String authenticatorType = null;
+		// Declared outside the try so the failure path can mark the ceremony it belongs to. It stays
+		// null for failures raised before the challenge resolves to an entry, which is why
+		// markAssertionFailed tolerates a null entry.
+		Fido2AuthenticationEntry authenticationEntity = null;
 
 		try {
 		// Apply external custom scripts
@@ -348,10 +357,15 @@ public class AssertionService {
 		String challenge = commonVerifiers.getChallenge(clientJsonNode);
 
 		// Find authentication entry
-		Fido2AuthenticationEntry authenticationEntity = authenticationPersistenceService.findByChallenge(challenge)
+		authenticationEntity = authenticationPersistenceService.findByChallenge(challenge)
 				.parallelStream().findFirst().orElseThrow(() -> new Fido2RuntimeException(
 						String.format("Can't find associated assertion request by challenge '%s'", challenge)));
 		Fido2AuthenticationData authenticationData = authenticationEntity.getAuthenticationData();
+
+		// Attribute the ceremony as early as it is known. Without this, every failure raised before
+		// the registration lookup below is recorded against a null username. Conditional-UI
+		// ceremonies legitimately have none, and are resolved by the registration lookup instead.
+		username = authenticationData.getUsername();
 
 		// FIDO2 conformance: explicitly compare the clientData challenge to the issued challenge
 		// instead of relying solely on the DB lookup above.
@@ -447,14 +461,61 @@ public class AssertionService {
 		return assertionResultResponse;
 		
 		} catch (Exception e) {
+			// Give the ceremony a terminal status. Done before the metrics calls below because those
+			// are dispatched asynchronously, whereas this has to complete on the request thread.
+			markAssertionFailed(authenticationEntity, e);
+
 			// Record metrics for failed authentication
 			recordAuthenticationFailureMetrics(username, httpRequest, startTime, e, authenticatorType);
-			
+
 			// Track fallback event for specific error types that might cause users to switch methods
 			recordFallbackForError(username, e);
-			
+
 			// Re-throw the original exception
 			throw e;
+		}
+	}
+
+	/**
+	 * Records a rejected assertion on the ceremony it belongs to.
+	 * <p>
+	 * Without this the entry is left at {@code pending} and deleted unlabelled when the
+	 * unfinished-request window lapses, even though a {@code FIDO2_AUTHENTICATION_FAILURE} metric was
+	 * written for the same event — so the database and the metrics store disagreed about it.
+	 *
+	 * @param authenticationEntity the ceremony being verified, or null when the failure was raised
+	 *        before the challenge resolved to one
+	 * @param error the exception that rejected the assertion
+	 */
+	private void markAssertionFailed(Fido2AuthenticationEntry authenticationEntity, Exception error) {
+		if (authenticationEntity == null) {
+			return;
+		}
+
+		try {
+			Fido2AuthenticationData authenticationData = authenticationEntity.getAuthenticationData();
+
+			// Only a ceremony still in flight can be rejected. Anything already terminal was resolved
+			// by an earlier request, and a late failure must not overwrite that outcome.
+			if (authenticationData.getStatus() != Fido2AuthenticationStatus.pending) {
+				return;
+			}
+
+			String errorReason = resolveErrorReason(error);
+			authenticationData.setStatus(Fido2AuthenticationStatus.failed);
+			authenticationData.setErrorReason(errorReason);
+			authenticationData.setErrorCategory(metricService.categorizeError(errorReason));
+
+			// Promote off the short unfinished-request window: the ceremony is over, and a failure is
+			// worth keeping for as long as the successes it is compared against.
+			int authenticationHistoryExpiration = appConfiguration.getFido2Configuration()
+					.getAuthenticationHistoryExpiration();
+			authenticationEntity.setExpiration(authenticationHistoryExpiration);
+
+			authenticationPersistenceService.update(authenticationEntity);
+		} catch (Exception persistenceError) {
+			// Bookkeeping must never mask the rejection that is about to be re-thrown to the client.
+			log.warn("Failed to mark assertion ceremony as failed: {}", persistenceError.getMessage());
 		}
 	}
 
@@ -522,10 +583,49 @@ public class AssertionService {
 	private void recordAuthenticationFailureMetrics(String username, HttpServletRequest httpRequest, 
 													long startTime, Exception error, String authenticatorType) {
 		try {
-			String errorReason = error.getMessage() != null ? error.getMessage() : "Unknown error";
-			metricService.recordPasskeyAuthenticationFailure(username, httpRequest, startTime, errorReason, authenticatorType);
+			metricService.recordPasskeyAuthenticationFailure(username, httpRequest, startTime, resolveErrorReason(error), authenticatorType);
 		} catch (Exception metricsException) {
 			log.debug("Failed to record authentication failure metrics", metricsException);
+		}
+	}
+
+	/**
+	 * The reason string recorded for a rejection. Shared by the metric and the entry so the two
+	 * cannot describe the same failure differently.
+	 */
+	private static String resolveErrorReason(Exception error) {
+		String reason = extractFido2ErrorMessage(error);
+		if (reason == null) {
+			reason = error.getMessage();
+		}
+		return reason != null ? reason : "Unknown error";
+	}
+
+	/**
+	 * The specific reason carried in a FIDO2 rejection's response envelope.
+	 * <p>
+	 * Every rejection raised through {@link ErrorResponseFactory} is a {@code WebApplicationException}
+	 * built from a {@code Response}, and such an exception's {@code getMessage()} is only the generic
+	 * status line — "HTTP 400 Bad Request" — for all of them alike. Reading the reason out of the
+	 * {@code {status, errorMessage}} entity is what keeps a stale challenge distinguishable from an
+	 * unknown credential once the failure is recorded.
+	 *
+	 * @return the reason, or null when this is not a FIDO2 envelope and the caller should fall back
+	 */
+	private static String extractFido2ErrorMessage(Exception error) {
+		if (!(error instanceof WebApplicationException)) {
+			return null;
+		}
+		try {
+			Object entity = ((WebApplicationException) error).getResponse().getEntity();
+			if (!(entity instanceof String)) {
+				return null;
+			}
+			JsonNode errorMessage = ERROR_ENVELOPE_MAPPER.readTree((String) entity).get("errorMessage");
+			return errorMessage != null && errorMessage.isTextual() ? errorMessage.asText() : null;
+		} catch (Exception parseError) {
+			// Not a FIDO2 envelope, or unreadable. The caller falls back to the exception message.
+			return null;
 		}
 	}
 	

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AssertionService.java
@@ -7,6 +7,7 @@
 package io.jans.fido2.service.operation;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -223,8 +224,7 @@ public class AssertionService {
 		}
 
 		// Set expiration
-		int unfinishedRequestExpiration = appConfiguration.getFido2Configuration().getUnfinishedRequestExpiration();
-		authenticationEntity.setExpiration(unfinishedRequestExpiration);
+		authenticationEntity.setExpiration(pendingCeremonyRetention());
 
 		authenticationPersistenceService.save(authenticationEntity);
 
@@ -302,8 +302,7 @@ public class AssertionService {
 		}
 
 		// Set expiration
-		int unfinishedRequestExpiration = appConfiguration.getFido2Configuration().getUnfinishedRequestExpiration();
-		authenticationEntity.setExpiration(unfinishedRequestExpiration);
+		authenticationEntity.setExpiration(pendingCeremonyRetention());
 
 		authenticationPersistenceService.save(authenticationEntity);
 
@@ -366,6 +365,8 @@ public class AssertionService {
 		// the registration lookup below is recorded against a null username. Conditional-UI
 		// ceremonies legitimately have none, and are resolved by the registration lookup instead.
 		username = authenticationData.getUsername();
+
+		verifyCeremonyIsStillOpen(authenticationEntity);
 
 		// FIDO2 conformance: explicitly compare the clientData challenge to the issued challenge
 		// instead of relying solely on the DB lookup above.
@@ -473,6 +474,47 @@ public class AssertionService {
 
 			// Re-throw the original exception
 			throw e;
+		}
+	}
+
+	/**
+	 * How long a {@code pending} ceremony is retained.
+	 * <p>
+	 * The row has to outlive its own ceremony window, otherwise it is deleted at the same instant the
+	 * sweep becomes eligible to claim it and abandonment goes unrecorded. The grace is derived from
+	 * the sweep cadence so a pass is guaranteed to fall inside it. It does not widen the window in
+	 * which an assertion is accepted — {@link #verifyCeremonyIsStillOpen} enforces that directly.
+	 * <p>
+	 * With the sweep disabled the retention is exactly what it always was, so nothing changes for a
+	 * deployment that has opted out.
+	 */
+	private int pendingCeremonyRetention() {
+		int unfinishedRequestExpiration = appConfiguration.getFido2Configuration().getUnfinishedRequestExpiration();
+		if (!appConfiguration.getFido2Configuration().isRecordAbandonedAssertions()) {
+			return unfinishedRequestExpiration;
+		}
+		int sweepInterval = Math.max(appConfiguration.getFido2Configuration().getAbandonedRequestSweepInterval(), 1);
+		return unfinishedRequestExpiration + (2 * sweepInterval);
+	}
+
+	/**
+	 * Rejects a ceremony that has outlived its window.
+	 * <p>
+	 * Checked against the issue time rather than inferred from the row still existing. Previously the
+	 * window was only enforced as a side effect of the cleaner having run, so a ceremony could outlive
+	 * its stated window by up to one clean interval; now that pending rows are deliberately retained
+	 * past it, enforcing it here is what keeps the grace from becoming extra time to authenticate.
+	 */
+	private void verifyCeremonyIsStillOpen(Fido2AuthenticationEntry authenticationEntity) {
+		Date issuedAt = authenticationEntity.getCreationDate();
+		if (issuedAt == null) {
+			return;
+		}
+
+		int unfinishedRequestExpiration = appConfiguration.getFido2Configuration().getUnfinishedRequestExpiration();
+		long elapsedSeconds = (System.currentTimeMillis() - issuedAt.getTime()) / 1000;
+		if (elapsedSeconds > unfinishedRequestExpiration) {
+			throw errorResponseFactory.invalidRequest("Assertion ceremony has expired");
 		}
 	}
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/AuthenticationPersistenceService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/persist/AuthenticationPersistenceService.java
@@ -28,6 +28,7 @@ import io.jans.orm.PersistenceEntryManager;
 import io.jans.orm.model.base.SimpleBranch;
 import io.jans.orm.model.fido2.Fido2AuthenticationData;
 import io.jans.orm.model.fido2.Fido2AuthenticationEntry;
+import io.jans.orm.model.fido2.Fido2AuthenticationStatus;
 import io.jans.orm.search.filter.Filter;
 import io.jans.util.StringHelper;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -160,6 +161,39 @@ public class AuthenticationPersistenceService {
         List<Fido2AuthenticationEntry> fido2AuthenticationEntries = persistenceEntryManager.findEntries(baseDn, Fido2AuthenticationEntry.class, filter);
 
         return fido2AuthenticationEntries;
+    }
+
+    /**
+     * The base DNs assertion ceremonies are stored under.
+     * <p>
+     * Identified ceremonies live beneath the owning person entry, while conditional-UI ceremonies
+     * have no user to hang off and live under the assertion base DN instead. A sweep that visited
+     * only the first would miss precisely the ceremonies most likely to be abandoned.
+     */
+    public List<String> getCeremonyBaseDns() {
+        return List.of(staticConfiguration.getBaseDn().getPeople(),
+                staticConfiguration.getBaseDn().getFido2Assertion());
+    }
+
+    /**
+     * Finds ceremonies still marked pending whose window has already elapsed.
+     * <p>
+     * Filtering on status rather than on the expiry column is what makes the sweep idempotent: the
+     * transition only fires from {@code pending}, so a row already relabelled — by an earlier sweep,
+     * or by another node, or by a second pass over a base DN that resolves to the same table — is
+     * simply not matched again.
+     *
+     * @param baseDn the subtree to search
+     * @param lapsedBefore ceremonies created at or before this instant have outlived their window
+     * @param batchSize maximum number of entries to return
+     */
+    public List<Fido2AuthenticationEntry> findLapsedPendingCeremonies(String baseDn, Date lapsedBefore, int batchSize) {
+        Filter pendingFilter = Filter.createEqualityFilter("jansStatus", Fido2AuthenticationStatus.pending.getValue());
+        Filter lapsedFilter = Filter.createLessOrEqualFilter("creationDate",
+                persistenceEntryManager.encodeTime(baseDn, lapsedBefore));
+
+        return persistenceEntryManager.findEntries(baseDn, Fido2AuthenticationEntry.class,
+                Filter.createANDFilter(pendingFilter, lapsedFilter), batchSize);
     }
 
     public String getDnForAuthenticationEntry(String userInum, String jsId) {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/shared/MetricService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/shared/MetricService.java
@@ -626,9 +626,12 @@ public class MetricService extends io.jans.service.metric.MetricService {
     }
 
     /**
-     * Categorize error reasons for analytics
+     * Categorize error reasons for analytics.
+     * <p>
+     * Public so the assertion entry can be labelled with the same category that is recorded in the
+     * metrics store. Deriving both from one place is what keeps the two sources from disagreeing.
      */
-    private String categorizeError(String errorReason) {
+    public String categorizeError(String errorReason) {
         if (errorReason == null) {
             return UNKNOWN_ERROR;
         }

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/shared/MetricService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/shared/MetricService.java
@@ -309,6 +309,22 @@ public class MetricService extends io.jans.service.metric.MetricService {
     }
 
     /**
+     * Record a passkey authentication that was started and never completed.
+     * <p>
+     * Unlike the success and failure recorders this runs on the sweep timer rather than a request
+     * thread, so there is no request to take device details from — {@code snapshotRequest} yields an
+     * empty snapshot. The ceremony's own start time is passed in so the recorded duration is how long
+     * the ceremony stayed open, not how long the sweep took.
+     *
+     * @param username the ceremony user, or null for a conditional-UI ceremony that never had one
+     * @param ceremonyStartTime when the ceremony was issued, in epoch millis
+     */
+    public void recordPasskeyAuthenticationAbandoned(String username, long ceremonyStartTime) {
+        recordAuthenticationMetrics(username, null, ceremonyStartTime, null, Fido2MetricsConstants.ABANDONED, null,
+                Fido2MetricType.FIDO2_AUTHENTICATION_ABANDONED);
+    }
+
+    /**
      * Common method to record authentication metrics
      */
     private void recordAuthenticationMetrics(String username, HttpServletRequest request, long startTime,

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/app/AbandonedCeremonyPolicyTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/app/AbandonedCeremonyPolicyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.app;
+
+import io.jans.fido2.model.conf.Fido2Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbandonedCeremonyPolicyTest {
+
+    /**
+     * The invariant the whole sweep rests on: a pending ceremony must still exist when the first sweep
+     * after its window runs. If retention did not exceed the window plus one full interval, the
+     * cleaner could delete a lapsed ceremony before it was ever labelled.
+     */
+    @Test
+    void pendingRetentionAlwaysOutlivesTheFirstSweepAfterTheWindow() {
+        int[][] configurations = {
+                { 180, 30 },    // the reported deployment
+                { 120, 30 },    // code defaults
+                { 120, 3600 },  // interval far larger than the window
+                { 120, 0 },     // unusable interval
+                { 1, 30 },      // window shorter than the interval
+        };
+
+        for (int[] configuration : configurations) {
+            Fido2Configuration fido2Configuration = configuration(configuration[0], configuration[1]);
+
+            int interval = AbandonedCeremonyPolicy.effectiveSweepInterval(fido2Configuration);
+            int retention = AbandonedCeremonyPolicy.pendingCeremonyRetention(fido2Configuration);
+
+            assertTrue(interval > 0, "interval must be runnable for " + configuration[0] + "/" + configuration[1]);
+            // Worst case, a ceremony lapses just after a pass, so the next one is a full interval later.
+            assertTrue(retention > configuration[0] + interval,
+                    "retention " + retention + " must outlive window " + configuration[0] + " plus interval "
+                            + interval);
+        }
+    }
+
+    /**
+     * An interval at or above the ceremony window is not usable: a ceremony could lapse and be deleted
+     * between two passes. It is capped rather than honoured.
+     */
+    @Test
+    void sweepIntervalIsCappedBelowTheCeremonyWindow() {
+        Fido2Configuration fido2Configuration = configuration(180, 3600);
+
+        int interval = AbandonedCeremonyPolicy.effectiveSweepInterval(fido2Configuration);
+
+        assertTrue(interval < 180, "interval must stay below the ceremony window, was " + interval);
+        assertTrue(AbandonedCeremonyPolicy.isSweepIntervalOverridden(fido2Configuration));
+    }
+
+    @Test
+    void usableSweepIntervalIsHonouredUnchanged() {
+        Fido2Configuration fido2Configuration = configuration(180, 30);
+
+        assertEquals(30, AbandonedCeremonyPolicy.effectiveSweepInterval(fido2Configuration));
+        assertFalse(AbandonedCeremonyPolicy.isSweepIntervalOverridden(fido2Configuration));
+    }
+
+    /**
+     * A deployment that opted out keeps exactly the retention it had before, so nothing changes for it.
+     */
+    @Test
+    void retentionIsUnchangedWhenRecordingIsDisabled() {
+        Fido2Configuration fido2Configuration = configuration(180, 30);
+        fido2Configuration.setRecordAbandonedAssertions(false);
+
+        assertEquals(180, AbandonedCeremonyPolicy.pendingCeremonyRetention(fido2Configuration));
+    }
+
+    private Fido2Configuration configuration(int unfinishedRequestExpiration, int sweepInterval) {
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setUnfinishedRequestExpiration(unfinishedRequestExpiration);
+        fido2Configuration.setAbandonedRequestSweepInterval(sweepInterval);
+        return fido2Configuration;
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/app/AbandonedCeremonyTimerTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/app/AbandonedCeremonyTimerTest.java
@@ -1,0 +1,258 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.fido2.service.app;
+
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
+import io.jans.fido2.service.persist.AuthenticationPersistenceService;
+import io.jans.fido2.service.shared.MetricService;
+import io.jans.orm.model.fido2.Fido2AuthenticationData;
+import io.jans.orm.model.fido2.Fido2AuthenticationEntry;
+import io.jans.orm.model.fido2.Fido2AuthenticationStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AbandonedCeremonyTimerTest {
+
+    private static final String PEOPLE_DN = "ou=people,o=jans";
+    private static final String ASSERTION_DN = "ou=fido2_auth,ou=fido2,o=jans";
+
+    @InjectMocks
+    private AbandonedCeremonyTimer timer;
+
+    @Mock
+    private Logger log;
+    @Mock
+    private AppConfiguration appConfiguration;
+    @Mock
+    private AuthenticationPersistenceService authenticationPersistenceService;
+    @Mock
+    private MetricService metricService;
+
+    private Fido2Configuration fido2Configuration;
+
+    @BeforeEach
+    void setUp() {
+        fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setUnfinishedRequestExpiration(180);
+        fido2Configuration.setAbandonedRequestExpiration(86400);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        when(authenticationPersistenceService.getCeremonyBaseDns()).thenReturn(List.of(PEOPLE_DN, ASSERTION_DN));
+    }
+
+    /**
+     * A ceremony that lapsed without ever being completed must be relabelled rather than left at
+     * pending for the cleaner to delete unlabelled, and retained on its own short window.
+     */
+    @Test
+    void processImpl_ifCeremonyLapsed_marksAbandonedAndRetainsOnAbandonedWindow() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = ceremonyEntry(authData);
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
+                .thenReturn(List.of(entry));
+
+        timer.processImpl();
+
+        assertEquals(Fido2AuthenticationStatus.abandoned, authData.getStatus());
+        assertEquals(86400, entry.getTtl());
+        verify(authenticationPersistenceService).update(entry);
+    }
+
+    /**
+     * Conditional-UI ceremonies live under the assertion base DN rather than beneath a person entry,
+     * and are the ones most likely to be abandoned. A sweep that visited only one subtree would miss
+     * exactly those.
+     */
+    @Test
+    void processImpl_sweepsBothCeremonySubtrees() {
+        Fido2AuthenticationData identified = pendingCeremony("alice");
+        Fido2AuthenticationData usernameless = pendingCeremony(null);
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
+                .thenReturn(List.of(ceremonyEntry(identified)));
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(ASSERTION_DN), any(), anyInt()))
+                .thenReturn(List.of(ceremonyEntry(usernameless)));
+
+        timer.processImpl();
+
+        assertEquals(Fido2AuthenticationStatus.abandoned, identified.getStatus());
+        assertEquals(Fido2AuthenticationStatus.abandoned, usernameless.getStatus());
+        verify(authenticationPersistenceService, times(2)).update(any());
+    }
+
+    /**
+     * The abandonment metric is attributed to the ceremony user and timed from when the ceremony was
+     * issued, not from when the sweep happened to run.
+     */
+    @Test
+    void processImpl_recordsAbandonmentAgainstCeremonyStartTime() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = ceremonyEntry(authData);
+        Date issuedAt = entry.getCreationDate();
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
+                .thenReturn(List.of(entry));
+
+        timer.processImpl();
+
+        verify(metricService).recordPasskeyAuthenticationAbandoned("alice", issuedAt.getTime());
+    }
+
+    /**
+     * The transition only fires from pending, which is what makes the sweep idempotent — across
+     * repeated passes, across nodes, and across two base DNs that resolve to the same table on RDBMS.
+     */
+    @Test
+    void processImpl_ifCeremonyAlreadyClaimed_doesNotRewriteOrDoubleCount() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        authData.setStatus(Fido2AuthenticationStatus.abandoned);
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
+                .thenReturn(List.of(ceremonyEntry(authData)));
+
+        timer.processImpl();
+
+        verify(authenticationPersistenceService, never()).update(any());
+        verify(metricService, never()).recordPasskeyAuthenticationAbandoned(any(), anyLong());
+    }
+
+    /**
+     * A ceremony that was completed after the sweep read it must keep its outcome.
+     */
+    @Test
+    void processImpl_ifCeremonyCompletedAfterRead_doesNotOverwriteOutcome() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        authData.setStatus(Fido2AuthenticationStatus.authenticated);
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
+                .thenReturn(List.of(ceremonyEntry(authData)));
+
+        timer.processImpl();
+
+        assertEquals(Fido2AuthenticationStatus.authenticated, authData.getStatus());
+        verify(authenticationPersistenceService, never()).update(any());
+    }
+
+    /**
+     * One unwritable row must not abort the rest of the batch.
+     */
+    @Test
+    void processImpl_ifOneRowCannotBeWritten_stillSweepsTheRest() {
+        Fido2AuthenticationData broken = pendingCeremony("alice");
+        Fido2AuthenticationData healthy = pendingCeremony("bob");
+        Fido2AuthenticationEntry brokenEntry = ceremonyEntry(broken);
+        Fido2AuthenticationEntry healthyEntry = ceremonyEntry(healthy);
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
+                .thenReturn(List.of(brokenEntry, healthyEntry));
+        doThrow(new IllegalStateException("persistence down")).when(authenticationPersistenceService)
+                .update(brokenEntry);
+
+        timer.processImpl();
+
+        verify(authenticationPersistenceService).update(healthyEntry);
+    }
+
+    /**
+     * One unreadable subtree must not stop the other from being swept.
+     */
+    @Test
+    void processImpl_ifOneSubtreeCannotBeRead_stillSweepsTheOther() {
+        Fido2AuthenticationData usernameless = pendingCeremony(null);
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
+                .thenThrow(new IllegalStateException("subtree unavailable"));
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(ASSERTION_DN), any(), anyInt()))
+                .thenReturn(List.of(ceremonyEntry(usernameless)));
+
+        timer.processImpl();
+
+        assertEquals(Fido2AuthenticationStatus.abandoned, usernameless.getStatus());
+    }
+
+    /**
+     * The master switch restores the previous delete-unlabelled behaviour, and is re-read each pass
+     * so it takes effect on a running server without a restart.
+     */
+    @Test
+    void processImpl_ifRecordingDisabled_sweepsNothing() {
+        fido2Configuration.setRecordAbandonedAssertions(false);
+
+        timer.processImpl();
+
+        verify(authenticationPersistenceService, never()).findLapsedPendingCeremonies(any(), any(), anyInt());
+        verify(authenticationPersistenceService, never()).update(any());
+    }
+
+    /**
+     * The sweep window is derived from the configured ceremony expiration, not a hard-coded default —
+     * the reproduction deployment runs 180s while the code default is 120s.
+     */
+    @Test
+    void processImpl_usesConfiguredCeremonyWindowForLapseCutoff() {
+        fido2Configuration.setUnfinishedRequestExpiration(180);
+        long before = System.currentTimeMillis();
+
+        timer.processImpl();
+
+        long after = System.currentTimeMillis();
+        ArgumentCaptor<Date> cutoff = ArgumentCaptor.forClass(Date.class);
+        verify(authenticationPersistenceService).findLapsedPendingCeremonies(eq(PEOPLE_DN), cutoff.capture(), anyInt());
+
+        // The cutoff sits exactly one configured ceremony window behind whenever the sweep ran, so
+        // anything issued at or before it has outlived its window.
+        long cutoffMillis = cutoff.getValue().getTime();
+        assertTrue(cutoffMillis >= before - 180_000L && cutoffMillis <= after - 180_000L,
+                "cutoff should be one 180s window behind the sweep, was " + (after - cutoffMillis) + "ms behind");
+    }
+
+    private Fido2AuthenticationData pendingCeremony(String username) {
+        Fido2AuthenticationData authData = new Fido2AuthenticationData();
+        authData.setUsername(username);
+        authData.setStatus(Fido2AuthenticationStatus.pending);
+        return authData;
+    }
+
+    /**
+     * Entries are identified by DN — two entries sharing one would compare equal and make any
+     * per-entry verification ambiguous.
+     */
+    private Fido2AuthenticationEntry ceremonyEntry(Fido2AuthenticationData authData) {
+        return ceremonyEntry(authData, "ceremony-" + nextCeremonyId++);
+    }
+
+    private Fido2AuthenticationEntry ceremonyEntry(Fido2AuthenticationData authData, String id) {
+        Fido2AuthenticationEntry entry = new Fido2AuthenticationEntry();
+        entry.setDn("jansId=" + id + "," + PEOPLE_DN);
+        entry.setId(id);
+        entry.setCreationDate(new Date(System.currentTimeMillis() - 200_000L));
+        entry.setAuthenticationData(authData);
+        entry.setAuthenticationStatus(authData.getStatus());
+        return entry;
+    }
+
+    private int nextCeremonyId = 1;
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
@@ -22,12 +22,17 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.slf4j.Logger;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -74,6 +79,78 @@ class Fido2MetricsServiceTest {
     @BeforeEach
     void setUp() {
         when(appConfiguration.isFido2MetricsEnabled()).thenReturn(true);
+    }
+
+    /**
+     * Abandonment is reported alongside the inferred dropOffRate, not instead of it. dropOffRate is
+     * the residual of attempts minus completions and so also absorbs ceremonies still in flight,
+     * whereas abandonedOperations counts ceremonies observed to have lapsed.
+     */
+    @Test
+    void getErrorAnalysis_reportsObservedAbandonmentAlongsideInferredDropOff() {
+        stubMetricsEntries(
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.ABANDONED));
+
+        Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now());
+
+        assertEquals(1L, analysis.get(Fido2MetricsConstants.ABANDONED_OPERATIONS));
+        assertEquals(0.25, (Double) analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE), 0.0001);
+        // Still inferred independently, and still larger, because it also covers the three attempts
+        // that produced no terminal entry at all.
+        assertEquals(0.75, (Double) analysis.get(Fido2MetricsConstants.DROP_OFF_RATE), 0.0001);
+    }
+
+    /**
+     * An ABANDONED entry must not be counted as a completion — it is neither a verified success nor a
+     * server-rejected failure, and folding it into either would misstate both rates.
+     */
+    @Test
+    void getErrorAnalysis_doesNotCountAbandonmentAsCompletion() {
+        stubMetricsEntries(
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.ABANDONED));
+
+        Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now());
+
+        assertEquals(0.5, (Double) analysis.get(Fido2MetricsConstants.SUCCESS_RATE), 0.0001);
+        assertEquals(0.0, (Double) analysis.get(Fido2MetricsConstants.FAILURE_RATE), 0.0001);
+        assertEquals(0.5, (Double) analysis.get(Fido2MetricsConstants.COMPLETION_RATE), 0.0001);
+    }
+
+    /**
+     * The response shape stays stable when there is nothing to report, so clients do not have to
+     * distinguish "absent key" from "zero".
+     */
+    @Test
+    void getErrorAnalysis_ifNoEntries_stillEmitsAbandonmentKeys() {
+        stubMetricsEntries();
+
+        Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now());
+
+        assertEquals(0L, analysis.get(Fido2MetricsConstants.ABANDONED_OPERATIONS));
+        assertEquals(0.0, (Double) analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE), 0.0001);
+    }
+
+    private void stubMetricsEntries(Fido2MetricsEntry... entries) {
+        when(persistenceEntryManager.findEntries(any(String.class), eq(Fido2MetricsEntry.class), any()))
+                .thenReturn(List.of(entries));
+    }
+
+    private Fido2MetricsEntry statusEntry(String status) {
+        Fido2MetricsEntry entry = new Fido2MetricsEntry();
+        entry.setStatus(status);
+        entry.setOperationType(Fido2MetricsConstants.AUTHENTICATION);
+        return entry;
     }
 
     @Test

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
@@ -7,6 +7,7 @@
 package io.jans.fido2.service.metric;
 
 import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.metric.Fido2MetricsAggregation;
 import io.jans.fido2.model.metric.Fido2MetricsConstants;
 import io.jans.fido2.model.metric.Fido2MetricsData;
 import io.jans.fido2.model.metric.Fido2MetricsEntry;
@@ -139,6 +140,99 @@ class Fido2MetricsServiceTest {
 
         assertEquals(0L, analysis.get(Fido2MetricsConstants.ABANDONED_OPERATIONS));
         assertEquals(0.0, (Double) analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE), 0.0001);
+    }
+
+    /**
+     * A completed operation writes two entries — the ATTEMPT recorded when it starts and the terminal
+     * one. Deriving failures from the operation total therefore counted the ATTEMPT as a failure,
+     * reporting one failure for every success. Each status is now counted directly.
+     */
+    @Test
+    void aggregation_ifAttemptCompletesSuccessfully_reportsOneAttemptOneSuccessNoFailure() {
+        Map<String, Object> metrics = aggregate(
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.SUCCESS));
+
+        assertEquals(1L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_ATTEMPTS));
+        assertEquals(1L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_SUCCESSES));
+        assertEquals(0L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_FAILURES));
+        assertEquals(1.0, (Double) metrics.get(Fido2MetricsConstants.AUTHENTICATION_SUCCESS_RATE), 0.0001);
+    }
+
+    /**
+     * The mirror case: a rejected ceremony must be one failure, not two.
+     */
+    @Test
+    void aggregation_ifAttemptFails_reportsOneFailureNotTwo() {
+        Map<String, Object> metrics = aggregate(
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.FAILURE));
+
+        assertEquals(1L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_ATTEMPTS));
+        assertEquals(0L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_SUCCESSES));
+        assertEquals(1L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_FAILURES));
+    }
+
+    /**
+     * An abandoned ceremony is neither verified nor server-rejected, so it must not land in either
+     * bucket — otherwise every abandonment would be reported as an authentication failure.
+     */
+    @Test
+    void aggregation_ifAttemptIsAbandoned_isNeitherSuccessNorFailure() {
+        Map<String, Object> metrics = aggregate(
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.ABANDONED));
+
+        assertEquals(1L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_ATTEMPTS));
+        assertEquals(0L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_SUCCESSES));
+        assertEquals(0L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_FAILURES));
+        assertEquals(1L, metrics.get(Fido2MetricsConstants.ABANDONED_OPERATIONS));
+    }
+
+    /**
+     * Registration carried the identical defect and is fixed the same way.
+     */
+    @Test
+    void aggregation_ifRegistrationCompletesSuccessfully_reportsNoFailure() {
+        Map<String, Object> metrics = aggregate(
+                statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.SUCCESS));
+
+        assertEquals(1L, metrics.get(Fido2MetricsConstants.REGISTRATION_ATTEMPTS));
+        assertEquals(1L, metrics.get(Fido2MetricsConstants.REGISTRATION_SUCCESSES));
+        assertEquals(0L, metrics.get(Fido2MetricsConstants.REGISTRATION_FAILURES));
+    }
+
+    /**
+     * Data recorded before ATTEMPT entries existed has no attempts to divide by; the rate is computed
+     * against the completions instead rather than being dropped entirely.
+     */
+    @Test
+    void aggregation_ifLegacyDataHasNoAttemptEntries_stillComputesSuccessRate() {
+        Map<String, Object> metrics = aggregate(
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.FAILURE));
+
+        assertEquals(0L, metrics.get(Fido2MetricsConstants.AUTHENTICATION_ATTEMPTS));
+        assertEquals(0.5, (Double) metrics.get(Fido2MetricsConstants.AUTHENTICATION_SUCCESS_RATE), 0.0001);
+    }
+
+    private Map<String, Object> aggregate(Fido2MetricsEntry... entries) {
+        stubMetricsEntries(entries);
+
+        fido2MetricsService.createHourlyAggregation(LocalDateTime.now());
+
+        ArgumentCaptor<Object> persisted = ArgumentCaptor.forClass(Object.class);
+        verify(persistenceEntryManager, timeout(5000)).persist(persisted.capture());
+        Fido2MetricsAggregation aggregation = (Fido2MetricsAggregation) persisted.getValue();
+        return aggregation.getMetricsData();
+    }
+
+    private Fido2MetricsEntry statusEntry(String operationType, String status) {
+        Fido2MetricsEntry entry = new Fido2MetricsEntry();
+        entry.setStatus(status);
+        entry.setOperationType(operationType);
+        return entry;
     }
 
     private void stubMetricsEntries(Fido2MetricsEntry... entries) {

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AssertionServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AssertionServiceTest.java
@@ -2,11 +2,13 @@ package io.jans.fido2.service.operation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jans.fido2.model.assertion.AssertionOptionsGenerate;
 import io.jans.fido2.model.assertion.AssertionResult;
 import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.conf.Fido2Configuration;
 import io.jans.fido2.model.error.ErrorResponseFactory;
 import io.jans.fido2.model.error.Fido2ErrorResponse;
+import io.jans.fido2.service.ChallengeGenerator;
 import io.jans.fido2.service.external.ExternalFido2Service;
 import io.jans.fido2.service.persist.AuthenticationPersistenceService;
 import io.jans.fido2.service.persist.RegistrationPersistenceService;
@@ -17,6 +19,7 @@ import io.jans.fido2.service.verifier.DomainVerifier;
 import io.jans.orm.model.fido2.Fido2AuthenticationData;
 import io.jans.orm.model.fido2.Fido2AuthenticationEntry;
 import io.jans.orm.model.fido2.Fido2AuthenticationStatus;
+import io.jans.orm.model.fido2.UserVerification;
 import io.jans.orm.model.fido2.Fido2RegistrationData;
 import io.jans.orm.model.fido2.Fido2RegistrationEntry;
 import jakarta.servlet.http.HttpServletRequest;
@@ -72,6 +75,8 @@ class AssertionServiceTest {
     private DomainVerifier domainVerifier;
     @Mock
     private MetricService metricService;
+    @Mock
+    private ChallengeGenerator challengeGenerator;
     @Mock
     private AppConfiguration appConfiguration;
     @Mock
@@ -588,6 +593,32 @@ class AssertionServiceTest {
         Fido2Configuration fido2Configuration = new Fido2Configuration();
         fido2Configuration.setUnfinishedRequestExpiration(seconds);
         when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+    }
+
+    /**
+     * A conditional-UI ceremony must count as an authentication attempt. It can produce a terminal
+     * outcome — most often abandonment — so leaving it out of the attempt count overstates every rate
+     * computed against attempts, in exactly the deployments that use conditional UI most.
+     */
+    @Test
+    void generateOptions_recordsAuthenticationAttemptForUsernamelessCeremony() {
+        AssertionOptionsGenerate optionsGenerate = mock(AssertionOptionsGenerate.class);
+        when(commonVerifiers.prepareUserVerification(any())).thenReturn(UserVerification.required);
+        when(commonVerifiers.verifyRpDomain(any(), any(), any())).thenReturn("rp");
+        when(challengeGenerator.getAssertionChallenge()).thenReturn("challenge");
+        stubCeremonyWindow(180);
+
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(authenticationPersistenceService.buildFido2AuthenticationEntry(any())).thenReturn(entry);
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            assertionService.generateOptions(optionsGenerate);
+        }
+
+        // Null username is correct here: no user is known, which is what makes it usernameless.
+        verify(metricService).recordPasskeyAuthenticationAttempt(eq(null), any(), anyLong());
     }
 
     /**

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AssertionServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AssertionServiceTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.slf4j.Logger;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -488,6 +489,64 @@ class AssertionServiceTest {
     }
 
     /**
+     * Pending rows are now deliberately retained past their ceremony window so the sweep can claim
+     * them before the cleaner deletes them. That grace must not become extra time to authenticate, so
+     * the window is enforced against the issue time directly.
+     */
+    @Test
+    void verify_ifCeremonyOutlivedItsWindow_isRejected() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+        // Issued 200s ago, one second past the configured 180s window.
+        when(entry.getCreationDate()).thenReturn(new Date(System.currentTimeMillis() - 200_000L));
+
+        stubCeremonyLookup(entry);
+        stubCeremonyWindow(180);
+        when(errorResponseFactory.invalidRequest(any()))
+                .thenReturn(new WebApplicationException(Response.status(400).entity("expired").build()));
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            WebApplicationException ex = assertThrows(WebApplicationException.class,
+                    () -> assertionService.verify(assertionResultWithChallenge()));
+            assertEquals(400, ex.getResponse().getStatus());
+        }
+
+        // Never reaches the domain check, which is the step immediately after the window guard.
+        verify(domainVerifier, never()).verifyDomain(any(), any());
+    }
+
+    /**
+     * A ceremony still inside its window must pass the guard rather than be rejected as stale.
+     */
+    @Test
+    void verify_ifCeremonyStillWithinItsWindow_passesWindowCheck() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+        when(entry.getCreationDate()).thenReturn(new Date(System.currentTimeMillis() - 10_000L));
+
+        stubCeremonyLookup(entry);
+        stubCeremonyWindow(180);
+
+        // Sentinel thrown by the step immediately after the window guard.
+        doThrow(new WebApplicationException(Response.status(499).entity("reached domain check").build()))
+                .when(domainVerifier).verifyDomain(any(), any());
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            WebApplicationException ex = assertThrows(WebApplicationException.class,
+                    () -> assertionService.verify(assertionResultWithChallenge()));
+            assertEquals(499, ex.getResponse().getStatus());
+        }
+    }
+
+    /**
      * A rejection shaped the way ErrorResponseFactory builds them: the reason is in the JSON entity,
      * never in the exception message.
      */
@@ -522,6 +581,12 @@ class AssertionServiceTest {
     private void stubHistoryExpiration(int seconds) {
         Fido2Configuration fido2Configuration = new Fido2Configuration();
         fido2Configuration.setAuthenticationHistoryExpiration(seconds);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+    }
+
+    private void stubCeremonyWindow(int seconds) {
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setUnfinishedRequestExpiration(seconds);
         when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
     }
 

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AssertionServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AssertionServiceTest.java
@@ -170,6 +170,7 @@ class AssertionServiceTest {
 
         Fido2AuthenticationData authData = new Fido2AuthenticationData();
         authData.setChallenge("clientChallenge"); // matches → guard must pass
+        authData.setStatus(Fido2AuthenticationStatus.pending);
         Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
         when(entry.getAuthenticationData()).thenReturn(authData);
         when(authenticationPersistenceService.findByChallenge("clientChallenge")).thenReturn(List.of(entry));
@@ -228,6 +229,7 @@ class AssertionServiceTest {
         Fido2AuthenticationData authData = new Fido2AuthenticationData();
         authData.setChallenge("clientChallenge");
         authData.setUsername("alice");
+        authData.setStatus(Fido2AuthenticationStatus.pending);
         Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
         when(entry.getAuthenticationData()).thenReturn(authData);
         when(entry.getRpId()).thenReturn("rp");
@@ -267,6 +269,7 @@ class AssertionServiceTest {
         Fido2AuthenticationData authData = new Fido2AuthenticationData();
         authData.setChallenge("clientChallenge");
         authData.setUsername("alice");
+        authData.setStatus(Fido2AuthenticationStatus.pending);
         Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
         when(entry.getAuthenticationData()).thenReturn(authData);
         when(entry.getRpId()).thenReturn("rp");
@@ -412,11 +415,12 @@ class AssertionServiceTest {
     }
 
     /**
-     * Only a ceremony still in flight can be rejected. A late failure must not overwrite an outcome
-     * an earlier request already recorded.
+     * A challenge is single-use. Replaying one against an already-resolved ceremony must be rejected
+     * outright — otherwise a retry after a rejection could carry the row from `failed` back to
+     * `authenticated` with a stale error reason still on it, and repeat the completion side effects.
      */
     @Test
-    void verify_ifCeremonyAlreadyTerminal_doesNotOverwriteOutcome() {
+    void verify_ifCeremonyAlreadyTerminal_isRejectedAndOutcomePreserved() {
         Fido2AuthenticationData authData = pendingCeremony("alice");
         authData.setStatus(Fido2AuthenticationStatus.authenticated);
         Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
@@ -424,9 +428,39 @@ class AssertionServiceTest {
         when(entry.getRpId()).thenReturn("rp");
 
         stubCeremonyLookup(entry);
+        when(errorResponseFactory.invalidRequest(any()))
+                .thenReturn(new WebApplicationException(Response.status(400).entity("no longer open").build()));
 
-        doThrow(new WebApplicationException(Response.status(400).entity("boom").build()))
-                .when(domainVerifier).verifyDomain(any(), any());
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            WebApplicationException ex = assertThrows(WebApplicationException.class,
+                    () -> assertionService.verify(assertionResultWithChallenge()));
+            assertEquals(400, ex.getResponse().getStatus());
+        }
+
+        assertEquals(Fido2AuthenticationStatus.authenticated, authData.getStatus());
+        verify(authenticationPersistenceService, never()).update(any());
+        // Rejected before any verification work is attempted.
+        verify(domainVerifier, never()).verifyDomain(any(), any());
+    }
+
+    /**
+     * The same guard covers a ceremony this server already rejected, which is the replay that could
+     * otherwise overwrite `failed` with `authenticated`.
+     */
+    @Test
+    void verify_ifCeremonyAlreadyFailed_isRejected() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        authData.setStatus(Fido2AuthenticationStatus.failed);
+        authData.setErrorReason("Challenge in clientData does not match");
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+
+        stubCeremonyLookup(entry);
+        when(errorResponseFactory.invalidRequest(any()))
+                .thenReturn(new WebApplicationException(Response.status(400).entity("no longer open").build()));
 
         try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
             mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
@@ -434,7 +468,8 @@ class AssertionServiceTest {
             assertThrows(WebApplicationException.class, () -> assertionService.verify(assertionResultWithChallenge()));
         }
 
-        assertEquals(Fido2AuthenticationStatus.authenticated, authData.getStatus());
+        assertEquals(Fido2AuthenticationStatus.failed, authData.getStatus());
+        assertEquals("Challenge in clientData does not match", authData.getErrorReason());
         verify(authenticationPersistenceService, never()).update(any());
     }
 

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AssertionServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AssertionServiceTest.java
@@ -3,7 +3,10 @@ package io.jans.fido2.service.operation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jans.fido2.model.assertion.AssertionResult;
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
 import io.jans.fido2.model.error.ErrorResponseFactory;
+import io.jans.fido2.model.error.Fido2ErrorResponse;
 import io.jans.fido2.service.external.ExternalFido2Service;
 import io.jans.fido2.service.persist.AuthenticationPersistenceService;
 import io.jans.fido2.service.persist.RegistrationPersistenceService;
@@ -13,6 +16,7 @@ import io.jans.fido2.service.verifier.CommonVerifiers;
 import io.jans.fido2.service.verifier.DomainVerifier;
 import io.jans.orm.model.fido2.Fido2AuthenticationData;
 import io.jans.orm.model.fido2.Fido2AuthenticationEntry;
+import io.jans.orm.model.fido2.Fido2AuthenticationStatus;
 import io.jans.orm.model.fido2.Fido2RegistrationData;
 import io.jans.orm.model.fido2.Fido2RegistrationEntry;
 import jakarta.servlet.http.HttpServletRequest;
@@ -35,9 +39,13 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,6 +71,8 @@ class AssertionServiceTest {
     private DomainVerifier domainVerifier;
     @Mock
     private MetricService metricService;
+    @Mock
+    private AppConfiguration appConfiguration;
     @Mock
     private HttpServletRequest httpRequest;
     @Mock
@@ -273,6 +283,246 @@ class AssertionServiceTest {
                     () -> assertionService.verify(assertionResult));
             assertEquals(400, ex.getResponse().getStatus());
         }
+    }
+
+    /**
+     * A rejected assertion must give the ceremony a terminal status instead of leaving it at
+     * pending, where it was indistinguishable from a ceremony still in flight and was then deleted
+     * unlabelled. The reason and category must match what the metrics store records for the same
+     * event, and the entry must be promoted off the short unfinished-request window.
+     */
+    @Test
+    void verify_ifAssertionRejected_marksEntryFailedWithReasonAndHistoryRetention() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+
+        stubCeremonyLookup(entry);
+        stubHistoryExpiration(1296000);
+        when(metricService.categorizeError("Challenge in clientData does not match")).thenReturn("INVALID_INPUT");
+
+        // Rejected after the ceremony is known, which is the case that used to leave the row pending.
+        doThrow(fido2Rejection("Challenge in clientData does not match"))
+                .when(domainVerifier).verifyDomain(any(), any());
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            assertThrows(WebApplicationException.class, () -> assertionService.verify(assertionResultWithChallenge()));
+        }
+
+        assertEquals(Fido2AuthenticationStatus.failed, authData.getStatus());
+        assertEquals("Challenge in clientData does not match", authData.getErrorReason());
+        assertEquals("INVALID_INPUT", authData.getErrorCategory());
+        verify(entry).setExpiration(1296000);
+        verify(authenticationPersistenceService).update(entry);
+    }
+
+    /**
+     * A rejection raised through ErrorResponseFactory is a WebApplicationException whose getMessage()
+     * is only the generic status line, identical for every such failure. The specific reason lives in
+     * the {status, errorMessage} envelope, and both the entry and the metric must record that instead
+     * — otherwise every rejection is stored as "HTTP 400 Bad Request" and categorized as OTHER.
+     */
+    @Test
+    void verify_ifRejectedWithFido2Envelope_recordsSpecificReasonNotTheStatusLine() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+
+        stubCeremonyLookup(entry);
+        stubHistoryExpiration(1296000);
+
+        WebApplicationException rejection = fido2Rejection("Couldn't find the key by PublicKeyId");
+        // Guards the premise: the generic message is what naive extraction would have recorded.
+        assertEquals("HTTP 400 Bad Request", rejection.getMessage());
+        doThrow(rejection).when(domainVerifier).verifyDomain(any(), any());
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            assertThrows(WebApplicationException.class, () -> assertionService.verify(assertionResultWithChallenge()));
+        }
+
+        assertEquals("Couldn't find the key by PublicKeyId", authData.getErrorReason());
+        verify(metricService).recordPasskeyAuthenticationFailure(any(), any(), anyLong(),
+                eq("Couldn't find the key by PublicKeyId"), any());
+    }
+
+    /**
+     * The reason recorded on the entry must be the same string the failure metric carries, including
+     * the fallback used when the exception has no message — otherwise the two sources still disagree.
+     */
+    @Test
+    void verify_ifRejectionHasNoMessage_entryAndMetricShareTheSameReason() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+
+        stubCeremonyLookup(entry);
+        stubHistoryExpiration(1296000);
+        when(metricService.categorizeError(any())).thenReturn("UNKNOWN_ERROR");
+
+        doThrow(new RuntimeException((String) null)).when(domainVerifier).verifyDomain(any(), any());
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            assertThrows(RuntimeException.class, () -> assertionService.verify(assertionResultWithChallenge()));
+        }
+
+        assertEquals("Unknown error", authData.getErrorReason());
+        verify(metricService).recordPasskeyAuthenticationFailure(any(), any(), anyLong(), eq("Unknown error"), any());
+    }
+
+    /**
+     * A failure raised before the ceremony is known must attribute the metric to the ceremony user
+     * anyway. Previously username was only assigned after the registration lookup, so every earlier
+     * failure was recorded against a null user.
+     */
+    @Test
+    void verify_ifRejectedBeforeRegistrationLookup_attributesFailureToCeremonyUser() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+
+        stubCeremonyLookup(entry);
+        stubHistoryExpiration(1296000);
+
+        doThrow(new WebApplicationException(Response.status(400).entity("boom").build()))
+                .when(domainVerifier).verifyDomain(any(), any());
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            assertThrows(WebApplicationException.class, () -> assertionService.verify(assertionResultWithChallenge()));
+        }
+
+        verify(metricService).recordPasskeyAuthenticationFailure(eq("alice"), any(), anyLong(), any(), any());
+    }
+
+    /**
+     * Only a ceremony still in flight can be rejected. A late failure must not overwrite an outcome
+     * an earlier request already recorded.
+     */
+    @Test
+    void verify_ifCeremonyAlreadyTerminal_doesNotOverwriteOutcome() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        authData.setStatus(Fido2AuthenticationStatus.authenticated);
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+
+        stubCeremonyLookup(entry);
+
+        doThrow(new WebApplicationException(Response.status(400).entity("boom").build()))
+                .when(domainVerifier).verifyDomain(any(), any());
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            assertThrows(WebApplicationException.class, () -> assertionService.verify(assertionResultWithChallenge()));
+        }
+
+        assertEquals(Fido2AuthenticationStatus.authenticated, authData.getStatus());
+        verify(authenticationPersistenceService, never()).update(any());
+    }
+
+    /**
+     * When the challenge never resolves to a ceremony there is no row to mark, and the original
+     * rejection must still surface unchanged.
+     */
+    @Test
+    void verify_ifChallengeNeverResolved_surfacesOriginalRejectionAndWritesNothing() {
+        AssertionResult assertionResult = mock(AssertionResult.class);
+        io.jans.fido2.model.assertion.Response response = mock(io.jans.fido2.model.assertion.Response.class);
+        when(assertionResult.getResponse()).thenReturn(response);
+        when(assertionResult.getRawId()).thenReturn("rawIdValue");
+        when(assertionResult.getId()).thenReturn("idValue");
+        when(commonVerifiers.verifyNullOrEmptyString("rawIdValue")).thenReturn("rawIdValue");
+        when(commonVerifiers.verifyNullOrEmptyString("idValue")).thenReturn("idValue");
+        when(errorResponseFactory.invalidRequest(any()))
+                .thenReturn(new WebApplicationException(Response.status(400).entity("rawId mismatch").build()));
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            WebApplicationException ex = assertThrows(WebApplicationException.class,
+                    () -> assertionService.verify(assertionResult));
+            assertEquals(400, ex.getResponse().getStatus());
+        }
+
+        verify(authenticationPersistenceService, never()).update(any());
+    }
+
+    /**
+     * Bookkeeping must never mask the rejection being returned to the client: if persisting the
+     * failed status itself fails, the original exception still surfaces.
+     */
+    @Test
+    void verify_ifMarkingFailedCannotPersist_originalRejectionStillSurfaces() {
+        Fido2AuthenticationData authData = pendingCeremony("alice");
+        Fido2AuthenticationEntry entry = mock(Fido2AuthenticationEntry.class);
+        when(entry.getAuthenticationData()).thenReturn(authData);
+        when(entry.getRpId()).thenReturn("rp");
+
+        stubCeremonyLookup(entry);
+        stubHistoryExpiration(1296000);
+        doThrow(new IllegalStateException("persistence down")).when(authenticationPersistenceService).update(any());
+
+        doThrow(new WebApplicationException(Response.status(400).entity("boom").build()))
+                .when(domainVerifier).verifyDomain(any(), any());
+
+        try (MockedStatic<CommonUtilService> mockedStatic = mockStatic(CommonUtilService.class)) {
+            mockedStatic.when(() -> CommonUtilService.toJsonNode(any())).thenReturn(mapper.createObjectNode());
+
+            WebApplicationException ex = assertThrows(WebApplicationException.class,
+                    () -> assertionService.verify(assertionResultWithChallenge()));
+            // The client still sees the rejection, not the persistence failure.
+            assertEquals(400, ex.getResponse().getStatus());
+        }
+    }
+
+    /**
+     * A rejection shaped the way ErrorResponseFactory builds them: the reason is in the JSON entity,
+     * never in the exception message.
+     */
+    private WebApplicationException fido2Rejection(String reason) {
+        return new WebApplicationException(Response.status(400)
+                .entity(Fido2ErrorResponse.failed(reason).toJson())
+                .build());
+    }
+
+    private Fido2AuthenticationData pendingCeremony(String username) {
+        Fido2AuthenticationData authData = new Fido2AuthenticationData();
+        authData.setChallenge("clientChallenge");
+        authData.setUsername(username);
+        authData.setStatus(Fido2AuthenticationStatus.pending);
+        return authData;
+    }
+
+    private AssertionResult assertionResultWithChallenge() {
+        AssertionResult assertionResult = mock(AssertionResult.class);
+        io.jans.fido2.model.assertion.Response response = mock(io.jans.fido2.model.assertion.Response.class);
+        when(assertionResult.getResponse()).thenReturn(response);
+        return assertionResult;
+    }
+
+    private void stubCeremonyLookup(Fido2AuthenticationEntry entry) {
+        when(commonVerifiers.verifyNullOrEmptyString(any())).thenReturn("keyId");
+        when(commonVerifiers.verifyClientJSON(any())).thenReturn(mapper.createObjectNode());
+        when(commonVerifiers.getChallenge(any())).thenReturn("clientChallenge");
+        when(authenticationPersistenceService.findByChallenge("clientChallenge")).thenReturn(List.of(entry));
+    }
+
+    private void stubHistoryExpiration(int seconds) {
+        Fido2Configuration fido2Configuration = new Fido2Configuration();
+        fido2Configuration.setAuthenticationHistoryExpiration(seconds);
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
     }
 
     /**

--- a/jans-linux-setup/jans_setup/templates/jans-fido2/dynamic-conf.json
+++ b/jans-linux-setup/jans_setup/templates/jans-fido2/dynamic-conf.json
@@ -37,7 +37,11 @@
 	  
       "userAutoEnrollment":false,
       "unfinishedRequestExpiration":180,
-	  
+
+      "recordAbandonedAssertions":true,
+      "abandonedRequestExpiration":86400,
+      "abandonedRequestSweepInterval":30,
+
       "disableMetadataService":false,
       "mdsDownloadStartupRetries":3,
       "mdsDownloadStartupRetryInterval":30,

--- a/jans-orm/model/src/main/java/io/jans/orm/model/fido2/Fido2AuthenticationData.java
+++ b/jans-orm/model/src/main/java/io/jans/orm/model/fido2/Fido2AuthenticationData.java
@@ -29,6 +29,18 @@ public class Fido2AuthenticationData extends Fido2Data {
 
     private String rpId;
 
+    /**
+     * Why the ceremony did not succeed. Set alongside a non-successful {@link #status} so the entry
+     * carries the same reason that is recorded in the metrics store, rather than the two disagreeing.
+     */
+    private String errorReason;
+
+    /**
+     * The bucket {@link #errorReason} falls into, using the same categorization the metrics store
+     * applies, so both can be grouped the same way.
+     */
+    private String errorCategory;
+
     public String getId() {
         return id;
     }
@@ -119,11 +131,28 @@ public class Fido2AuthenticationData extends Fido2Data {
 		this.credId = credId;
 	}
 
+	public String getErrorReason() {
+		return errorReason;
+	}
+
+	public void setErrorReason(String errorReason) {
+		this.errorReason = errorReason;
+	}
+
+	public String getErrorCategory() {
+		return errorCategory;
+	}
+
+	public void setErrorCategory(String errorCategory) {
+		this.errorCategory = errorCategory;
+	}
+
 	@Override
 	public String toString() {
 		return "Fido2AuthenticationData [id=" + id + ", username=" + username + ", origin=" + origin + ", userId="
 				+ userId + ", challenge=" + challenge + ", credId=" + credId + ", assertionRequest=" + assertionRequest
 				+ ", assertionResponse=" + assertionResponse + ", userVerificationOption=" + userVerificationOption
-				+ ", status=" + status + ", rpId=" + rpId + "]";
+				+ ", status=" + status + ", rpId=" + rpId + ", errorReason=" + errorReason + ", errorCategory="
+				+ errorCategory + "]";
 	}
 }

--- a/jans-orm/model/src/main/java/io/jans/orm/model/fido2/Fido2AuthenticationStatus.java
+++ b/jans-orm/model/src/main/java/io/jans/orm/model/fido2/Fido2AuthenticationStatus.java
@@ -17,7 +17,20 @@ import io.jans.orm.annotation.AttributeEnum;
  */
 public enum Fido2AuthenticationStatus implements AttributeEnum {
 
-	pending("pending", "Pending"), authenticated("authenticated", "Authenticated"), canceled("canceled", "Canceled");
+	pending("pending", "Pending"), authenticated("authenticated", "Authenticated"), canceled("canceled", "Canceled"),
+
+	/**
+	 * An assertion was posted and the server rejected it. Distinct from {@link #canceled}, which
+	 * would not say whether the ceremony was rejected or simply never finished.
+	 */
+	failed("failed", "Failed"),
+
+	/**
+	 * The ceremony window elapsed and no assertion was ever posted back. Recorded in place of
+	 * deleting the entry unlabelled, so an abandoned ceremony stays distinguishable from one that
+	 * never happened.
+	 */
+	abandoned("abandoned", "Abandoned");
 
     private String value;
     private String displayName;


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
A passkey authentication ceremony that fails or is abandoned leaves no usable trace in jansFido2AuthnEntry. The table only ever holds two of the three statuses it declares, so a sign-in that failed is indistinguishable from one still in progress — and once the unfinished-request window lapses, it is indistinguishable from one that never happened.
closes #14737 

#### Implementation Details

The assertion lifecycle only ever wrote two of the three statuses it declares. `POST /assertion/options`
wrote `pending`; `POST /assertion/result` flipped it to `authenticated`. There was no third path, so a
rejected assertion was left at `pending` even though a `FIDO2_AUTHENTICATION_FAILURE` metric was written
for it, and an abandoned ceremony stayed `pending` until the cleaner deleted it unlabelled.

Every ceremony now reaches a terminal status:

| Outcome | `jansStatus` | Metric status |
|---|---|---|
| Verified success | `authenticated` | `SUCCESS` |
| Verified failure | `failed` *(new)* | `FAILURE` |
| Abandonment | `abandoned` *(new)* | `ABANDONED` *(new)* |

**Rejected assertions.** The entry is hoisted out of `verify()`'s `try` so the failure path can reach it.
`markAssertionFailed()` writes `failed` with the reason and category and promotes retention from the
unfinished-request window to `authenticationHistoryExpiration`. It only transitions from `pending`, so a
late failure cannot overwrite an outcome an earlier request recorded, and the whole thing is wrapped so a
persistence error never masks the rejection returned to the client.

**Abandoned ceremonies.** `AbandonedCeremonyTimer` sweeps on its own cadence and relabels ceremonies still
`pending` past `unfinishedRequestExpiration`. It sweeps **both** subtrees — identified ceremonies under the
person entry and usernameless conditional-UI ceremonies under the assertion base DN, which are the ones
most likely to be abandoned. Because the transition only fires from `pending`, the sweep is idempotent
across repeated passes, across nodes, and across two base DNs that resolve to the same table on RDBMS.

The sweep is deliberately **not** coordinated across nodes, so abandonment is counted at least once rather
than exactly once. Two locking approaches were examined and rejected: the metrics aggregation scheduler's
cluster lock is only initialised behind that scheduler's own enabled check, so with aggregation disabled it
silently reports success on every node; and a dedicated `ClusterNode` type would allocate an index into a
base DN other components already populate. The stored value converges regardless of which node writes it —
only the emitted metric can duplicate. `abandonmentRate` is documented as approximate.

**Reporting.** `abandonedOperations` and `abandonmentRate` are added to `analytics/errors` alongside — not
replacing — `dropOffRate`. They answer different questions: `dropOffRate` is inferred as the residual of
attempts minus completions and so also absorbs ceremonies still in flight at the edge of the query window,
whereas `abandonmentRate` counts ceremonies observed to have lapsed.

New properties under `fido2Configuration`: `recordAbandonedAssertions` (default `true`, `false` restores the
previous delete-unlabelled behaviour), `abandonedRequestExpiration` (default 1 day) and
`abandonedRequestSweepInterval` (default 30s). Abandoned rows get their own short retention rather than the
15-day `authenticationHistoryExpiration`, because conditional-UI ceremonies start on virtually every login
page load and abandonment is therefore the highest-volume outcome by far.

No schema migration: `jansStatus` is `VARCHAR(16)` and both new values are shorter than `authenticated`;
`errorReason`/`errorCategory` live in the existing `@JsonObject` blob. The enum has one behavioural consumer
in the monorepo and no exhaustive `switch`, so adding values is non-breaking. `server-fips` builds clean.

##### Three changes to existing behaviour, called out deliberately

1. **Recorded error reasons change.** Every rejection raised through `ErrorResponseFactory` is a
   `WebApplicationException` built from a `Response`, whose `getMessage()` is only the generic status line —
   so `FIDO2_AUTHENTICATION_FAILURE` was recording `"HTTP 400 Bad Request"` for nearly every authentication
   failure, categorized `OTHER`. The reason is now read from the `{status, errorMessage}` envelope. The
   metric and the entry share one helper so they cannot drift. Public FIDO responses are unchanged.

2. **Conditional-UI ceremonies now count as attempts.** `generateOptions()` never recorded an `ATTEMPT`
   metric, so a usernameless ceremony could produce a terminal outcome without ever entering the attempt
   count — which would have made `abandonmentRate` saturate in exactly the deployments that use conditional
   UI most. Attempt totals will rise for those deployments, and `dropOffRate` becomes meaningful for them.

3. **The ceremony window is now enforced directly.** Pending rows are deliberately retained past their
   window so the sweep can claim them before the cleaner deletes them. To stop that grace becoming extra
   time to authenticate, `verify()` checks the issue time itself. Previously the window was only enforced as
   a side effect of the cleaner having run, so a ceremony could outlive its stated window by up to one clean
   interval; that is now tightened to the configured value.

##### Scope limitation

The `NotAllowedError` in the reported reproduction is not itself recordable — it is produced entirely in the
browser and no request reaches this server. With platform authenticators, user verification happens inside
the authenticator, so **the count of failed biometric attempts is not obtainable by any relying party** and
"the user failed their fingerprint" can never be recorded as a `FAILURE`. What is observable server-side, and
was previously being thrown away, is that a ceremony was started and never completed. Separating a deliberate
cancel from repeated verification failures needs a client-reported outcome relayed through the Authorization
Server; that is a follow-up and is not in this PR.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tracking for abandoned passkey authentication ceremonies.
  - Added configurable expiration, retention, and cleanup settings for incomplete authentication attempts.
  - FIDO2 analytics now report abandoned operation counts and abandonment rates separately from drop-off rates.
  - Authentication failures include categorized error details for improved analysis.

- **Documentation**
  - Clarified authentication outcomes, abandonment detection, retention settings, and biometric failure limitations.
  - Updated API examples and schemas with abandonment statuses and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->