### PR TITLE
fix(docs): autogenerate docs

### DIFF
--- a/docs/janssen-server/reference/json/feature-flags/janssenauthserver-feature-flags.md
+++ b/docs/janssen-server/reference/json/feature-flags/janssenauthserver-feature-flags.md
@@ -38,7 +38,7 @@ tags:
 | USERINFO | Enable/Disable OpenID Connect [userinfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) | [Details](#userinfo) |
 
 
-### ACCESS_EVALUATION
+## ACCESS_EVALUATION
 
 - Description: Enable/Disable Access Evaluation Endpoint
 
@@ -47,7 +47,7 @@ tags:
 - Default value: Enabled
 
 
-### ACTIVE_SESSION
+## ACTIVE_SESSION
 
 - Description: Enable/Disable active session endpoint
 
@@ -56,7 +56,7 @@ tags:
 - Default value: Enabled
 
 
-### CIBA
+## CIBA
 
 - Description: Enable/Disable OpenID Connect Client Initiated Backchannel Authentication Flow(CIBA) flow support
 
@@ -65,7 +65,7 @@ tags:
 - Default value: Enabled
 
 
-### CLIENT_ID_METADATA_DOCUMENT
+## CLIENT_ID_METADATA_DOCUMENT
 
 - Description: Enable/Disable OAuth Client ID Metadata Document support (URL-based client_id)
 
@@ -74,7 +74,7 @@ tags:
 - Default value: Disabled
 
 
-### CLIENTINFO
+## CLIENTINFO
 
 - Description: Enable/Disable client info endpoint
 
@@ -83,7 +83,7 @@ tags:
 - Default value: Enabled
 
 
-### DEVICE_AUTHZ
+## DEVICE_AUTHZ
 
 - Description: Enable/Disable support for device authorization
 
@@ -92,7 +92,7 @@ tags:
 - Default value: Enabled
 
 
-### END_SESSION
+## END_SESSION
 
 - Description: Enable/Disable end session endpoint
 
@@ -101,7 +101,7 @@ tags:
 - Default value: Enabled
 
 
-### GLOBAL_TOKEN_REVOCATION
+## GLOBAL_TOKEN_REVOCATION
 
 - Description: Enable/Disable global token revocation endpoint
 
@@ -110,7 +110,7 @@ tags:
 - Default value: Enabled
 
 
-### HEALTH_CHECK
+## HEALTH_CHECK
 
 - Description: Enable/Disable health-check endpoint
 
@@ -119,7 +119,7 @@ tags:
 - Default value: Enabled
 
 
-### ID_GENERATION
+## ID_GENERATION
 
 - Description: Enable/Disable ID Generation endpoint
 
@@ -128,7 +128,7 @@ tags:
 - Default value: Enabled
 
 
-### IDENTITY_ASSERTION_AUTHZ_GRANT
+## IDENTITY_ASSERTION_AUTHZ_GRANT
 
 - Description: Enable/Disable Identity Assertion Authorization Grant (Cross-App Access / ID-JAG) support
 
@@ -137,7 +137,7 @@ tags:
 - Default value: Disabled
 
 
-### INTROSPECTION
+## INTROSPECTION
 
 - Description: Enable/Disable token introspection endpoint
 
@@ -146,7 +146,7 @@ tags:
 - Default value: Enabled
 
 
-### JANS_CONFIGURATION
+## JANS_CONFIGURATION
 
 - Description: Enable/Disable *.well-known* configuration endpoint
 
@@ -155,7 +155,7 @@ tags:
 - Default value: Enabled
 
 
-### LOGOUT_STATUS_JWT
+## LOGOUT_STATUS_JWT
 
 - Description: Enable/Disable logout status jwt
 
@@ -164,7 +164,7 @@ tags:
 - Default value: Enabled
 
 
-### METRIC
+## METRIC
 
 - Description: Enable/Disable metric reporter feature
 
@@ -173,7 +173,7 @@ tags:
 - Default value: Enabled
 
 
-### PAR
+## PAR
 
 - Description: Enable/Disable Pushed Authorization Requests(PAR) feature
 
@@ -182,7 +182,7 @@ tags:
 - Default value: Enabled
 
 
-### RATE_LIMIT
+## RATE_LIMIT
 
 - Description: Enable/Disable Rate Limit
 
@@ -191,7 +191,7 @@ tags:
 - Default value: Enabled
 
 
-### REGISTRATION
+## REGISTRATION
 
 - Description: Enable/Disable client registration endpoint
 
@@ -200,7 +200,7 @@ tags:
 - Default value: Enabled
 
 
-### REVOKE_TOKEN
+## REVOKE_TOKEN
 
 - Description: Enable/Disable token revocation endpoint
 
@@ -209,7 +209,7 @@ tags:
 - Default value: Enabled
 
 
-### SSA
+## SSA
 
 - Description: Enable/Disable Software Statement Assertion(SSA) feature
 
@@ -218,7 +218,7 @@ tags:
 - Default value: Enabled
 
 
-### STAT
+## STAT
 
 - Description: Enable/Disable Stat service
 
@@ -227,7 +227,7 @@ tags:
 - Default value: Enabled
 
 
-### STATUS_LIST
+## STATUS_LIST
 
 - Description: Enable/Disable status list endpoint
 
@@ -236,7 +236,7 @@ tags:
 - Default value: Enabled
 
 
-### STATUS_SESSION
+## STATUS_SESSION
 
 - Description: Enable/Disable session status check endpoint
 
@@ -245,7 +245,7 @@ tags:
 - Default value: Enabled
 
 
-### U2F
+## U2F
 
 - Description: Enable/Disable support for Universal 2nd Factor(U2F) protocol
 
@@ -254,7 +254,7 @@ tags:
 - Default value: Disabled
 
 
-### UMA
+## UMA
 
 - Description: Enable/Disable support for User-Managed Access (UMA)
 
@@ -263,7 +263,7 @@ tags:
 - Default value: Disabled
 
 
-### USERINFO
+## USERINFO
 
 - Description: Enable/Disable OpenID Connect [userinfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
 

--- a/docs/janssen-server/reference/json/properties/config-api-properties.md
+++ b/docs/janssen-server/reference/json/properties/config-api-properties.md
@@ -14,7 +14,7 @@ tags:
 | protectionMode | Protection mode for the Lock server (OAuth or Cedarling) | [Details](#protectionmode) |
 
 
-### disableExternalLoggerConfiguration
+## disableExternalLoggerConfiguration
 
 - Description: Choose whether to disable external log4j configuration override
 
@@ -23,12 +23,12 @@ tags:
 - Default value: true
 
 
-### protectionMode
+## protectionMode
 
 - Description: Protection mode for the Lock server (OAuth or Cedarling)
 
 - Required: No
 
-- Default value: None
+- Default value: oauth
 
 

--- a/docs/janssen-server/reference/json/properties/fido2-properties.md
+++ b/docs/janssen-server/reference/json/properties/fido2-properties.md
@@ -10,6 +10,8 @@ tags:
 
 | Property Name | Description |  | 
 |-----|-----|-----|
+| abandonedRequestExpiration | Expiration time in seconds for abandoned assertion ceremonies. Kept much shorter than authenticationHistoryExpiration because conditional-UI ceremonies start on nearly every login page load, making abandonment the highest-volume outcome | [Details](#abandonedrequestexpiration) |
+| abandonedRequestSweepInterval | Interval in seconds between sweeps for lapsed assertion ceremonies. Must stay below unfinishedRequestExpiration so a ceremony cannot lapse and be deleted between two sweeps | [Details](#abandonedrequestsweepinterval) |
 | attestationMode | String value indicating whether MDS validation should be omitted during attestation | [Details](#attestationmode) |
 | authenticationHistoryExpiration | Expiration time in seconds for approved authentication requests | [Details](#authenticationhistoryexpiration) |
 | authenticatorCertsFolder | Authenticators certificates folder | [Details](#authenticatorcertsfolder) |
@@ -42,6 +44,7 @@ tags:
 | metricReporterInterval | The interval for metric reporter in seconds | [Details](#metricreporterinterval) |
 | metricReporterKeepDataDays | The days to keep report data | [Details](#metricreporterkeepdatadays) |
 | personCustomObjectClassList | Custom object class list for dynamic person enrolment | [Details](#personcustomobjectclasslist) |
+| recordAbandonedAssertions | Boolean value indicating whether assertion ceremonies that lapse without being completed are relabelled as abandoned instead of being deleted unlabelled | [Details](#recordabandonedassertions) |
 | requestedParties | Authenticators metadata in json format | [Details](#requestedparties) |
 | serverMetadataFolder | Authenticators metadata in json format | [Details](#servermetadatafolder) |
 | unfinishedRequestExpiration | Expiration time in seconds for pending enrollment/authentication requests | [Details](#unfinishedrequestexpiration) |
@@ -49,16 +52,34 @@ tags:
 | userAutoEnrollment | Allow to enroll users on enrollment/authentication requests | [Details](#userautoenrollment) |
 
 
-### attestationMode
+## abandonedRequestExpiration
+
+- Description: Expiration time in seconds for abandoned assertion ceremonies. Kept much shorter than authenticationHistoryExpiration because conditional-UI ceremonies start on nearly every login page load, making abandonment the highest-volume outcome
+
+- Required: No
+
+- Default value: 86400
+
+
+## abandonedRequestSweepInterval
+
+- Description: Interval in seconds between sweeps for lapsed assertion ceremonies. Must stay below unfinishedRequestExpiration so a ceremony cannot lapse and be deleted between two sweeps
+
+- Required: No
+
+- Default value: 30
+
+
+## attestationMode
 
 - Description: String value indicating whether MDS validation should be omitted during attestation
 
 - Required: No
 
-- Default value: None
+- Default value: monitor
 
 
-### authenticationHistoryExpiration
+## authenticationHistoryExpiration
 
 - Description: Expiration time in seconds for approved authentication requests
 
@@ -67,7 +88,7 @@ tags:
 - Default value: None
 
 
-### authenticatorCertsFolder
+## authenticatorCertsFolder
 
 - Description: Authenticators certificates folder
 
@@ -76,7 +97,7 @@ tags:
 - Default value: None
 
 
-### baseEndpoint
+## baseEndpoint
 
 - Description: The base URL for Fido2 endpoints
 
@@ -85,7 +106,7 @@ tags:
 - Default value: None
 
 
-### cleanServiceBatchChunkSize
+## cleanServiceBatchChunkSize
 
 - Description: Each clean up iteration fetches chunk of expired data per base dn and removes it from storage
 
@@ -94,7 +115,7 @@ tags:
 - Default value: None
 
 
-### cleanServiceInterval
+## cleanServiceInterval
 
 - Description: Time interval for the Clean Service in seconds
 
@@ -103,7 +124,7 @@ tags:
 - Default value: None
 
 
-### disableExternalLoggerConfiguration
+## disableExternalLoggerConfiguration
 
 - Description: Choose whether to disable external log4j configuration override
 
@@ -112,7 +133,7 @@ tags:
 - Default value: true
 
 
-### disableJdkLogger
+## disableJdkLogger
 
 - Description: Boolean value specifying whether to enable JDK Loggers
 
@@ -121,16 +142,16 @@ tags:
 - Default value: None
 
 
-### disableMetadataService
+## disableMetadataService
 
 - Description: Boolean value indicating whether the MDS download should be omitted
 
 - Required: No
 
-- Default value: None
+- Default value: false
 
 
-### enabledFidoAlgorithms
+## enabledFidoAlgorithms
 
 - Description: List of Requested Credential Types
 
@@ -139,16 +160,16 @@ tags:
 - Default value: None
 
 
-### enterpriseAttestation
+## enterpriseAttestation
 
 - Description: If authenticators have been enabled for use in a specific protected envt (enterprise authenticators)
 
 - Required: No
 
-- Default value: None
+- Default value: false
 
 
-### externalLoggerConfiguration
+## externalLoggerConfiguration
 
 - Description: Path to external Fido2 logging configuration
 
@@ -157,7 +178,7 @@ tags:
 - Default value: None
 
 
-### fido2DeviceInfoCollection
+## fido2DeviceInfoCollection
 
 - Description: Boolean value specifying whether to collect device information in FIDO2 metrics
 
@@ -166,7 +187,7 @@ tags:
 - Default value: true
 
 
-### fido2ErrorCategorization
+## fido2ErrorCategorization
 
 - Description: Boolean value specifying whether to categorize errors in FIDO2 metrics
 
@@ -175,7 +196,7 @@ tags:
 - Default value: true
 
 
-### fido2MetricsAggregationEnabled
+## fido2MetricsAggregationEnabled
 
 - Description: Boolean value specifying whether FIDO2 metrics aggregation is enabled
 
@@ -184,7 +205,7 @@ tags:
 - Default value: true
 
 
-### fido2MetricsAggregationInterval
+## fido2MetricsAggregationInterval
 
 - Description: Interval in minutes for FIDO2 metrics aggregation
 
@@ -193,7 +214,7 @@ tags:
 - Default value: 60
 
 
-### fido2MetricsEnabled
+## fido2MetricsEnabled
 
 - Description: Boolean value specifying whether FIDO2 passkey metrics collection is enabled
 
@@ -202,7 +223,7 @@ tags:
 - Default value: true
 
 
-### fido2MetricsRetentionDays
+## fido2MetricsRetentionDays
 
 - Description: Number of days to keep FIDO2 passkey metrics data
 
@@ -211,7 +232,7 @@ tags:
 - Default value: 90
 
 
-### fido2PerformanceMetrics
+## fido2PerformanceMetrics
 
 - Description: Boolean value specifying whether to collect detailed performance metrics for FIDO2 operations
 
@@ -220,7 +241,7 @@ tags:
 - Default value: true
 
 
-### hints
+## hints
 
 - Description: Hints to the RP - security-key, client-device, hybrid
 
@@ -229,7 +250,7 @@ tags:
 - Default value: None
 
 
-### issuer
+## issuer
 
 - Description: URL using the https scheme for Issuer identifier
 
@@ -238,7 +259,7 @@ tags:
 - Default value: None
 
 
-### loggingLayout
+## loggingLayout
 
 - Description: Logging layout used for Fido2
 
@@ -247,7 +268,7 @@ tags:
 - Default value: None
 
 
-### loggingLevel
+## loggingLevel
 
 - Description: Logging level for Fido2 logger
 
@@ -256,7 +277,7 @@ tags:
 - Default value: None
 
 
-### mdsCertsFolder
+## mdsCertsFolder
 
 - Description: MDS TOC root certificates folder
 
@@ -265,7 +286,7 @@ tags:
 - Default value: None
 
 
-### mdsDownloadStartupRetries
+## mdsDownloadStartupRetries
 
 - Description: Number of times the MDS TOC download is retried at server startup when the TOC blob is missing (a missing TOC prevents attestation validation)
 
@@ -274,7 +295,7 @@ tags:
 - Default value: 3
 
 
-### mdsDownloadStartupRetryInterval
+## mdsDownloadStartupRetryInterval
 
 - Description: Delay in seconds between MDS TOC download retries at server startup when the TOC blob is missing
 
@@ -283,7 +304,7 @@ tags:
 - Default value: 30
 
 
-### mdsTocsFolder
+## mdsTocsFolder
 
 - Description: MDS TOC files folder
 
@@ -292,7 +313,7 @@ tags:
 - Default value: None
 
 
-### metadataServers
+## metadataServers
 
 - Description: String value to provide source of URLs with external metadata
 
@@ -301,7 +322,7 @@ tags:
 - Default value: None
 
 
-### metricReporterEnabled
+## metricReporterEnabled
 
 - Description: Boolean value specifying whether metric reporter is enabled
 
@@ -310,7 +331,7 @@ tags:
 - Default value: None
 
 
-### metricReporterInterval
+## metricReporterInterval
 
 - Description: The interval for metric reporter in seconds
 
@@ -319,7 +340,7 @@ tags:
 - Default value: None
 
 
-### metricReporterKeepDataDays
+## metricReporterKeepDataDays
 
 - Description: The days to keep report data
 
@@ -328,7 +349,7 @@ tags:
 - Default value: None
 
 
-### personCustomObjectClassList
+## personCustomObjectClassList
 
 - Description: Custom object class list for dynamic person enrolment
 
@@ -337,7 +358,16 @@ tags:
 - Default value: None
 
 
-### requestedParties
+## recordAbandonedAssertions
+
+- Description: Boolean value indicating whether assertion ceremonies that lapse without being completed are relabelled as abandoned instead of being deleted unlabelled
+
+- Required: No
+
+- Default value: true
+
+
+## requestedParties
 
 - Description: Authenticators metadata in json format
 
@@ -346,7 +376,7 @@ tags:
 - Default value: None
 
 
-### serverMetadataFolder
+## serverMetadataFolder
 
 - Description: Authenticators metadata in json format
 
@@ -355,7 +385,7 @@ tags:
 - Default value: None
 
 
-### unfinishedRequestExpiration
+## unfinishedRequestExpiration
 
 - Description: Expiration time in seconds for pending enrollment/authentication requests
 
@@ -364,7 +394,7 @@ tags:
 - Default value: None
 
 
-### useLocalCache
+## useLocalCache
 
 - Description: Boolean value to indicate if Local Cache is to be used
 
@@ -373,7 +403,7 @@ tags:
 - Default value: None
 
 
-### userAutoEnrollment
+## userAutoEnrollment
 
 - Description: Allow to enroll users on enrollment/authentication requests
 

--- a/docs/janssen-server/reference/json/properties/janssenauthserver-properties.md
+++ b/docs/janssen-server/reference/json/properties/janssenauthserver-properties.md
@@ -17,7 +17,7 @@ tags:
 | accessTokenSigningAlgValuesSupported | A list of the JWS signing algorithms (alg values) supported by the OP for the access token to encode the Claims in a JWT | [Details](#accesstokensigningalgvaluessupported) |
 | acrMappings | The acr mappings. When AS meets key-value in map, it tries to replace 'key' with 'value' as very first thing and use that 'value' in further processing. | [Details](#acrmappings) |
 | acrToAgamaConsentFlowMapping | The acr mapping to agama consent flow name. When AS meets acr it tries to match agama consent name and set it into session attributes under 'consent_flow' name. This makes it available for main Agama Consent script, so it knows which flow to invoke. | [Details](#acrtoagamaconsentflowmapping) |
-| acrToConsentScriptNameMapping | The acr mapping to consent script name. When AS meets acr it tries to match consent script name and invoke it during authorization. This takes higher precedence then client consent script configuration. | [Details](#acrtoconsentscriptnamemapping) |
+| acrToConsentScriptNameMapping | The acr mapping to consent script name. When AS meets acr it tries to match consent script name and invoke it during authorization. This takes higher precedence than client consent script configuration. | [Details](#acrtoconsentscriptnamemapping) |
 | activeSessionAuthorizationScope | Authorization Scope for active session | [Details](#activesessionauthorizationscope) |
 | agamaConfiguration | Engine Config which offers an alternative way to build authentication flows in Janssen server | [Details](#agamaconfiguration) |
 | allowAllValueForRevokeEndpoint | Boolean value true allow all value for revoke endpoint | [Details](#allowallvalueforrevokeendpoint) |
@@ -83,7 +83,7 @@ tags:
 | clientBlackList | This list specified which client redirection URIs are black-listed | [Details](#clientblacklist) |
 | clientInfoEndpoint | The Client Info endpoint URL | [Details](#clientinfoendpoint) |
 | clientPeriodicUpdateTimerInterval | Interval for client periodic update timer. Update timer is used to debounce frequent updates of the client to avoid performance degradation. | [Details](#clientperiodicupdatetimerinterval) |
-| clientRegDefaultToCodeFlowWithRefresh | Boolean value specifying whether to add Authorization Code Flow with Refresh grant during client registratio | [Details](#clientregdefaulttocodeflowwithrefresh) |
+| clientRegDefaultToCodeFlowWithRefresh | Boolean value specifying whether to add Authorization Code Flow with Refresh grant during client registration | [Details](#clientregdefaulttocodeflowwithrefresh) |
 | clientWhiteList | This list specifies which client redirection URIs are white-listed | [Details](#clientwhitelist) |
 | configurationUpdateInterval | The interval for configuration update in seconds | [Details](#configurationupdateinterval) |
 | connectionServiceConfiguration | Connection service Configuration | [Details](#connectionserviceconfiguration) |
@@ -174,12 +174,12 @@ tags:
 | idTokenTokenBindingCnfValuesSupported | Array containing a list of the JWT Confirmation Method member names supported by the OP for Token Binding of ID Tokens. The presence of this parameter indicates that the OpenID Provider supports Token Binding of ID Tokens. If omitted, the default is that the OpenID Provider does not support Token Binding of ID Tokens | [Details](#idtokentokenbindingcnfvaluessupported) |
 | imgLocation | The location for image files | [Details](#imglocation) |
 | includeRefreshTokenLifetimeInTokenResponse | Boolean value specifying whether to include refresh token lifetime in token response | [Details](#includerefreshtokenlifetimeintokenresponse) |
-| includeRequestedClaimsInIdToken | Boolean value to indicate whether to include requested claims in id_token (specified by 'claims' parameter at Authorization Endpoint). Default value is false to put minimize claims in token (for security). | [Details](#includerequestedclaimsinidtoken) |
+| includeRequestedClaimsInIdToken | Boolean value to indicate whether to include requested claims in id_token (specified by 'claims' parameter at Authorization Endpoint). Default value is false to minimize the claims in the id_token (for security). | [Details](#includerequestedclaimsinidtoken) |
 | includeSidInResponse | Boolean value specifying whether to include sessionId in response | [Details](#includesidinresponse) |
 | introspectionAccessTokenMustHaveIntrospectionScope | If True, rejects introspection requests if access_token does not have the 'introspection' scope in its authorization header. Comparing to 'uma_protection', 'introspection' scope is not allowed for dynamic registration' | [Details](#introspectionaccesstokenmusthaveintrospectionscope) |
 | introspectionAccessTokenMustHaveUmaProtectionScope | If True, rejects introspection requests if access_token does not have the uma_protection scope in its authorization header | [Details](#introspectionaccesstokenmusthaveumaprotectionscope) |
-| introspectionEncryptionAlgValuesSupported | This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT | [Details](#introspectionencryptionalgvaluessupported) |
-| introspectionEncryptionEncValuesSupported | This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT | [Details](#introspectionencryptionencvaluessupported) |
+| introspectionEncryptionAlgValuesSupported | This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT | [Details](#introspectionencryptionalgvaluessupported) |
+| introspectionEncryptionEncValuesSupported | This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT | [Details](#introspectionencryptionencvaluessupported) |
 | introspectionEndpoint | Introspection endpoint URL | [Details](#introspectionendpoint) |
 | introspectionResponseScopesBackwardCompatibility | Boolean value specifying introspection response backward compatibility mode | [Details](#introspectionresponsescopesbackwardcompatibility) |
 | introspectionRestrictBasicAuthnToOwnTokens | If True, allow client request only own tokens. Otherwise allow to introspect all tokens. | [Details](#introspectionrestrictbasicauthntoowntokens) |
@@ -242,7 +242,7 @@ tags:
 | pairwiseCalculationSalt | Salt to calculate algorithmic pairwise IDs | [Details](#pairwisecalculationsalt) |
 | pairwiseIdType | the pairwise ID type | [Details](#pairwiseidtype) |
 | parEndpoint | URL for Pushed Authorisation Request (PAR) Endpoint | [Details](#parendpoint) |
-| parForbidPublicClient | Boolean value to indicate whether public client is allowed for Pushed Authorisation Request(PAR) | [Details](#parforbidpublicclient) |
+| parForbidPublicClient | Boolean value indicating whether public clients are forbidden from using Pushed Authorization Requests (PAR); when true, public clients are not allowed to use PAR. | [Details](#parforbidpublicclient) |
 | persistIdToken | Specifies whether to persist id_token (otherwise saves into cache) | [Details](#persistidtoken) |
 | persistRefreshToken | Specifies whether to persist refresh_token (otherwise saves into cache) | [Details](#persistrefreshtoken) |
 | personCustomObjectClassList | This list details custom object classes for dynamic person enrollment | [Details](#personcustomobjectclasslist) |
@@ -287,7 +287,7 @@ tags:
 | sessionIdUnusedLifetime | The lifetime for unused session states | [Details](#sessionidunusedlifetime) |
 | sessionIdUserClaimsInAttributes | Defines list of user claims that has to be put in session attributes | [Details](#sessioniduserclaimsinattributes) |
 | shareSubjectIdBetweenClientsWithSameSectorId | When true, clients with the same Sector ID also share the same Subject ID | [Details](#sharesubjectidbetweenclientswithsamesectorid) |
-| skipAuthenticationFilterOptionsMethod | Force Authentication Filtker to process OPTIONS request | [Details](#skipauthenticationfilteroptionsmethod) |
+| skipAuthenticationFilterOptionsMethod | When true, skips authentication filter processing for OPTIONS requests (the filter returns early before client authentication) | [Details](#skipauthenticationfilteroptionsmethod) |
 | skipAuthorizationForOpenIdScopeAndPairwiseId | Choose whether to skip authorization if a client has an OpenId scope and a pairwise ID | [Details](#skipauthorizationforopenidscopeandpairwiseid) |
 | skipRefreshTokenDuringRefreshing | Boolean value specifying whether to skip refreshing tokens on refreshing | [Details](#skiprefreshtokenduringrefreshing) |
 | skipSessionAuthnTimeCheckDuringPromptLogin | Boolean value true allows to skip session authentication time check when client is configured from prompt login (has property defaultPromptLogin=true) | [Details](#skipsessionauthntimecheckduringpromptlogin) |
@@ -312,8 +312,8 @@ tags:
 | tokenRevocationEndpoint | The URL for the access_token or refresh_token revocation endpoint | [Details](#tokenrevocationendpoint) |
 | trustedClientEnabled | Boolean value specifying whether a client is trusted and no authorization is required | [Details](#trustedclientenabled) |
 | trustedSsaIssuers | List of trusted SSA issuers with configuration (e.g. automatically granted scopes). | [Details](#trustedssaissuers) |
-| txTokenEncryptionAlgValuesSupported | This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT | [Details](#txtokenencryptionalgvaluessupported) |
-| txTokenEncryptionEncValuesSupported | This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT | [Details](#txtokenencryptionencvaluessupported) |
+| txTokenEncryptionAlgValuesSupported | This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT | [Details](#txtokenencryptionalgvaluessupported) |
+| txTokenEncryptionEncValuesSupported | This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT | [Details](#txtokenencryptionencvaluessupported) |
 | txTokenLifetime | The lifetime of the Transaction Token | [Details](#txtokenlifetime) |
 | txTokenSigningAlgValuesSupported | This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT | [Details](#txtokensigningalgvaluessupported) |
 | uiLocalesSupported | This list details the languages and scripts supported for the user interface | [Details](#uilocalessupported) |
@@ -329,13 +329,13 @@ tags:
 | umaValidateClaimToken | Validate claim_token as id_token assuming it is issued by local id | [Details](#umavalidateclaimtoken) |
 | updateClientAccessTime | Choose if application should update oxLastAccessTime/oxLastLogonTime attributes upon client authentication | [Details](#updateclientaccesstime) |
 | updateUserLastLogonTime | Choose if application should update oxLastLogonTime attribute upon user authentication | [Details](#updateuserlastlogontime) |
-| uppercaseResponseKeysInAccountAccessConsent | Boolean value to indicate whether to uppercase keys returns from /open-banking/v3.1/aisp/account-access-consents endpoint | [Details](#uppercaseresponsekeysinaccountaccessconsent) |
+| uppercaseResponseKeysInAccountAccessConsent | Boolean value to indicate whether to uppercase keys returned from /open-banking/v3.1/aisp/account-access-consents endpoint | [Details](#uppercaseresponsekeysinaccountaccessconsent) |
 | useHighestLevelScriptIfAcrScriptNotFound | Enable/Disable usage of highest level script in case ACR script does not exist | [Details](#usehighestlevelscriptifacrscriptnotfound) |
 | useLocalCache | Cache in local memory cache attributes, scopes, clients and organization entry with expiration 60 seconds | [Details](#uselocalcache) |
 | useNestedJwtDuringEncryption | Boolean value specifying whether to use nested Jwt during encryption | [Details](#usenestedjwtduringencryption) |
 | useOpenidSubAttributeValueForPairwiseLocalAccountId | Use openidSubAttribute value of user as local account id for algorithmic pairwise look up | [Details](#useopenidsubattributevalueforpairwiselocalaccountid) |
-| userInfoEncryptionAlgValuesSupported | This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT | [Details](#userinfoencryptionalgvaluessupported) |
-| userInfoEncryptionEncValuesSupported | This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT | [Details](#userinfoencryptionencvaluessupported) |
+| userInfoEncryptionAlgValuesSupported | This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT | [Details](#userinfoencryptionalgvaluessupported) |
+| userInfoEncryptionEncValuesSupported | This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT | [Details](#userinfoencryptionencvaluessupported) |
 | userInfoEndpoint | The User Info endpoint URL | [Details](#userinfoendpoint) |
 | userInfoLifetime | The lifetime of the User Info | [Details](#userinfolifetime) |
 | userInfoSigningAlgValuesSupported | This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT | [Details](#userinfosigningalgvaluessupported) |
@@ -344,7 +344,7 @@ tags:
 | xframeOptionsHeaderValue | Add X-Frame-Options header to response if any string in the list is contained by request uri. | [Details](#xframeoptionsheadervalue) |
 
 
-### accessEvaluationAllowBasicClientAuthorization
+## accessEvaluationAllowBasicClientAuthorization
 
 - Description: Allow basic client authorization for access evaluation endpoint.
 
@@ -353,7 +353,7 @@ tags:
 - Default value: false
 
 
-### accessEvaluationDiscoveryCacheLifetimeInMinutes
+## accessEvaluationDiscoveryCacheLifetimeInMinutes
 
 - Description: Lifetime of access evaluation discovery cache (/.well-known/authzen-configuration).
 
@@ -362,7 +362,7 @@ tags:
 - Default value: 5
 
 
-### accessEvaluationScriptName
+## accessEvaluationScriptName
 
 - Description: Access evaluation custom script name.
 
@@ -371,7 +371,7 @@ tags:
 - Default value: None
 
 
-### accessTokenLifetime
+## accessTokenLifetime
 
 - Description: The lifetime of the short lived Access Token
 
@@ -380,7 +380,7 @@ tags:
 - Default value: None
 
 
-### accessTokenSigningAlgValuesSupported
+## accessTokenSigningAlgValuesSupported
 
 - Description: A list of the JWS signing algorithms (alg values) supported by the OP for the access token to encode the Claims in a JWT
 
@@ -389,7 +389,7 @@ tags:
 - Default value: None
 
 
-### acrMappings
+## acrMappings
 
 - Description: The acr mappings. When AS meets key-value in map, it tries to replace 'key' with 'value' as very first thing and use that 'value' in further processing.
 
@@ -398,7 +398,7 @@ tags:
 - Default value: None
 
 
-### acrToAgamaConsentFlowMapping
+## acrToAgamaConsentFlowMapping
 
 - Description: The acr mapping to agama consent flow name. When AS meets acr it tries to match agama consent name and set it into session attributes under 'consent_flow' name. This makes it available for main Agama Consent script, so it knows which flow to invoke.
 
@@ -407,16 +407,16 @@ tags:
 - Default value: None
 
 
-### acrToConsentScriptNameMapping
+## acrToConsentScriptNameMapping
 
-- Description: The acr mapping to consent script name. When AS meets acr it tries to match consent script name and invoke it during authorization. This takes higher precedence then client consent script configuration.
+- Description: The acr mapping to consent script name. When AS meets acr it tries to match consent script name and invoke it during authorization. This takes higher precedence than client consent script configuration.
 
 - Required: No
 
 - Default value: None
 
 
-### activeSessionAuthorizationScope
+## activeSessionAuthorizationScope
 
 - Description: Authorization Scope for active session
 
@@ -425,7 +425,7 @@ tags:
 - Default value: None
 
 
-### agamaConfiguration
+## agamaConfiguration
 
 - Description: Engine Config which offers an alternative way to build authentication flows in Janssen server
 
@@ -434,7 +434,7 @@ tags:
 - Default value: None
 
 
-### allowAllValueForRevokeEndpoint
+## allowAllValueForRevokeEndpoint
 
 - Description: Boolean value true allow all value for revoke endpoint
 
@@ -443,7 +443,7 @@ tags:
 - Default value: false
 
 
-### allowBlankValuesInDiscoveryResponse
+## allowBlankValuesInDiscoveryResponse
 
 - Description: Boolean value specifying whether to allow blank values in discovery response
 
@@ -452,7 +452,7 @@ tags:
 - Default value: false
 
 
-### allowClientAssertionAudWithoutStrictIssuerMatch
+## allowClientAssertionAudWithoutStrictIssuerMatch
 
 - Description: Boolean value to indicate whether to allow client assertion 'aud' without strict server issuer match. Default value is false which means that server requires strict match.
 
@@ -461,7 +461,7 @@ tags:
 - Default value: false
 
 
-### allowEndSessionWithUnmatchedSid
+## allowEndSessionWithUnmatchedSid
 
 - Description: default value false. If true, sid check will be skipped
 
@@ -470,7 +470,7 @@ tags:
 - Default value: false
 
 
-### allowIdTokenWithoutImplicitGrantType
+## allowIdTokenWithoutImplicitGrantType
 
 - Description: Specifies if a token without implicit grant types is allowed
 
@@ -479,7 +479,7 @@ tags:
 - Default value: None
 
 
-### allowPostLogoutRedirectWithoutValidation
+## allowPostLogoutRedirectWithoutValidation
 
 - Description: Allows post-logout redirect without validation for the End Session endpoint (still AS validates it against clientWhiteList url pattern property)
 
@@ -488,7 +488,7 @@ tags:
 - Default value: false
 
 
-### allowRevokeForOtherClients
+## allowRevokeForOtherClients
 
 - Description: Boolean value true allows revoking of any token for any client. False value allows remove only tokens issued by client used at Revoke Endpoint
 
@@ -497,7 +497,7 @@ tags:
 - Default value: false
 
 
-### allowSpontaneousScopes
+## allowSpontaneousScopes
 
 - Description: Specifies whether to allow spontaneous scopes
 
@@ -506,7 +506,7 @@ tags:
 - Default value: None
 
 
-### applyXFrameOptionsHeaderIfUriContainsAny
+## applyXFrameOptionsHeaderIfUriContainsAny
 
 - Description: Add X-Frame-Options header to response if any string in the list is contained by request uri.
 
@@ -515,7 +515,7 @@ tags:
 - Default value: None
 
 
-### archivedJwkLifetimeInSeconds
+## archivedJwkLifetimeInSeconds
 
 - Description: Archived JWK lifetime in seconds
 
@@ -524,7 +524,7 @@ tags:
 - Default value: None
 
 
-### archivedJwksUri
+## archivedJwksUri
 
 - Description: URL of the OP's Archived JSON Web Key Set (JWK) document. This contains the signing key(s) the RP uses to validate signatures from the OP
 
@@ -533,7 +533,7 @@ tags:
 - Default value: None
 
 
-### authenticationFilters
+## authenticationFilters
 
 - Description: This list details filters for user authentication
 
@@ -542,7 +542,7 @@ tags:
 - Default value: None
 
 
-### authenticationFiltersEnabled
+## authenticationFiltersEnabled
 
 - Description: Boolean value specifying whether to enable user authentication filters
 
@@ -551,7 +551,7 @@ tags:
 - Default value: None
 
 
-### authenticationProtectionConfiguration
+## authenticationProtectionConfiguration
 
 - Description: Authentication Brute Force Protection Configuration
 
@@ -560,7 +560,7 @@ tags:
 - Default value: None
 
 
-### authorizationChallengeDefaultAcr
+## authorizationChallengeDefaultAcr
 
 - Description: Authorization Challenge Endpoint Default ACR if no value is specified in acr_values request parameter.
 
@@ -569,7 +569,7 @@ tags:
 - Default value: default_challenge
 
 
-### authorizationChallengeEndpoint
+## authorizationChallengeEndpoint
 
 - Description: The authorization challenge endpoint URL
 
@@ -578,7 +578,7 @@ tags:
 - Default value: None
 
 
-### authorizationChallengeSessionLifetimeInSeconds
+## authorizationChallengeSessionLifetimeInSeconds
 
 - Description: Authorization challenge session lifetime in seconds
 
@@ -587,7 +587,7 @@ tags:
 - Default value: None
 
 
-### authorizationChallengeShouldGenerateSession
+## authorizationChallengeShouldGenerateSession
 
 - Description: Boolean value specifying whether to generate session_id (AS object and cookie) during authorization at Authorization Challenge Endpoint
 
@@ -596,7 +596,7 @@ tags:
 - Default value: false
 
 
-### authorizationCodeLifetime
+## authorizationCodeLifetime
 
 - Description: The lifetime of the Authorization Code
 
@@ -605,7 +605,7 @@ tags:
 - Default value: None
 
 
-### authorizationEncryptionAlgValuesSupported
+## authorizationEncryptionAlgValuesSupported
 
 - Description: List of authorization encryption algorithms supported by this OP
 
@@ -614,7 +614,7 @@ tags:
 - Default value: None
 
 
-### authorizationEncryptionEncValuesSupported
+## authorizationEncryptionEncValuesSupported
 
 - Description: A list of the authorization encryption algorithms supported
 
@@ -623,7 +623,7 @@ tags:
 - Default value: None
 
 
-### authorizationEndpoint
+## authorizationEndpoint
 
 - Description: The authorization endpoint URL
 
@@ -632,7 +632,7 @@ tags:
 - Default value: None
 
 
-### authorizationRequestCustomAllowedParameters
+## authorizationRequestCustomAllowedParameters
 
 - Description: This list details the allowed custom parameters for authorization requests
 
@@ -641,7 +641,7 @@ tags:
 - Default value: None
 
 
-### authorizationResponseIssParameterSupported
+## authorizationResponseIssParameterSupported
 
 - Description: Boolean value specifying whether the authorization server includes the iss parameter in authorization responses per RFC 9207. Default: false.
 
@@ -650,7 +650,7 @@ tags:
 - Default value: false
 
 
-### authorizationSigningAlgValuesSupported
+## authorizationSigningAlgValuesSupported
 
 - Description: List of authorization signing algorithms supported by this OP
 
@@ -659,7 +659,7 @@ tags:
 - Default value: None
 
 
-### backchannelAuthenticationEndpoint
+## backchannelAuthenticationEndpoint
 
 - Description: Backchannel Authentication Endpoint
 
@@ -668,7 +668,7 @@ tags:
 - Default value: None
 
 
-### backchannelAuthenticationRequestSigningAlgValuesSupported
+## backchannelAuthenticationRequestSigningAlgValuesSupported
 
 - Description: Backchannel Authentication Request Signing Alg Values Supported
 
@@ -677,7 +677,7 @@ tags:
 - Default value: None
 
 
-### backchannelAuthenticationResponseExpiresIn
+## backchannelAuthenticationResponseExpiresIn
 
 - Description: Backchannel Authentication Response Expires In
 
@@ -686,7 +686,7 @@ tags:
 - Default value: None
 
 
-### backchannelAuthenticationResponseInterval
+## backchannelAuthenticationResponseInterval
 
 - Description: Backchannel Authentication Response Interval
 
@@ -695,7 +695,7 @@ tags:
 - Default value: None
 
 
-### backchannelBindingMessagePattern
+## backchannelBindingMessagePattern
 
 - Description: Backchannel Binding Message Pattern
 
@@ -704,7 +704,7 @@ tags:
 - Default value: None
 
 
-### backchannelClientId
+## backchannelClientId
 
 - Description: Backchannel Client Id
 
@@ -713,7 +713,7 @@ tags:
 - Default value: None
 
 
-### backchannelDeviceRegistrationEndpoint
+## backchannelDeviceRegistrationEndpoint
 
 - Description: Backchannel Device Registration Endpoint
 
@@ -722,7 +722,7 @@ tags:
 - Default value: None
 
 
-### backchannelLoginHintClaims
+## backchannelLoginHintClaims
 
 - Description: Backchannel Login Hint Claims
 
@@ -731,7 +731,7 @@ tags:
 - Default value: None
 
 
-### backchannelRedirectUri
+## backchannelRedirectUri
 
 - Description: Backchannel Redirect Uri
 
@@ -740,7 +740,7 @@ tags:
 - Default value: None
 
 
-### backchannelRequestsProcessorJobChunkSize
+## backchannelRequestsProcessorJobChunkSize
 
 - Description: Each backchannel request processor iteration fetches chunk of data to be processed
 
@@ -749,7 +749,7 @@ tags:
 - Default value: None
 
 
-### backchannelRequestsProcessorJobIntervalSec
+## backchannelRequestsProcessorJobIntervalSec
 
 - Description: Specifies the allowable elapsed time in seconds backchannel request processor executes
 
@@ -758,7 +758,7 @@ tags:
 - Default value: None
 
 
-### backchannelTokenDeliveryModesSupported
+## backchannelTokenDeliveryModesSupported
 
 - Description: Backchannel Token Delivery Modes Supported
 
@@ -767,7 +767,7 @@ tags:
 - Default value: None
 
 
-### backchannelUserCodeParameterSupported
+## backchannelUserCodeParameterSupported
 
 - Description: Backchannel User Code Parameter Supported
 
@@ -776,7 +776,7 @@ tags:
 - Default value: None
 
 
-### baseEndpoint
+## baseEndpoint
 
 - Description: The base URL for endpoints
 
@@ -785,7 +785,7 @@ tags:
 - Default value: None
 
 
-### blockWebviewAuthorizationEnabled
+## blockWebviewAuthorizationEnabled
 
 - Description: Enable/Disable block authorizations that originate from Webview (Mobile apps).
 
@@ -794,7 +794,7 @@ tags:
 - Default value: false
 
 
-### changeSessionIdOnAuthentication
+## changeSessionIdOnAuthentication
 
 - Description: Boolean value specifying whether change session_id on authentication. Default value is true
 
@@ -803,7 +803,7 @@ tags:
 - Default value: true
 
 
-### checkSessionIFrame
+## checkSessionIFrame
 
 - Description: URL for an OP IFrame that supports cross-origin communications for session state information with the RP Client using the HTML5 postMessage API
 
@@ -812,7 +812,7 @@ tags:
 - Default value: None
 
 
-### checkUserPresenceOnRefreshToken
+## checkUserPresenceOnRefreshToken
 
 - Description: Check whether user exists and is active before creating RefreshToken. Set it to true if check is needed(Default value is false - don't check.
 
@@ -821,7 +821,7 @@ tags:
 - Default value: false
 
 
-### cibaEndUserNotificationConfig
+## cibaEndUserNotificationConfig
 
 - Description: CIBA End User Notification Config
 
@@ -830,7 +830,7 @@ tags:
 - Default value: None
 
 
-### cibaGrantLifeExtraTimeSec
+## cibaGrantLifeExtraTimeSec
 
 - Description: Specifies the CIBA Grant life extra time in seconds
 
@@ -839,7 +839,7 @@ tags:
 - Default value: None
 
 
-### cibaMaxExpirationTimeAllowedSec
+## cibaMaxExpirationTimeAllowedSec
 
 - Description: Specifies the CIBA token expiration time in seconds
 
@@ -848,7 +848,7 @@ tags:
 - Default value: None
 
 
-### cimdBlockPrivateIp
+## cimdBlockPrivateIp
 
 - Description: Block private/internal IP ranges for CIMD (RFC 1918, loopback, link-local)
 
@@ -857,7 +857,7 @@ tags:
 - Default value: true
 
 
-### cimdConnectTimeoutMs
+## cimdConnectTimeoutMs
 
 - Description: Connection timeout in milliseconds for CIMD fetch
 
@@ -866,7 +866,7 @@ tags:
 - Default value: 5000
 
 
-### cimdDomainAllowlist
+## cimdDomainAllowlist
 
 - Description: Allowed domains for CIMD client_id URLs
 
@@ -875,7 +875,7 @@ tags:
 - Default value: None
 
 
-### cimdDomainBlocklist
+## cimdDomainBlocklist
 
 - Description: Blocked domains for CIMD client_id URLs
 
@@ -884,7 +884,7 @@ tags:
 - Default value: None
 
 
-### cimdMaxResponseSize
+## cimdMaxResponseSize
 
 - Description: Maximum response size in bytes for CIMD fetch
 
@@ -893,7 +893,7 @@ tags:
 - Default value: 65536
 
 
-### cimdMaxTtlMinutes
+## cimdMaxTtlMinutes
 
 - Description: Maximum TTL in minutes for persisted CIMD client metadata (upper bound, even if HTTP Cache-Control specifies longer)
 
@@ -902,7 +902,7 @@ tags:
 - Default value: 1440
 
 
-### cimdReadTimeoutMs
+## cimdReadTimeoutMs
 
 - Description: Read timeout in milliseconds for CIMD fetch
 
@@ -911,16 +911,16 @@ tags:
 - Default value: 10000
 
 
-### cimdSchemeAllowlist
+## cimdSchemeAllowlist
 
 - Description: Allowed URL schemes for CIMD client_id (default: https only)
 
 - Required: No
 
-- Default value: None
+- Default value: ["https"]
 
 
-### cimdTtlMinutes
+## cimdTtlMinutes
 
 - Description: Default TTL in minutes for persisted CIMD client metadata (also used as fallback when HTTP Cache-Control header is absent)
 
@@ -929,7 +929,7 @@ tags:
 - Default value: 60
 
 
-### claimsLocalesSupported
+## claimsLocalesSupported
 
 - Description: This list details the languages and scripts supported for values in the claims being returned
 
@@ -938,7 +938,7 @@ tags:
 - Default value: None
 
 
-### claimsParameterSupported
+## claimsParameterSupported
 
 - Description: Specifies whether the OP supports use of the claims parameter
 
@@ -947,7 +947,7 @@ tags:
 - Default value: None
 
 
-### claimTypesSupported
+## claimTypesSupported
 
 - Description: A list of the Claim Types that the OpenID Provider supports
 
@@ -956,7 +956,7 @@ tags:
 - Default value: None
 
 
-### clientAuthenticationFilters
+## clientAuthenticationFilters
 
 - Description: This list details filters for client authentication
 
@@ -965,7 +965,7 @@ tags:
 - Default value: None
 
 
-### clientAuthenticationFiltersEnabled
+## clientAuthenticationFiltersEnabled
 
 - Description: Boolean value specifying whether to enable client authentication filters
 
@@ -974,7 +974,7 @@ tags:
 - Default value: None
 
 
-### clientBlackList
+## clientBlackList
 
 - Description: This list specified which client redirection URIs are black-listed
 
@@ -983,7 +983,7 @@ tags:
 - Default value: None
 
 
-### clientInfoEndpoint
+## clientInfoEndpoint
 
 - Description: The Client Info endpoint URL
 
@@ -992,7 +992,7 @@ tags:
 - Default value: None
 
 
-### clientPeriodicUpdateTimerInterval
+## clientPeriodicUpdateTimerInterval
 
 - Description: Interval for client periodic update timer. Update timer is used to debounce frequent updates of the client to avoid performance degradation.
 
@@ -1001,16 +1001,16 @@ tags:
 - Default value: None
 
 
-### clientRegDefaultToCodeFlowWithRefresh
+## clientRegDefaultToCodeFlowWithRefresh
 
-- Description: Boolean value specifying whether to add Authorization Code Flow with Refresh grant during client registratio
+- Description: Boolean value specifying whether to add Authorization Code Flow with Refresh grant during client registration
 
 - Required: No
 
 - Default value: None
 
 
-### clientWhiteList
+## clientWhiteList
 
 - Description: This list specifies which client redirection URIs are white-listed
 
@@ -1019,7 +1019,7 @@ tags:
 - Default value: None
 
 
-### configurationUpdateInterval
+## configurationUpdateInterval
 
 - Description: The interval for configuration update in seconds
 
@@ -1028,7 +1028,7 @@ tags:
 - Default value: None
 
 
-### connectionServiceConfiguration
+## connectionServiceConfiguration
 
 - Description: Connection service Configuration
 
@@ -1037,7 +1037,7 @@ tags:
 - Default value: None
 
 
-### consentGatheringScriptBackwardCompatibility
+## consentGatheringScriptBackwardCompatibility
 
 - Description: Boolean value specifying whether to turn on Consent Gathering Script backward compatibility mode. If true AS will pick up script with higher level globally. If false (default) AS will pick up script based on client configuration
 
@@ -1046,7 +1046,7 @@ tags:
 - Default value: false
 
 
-### cookieDomain
+## cookieDomain
 
 - Description: Sets cookie domain for all cookies created by OP
 
@@ -1055,7 +1055,7 @@ tags:
 - Default value: None
 
 
-### corsConfigurationFilters
+## corsConfigurationFilters
 
 - Description: This list specifies the CORS configuration filters
 
@@ -1064,7 +1064,7 @@ tags:
 - Default value: None
 
 
-### cssLocation
+## cssLocation
 
 - Description: The location for CSS files
 
@@ -1073,7 +1073,7 @@ tags:
 - Default value: None
 
 
-### customHeadersWithAuthorizationResponse
+## customHeadersWithAuthorizationResponse
 
 - Description: Choose whether to enable the custom response header parameter to return custom headers with the authorization response
 
@@ -1082,7 +1082,7 @@ tags:
 - Default value: None
 
 
-### dateFormatterPatterns
+## dateFormatterPatterns
 
 - Description: List of key value date formatters, e.g. 'userinfo: 'yyyy-MM-dd', etc.
 
@@ -1091,7 +1091,7 @@ tags:
 - Default value: None
 
 
-### dcrAttestationEvidenceRequired
+## dcrAttestationEvidenceRequired
 
 - Description: Boolean value indicating if DCR attestation evidence is required
 
@@ -1100,7 +1100,7 @@ tags:
 - Default value: false
 
 
-### dcrAuthorizationWithClientCredentials
+## dcrAuthorizationWithClientCredentials
 
 - Description: Boolean value indicating if DCR authorization to be performed using client credentials
 
@@ -1109,7 +1109,7 @@ tags:
 - Default value: false
 
 
-### dcrAuthorizationWithMTLS
+## dcrAuthorizationWithMTLS
 
 - Description: Boolean value indicating if DCR authorization allowed with MTLS
 
@@ -1118,7 +1118,7 @@ tags:
 - Default value: false
 
 
-### dcrForbidExpirationTimeInRequest
+## dcrForbidExpirationTimeInRequest
 
 - Description: Boolean value specifying whether to allow to set client's expiration time in seconds during dynamic registration.
 
@@ -1127,7 +1127,7 @@ tags:
 - Default value: false
 
 
-### dcrSignatureValidationEnabled
+## dcrSignatureValidationEnabled
 
 - Description: Boolean value enables DCR signature validation. Default is false
 
@@ -1136,7 +1136,7 @@ tags:
 - Default value: false
 
 
-### dcrSignatureValidationJwks
+## dcrSignatureValidationJwks
 
 - Description: Specifies JWKS for all DCR's validations
 
@@ -1145,7 +1145,7 @@ tags:
 - Default value: None
 
 
-### dcrSignatureValidationJwksUri
+## dcrSignatureValidationJwksUri
 
 - Description: Specifies JWKS URI for all DCR's validations
 
@@ -1154,7 +1154,7 @@ tags:
 - Default value: None
 
 
-### dcrSignatureValidationSharedSecret
+## dcrSignatureValidationSharedSecret
 
 - Description: Specifies shared secret for Dynamic Client Registration
 
@@ -1163,7 +1163,7 @@ tags:
 - Default value: None
 
 
-### dcrSignatureValidationSoftwareStatementJwksClaim
+## dcrSignatureValidationSoftwareStatementJwksClaim
 
 - Description: Specifies claim name inside software statement. Value of claim should point to inlined JWKS
 
@@ -1172,7 +1172,7 @@ tags:
 - Default value: None
 
 
-### dcrSignatureValidationSoftwareStatementJwksURIClaim
+## dcrSignatureValidationSoftwareStatementJwksURIClaim
 
 - Description: Specifies claim name inside software statement. Value of claim should point to JWKS URI
 
@@ -1181,7 +1181,7 @@ tags:
 - Default value: None
 
 
-### dcrSsaValidationConfigs
+## dcrSsaValidationConfigs
 
 - Description: DCR SSA Validation configurations used to perform validation of SSA or DCR. Only needed if softwareStatementValidationType=builtin
 
@@ -1190,7 +1190,7 @@ tags:
 - Default value: None
 
 
-### defaultSignatureAlgorithm
+## defaultSignatureAlgorithm
 
 - Description: The default signature algorithm to sign ID Tokens
 
@@ -1199,7 +1199,7 @@ tags:
 - Default value: None
 
 
-### defaultSubjectType
+## defaultSubjectType
 
 - Description: The default subject type used for dynamic client registration
 
@@ -1208,7 +1208,7 @@ tags:
 - Default value: None
 
 
-### deviceAuthzAcr
+## deviceAuthzAcr
 
 - Description: Device authz acr
 
@@ -1217,7 +1217,7 @@ tags:
 - Default value: None
 
 
-### deviceAuthzEndpoint
+## deviceAuthzEndpoint
 
 - Description: URL for the Device Authorization
 
@@ -1226,7 +1226,7 @@ tags:
 - Default value: None
 
 
-### deviceAuthzRequestExpiresIn
+## deviceAuthzRequestExpiresIn
 
 - Description: Expiration time given for device authorization requests
 
@@ -1235,7 +1235,7 @@ tags:
 - Default value: None
 
 
-### deviceAuthzResponseTypeToProcessAuthz
+## deviceAuthzResponseTypeToProcessAuthz
 
 - Description: Response type used to process device authz requests
 
@@ -1244,7 +1244,7 @@ tags:
 - Default value: None
 
 
-### deviceAuthzTokenPollInterval
+## deviceAuthzTokenPollInterval
 
 - Description: Default interval returned to the client to process device token requests
 
@@ -1253,7 +1253,7 @@ tags:
 - Default value: None
 
 
-### disableAuthnForMaxAgeZero
+## disableAuthnForMaxAgeZero
 
 - Description: Boolean value specifying whether to disable authentication when max_age=0
 
@@ -1262,7 +1262,7 @@ tags:
 - Default value: false
 
 
-### disableExternalLoggerConfiguration
+## disableExternalLoggerConfiguration
 
 - Description: Choose whether to disable external log4j configuration override
 
@@ -1271,7 +1271,7 @@ tags:
 - Default value: true
 
 
-### disableJdkLogger
+## disableJdkLogger
 
 - Description: Choose whether to disable JDK loggers
 
@@ -1280,7 +1280,7 @@ tags:
 - Default value: true
 
 
-### disablePromptConsent
+## disablePromptConsent
 
 - Description: Boolean value specifying whether to disable prompt=consent
 
@@ -1289,7 +1289,7 @@ tags:
 - Default value: false
 
 
-### disablePromptCreate
+## disablePromptCreate
 
 - Description: Disables prompt=create user registration functionality
 
@@ -1298,7 +1298,7 @@ tags:
 - Default value: None
 
 
-### disablePromptLogin
+## disablePromptLogin
 
 - Description: Boolean value specifying whether to disable prompt=login
 
@@ -1307,7 +1307,7 @@ tags:
 - Default value: false
 
 
-### disableU2fEndpoint
+## disableU2fEndpoint
 
 - Description: Choose whether to disable U2F endpoints
 
@@ -1316,7 +1316,7 @@ tags:
 - Default value: false
 
 
-### discoveryAllowedKeys
+## discoveryAllowedKeys
 
 - Description: List of configuration response claim allowed to be displayed in discovery endpoint
 
@@ -1325,7 +1325,7 @@ tags:
 - Default value: None
 
 
-### discoveryCacheLifetimeInMinutes
+## discoveryCacheLifetimeInMinutes
 
 - Description: Lifetime of discovery cache
 
@@ -1334,7 +1334,7 @@ tags:
 - Default value: 60
 
 
-### discoveryDenyKeys
+## discoveryDenyKeys
 
 - Description: List of configuration response claims which must not be displayed in discovery endpoint response
 
@@ -1343,7 +1343,7 @@ tags:
 - Default value: None
 
 
-### displayValuesSupported
+## displayValuesSupported
 
 - Description: A list of the display parameter values that the OpenID Provider supports
 
@@ -1352,7 +1352,7 @@ tags:
 - Default value: None
 
 
-### dnName
+## dnName
 
 - Description: DN of certificate issuer
 
@@ -1361,7 +1361,7 @@ tags:
 - Default value: None
 
 
-### dpopJktForceForAuthorizationCode
+## dpopJktForceForAuthorizationCode
 
 - Description: Force dpop_jkt presence and reject calls without it.
 
@@ -1370,7 +1370,7 @@ tags:
 - Default value: false
 
 
-### dpopJtiCacheTime
+## dpopJtiCacheTime
 
 - Description: Demonstration of Proof-of-Possession (DPoP) cache time
 
@@ -1379,7 +1379,7 @@ tags:
 - Default value: 3600
 
 
-### dpopNonceCacheTime
+## dpopNonceCacheTime
 
 - Description: Demonstration of Proof-of-Possession (DPoP) nonce cache time
 
@@ -1388,7 +1388,7 @@ tags:
 - Default value: 3600
 
 
-### dpopSigningAlgValuesSupported
+## dpopSigningAlgValuesSupported
 
 - Description: Demonstration of Proof-of-Possession (DPoP) authorization signing algorithms supported
 
@@ -1397,7 +1397,7 @@ tags:
 - Default value: None
 
 
-### dpopTimeframe
+## dpopTimeframe
 
 - Description: Demonstration of Proof-of-Possession (DPoP) timeout
 
@@ -1406,7 +1406,7 @@ tags:
 - Default value: 5
 
 
-### dpopUseNonce
+## dpopUseNonce
 
 - Description: Demonstration of Proof-of-Possession (DPoP) use nonce
 
@@ -1415,7 +1415,7 @@ tags:
 - Default value: false
 
 
-### dynamicRegistrationAllowedPasswordGrantScopes
+## dynamicRegistrationAllowedPasswordGrantScopes
 
 - Description: List of grant scopes for dynamic registration
 
@@ -1424,7 +1424,7 @@ tags:
 - Default value: None
 
 
-### dynamicRegistrationCustomAttributes
+## dynamicRegistrationCustomAttributes
 
 - Description: This list details the custom attributes allowed for dynamic registration
 
@@ -1433,7 +1433,7 @@ tags:
 - Default value: None
 
 
-### dynamicRegistrationCustomObjectClass
+## dynamicRegistrationCustomObjectClass
 
 - Description: Custom object class for dynamic registration
 
@@ -1442,7 +1442,7 @@ tags:
 - Default value: None
 
 
-### dynamicRegistrationDefaultCustomAttributes
+## dynamicRegistrationDefaultCustomAttributes
 
 - Description: This map provides default custom attributes with values for dynamic registration
 
@@ -1451,7 +1451,7 @@ tags:
 - Default value: None
 
 
-### dynamicRegistrationExpirationTime
+## dynamicRegistrationExpirationTime
 
 - Description: Expiration time in seconds for clients created with dynamic registration, 0 or -1 means never expire
 
@@ -1460,7 +1460,7 @@ tags:
 - Default value: -1
 
 
-### dynamicRegistrationPasswordGrantTypeEnabled
+## dynamicRegistrationPasswordGrantTypeEnabled
 
 - Description: Boolean value specifying whether to enable Password Grant Type during Dynamic Registration
 
@@ -1469,7 +1469,7 @@ tags:
 - Default value: false
 
 
-### dynamicRegistrationPersistClientAuthorizations
+## dynamicRegistrationPersistClientAuthorizations
 
 - Description: Boolean value specifying whether to persist client authorizations
 
@@ -1478,7 +1478,7 @@ tags:
 - Default value: None
 
 
-### dynamicRegistrationScopesParamEnabled
+## dynamicRegistrationScopesParamEnabled
 
 - Description: Boolean value specifying whether to enable scopes parameter in dynamic registration
 
@@ -1487,7 +1487,7 @@ tags:
 - Default value: None
 
 
-### enableClientGrantTypeUpdate
+## enableClientGrantTypeUpdate
 
 - Description: Choose if client can update Grant Type values
 
@@ -1496,7 +1496,7 @@ tags:
 - Default value: None
 
 
-### enabledOAuthAuditLogging
+## enabledOAuthAuditLogging
 
 - Description: enable OAuth Audit Logging
 
@@ -1505,7 +1505,7 @@ tags:
 - Default value: None
 
 
-### enableTokenMessages
+## enableTokenMessages
 
 - Description: Enable Publish messages on access token issue/revoke
 
@@ -1514,7 +1514,7 @@ tags:
 - Default value: None
 
 
-### endSessionEndpoint
+## endSessionEndpoint
 
 - Description: URL at the OP to which an RP can perform a redirect to request that the end user be logged out at the OP
 
@@ -1523,7 +1523,7 @@ tags:
 - Default value: None
 
 
-### endSessionWithAccessToken
+## endSessionWithAccessToken
 
 - Description: Choose whether to accept access tokens to call end_session endpoint
 
@@ -1532,7 +1532,7 @@ tags:
 - Default value: None
 
 
-### errorHandlingMethod
+## errorHandlingMethod
 
 - Description: A list of possible error handling methods. Possible values: remote (send error back to RP), internal (show error page)
 
@@ -1541,7 +1541,7 @@ tags:
 - Default value: remote
 
 
-### errorReasonEnabled
+## errorReasonEnabled
 
 - Description: Boolean value specifying whether to return detailed reason of the error from AS. Default value is false
 
@@ -1550,7 +1550,7 @@ tags:
 - Default value: false
 
 
-### expirationNotificatorEnabled
+## expirationNotificatorEnabled
 
 - Description: Boolean value specifying whether expiration notificator is enabled (used to identify expiration for persistence that support TTL, like Couchbase)
 
@@ -1559,7 +1559,7 @@ tags:
 - Default value: false
 
 
-### expirationNotificatorIntervalInSeconds
+## expirationNotificatorIntervalInSeconds
 
 - Description: The expiration notificator interval in second
 
@@ -1568,7 +1568,7 @@ tags:
 - Default value: None
 
 
-### expirationNotificatorMapSizeLimit
+## expirationNotificatorMapSizeLimit
 
 - Description: The expiration notificator maximum size limit
 
@@ -1577,7 +1577,7 @@ tags:
 - Default value: None
 
 
-### externalLoggerConfiguration
+## externalLoggerConfiguration
 
 - Description: The path to the external log4j2 logging configuration
 
@@ -1586,7 +1586,7 @@ tags:
 - Default value: None
 
 
-### externalUriWhiteList
+## externalUriWhiteList
 
 - Description: This list specifies which external URIs can be called by AS (if empty any URI can be called)
 
@@ -1595,7 +1595,7 @@ tags:
 - Default value: None
 
 
-### fapiCompatibility
+## fapiCompatibility
 
 - Description: Boolean value specifying whether to turn on FAPI compatibility mode. If true AS behaves in more strict mode
 
@@ -1604,7 +1604,7 @@ tags:
 - Default value: false
 
 
-### featureFlags
+## featureFlags
 
 - Description: List of enabled feature flags
 
@@ -1613,7 +1613,7 @@ tags:
 - Default value: None
 
 
-### forceIdTokenHintPresence
+## forceIdTokenHintPresence
 
 - Description: Boolean value specifying whether force id_token_hint parameter presence
 
@@ -1622,7 +1622,7 @@ tags:
 - Default value: false
 
 
-### forceOfflineAccessScopeToEnableRefreshToken
+## forceOfflineAccessScopeToEnableRefreshToken
 
 - Description: Boolean value specifying whether force offline_access scope to enable refresh_token grant type. Default value is true
 
@@ -1631,7 +1631,7 @@ tags:
 - Default value: true
 
 
-### forceRopcInAuthorizationEndpoint
+## forceRopcInAuthorizationEndpoint
 
 - Description: Specifies whether to force ROPC custom script for Authorization Endpoint.
 
@@ -1640,7 +1640,7 @@ tags:
 - Default value: false
 
 
-### forceSignedRequestObject
+## forceSignedRequestObject
 
 - Description: Boolean value true indicates that signed request object is mandatory
 
@@ -1649,7 +1649,7 @@ tags:
 - Default value: false
 
 
-### frontChannelLogoutSessionSupported
+## frontChannelLogoutSessionSupported
 
 - Description: Choose whether to support front channel session logout
 
@@ -1658,7 +1658,7 @@ tags:
 - Default value: None
 
 
-### grantTypesAndResponseTypesAutofixEnabled
+## grantTypesAndResponseTypesAutofixEnabled
 
 - Description: Boolean value specifying whether to Grant types and Response types can be auto fixed
 
@@ -1667,7 +1667,7 @@ tags:
 - Default value: None
 
 
-### grantTypesSupported
+## grantTypesSupported
 
 - Description: This list details which OAuth 2.0 grant types are supported by this OP
 
@@ -1676,7 +1676,7 @@ tags:
 - Default value: None
 
 
-### grantTypesSupportedByDynamicRegistration
+## grantTypesSupportedByDynamicRegistration
 
 - Description: This list details which OAuth 2.0 grant types can be set up with the dynamic client registration API
 
@@ -1685,7 +1685,7 @@ tags:
 - Default value: None
 
 
-### httpLoggingEnabled
+## httpLoggingEnabled
 
 - Description: Enable/disable request/response logging filter
 
@@ -1694,7 +1694,7 @@ tags:
 - Default value: None
 
 
-### httpLoggingExcludePaths
+## httpLoggingExcludePaths
 
 - Description: This list details the base URIs for which the request/response logging filter will not record activity
 
@@ -1703,7 +1703,7 @@ tags:
 - Default value: None
 
 
-### httpLoggingResponseBodyContent
+## httpLoggingResponseBodyContent
 
 - Description: Defines if Response body will be logged. Default value is false
 
@@ -1712,7 +1712,7 @@ tags:
 - Default value: false
 
 
-### idGenerationEndpoint
+## idGenerationEndpoint
 
 - Description: ID Generation endpoint URL
 
@@ -1721,7 +1721,7 @@ tags:
 - Default value: None
 
 
-### idJagIssueRefreshToken
+## idJagIssueRefreshToken
 
 - Description: Whether to issue refresh tokens after accepting an ID-JAG (Resource AS role). Spec recommends false.
 
@@ -1730,7 +1730,7 @@ tags:
 - Default value: false
 
 
-### idJagLifetime
+## idJagLifetime
 
 - Description: Lifetime in seconds for ID-JAGs issued by this AS (IdP role).
 
@@ -1739,7 +1739,7 @@ tags:
 - Default value: 300
 
 
-### idJagTrustedIdpIssuers
+## idJagTrustedIdpIssuers
 
 - Description: Trusted IdP issuers whose ID-JAGs this AS will accept (Resource AS role). Map keyed by IdP issuer URI.
 
@@ -1748,7 +1748,7 @@ tags:
 - Default value: empty
 
 
-### idTokenEncryptionAlgValuesSupported
+## idTokenEncryptionAlgValuesSupported
 
 - Description: A list of the JWE encryption algorithms (alg values) supported by the OP for the ID Token to encode the Claims in a JWT
 
@@ -1757,7 +1757,7 @@ tags:
 - Default value: None
 
 
-### idTokenEncryptionEncValuesSupported
+## idTokenEncryptionEncValuesSupported
 
 - Description: A list of the JWE encryption algorithms (enc values) supported by the OP for the ID Token to encode the Claims in a JWT
 
@@ -1766,7 +1766,7 @@ tags:
 - Default value: None
 
 
-### idTokenFilterClaimsBasedOnAccessToken
+## idTokenFilterClaimsBasedOnAccessToken
 
 - Description: Boolean value specifying whether idToken filters claims based on accessToken
 
@@ -1775,7 +1775,7 @@ tags:
 - Default value: None
 
 
-### idTokenLifetime
+## idTokenLifetime
 
 - Description: The lifetime of the ID Token
 
@@ -1784,7 +1784,7 @@ tags:
 - Default value: None
 
 
-### idTokenSigningAlgValuesSupported
+## idTokenSigningAlgValuesSupported
 
 - Description: A list of the JWS signing algorithms (alg values) supported by the OP for the ID Token to encode the Claims in a JWT
 
@@ -1793,7 +1793,7 @@ tags:
 - Default value: None
 
 
-### idTokenTokenBindingCnfValuesSupported
+## idTokenTokenBindingCnfValuesSupported
 
 - Description: Array containing a list of the JWT Confirmation Method member names supported by the OP for Token Binding of ID Tokens. The presence of this parameter indicates that the OpenID Provider supports Token Binding of ID Tokens. If omitted, the default is that the OpenID Provider does not support Token Binding of ID Tokens
 
@@ -1802,7 +1802,7 @@ tags:
 - Default value: None
 
 
-### imgLocation
+## imgLocation
 
 - Description: The location for image files
 
@@ -1811,7 +1811,7 @@ tags:
 - Default value: None
 
 
-### includeRefreshTokenLifetimeInTokenResponse
+## includeRefreshTokenLifetimeInTokenResponse
 
 - Description: Boolean value specifying whether to include refresh token lifetime in token response
 
@@ -1820,16 +1820,16 @@ tags:
 - Default value: false
 
 
-### includeRequestedClaimsInIdToken
+## includeRequestedClaimsInIdToken
 
-- Description: Boolean value to indicate whether to include requested claims in id_token (specified by 'claims' parameter at Authorization Endpoint). Default value is false to put minimize claims in token (for security).
+- Description: Boolean value to indicate whether to include requested claims in id_token (specified by 'claims' parameter at Authorization Endpoint). Default value is false to minimize the claims in the id_token (for security).
 
 - Required: No
 
-- Default value: None
+- Default value: false
 
 
-### includeSidInResponse
+## includeSidInResponse
 
 - Description: Boolean value specifying whether to include sessionId in response
 
@@ -1838,7 +1838,7 @@ tags:
 - Default value: false
 
 
-### introspectionAccessTokenMustHaveIntrospectionScope
+## introspectionAccessTokenMustHaveIntrospectionScope
 
 - Description: If True, rejects introspection requests if access_token does not have the 'introspection' scope in its authorization header. Comparing to 'uma_protection', 'introspection' scope is not allowed for dynamic registration'
 
@@ -1847,7 +1847,7 @@ tags:
 - Default value: false
 
 
-### introspectionAccessTokenMustHaveUmaProtectionScope
+## introspectionAccessTokenMustHaveUmaProtectionScope
 
 - Description: If True, rejects introspection requests if access_token does not have the uma_protection scope in its authorization header
 
@@ -1856,25 +1856,25 @@ tags:
 - Default value: false
 
 
-### introspectionEncryptionAlgValuesSupported
+## introspectionEncryptionAlgValuesSupported
 
-- Description: This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT
-
-- Required: No
-
-- Default value: None
-
-
-### introspectionEncryptionEncValuesSupported
-
-- Description: This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT
+- Description: This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT
 
 - Required: No
 
 - Default value: None
 
 
-### introspectionEndpoint
+## introspectionEncryptionEncValuesSupported
+
+- Description: This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT
+
+- Required: No
+
+- Default value: None
+
+
+## introspectionEndpoint
 
 - Description: Introspection endpoint URL
 
@@ -1883,7 +1883,7 @@ tags:
 - Default value: None
 
 
-### introspectionResponseScopesBackwardCompatibility
+## introspectionResponseScopesBackwardCompatibility
 
 - Description: Boolean value specifying introspection response backward compatibility mode
 
@@ -1892,7 +1892,7 @@ tags:
 - Default value: false
 
 
-### introspectionRestrictBasicAuthnToOwnTokens
+## introspectionRestrictBasicAuthnToOwnTokens
 
 - Description: If True, allow client request only own tokens. Otherwise allow to introspect all tokens.
 
@@ -1901,7 +1901,7 @@ tags:
 - Default value: false
 
 
-### introspectionScriptBackwardCompatibility
+## introspectionScriptBackwardCompatibility
 
 - Description: Boolean value specifying whether switch off client's introspection scripts (true value) and run all scripts that exists on server. Default value is false
 
@@ -1910,7 +1910,7 @@ tags:
 - Default value: false
 
 
-### introspectionSigningAlgValuesSupported
+## introspectionSigningAlgValuesSupported
 
 - Description: This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the Introspection endpoint to encode the claims in a JWT
 
@@ -1919,7 +1919,7 @@ tags:
 - Default value: None
 
 
-### introspectionSkipAuthorization
+## introspectionSkipAuthorization
 
 - Description: Specifies if authorization to be skipped for introspection
 
@@ -1928,7 +1928,7 @@ tags:
 - Default value: None
 
 
-### invalidateSessionCookiesAfterAuthorizationFlow
+## invalidateSessionCookiesAfterAuthorizationFlow
 
 - Description: Boolean value to specify whether to invalidate session_id and consent_session_id cookies right after successful or unsuccessful authorization
 
@@ -1937,7 +1937,7 @@ tags:
 - Default value: false
 
 
-### issuer
+## issuer
 
 - Description: URL using the https scheme that OP asserts as Issuer identifier
 
@@ -1946,7 +1946,7 @@ tags:
 - Default value: None
 
 
-### jansId
+## jansId
 
 - Description: URL for the Inum generator Service
 
@@ -1955,7 +1955,7 @@ tags:
 - Default value: None
 
 
-### jansOpenIdConnectVersion
+## jansOpenIdConnectVersion
 
 - Description: OpenID Connect Version
 
@@ -1964,7 +1964,7 @@ tags:
 - Default value: None
 
 
-### jmsBrokerURISet
+## jmsBrokerURISet
 
 - Description: JMS Broker URI Set
 
@@ -1973,7 +1973,7 @@ tags:
 - Default value: None
 
 
-### jmsPassword
+## jmsPassword
 
 - Description: JMS Password
 
@@ -1982,7 +1982,7 @@ tags:
 - Default value: None
 
 
-### jmsUserName
+## jmsUserName
 
 - Description: JMS UserName
 
@@ -1991,7 +1991,7 @@ tags:
 - Default value: None
 
 
-### jsLocation
+## jsLocation
 
 - Description: The location for JavaScript files
 
@@ -2000,7 +2000,7 @@ tags:
 - Default value: None
 
 
-### jwksAlgorithmsSupported
+## jwksAlgorithmsSupported
 
 - Description: A list of algorithms that will be used in JWKS endpoint
 
@@ -2009,7 +2009,7 @@ tags:
 - Default value: None
 
 
-### jwksUri
+## jwksUri
 
 - Description: URL of the OP's JSON Web Key Set (JWK) document. This contains the signing key(s) the RP uses to validate signatures from the OP
 
@@ -2018,7 +2018,7 @@ tags:
 - Default value: None
 
 
-### jwtGrantAllowUserByUidInAssertion
+## jwtGrantAllowUserByUidInAssertion
 
 - Description: Boolean value to indicate whether to allow user identification by uid claim from assertion at Token Endpoint
 
@@ -2027,7 +2027,7 @@ tags:
 - Default value: false
 
 
-### keepAuthenticatorAttributesOnAcrChange
+## keepAuthenticatorAttributesOnAcrChange
 
 - Description: Boolean value specifying whether to keep authenticator attributes on ACR change
 
@@ -2036,7 +2036,7 @@ tags:
 - Default value: false
 
 
-### keyAlgsAllowedForGeneration
+## keyAlgsAllowedForGeneration
 
 - Description: List of algorithm allowed to be used for key generation
 
@@ -2045,7 +2045,7 @@ tags:
 - Default value: None
 
 
-### keyRegenerationEnabled
+## keyRegenerationEnabled
 
 - Description: Boolean value specifying whether to regenerate keys
 
@@ -2054,7 +2054,7 @@ tags:
 - Default value: None
 
 
-### keyRegenerationInterval
+## keyRegenerationInterval
 
 - Description: The interval for key regeneration in hours
 
@@ -2063,7 +2063,7 @@ tags:
 - Default value: None
 
 
-### keySelectionStrategy
+## keySelectionStrategy
 
 - Description: Key Selection Strategy : OLDER, NEWER, FIRST
 
@@ -2072,7 +2072,7 @@ tags:
 - Default value: OLDER
 
 
-### keySignWithSameKeyButDiffAlg
+## keySignWithSameKeyButDiffAlg
 
 - Description: Specifies if signing to be done with same key but apply different algorithms
 
@@ -2081,7 +2081,7 @@ tags:
 - Default value: None
 
 
-### keyStoreFile
+## keyStoreFile
 
 - Description: The Key Store File (JKS)
 
@@ -2090,7 +2090,7 @@ tags:
 - Default value: None
 
 
-### keyStoreSecret
+## keyStoreSecret
 
 - Description: The Key Store password
 
@@ -2099,7 +2099,7 @@ tags:
 - Default value: None
 
 
-### legacyIdTokenClaims
+## legacyIdTokenClaims
 
 - Description: Choose whether to include claims in ID tokens
 
@@ -2108,7 +2108,7 @@ tags:
 - Default value: None
 
 
-### lockMessageConfig
+## lockMessageConfig
 
 - Description: Lock message Pub configuration
 
@@ -2117,7 +2117,7 @@ tags:
 - Default value: false
 
 
-### logClientIdOnClientAuthentication
+## logClientIdOnClientAuthentication
 
 - Description: Choose if application should log the Client ID on client authentication
 
@@ -2126,7 +2126,7 @@ tags:
 - Default value: None
 
 
-### logClientNameOnClientAuthentication
+## logClientNameOnClientAuthentication
 
 - Description: Choose if application should log the Client Name on client authentication
 
@@ -2135,7 +2135,7 @@ tags:
 - Default value: None
 
 
-### loggingLayout
+## loggingLayout
 
 - Description: Logging layout used for Jans Authorization Server loggers
 
@@ -2144,7 +2144,7 @@ tags:
 - Default value: None
 
 
-### loggingLevel
+## loggingLevel
 
 - Description: Specify the logging level of loggers
 
@@ -2153,7 +2153,7 @@ tags:
 - Default value: None
 
 
-### logNotFoundEntityAsError
+## logNotFoundEntityAsError
 
 - Description: Boolean value specifying whether to log not_found entity exception as error or as trace. Default value is false (trace).
 
@@ -2162,7 +2162,7 @@ tags:
 - Default value: None
 
 
-### logoutStatusJwtLifetime
+## logoutStatusJwtLifetime
 
 - Description: The lifetime of Logout Status JWT. If not set falls back to 1 day
 
@@ -2171,7 +2171,7 @@ tags:
 - Default value: 86400
 
 
-### logoutStatusJwtSigningAlgValuesSupported
+## logoutStatusJwtSigningAlgValuesSupported
 
 - Description: This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the Logout Status JWT at Authorization Endpoint to encode the claims in a JWT
 
@@ -2180,7 +2180,7 @@ tags:
 - Default value: None
 
 
-### maxPerRoute
+## maxPerRoute
 
 - Description: Set the maximum number of concurrent connections per route
 
@@ -2189,7 +2189,7 @@ tags:
 - Default value: 50
 
 
-### maxTotal
+## maxTotal
 
 - Description: Set the maximum number of total open connections
 
@@ -2198,7 +2198,7 @@ tags:
 - Default value: 200
 
 
-### metricReporterInterval
+## metricReporterInterval
 
 - Description: The interval for metric reporter in seconds
 
@@ -2207,7 +2207,7 @@ tags:
 - Default value: None
 
 
-### metricReporterKeepDataDays
+## metricReporterKeepDataDays
 
 - Description: The days to keep metric reported data
 
@@ -2216,7 +2216,7 @@ tags:
 - Default value: None
 
 
-### mtlsAuthorizationChallengeEndpoint
+## mtlsAuthorizationChallengeEndpoint
 
 - Description: URL for Mutual TLS (mTLS) Client Authentication and Certificate-Bound Access Tokens (MTLS) Authorization Challenge Endpoint
 
@@ -2225,7 +2225,7 @@ tags:
 - Default value: None
 
 
-### mtlsAuthorizationEndpoint
+## mtlsAuthorizationEndpoint
 
 - Description: URL for Mutual TLS (mTLS) Client Authentication and Certificate-Bound Access Tokens (MTLS) Endpoint
 
@@ -2234,7 +2234,7 @@ tags:
 - Default value: None
 
 
-### mtlsCheckSessionIFrame
+## mtlsCheckSessionIFrame
 
 - Description: URL for Mutual TLS (mTLS) IFrame that supports cross-origin communications for session state information with the RP Client using the HTML5 postMessage API
 
@@ -2243,7 +2243,7 @@ tags:
 - Default value: None
 
 
-### mtlsClientInfoEndpoint
+## mtlsClientInfoEndpoint
 
 - Description: URL for Mutual TLS (mTLS) Client Info endpoint
 
@@ -2252,7 +2252,7 @@ tags:
 - Default value: None
 
 
-### mtlsDeviceAuthzEndpoint
+## mtlsDeviceAuthzEndpoint
 
 - Description: Mutual TLS (mTLS) device authorization endpoint URL
 
@@ -2261,7 +2261,7 @@ tags:
 - Default value: None
 
 
-### mtlsEndSessionEndpoint
+## mtlsEndSessionEndpoint
 
 - Description: URL for Mutual TLS (mTLS) to which an RP can perform a redirect to request that the end user be logged out at the OP
 
@@ -2270,7 +2270,7 @@ tags:
 - Default value: None
 
 
-### mtlsIdGenerationEndpoint
+## mtlsIdGenerationEndpoint
 
 - Description: Mutual TLS (mTLS) ID generation endpoint URL
 
@@ -2279,7 +2279,7 @@ tags:
 - Default value: None
 
 
-### mtlsIntrospectionEndpoint
+## mtlsIntrospectionEndpoint
 
 - Description: Mutual TLS (mTLS) introspection endpoint URL
 
@@ -2288,7 +2288,7 @@ tags:
 - Default value: None
 
 
-### mtlsJwksUri
+## mtlsJwksUri
 
 - Description: URL for Mutual TLS (mTLS) of the OP's JSON Web Key Set (JWK) document
 
@@ -2297,7 +2297,7 @@ tags:
 - Default value: None
 
 
-### mtlsParEndpoint
+## mtlsParEndpoint
 
 - Description: Mutual TLS (mTLS) Pushed Authorization Requests(PAR) endpoint URL
 
@@ -2306,7 +2306,7 @@ tags:
 - Default value: None
 
 
-### mtlsRegistrationEndpoint
+## mtlsRegistrationEndpoint
 
 - Description: Mutual TLS (mTLS) registration endpoint URL
 
@@ -2315,7 +2315,7 @@ tags:
 - Default value: None
 
 
-### mtlsTokenEndpoint
+## mtlsTokenEndpoint
 
 - Description: URL for Mutual TLS (mTLS) Authorization token Endpoint
 
@@ -2324,7 +2324,7 @@ tags:
 - Default value: None
 
 
-### mtlsTokenRevocationEndpoint
+## mtlsTokenRevocationEndpoint
 
 - Description: URL for Mutual TLS (mTLS) Authorization token revocation endpoint
 
@@ -2333,7 +2333,7 @@ tags:
 - Default value: None
 
 
-### mtlsUserInfoEndpoint
+## mtlsUserInfoEndpoint
 
 - Description: Mutual TLS (mTLS) user info endpoint URL
 
@@ -2342,7 +2342,7 @@ tags:
 - Default value: None
 
 
-### openIdConfigurationEndpoint
+## openIdConfigurationEndpoint
 
 - Description: URL for the Open ID Connect Configuration Endpoint
 
@@ -2351,7 +2351,7 @@ tags:
 - Default value: None
 
 
-### openIdDiscoveryEndpoint
+## openIdDiscoveryEndpoint
 
 - Description: Discovery endpoint URL
 
@@ -2360,7 +2360,7 @@ tags:
 - Default value: None
 
 
-### openidScopeBackwardCompatibility
+## openidScopeBackwardCompatibility
 
 - Description: Set to false to only allow token endpoint request for openid scope with grant type equals to authorization_code, restrict access to userinfo to scope openid and only return id_token if scope contains openid
 
@@ -2369,7 +2369,7 @@ tags:
 - Default value: false
 
 
-### openidSubAttribute
+## openidSubAttribute
 
 - Description: Specifies which attribute is used for the subject identifier claim
 
@@ -2378,7 +2378,7 @@ tags:
 - Default value: None
 
 
-### opPolicyUri
+## opPolicyUri
 
 - Description: URL that the OpenID Provider provides to the person registering the Client to read about the OP's requirements on how the Relying Party can use the data provided by the OP
 
@@ -2387,7 +2387,7 @@ tags:
 - Default value: None
 
 
-### opTosUri
+## opTosUri
 
 - Description: URL that the OpenID Provider provides to the person registering the Client to read about OpenID Provider's terms of service
 
@@ -2396,7 +2396,7 @@ tags:
 - Default value: None
 
 
-### pairwiseCalculationKey
+## pairwiseCalculationKey
 
 - Description: Key to calculate algorithmic pairwise IDs
 
@@ -2405,7 +2405,7 @@ tags:
 - Default value: None
 
 
-### pairwiseCalculationSalt
+## pairwiseCalculationSalt
 
 - Description: Salt to calculate algorithmic pairwise IDs
 
@@ -2414,7 +2414,7 @@ tags:
 - Default value: None
 
 
-### pairwiseIdType
+## pairwiseIdType
 
 - Description: the pairwise ID type
 
@@ -2423,7 +2423,7 @@ tags:
 - Default value: None
 
 
-### parEndpoint
+## parEndpoint
 
 - Description: URL for Pushed Authorisation Request (PAR) Endpoint
 
@@ -2432,16 +2432,16 @@ tags:
 - Default value: None
 
 
-### parForbidPublicClient
+## parForbidPublicClient
 
-- Description: Boolean value to indicate whether public client is allowed for Pushed Authorisation Request(PAR)
+- Description: Boolean value indicating whether public clients are forbidden from using Pushed Authorization Requests (PAR); when true, public clients are not allowed to use PAR.
 
 - Required: No
 
 - Default value: false
 
 
-### persistIdToken
+## persistIdToken
 
 - Description: Specifies whether to persist id_token (otherwise saves into cache)
 
@@ -2450,7 +2450,7 @@ tags:
 - Default value: false
 
 
-### persistRefreshToken
+## persistRefreshToken
 
 - Description: Specifies whether to persist refresh_token (otherwise saves into cache)
 
@@ -2459,7 +2459,7 @@ tags:
 - Default value: true
 
 
-### personCustomObjectClassList
+## personCustomObjectClassList
 
 - Description: This list details custom object classes for dynamic person enrollment
 
@@ -2468,7 +2468,7 @@ tags:
 - Default value: None
 
 
-### publicSubjectIdentifierPerClientEnabled
+## publicSubjectIdentifierPerClientEnabled
 
 - Description: Specifies whether public subject identifier is allowed per client
 
@@ -2477,7 +2477,7 @@ tags:
 - Default value: false
 
 
-### rateLimitConfiguration
+## rateLimitConfiguration
 
 - Description: Rate Limit Configuration
 
@@ -2486,7 +2486,7 @@ tags:
 - Default value: None
 
 
-### redirectUrisRegexEnabled
+## redirectUrisRegexEnabled
 
 - Description: Enable/Disable redirect uris validation using regular expression
 
@@ -2495,7 +2495,7 @@ tags:
 - Default value: false
 
 
-### refreshTokenExtendLifetimeOnRotation
+## refreshTokenExtendLifetimeOnRotation
 
 - Description: Boolean value specifying whether to extend refresh tokens on rotation
 
@@ -2504,7 +2504,7 @@ tags:
 - Default value: false
 
 
-### refreshTokenLifetime
+## refreshTokenLifetime
 
 - Description: The lifetime of the Refresh Token
 
@@ -2513,7 +2513,7 @@ tags:
 - Default value: None
 
 
-### registrationEndpoint
+## registrationEndpoint
 
 - Description: Registration endpoint URL
 
@@ -2522,7 +2522,7 @@ tags:
 - Default value: None
 
 
-### rejectEndSessionIfIdTokenExpired
+## rejectEndSessionIfIdTokenExpired
 
 - Description: default value false. If true and id_token is not found in db, request is rejected
 
@@ -2531,7 +2531,7 @@ tags:
 - Default value: false
 
 
-### rejectJwtWithNoneAlg
+## rejectJwtWithNoneAlg
 
 - Description: Boolean value specifying whether reject JWT requested or validated with algorithm None. Default value is true
 
@@ -2540,7 +2540,7 @@ tags:
 - Default value: true
 
 
-### removeRefreshTokensForClientOnLogout
+## removeRefreshTokensForClientOnLogout
 
 - Description: Boolean value specifying whether to remove Refresh Tokens on logout. Default value is true
 
@@ -2549,7 +2549,7 @@ tags:
 - Default value: true
 
 
-### requestObjectEncryptionAlgValuesSupported
+## requestObjectEncryptionAlgValuesSupported
 
 - Description: A list of the JWE encryption algorithms (alg values) supported by the OP for Request Objects
 
@@ -2558,7 +2558,7 @@ tags:
 - Default value: None
 
 
-### requestObjectEncryptionEncValuesSupported
+## requestObjectEncryptionEncValuesSupported
 
 - Description: A list of the JWE encryption algorithms (enc values) supported by the OP for Request Objects
 
@@ -2567,7 +2567,7 @@ tags:
 - Default value: None
 
 
-### requestObjectSigningAlgValuesSupported
+## requestObjectSigningAlgValuesSupported
 
 - Description: A list of the JWS signing algorithms (alg values) supported by the OP for Request Objects
 
@@ -2576,7 +2576,7 @@ tags:
 - Default value: None
 
 
-### requestParameterSupported
+## requestParameterSupported
 
 - Description: Boolean value specifying whether the OP supports use of the request parameter
 
@@ -2585,7 +2585,7 @@ tags:
 - Default value: None
 
 
-### requestUriBlockList
+## requestUriBlockList
 
 - Description: Block list for requestUri that can come to Authorization Endpoint (e.g. localhost)
 
@@ -2594,7 +2594,7 @@ tags:
 - Default value: None
 
 
-### requestUriHashVerificationEnabled
+## requestUriHashVerificationEnabled
 
 - Description: Boolean value specifying whether the OP supports use of the request_uri hash verification
 
@@ -2603,7 +2603,7 @@ tags:
 - Default value: None
 
 
-### requestUriParameterSupported
+## requestUriParameterSupported
 
 - Description: Boolean value specifying whether the OP supports use of the request_uri parameter
 
@@ -2612,7 +2612,7 @@ tags:
 - Default value: None
 
 
-### requirePar
+## requirePar
 
 - Description: Boolean value to indicate of Pushed Authorisation Request(PAR)is required
 
@@ -2621,7 +2621,7 @@ tags:
 - Default value: false
 
 
-### requirePkce
+## requirePkce
 
 - Description: Boolean value true check for Proof Key for Code Exchange (PKCE)
 
@@ -2630,7 +2630,7 @@ tags:
 - Default value: false
 
 
-### requireRequestObjectEncryption
+## requireRequestObjectEncryption
 
 - Description: Boolean value true encrypts request object
 
@@ -2639,7 +2639,7 @@ tags:
 - Default value: false
 
 
-### requireRequestUriRegistration
+## requireRequestUriRegistration
 
 - Description: Boolean value specifying whether the OP requires any request_uri values used to be pre-registered using the request_uris registration parameter
 
@@ -2648,7 +2648,7 @@ tags:
 - Default value: None
 
 
-### responseModesSupported
+## responseModesSupported
 
 - Description: This list details which OAuth 2.0 response modes are supported by this OP
 
@@ -2657,7 +2657,7 @@ tags:
 - Default value: None
 
 
-### responseTypesSupported
+## responseTypesSupported
 
 - Description: This list details which OAuth 2.0 response_type values are supported by this OP.
 
@@ -2666,7 +2666,7 @@ tags:
 - Default value: By default, every combination of code, token and id_token is supported.
 
 
-### returnClientSecretOnRead
+## returnClientSecretOnRead
 
 - Description: Boolean value specifying whether a client_secret is returned on client GET or PUT. Set to true by default which means to return secret
 
@@ -2675,7 +2675,7 @@ tags:
 - Default value: false
 
 
-### returnDeviceSecretFromAuthzEndpoint
+## returnDeviceSecretFromAuthzEndpoint
 
 - Description: 
 
@@ -2684,7 +2684,7 @@ tags:
 - Default value: false
 
 
-### rotateClientRegistrationAccessTokenOnUsage
+## rotateClientRegistrationAccessTokenOnUsage
 
 - Description: Boolean value specifying whether to rotate client registration access token after each usage
 
@@ -2693,7 +2693,7 @@ tags:
 - Default value: false
 
 
-### rotateDeviceSecret
+## rotateDeviceSecret
 
 - Description: 
 
@@ -2702,7 +2702,7 @@ tags:
 - Default value: false
 
 
-### runAllUpdateTokenScripts
+## runAllUpdateTokenScripts
 
 - Description: Boolean value specifying whether to run all Update Token scripts
 
@@ -2711,7 +2711,7 @@ tags:
 - Default value: false
 
 
-### saveTokensInCache
+## saveTokensInCache
 
 - Description: Boolean value specifying whether to save access_token, id_token and refresh_token in cache (with cacheKey=sha256Hex(token_code))
 
@@ -2720,7 +2720,7 @@ tags:
 - Default value: None
 
 
-### saveTokensInCacheAndDontSaveInPersistence
+## saveTokensInCacheAndDontSaveInPersistence
 
 - Description: Boolean value specifying whether to save access_token, id_token and refresh_token in cache and skip persistence in DB at the same time (with cacheKey=sha256Hex(token_code))
 
@@ -2729,7 +2729,7 @@ tags:
 - Default value: None
 
 
-### sectorIdentifierCacheLifetimeInMinutes
+## sectorIdentifierCacheLifetimeInMinutes
 
 - Description: Sector Identifier cache lifetime in minutes
 
@@ -2738,7 +2738,7 @@ tags:
 - Default value: 1440
 
 
-### serviceDocumentation
+## serviceDocumentation
 
 - Description: URL of a page containing human-readable information that developers might want or need to know when using the OpenID Provider
 
@@ -2747,7 +2747,7 @@ tags:
 - Default value: None
 
 
-### sessionAuthnTimeCheckDuringPromptLoginThresholdMs
+## sessionAuthnTimeCheckDuringPromptLoginThresholdMs
 
 - Description: Integer value that allows to specify session authentication time threshold in milliseconds when client is configured from prompt login (has property defaultPromptLogin=true). For high-latency environments, consider increasing this value to 2000-5000ms.
 
@@ -2756,7 +2756,7 @@ tags:
 - Default value: None
 
 
-### sessionIdCookieLifetime
+## sessionIdCookieLifetime
 
 - Description: The lifetime of session_id cookie in seconds. If 0 or -1 then expiration is not set. session_id cookie expires when browser session ends
 
@@ -2765,7 +2765,7 @@ tags:
 - Default value: 86400
 
 
-### sessionIdLifetime
+## sessionIdLifetime
 
 - Description: The lifetime of session_id server object in seconds. If not set falls back to session_id cookie expiration set by 'sessionIdCookieLifetime' configuration property
 
@@ -2774,7 +2774,7 @@ tags:
 - Default value: 86400
 
 
-### sessionIdPersistInCache
+## sessionIdPersistInCache
 
 - Description: Boolean value specifying whether to persist session_id in cache
 
@@ -2783,7 +2783,7 @@ tags:
 - Default value: false
 
 
-### sessionIdPersistOnPromptNone
+## sessionIdPersistOnPromptNone
 
 - Description: Boolean value specifying whether to persist session ID on prompt none
 
@@ -2792,7 +2792,7 @@ tags:
 - Default value: false
 
 
-### sessionIdRequestParameterEnabled
+## sessionIdRequestParameterEnabled
 
 - Description: Boolean value specifying whether to enable session_id HTTP request parameter
 
@@ -2801,7 +2801,7 @@ tags:
 - Default value: false
 
 
-### sessionIdUnauthenticatedUnusedLifetime
+## sessionIdUnauthenticatedUnusedLifetime
 
 - Description: The lifetime for unused unauthenticated session states
 
@@ -2810,7 +2810,7 @@ tags:
 - Default value: 7200
 
 
-### sessionIdUnusedLifetime
+## sessionIdUnusedLifetime
 
 - Description: The lifetime for unused session states
 
@@ -2819,7 +2819,7 @@ tags:
 - Default value: None
 
 
-### sessionIdUserClaimsInAttributes
+## sessionIdUserClaimsInAttributes
 
 - Description: Defines list of user claims that has to be put in session attributes
 
@@ -2828,7 +2828,7 @@ tags:
 - Default value: None
 
 
-### shareSubjectIdBetweenClientsWithSameSectorId
+## shareSubjectIdBetweenClientsWithSameSectorId
 
 - Description: When true, clients with the same Sector ID also share the same Subject ID
 
@@ -2837,16 +2837,16 @@ tags:
 - Default value: false
 
 
-### skipAuthenticationFilterOptionsMethod
+## skipAuthenticationFilterOptionsMethod
 
-- Description: Force Authentication Filtker to process OPTIONS request
+- Description: When true, skips authentication filter processing for OPTIONS requests (the filter returns early before client authentication)
 
 - Required: No
 
 - Default value: true
 
 
-### skipAuthorizationForOpenIdScopeAndPairwiseId
+## skipAuthorizationForOpenIdScopeAndPairwiseId
 
 - Description: Choose whether to skip authorization if a client has an OpenId scope and a pairwise ID
 
@@ -2855,7 +2855,7 @@ tags:
 - Default value: false
 
 
-### skipRefreshTokenDuringRefreshing
+## skipRefreshTokenDuringRefreshing
 
 - Description: Boolean value specifying whether to skip refreshing tokens on refreshing
 
@@ -2864,7 +2864,7 @@ tags:
 - Default value: false
 
 
-### skipSessionAuthnTimeCheckDuringPromptLogin
+## skipSessionAuthnTimeCheckDuringPromptLogin
 
 - Description: Boolean value true allows to skip session authentication time check when client is configured from prompt login (has property defaultPromptLogin=true)
 
@@ -2873,7 +2873,7 @@ tags:
 - Default value: None
 
 
-### softwareStatementValidationClaimName
+## softwareStatementValidationClaimName
 
 - Description: Validation claim name for software statement
 
@@ -2882,7 +2882,7 @@ tags:
 - Default value: None
 
 
-### softwareStatementValidationType
+## softwareStatementValidationType
 
 - Description: Validation type used for software statement
 
@@ -2891,7 +2891,7 @@ tags:
 - Default value: None
 
 
-### spontaneousScopeLifetime
+## spontaneousScopeLifetime
 
 - Description: The lifetime of spontaneous scope in seconds
 
@@ -2900,7 +2900,7 @@ tags:
 - Default value: None
 
 
-### ssaConfiguration
+## ssaConfiguration
 
 - Description: SSA Configuration
 
@@ -2909,7 +2909,7 @@ tags:
 - Default value: None
 
 
-### statAuthorizationScope
+## statAuthorizationScope
 
 - Description: Scope required for Statistical Authorization
 
@@ -2918,7 +2918,7 @@ tags:
 - Default value: None
 
 
-### staticDecryptionKid
+## staticDecryptionKid
 
 - Description: Specifies static decryption Kid
 
@@ -2927,7 +2927,7 @@ tags:
 - Default value: None
 
 
-### staticKid
+## staticKid
 
 - Description: Specifies static Kid
 
@@ -2936,7 +2936,7 @@ tags:
 - Default value: None
 
 
-### statTimerIntervalInSeconds
+## statTimerIntervalInSeconds
 
 - Description: Statistical data capture time interval
 
@@ -2945,7 +2945,7 @@ tags:
 - Default value: None
 
 
-### statusListBitSize
+## statusListBitSize
 
 - Description: Specifies status list bit size. (2 bits - 4 statuses, 4 bits - 16 statuses). Defaults to 2.
 
@@ -2954,7 +2954,7 @@ tags:
 - Default value: None
 
 
-### statusListIndexAllocationBlockSize
+## statusListIndexAllocationBlockSize
 
 - Description: Specifies how many status list indexes AS can reserve at once within pool (when status_list feature flag is enabled). Defaults to 100.
 
@@ -2963,7 +2963,7 @@ tags:
 - Default value: None
 
 
-### statusListResponseJwtLifetime
+## statusListResponseJwtLifetime
 
 - Description: The status list response JWT lifetime (used to set exp claim in JWT).
 
@@ -2972,7 +2972,7 @@ tags:
 - Default value: None
 
 
-### statusListResponseJwtSignatureAlgorithm
+## statusListResponseJwtSignatureAlgorithm
 
 - Description: The status list signature algorithm to sign response JWT. Defaults to RS256.
 
@@ -2981,7 +2981,7 @@ tags:
 - Default value: None
 
 
-### subjectIdentifiersPerClientSupported
+## subjectIdentifiersPerClientSupported
 
 - Description: A list of the subject identifiers supported per client
 
@@ -2990,7 +2990,7 @@ tags:
 - Default value: None
 
 
-### subjectTypesSupported
+## subjectTypesSupported
 
 - Description: This list details which Subject Identifier types that the OP supports. Valid types include pairwise and public.
 
@@ -2999,7 +2999,7 @@ tags:
 - Default value: None
 
 
-### tokenEndpoint
+## tokenEndpoint
 
 - Description: The token endpoint URL
 
@@ -3008,7 +3008,7 @@ tags:
 - Default value: None
 
 
-### tokenEndpointAuthMethodsSupported
+## tokenEndpointAuthMethodsSupported
 
 - Description: A list of Client Authentication methods supported by this Token Endpoint
 
@@ -3017,7 +3017,7 @@ tags:
 - Default value: None
 
 
-### tokenEndpointAuthSigningAlgValuesSupported
+## tokenEndpointAuthSigningAlgValuesSupported
 
 - Description: A list of the JWS signing algorithms (alg values) supported by the Token Endpoint for the signature on the JWT used to authenticate the Client at the Token Endpoint for the private_key_jwt and client_secret_jwt authentication methods
 
@@ -3026,7 +3026,7 @@ tags:
 - Default value: None
 
 
-### tokenMessagesChannel
+## tokenMessagesChannel
 
 - Description: Channel for token messages
 
@@ -3035,7 +3035,7 @@ tags:
 - Default value: None
 
 
-### tokenRevocationEndpoint
+## tokenRevocationEndpoint
 
 - Description: The URL for the access_token or refresh_token revocation endpoint
 
@@ -3044,7 +3044,7 @@ tags:
 - Default value: None
 
 
-### trustedClientEnabled
+## trustedClientEnabled
 
 - Description: Boolean value specifying whether a client is trusted and no authorization is required
 
@@ -3053,7 +3053,7 @@ tags:
 - Default value: None
 
 
-### trustedSsaIssuers
+## trustedSsaIssuers
 
 - Description: List of trusted SSA issuers with configuration (e.g. automatically granted scopes).
 
@@ -3062,25 +3062,25 @@ tags:
 - Default value: None
 
 
-### txTokenEncryptionAlgValuesSupported
+## txTokenEncryptionAlgValuesSupported
 
-- Description: This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT
-
-- Required: No
-
-- Default value: None
-
-
-### txTokenEncryptionEncValuesSupported
-
-- Description: This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT
+- Description: This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT
 
 - Required: No
 
 - Default value: None
 
 
-### txTokenLifetime
+## txTokenEncryptionEncValuesSupported
+
+- Description: This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT
+
+- Required: No
+
+- Default value: None
+
+
+## txTokenLifetime
 
 - Description: The lifetime of the Transaction Token
 
@@ -3089,7 +3089,7 @@ tags:
 - Default value: None
 
 
-### txTokenSigningAlgValuesSupported
+## txTokenSigningAlgValuesSupported
 
 - Description: This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the Transaction Tokens at Token Endpoint to encode the claims in a JWT
 
@@ -3098,7 +3098,7 @@ tags:
 - Default value: None
 
 
-### uiLocalesSupported
+## uiLocalesSupported
 
 - Description: This list details the languages and scripts supported for the user interface
 
@@ -3107,7 +3107,7 @@ tags:
 - Default value: None
 
 
-### umaAddScopesAutomatically
+## umaAddScopesAutomatically
 
 - Description: Add UMA scopes automatically if it is not registered yet
 
@@ -3116,7 +3116,7 @@ tags:
 - Default value: None
 
 
-### umaConfigurationEndpoint
+## umaConfigurationEndpoint
 
 - Description: UMA Configuration endpoint URL
 
@@ -3125,7 +3125,7 @@ tags:
 - Default value: None
 
 
-### umaGrantAccessIfNoPolicies
+## umaGrantAccessIfNoPolicies
 
 - Description: Specify whether to grant access to resources if there is no any policies associated with scopes
 
@@ -3134,7 +3134,7 @@ tags:
 - Default value: false
 
 
-### umaPctLifetime
+## umaPctLifetime
 
 - Description: UMA PCT lifetime
 
@@ -3143,7 +3143,7 @@ tags:
 - Default value: None
 
 
-### umaResourceLifetime
+## umaResourceLifetime
 
 - Description: UMA Resource lifetime
 
@@ -3152,7 +3152,7 @@ tags:
 - Default value: None
 
 
-### umaRestrictResourceToAssociatedClient
+## umaRestrictResourceToAssociatedClient
 
 - Description: Restrict access to resource by associated client
 
@@ -3161,7 +3161,7 @@ tags:
 - Default value: false
 
 
-### umaRptAsJwt
+## umaRptAsJwt
 
 - Description: Issue RPT as JWT or as random string
 
@@ -3170,7 +3170,7 @@ tags:
 - Default value: false
 
 
-### umaRptLifetime
+## umaRptLifetime
 
 - Description: UMA RPT lifetime
 
@@ -3179,7 +3179,7 @@ tags:
 - Default value: None
 
 
-### umaTicketLifetime
+## umaTicketLifetime
 
 - Description: UMA ticket lifetime
 
@@ -3188,7 +3188,7 @@ tags:
 - Default value: None
 
 
-### umaValidateClaimToken
+## umaValidateClaimToken
 
 - Description: Validate claim_token as id_token assuming it is issued by local id
 
@@ -3197,7 +3197,7 @@ tags:
 - Default value: false
 
 
-### updateClientAccessTime
+## updateClientAccessTime
 
 - Description: Choose if application should update oxLastAccessTime/oxLastLogonTime attributes upon client authentication
 
@@ -3206,7 +3206,7 @@ tags:
 - Default value: None
 
 
-### updateUserLastLogonTime
+## updateUserLastLogonTime
 
 - Description: Choose if application should update oxLastLogonTime attribute upon user authentication
 
@@ -3215,16 +3215,16 @@ tags:
 - Default value: None
 
 
-### uppercaseResponseKeysInAccountAccessConsent
+## uppercaseResponseKeysInAccountAccessConsent
 
-- Description: Boolean value to indicate whether to uppercase keys returns from /open-banking/v3.1/aisp/account-access-consents endpoint
+- Description: Boolean value to indicate whether to uppercase keys returned from /open-banking/v3.1/aisp/account-access-consents endpoint
 
 - Required: No
 
 - Default value: false
 
 
-### useHighestLevelScriptIfAcrScriptNotFound
+## useHighestLevelScriptIfAcrScriptNotFound
 
 - Description: Enable/Disable usage of highest level script in case ACR script does not exist
 
@@ -3233,7 +3233,7 @@ tags:
 - Default value: false
 
 
-### useLocalCache
+## useLocalCache
 
 - Description: Cache in local memory cache attributes, scopes, clients and organization entry with expiration 60 seconds
 
@@ -3242,7 +3242,7 @@ tags:
 - Default value: false
 
 
-### useNestedJwtDuringEncryption
+## useNestedJwtDuringEncryption
 
 - Description: Boolean value specifying whether to use nested Jwt during encryption
 
@@ -3251,7 +3251,7 @@ tags:
 - Default value: true
 
 
-### useOpenidSubAttributeValueForPairwiseLocalAccountId
+## useOpenidSubAttributeValueForPairwiseLocalAccountId
 
 - Description: Use openidSubAttribute value of user as local account id for algorithmic pairwise look up
 
@@ -3260,25 +3260,25 @@ tags:
 - Default value: false
 
 
-### userInfoEncryptionAlgValuesSupported
+## userInfoEncryptionAlgValuesSupported
 
-- Description: This JSON Array lists which JWS encryption algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT
-
-- Required: No
-
-- Default value: None
-
-
-### userInfoEncryptionEncValuesSupported
-
-- Description: This JSON Array lists which JWS encryption algorithms (enc values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT
+- Description: This JSON Array lists which JWE encryption algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT
 
 - Required: No
 
 - Default value: None
 
 
-### userInfoEndpoint
+## userInfoEncryptionEncValuesSupported
+
+- Description: This JSON Array lists which JWE encryption algorithms (enc values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT
+
+- Required: No
+
+- Default value: None
+
+
+## userInfoEndpoint
 
 - Description: The User Info endpoint URL
 
@@ -3287,7 +3287,7 @@ tags:
 - Default value: None
 
 
-### userInfoLifetime
+## userInfoLifetime
 
 - Description: The lifetime of the User Info
 
@@ -3296,7 +3296,7 @@ tags:
 - Default value: 3600
 
 
-### userInfoSigningAlgValuesSupported
+## userInfoSigningAlgValuesSupported
 
 - Description: This JSON Array lists which JWS signing algorithms (alg values) [JWA] can be used by for the UserInfo endpoint to encode the claims in a JWT
 
@@ -3305,7 +3305,7 @@ tags:
 - Default value: None
 
 
-### validateAfterInactivity
+## validateAfterInactivity
 
 - Description: Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer
 
@@ -3314,7 +3314,7 @@ tags:
 - Default value: 2000
 
 
-### webKeysStorage
+## webKeysStorage
 
 - Description: Web Key Storage Type
 
@@ -3323,7 +3323,7 @@ tags:
 - Default value: None
 
 
-### xframeOptionsHeaderValue
+## xframeOptionsHeaderValue
 
 - Description: Add X-Frame-Options header to response if any string in the list is contained by request uri.
 

--- a/docs/janssen-server/reference/json/properties/lock-properties.md
+++ b/docs/janssen-server/reference/json/properties/lock-properties.md
@@ -41,7 +41,7 @@ tags:
 | useTls | Use TLS for gRPC communication | [Details](#usetls) |
 
 
-### auditPersistenceMode
+## auditPersistenceMode
 
 - Description: Audit persistence mode
 
@@ -50,7 +50,7 @@ tags:
 - Default value: None
 
 
-### baseDN
+## baseDN
 
 - Description: Entry Base distinguished name (DN) that identifies the starting point of a search
 
@@ -59,7 +59,7 @@ tags:
 - Default value: None
 
 
-### baseEndpoint
+## baseEndpoint
 
 - Description: Lock base endpoint URL
 
@@ -68,7 +68,7 @@ tags:
 - Default value: None
 
 
-### cedarlingConfiguration
+## cedarlingConfiguration
 
 - Description: Cedarling configuration
 
@@ -77,7 +77,7 @@ tags:
 - Default value: None
 
 
-### cleanServiceBatchChunkSize
+## cleanServiceBatchChunkSize
 
 - Description: Each clean up iteration fetches chunk of expired data per base dn and removes it from storage
 
@@ -86,7 +86,7 @@ tags:
 - Default value: None
 
 
-### cleanServiceInterval
+## cleanServiceInterval
 
 - Description: Time interval for the Clean Service in seconds
 
@@ -95,7 +95,7 @@ tags:
 - Default value: None
 
 
-### clientId
+## clientId
 
 - Description: Lock Client ID
 
@@ -104,7 +104,7 @@ tags:
 - Default value: None
 
 
-### clientPassword
+## clientPassword
 
 - Description: Lock client password
 
@@ -113,7 +113,7 @@ tags:
 - Default value: None
 
 
-### disableExternalLoggerConfiguration
+## disableExternalLoggerConfiguration
 
 - Description: Choose whether to disable external log4j configuration override
 
@@ -122,7 +122,7 @@ tags:
 - Default value: true
 
 
-### disableJdkLogger
+## disableJdkLogger
 
 - Description: Choose whether to disable JDK loggers
 
@@ -131,7 +131,7 @@ tags:
 - Default value: true
 
 
-### errorReasonEnabled
+## errorReasonEnabled
 
 - Description: Boolean value specifying whether to return detailed reason of the error from AS. Default value is false
 
@@ -140,7 +140,7 @@ tags:
 - Default value: false
 
 
-### externalLoggerConfiguration
+## externalLoggerConfiguration
 
 - Description: The path to the external log4j2 logging configuration
 
@@ -149,7 +149,7 @@ tags:
 - Default value: None
 
 
-### grpcConfiguration
+## grpcConfiguration
 
 - Description: gRPC server configuration
 
@@ -158,7 +158,7 @@ tags:
 - Default value: None
 
 
-### grpcPort
+## grpcPort
 
 - Description: Specify grpc port
 
@@ -167,7 +167,7 @@ tags:
 - Default value: 50051
 
 
-### loggingLayout
+## loggingLayout
 
 - Description: Logging layout used for Jans Authorization Server loggers
 
@@ -176,7 +176,7 @@ tags:
 - Default value: None
 
 
-### loggingLevel
+## loggingLevel
 
 - Description: Specify the logging level of loggers
 
@@ -185,7 +185,7 @@ tags:
 - Default value: None
 
 
-### messageConsumerType
+## messageConsumerType
 
 - Description: PubSub consumer service
 
@@ -194,7 +194,7 @@ tags:
 - Default value: None
 
 
-### metricReporterEnabled
+## metricReporterEnabled
 
 - Description: Enable metric reporter
 
@@ -203,7 +203,7 @@ tags:
 - Default value: None
 
 
-### metricReporterInterval
+## metricReporterInterval
 
 - Description: The interval for metric reporter in seconds
 
@@ -212,7 +212,7 @@ tags:
 - Default value: None
 
 
-### metricReporterKeepDataDays
+## metricReporterKeepDataDays
 
 - Description: The days to keep metric reported data
 
@@ -221,7 +221,7 @@ tags:
 - Default value: None
 
 
-### openIdIssuer
+## openIdIssuer
 
 - Description: OpenID issuer URL
 
@@ -230,7 +230,7 @@ tags:
 - Default value: None
 
 
-### protectionMode
+## protectionMode
 
 - Description: Protection mode for the Lock server (OAuth or Cedarling)
 
@@ -239,7 +239,7 @@ tags:
 - Default value: None
 
 
-### serverMode
+## serverMode
 
 - Description: gRPC server mode
 
@@ -248,7 +248,7 @@ tags:
 - Default value: None
 
 
-### statEnabled
+## statEnabled
 
 - Description: Active stat enabled
 
@@ -257,7 +257,7 @@ tags:
 - Default value: None
 
 
-### statTimerIntervalInSeconds
+## statTimerIntervalInSeconds
 
 - Description: Statistical data capture time interval
 
@@ -266,7 +266,7 @@ tags:
 - Default value: None
 
 
-### tlsCertChainFilePath
+## tlsCertChainFilePath
 
 - Description: TLS Cert Chain File Path
 
@@ -275,7 +275,7 @@ tags:
 - Default value: 
 
 
-### tlsPrivateKeyFilePath
+## tlsPrivateKeyFilePath
 
 - Description: TLS Private Key File Path
 
@@ -284,7 +284,7 @@ tags:
 - Default value: 
 
 
-### tokenChannels
+## tokenChannels
 
 - Description: List of token channel names
 
@@ -293,7 +293,7 @@ tags:
 - Default value: jans_token
 
 
-### useTls
+## useTls
 
 - Description: Use TLS for gRPC communication
 

--- a/docs/janssen-server/reference/json/properties/scim-properties.md
+++ b/docs/janssen-server/reference/json/properties/scim-properties.md
@@ -33,7 +33,7 @@ tags:
 | userExtensionSchemaURI | User Extension Schema URI | [Details](#userextensionschemauri) |
 
 
-### applicationUrl
+## applicationUrl
 
 - Description: Application base URL
 
@@ -42,7 +42,7 @@ tags:
 - Default value: None
 
 
-### baseDN
+## baseDN
 
 - Description: Application config Base DN
 
@@ -51,7 +51,7 @@ tags:
 - Default value: None
 
 
-### baseEndpoint
+## baseEndpoint
 
 - Description: SCIM base endpoint URL
 
@@ -60,7 +60,7 @@ tags:
 - Default value: None
 
 
-### bulkMaxOperations
+## bulkMaxOperations
 
 - Description: Specifies maximum bulk operations
 
@@ -69,7 +69,7 @@ tags:
 - Default value: None
 
 
-### bulkMaxPayloadSize
+## bulkMaxPayloadSize
 
 - Description: Specifies maximum payload size of bulk operations
 
@@ -78,7 +78,7 @@ tags:
 - Default value: None
 
 
-### disableExternalLoggerConfiguration
+## disableExternalLoggerConfiguration
 
 - Description: Choose whether to disable external log4j configuration override
 
@@ -87,7 +87,7 @@ tags:
 - Default value: true
 
 
-### disableJdkLogger
+## disableJdkLogger
 
 - Description: Boolean value specifying whether to enable JDK Loggers
 
@@ -96,7 +96,7 @@ tags:
 - Default value: None
 
 
-### disableLoggerTimer
+## disableLoggerTimer
 
 - Description: Boolean value specifying whether to enable the logger refresh timer
 
@@ -105,7 +105,7 @@ tags:
 - Default value: None
 
 
-### externalLoggerConfiguration
+## externalLoggerConfiguration
 
 - Description: Path to external log4j2 logging configuration
 
@@ -114,7 +114,7 @@ tags:
 - Default value: None
 
 
-### loggingLayout
+## loggingLayout
 
 - Description: Logging layout used for Server loggers
 
@@ -123,7 +123,7 @@ tags:
 - Default value: None
 
 
-### loggingLevel
+## loggingLevel
 
 - Description: Logging level for scim logger
 
@@ -132,7 +132,7 @@ tags:
 - Default value: None
 
 
-### maxCount
+## maxCount
 
 - Description: Maximum number of results per page
 
@@ -141,7 +141,7 @@ tags:
 - Default value: None
 
 
-### metricReporterEnabled
+## metricReporterEnabled
 
 - Description: Metric reported data enabled flag
 
@@ -150,7 +150,7 @@ tags:
 - Default value: None
 
 
-### metricReporterInterval
+## metricReporterInterval
 
 - Description: The interval for metric reporter in seconds
 
@@ -159,7 +159,7 @@ tags:
 - Default value: None
 
 
-### metricReporterKeepDataDays
+## metricReporterKeepDataDays
 
 - Description: The days to keep metric reported data
 
@@ -168,7 +168,7 @@ tags:
 - Default value: None
 
 
-### oxAuthIssuer
+## oxAuthIssuer
 
 - Description: Jans Auth - Issuer identifier
 
@@ -177,7 +177,7 @@ tags:
 - Default value: None
 
 
-### personCustomObjectClass
+## personCustomObjectClass
 
 - Description: Person Object Class
 
@@ -186,7 +186,7 @@ tags:
 - Default value: None
 
 
-### protectionMode
+## protectionMode
 
 - Description: SCIM Protection Mode
 
@@ -195,7 +195,7 @@ tags:
 - Default value: None
 
 
-### skipDefinedPasswordValidation
+## skipDefinedPasswordValidation
 
 - Description: Boolean value specifying whether to bypass the validation defined upon the password attribute
 
@@ -204,7 +204,7 @@ tags:
 - Default value: None
 
 
-### useLocalCache
+## useLocalCache
 
 - Description: Boolean value specifying whether to enable local in-memory cache
 
@@ -213,7 +213,7 @@ tags:
 - Default value: None
 
 
-### userExtensionSchemaURI
+## userExtensionSchemaURI
 
 - Description: User Extension Schema URI
 

--- a/jans-config-api/docs/jans-config-api-swagger.yaml
+++ b/jans-config-api/docs/jans-config-api-swagger.yaml
@@ -17830,7 +17830,7 @@ components:
           description: External policy store URI
         maxEntries:
           type: integer
-          description: maximum number of enteries in policy store file
+          description: maximum number of entries in policy store file
           format: int32
       description: Cedar Configuration for authorization.
     DataFormatConversionConf:

--- a/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
@@ -298,8 +298,7 @@ paths:
                   description: Response example
                   value: "{\n    \"errorCategories\": {},\n    \"failureRate\": 0.75,\n\
                     \    \"successRate\": 0.25,\n\t\"completionRate\": 0.48,\n\t\"\
-                    dropOffRate\": 0.52,\n\t\"abandonedOperations\": 37,\n\t\"abandonmentRate\"\
-                    : 0.31,\n    \"topErrors\": {}\n}\n"
+                    dropOffRate\": 0.52,\n    \"topErrors\": {}\n}\n"
         "400":
           description: Bad Request
         "401":
@@ -1673,6 +1672,14 @@ components:
           type: integer
           format: int32
         authenticationHistoryExpiration:
+          type: integer
+          format: int32
+        recordAbandonedAssertions:
+          type: boolean
+        abandonedRequestExpiration:
+          type: integer
+          format: int32
+        abandonedRequestSweepInterval:
           type: integer
           format: int32
         serverMetadataFolder:

--- a/jans-config-api/plugins/docs/lock-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/lock-plugin-swagger.yaml
@@ -904,7 +904,7 @@ components:
           description: External policy store URI
         maxEntries:
           type: integer
-          description: maximum number of enteries in policy store file
+          description: maximum number of entries in policy store file
           format: int32
       description: Cedarling configuration
     GrpcConfiguration:


### PR DESCRIPTION
Auto generated docs
Closes #14751, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved heading consistency across Auth Server configuration, feature-flag, FIDO2, lock, and SCIM references.
  - Added documentation for FIDO2 abandoned-request settings and clarified several default values.
  - Updated API specifications to reflect new FIDO2 configuration options.
  - Corrected “enteries” to “entries” in configuration descriptions.
  - Removed outdated FIDO2 abandonment metrics from an error analytics example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->