### PR TITLE
fix(jans-fido2): stop counting usernameless ceremonies as abandonment

### DIFF
--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -95,10 +95,21 @@ normal cleanup, as it was before:
 
 Abandonment is detected by a sweep that runs every `abandonedRequestSweepInterval` seconds and
 relabels ceremonies still marked `pending` past `unfinishedRequestExpiration`. Abandoned rows are
-retained for `abandonedRequestExpiration` — deliberately much shorter than
-`authenticationHistoryExpiration`, because conditional-UI ceremonies start on virtually every login
-page load and abandonment is therefore the highest-volume outcome by far. Set
-`recordAbandonedAssertions` to `false` to disable the sweep.
+retained for `abandonedRequestExpiration`, deliberately much shorter than
+`authenticationHistoryExpiration`. Set `recordAbandonedAssertions` to `false` to disable the sweep.
+
+!!! note "Usernameless ceremonies are not counted as abandonment"
+    A login page offering usernameless (conditional-UI) sign-in starts a ceremony on every page load,
+    before it knows who is signing in. If the user then identifies themselves, a second, named ceremony
+    is issued and that is the one they complete — the first is simply left untouched.
+
+    Those ceremonies are **not** swept. Counting them produced an abandonment for every successful
+    sign-in, attributed to no user at all. They are skipped rather than recorded under a different
+    label because the server cannot tell the two cases apart: a usernameless ceremony nobody looked at
+    and one the user engaged with and gave up on are both just `pending` when the window elapses.
+
+    They keep the behaviour they had before abandonment recording existed — they stay `pending` and the
+    cleaner removes them. `abandonmentRate` therefore covers ceremonies issued for a named user.
 
 `abandonmentRate` and `dropOffRate` answer different questions and are reported side by side.
 `dropOffRate` is inferred as the residual of attempts minus completions, so it also absorbs

--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -75,26 +75,27 @@ Two kinds of data are produced:
 
 !!! note "ATTEMPT vs. completion"
     Each operation produces a separate `ATTEMPT` entry when the user starts and a
-    `SUCCESS`/`FAILURE`/`ABANDONED` entry when it resolves. An `ATTEMPT` with no matching entry is
+    `SUCCESS`/`FAILURE`/`ABANDONED` entry if it resolves. An `ATTEMPT` with no matching entry is
     either a ceremony **still in flight** or one the user **dropped off** from — the two are not
     distinguishable at query time, which is why `dropOffRate`, computed as that residual, is an
     inference rather than a count.
 
-### The three outcomes of an authentication ceremony
+### The outcomes of an authentication ceremony
 
-With `recordAbandonedAssertions` enabled (the default), every assertion ceremony resolves to one of
-three server-observable outcomes, recorded both as the `jansStatus` of its `jansFido2AuthnEntry` row
-and as a metrics entry status. With it disabled, a lapsed ceremony stays `pending` and is deleted by
-normal cleanup, as it was before:
+A ceremony that is posted back — whether it passes verification or is rejected — always reaches one of
+the first two outcomes below. The third applies only to ceremonies issued for a named user, and only
+while `recordAbandonedAssertions` is enabled (the default); anything else that lapses stays `pending`
+and is deleted by normal cleanup, as it was before. Each outcome is recorded both as the `jansStatus` of
+the `jansFido2AuthnEntry` row and as a metrics entry status:
 
 | Outcome | `jansStatus` | Metric status | Meaning |
 |---|---|---|---|
 | Verified success | `authenticated` | `SUCCESS` | An assertion was posted and passed verification |
 | Verified failure | `failed` | `FAILURE` | An assertion was posted and the server rejected it — bad signature, stale challenge, unknown credential, RP ID mismatch |
-| Abandonment | `abandoned` | `ABANDONED` | The ceremony window elapsed and nothing was ever posted back |
+| Abandonment | `abandoned` | `ABANDONED` | A ceremony issued for a named user whose window elapsed with nothing posted back. Usernameless ceremonies are excluded — see below |
 
-Abandonment is detected by a sweep that runs every `abandonedRequestSweepInterval` seconds and
-relabels ceremonies still marked `pending` past `unfinishedRequestExpiration`. Abandoned rows are
+Abandonment is detected by a sweep that runs every `abandonedRequestSweepInterval` seconds and relabels
+named-user ceremonies still marked `pending` past `unfinishedRequestExpiration`. Abandoned rows are
 retained for `abandonedRequestExpiration`, deliberately much shorter than
 `authenticationHistoryExpiration`. Set `recordAbandonedAssertions` to `false` to disable the sweep.
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyTimer.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/app/AbandonedCeremonyTimer.java
@@ -21,6 +21,7 @@ import io.jans.fido2.service.shared.MetricService;
 import io.jans.orm.model.fido2.Fido2AuthenticationData;
 import io.jans.orm.model.fido2.Fido2AuthenticationEntry;
 import io.jans.orm.model.fido2.Fido2AuthenticationStatus;
+import io.jans.util.StringHelper;
 import io.jans.service.cdi.async.Asynchronous;
 import io.jans.service.cdi.event.Scheduled;
 import io.jans.service.timer.event.TimerEvent;
@@ -40,6 +41,10 @@ import jakarta.inject.Named;
  * until the cleaner deletes it, and an abandoned ceremony is indistinguishable first from one still
  * in flight and then from one that never happened at all.
  * <p>
+ * Only ceremonies issued for a named user are swept. A usernameless one is offered on every login page
+ * load and left untouched as soon as the user identifies themselves, so sweeping it recorded an
+ * abandonment for every successful sign-in — see {@link #isSpeculative}.
+ * <p>
  * The sweep is deliberately <em>not</em> coordinated across nodes, so abandonment is counted at least
  * once rather than exactly once. Two locking approaches were examined and rejected: the metrics
  * aggregation scheduler's cluster lock is only initialised behind that scheduler's own enabled check,
@@ -56,10 +61,7 @@ import jakarta.inject.Named;
 @Named
 public class AbandonedCeremonyTimer {
 
-	/**
-	 * Ceilings one sweep. Abandonment is the highest-volume outcome — conditional-UI ceremonies start
-	 * on virtually every login page load — so a backlog is bounded per pass rather than read at once.
-	 */
+	/** Ceilings one sweep, so a backlog is bounded per pass rather than read at once. */
 	public static final int BATCH_SIZE = 1000;
 
 	@Inject
@@ -186,6 +188,10 @@ public class AbandonedCeremonyTimer {
 				return false;
 			}
 
+			if (isSpeculative(authenticationData)) {
+				return false;
+			}
+
 			authenticationData.setStatus(Fido2AuthenticationStatus.abandoned);
 			entry.setExpiration(appConfiguration.getFido2Configuration().getAbandonedRequestExpiration());
 			authenticationPersistenceService.update(entry);
@@ -197,6 +203,28 @@ public class AbandonedCeremonyTimer {
 			log.warn("Failed to mark assertion ceremony {} as abandoned: {}", entry.getId(), e.getMessage());
 			return false;
 		}
+	}
+
+	/**
+	 * Whether this ceremony was offered rather than attempted.
+	 * <p>
+	 * A ceremony issued without a username is the usernameless (conditional-UI) option the login page
+	 * puts up on every page load, before it knows who is signing in. When the user instead identifies
+	 * themselves, a second, named ceremony is issued and that is the one they complete — leaving the
+	 * first sitting untouched. Sweeping it produced an abandonment for every successful sign-in, and one
+	 * attributable to no user at all, which is not what abandonment is meant to mean.
+	 * <p>
+	 * These are skipped rather than recorded under a different label because the server genuinely cannot
+	 * tell the two cases apart: a usernameless ceremony nobody ever looked at and one the user engaged
+	 * with and gave up on are both simply {@code pending} when the window elapses. Recording a number
+	 * that conflates them would be worse than not recording one. Distinguishing them needs the browser
+	 * to say which happened, which is what the client-reported ceremony outcome work covers.
+	 * <p>
+	 * Skipped ceremonies keep the behaviour they had before abandonment recording existed: they stay
+	 * {@code pending} and the cleaner removes them.
+	 */
+	private boolean isSpeculative(Fido2AuthenticationData authenticationData) {
+		return StringHelper.isEmpty(authenticationData.getUsername());
 	}
 
 	private void recordAbandonment(Fido2AuthenticationEntry entry, Fido2AuthenticationData authenticationData) {

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/app/AbandonedCeremonyTimerTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/app/AbandonedCeremonyTimerTest.java
@@ -88,24 +88,77 @@ class AbandonedCeremonyTimerTest {
     }
 
     /**
-     * Conditional-UI ceremonies live under the assertion base DN rather than beneath a person entry,
-     * and are the ones most likely to be abandoned. A sweep that visited only one subtree would miss
-     * exactly those.
+     * Named ceremonies can sit under either base DN — beneath the person entry when the user resolved,
+     * and under the assertion base DN when it did not. A sweep visiting only one subtree would miss the
+     * second kind.
      */
     @Test
     void processImpl_sweepsBothCeremonySubtrees() {
-        Fido2AuthenticationData identified = pendingCeremony("alice");
-        Fido2AuthenticationData usernameless = pendingCeremony(null);
+        Fido2AuthenticationData underPerson = pendingCeremony("alice");
+        Fido2AuthenticationData underAssertionDn = pendingCeremony("bob");
         when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
-                .thenReturn(List.of(ceremonyEntry(identified)));
+                .thenReturn(List.of(ceremonyEntry(underPerson)));
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(ASSERTION_DN), any(), anyInt()))
+                .thenReturn(List.of(ceremonyEntry(underAssertionDn)));
+
+        timer.processImpl();
+
+        assertEquals(Fido2AuthenticationStatus.abandoned, underPerson.getStatus());
+        assertEquals(Fido2AuthenticationStatus.abandoned, underAssertionDn.getStatus());
+        verify(authenticationPersistenceService, times(2)).update(any());
+    }
+
+    /**
+     * The usernameless ceremony the login page offers on every page load is left untouched as soon as
+     * the user identifies themselves. Sweeping it produced an abandonment for every successful sign-in,
+     * attributed to no user at all. It must be left alone.
+     */
+    @Test
+    void processImpl_ifCeremonyIsUsernameless_isNotMarkedAbandoned() {
+        Fido2AuthenticationData usernameless = pendingCeremony(null);
         when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(ASSERTION_DN), any(), anyInt()))
                 .thenReturn(List.of(ceremonyEntry(usernameless)));
 
         timer.processImpl();
 
-        assertEquals(Fido2AuthenticationStatus.abandoned, identified.getStatus());
-        assertEquals(Fido2AuthenticationStatus.abandoned, usernameless.getStatus());
-        verify(authenticationPersistenceService, times(2)).update(any());
+        // Left exactly as it was before abandonment recording existed: pending, for the cleaner to remove.
+        assertEquals(Fido2AuthenticationStatus.pending, usernameless.getStatus());
+        verify(authenticationPersistenceService, never()).update(any());
+        verify(metricService, never()).recordPasskeyAuthenticationAbandoned(any(), anyLong());
+    }
+
+    /**
+     * An empty username is the same case as a missing one, and must be treated the same way.
+     */
+    @Test
+    void processImpl_ifUsernameIsBlank_isNotMarkedAbandoned() {
+        Fido2AuthenticationData blank = pendingCeremony("   ");
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(ASSERTION_DN), any(), anyInt()))
+                .thenReturn(List.of(ceremonyEntry(blank)));
+
+        timer.processImpl();
+
+        assertEquals(Fido2AuthenticationStatus.pending, blank.getStatus());
+        verify(authenticationPersistenceService, never()).update(any());
+    }
+
+    /**
+     * Skipping the usernameless ones must not stop the named ceremonies in the same batch being swept —
+     * a real abandonment sitting behind a speculative one still has to be recorded.
+     */
+    @Test
+    void processImpl_ifBatchMixesSpeculativeAndNamed_sweepsOnlyTheNamed() {
+        Fido2AuthenticationData usernameless = pendingCeremony(null);
+        Fido2AuthenticationData named = pendingCeremony("alice");
+        Fido2AuthenticationEntry namedEntry = ceremonyEntry(named);
+        when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
+                .thenReturn(List.of(ceremonyEntry(usernameless), namedEntry));
+
+        timer.processImpl();
+
+        assertEquals(Fido2AuthenticationStatus.pending, usernameless.getStatus());
+        assertEquals(Fido2AuthenticationStatus.abandoned, named.getStatus());
+        verify(authenticationPersistenceService).update(namedEntry);
     }
 
     /**
@@ -182,15 +235,15 @@ class AbandonedCeremonyTimerTest {
      */
     @Test
     void processImpl_ifOneSubtreeCannotBeRead_stillSweepsTheOther() {
-        Fido2AuthenticationData usernameless = pendingCeremony(null);
+        Fido2AuthenticationData reachable = pendingCeremony("alice");
         when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(PEOPLE_DN), any(), anyInt()))
                 .thenThrow(new IllegalStateException("subtree unavailable"));
         when(authenticationPersistenceService.findLapsedPendingCeremonies(eq(ASSERTION_DN), any(), anyInt()))
-                .thenReturn(List.of(ceremonyEntry(usernameless)));
+                .thenReturn(List.of(ceremonyEntry(reachable)));
 
         timer.processImpl();
 
-        assertEquals(Fido2AuthenticationStatus.abandoned, usernameless.getStatus());
+        assertEquals(Fido2AuthenticationStatus.abandoned, reachable.getStatus());
     }
 
     /**


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14754 

#### Implementation Details

The abandonment sweep added in #14738 swept every lapsed `pending` ceremony. That included the
usernameless (conditional-UI) ceremony a login page starts on every page load, before it knows who is
signing in. When the user identifies themselves, a second, named ceremony is issued and completed, and
the first is left untouched — so every successful sign-in produced an abandonment attributed to no user.

The sweep now skips ceremonies issued without a username. Four lines of logic; the rest of the diff is
comments and docs.

They are skipped rather than recorded under a different label because the server cannot tell the two
cases apart: a usernameless ceremony nobody looked at and one the user engaged with and gave up on are
both just `pending` when the window elapses. Recording a number that conflates them is worse than not
recording one. Distinguishing them needs the browser to report which happened — #14744.

Skipped ceremonies keep exactly the behaviour they had before #14738: they stay `pending` and the
cleaner removes them.

##### Verified against the reported run

| Reported `ABANDONED` | User | After |
|---|---|---|
| 6 metrics entries | NULL | gone |
| 1 metrics entry | `admin` | kept — genuine, ATTEMPT at 09:08:47 with no SUCCESS |
| 4 `jansFido2AuthnEntry` rows | `personInum` NULL | never created |
| `test` ceremony | `66ba2678…` | unchanged, `authenticated` |

##### Scope

Named ceremonies sweep as before. `failed` recording, the ceremony-window check, `ATTEMPT` metrics,
aggregation and the analytics endpoints are untouched. Only one place writes `abandoned`; every other
reference is read-only reporting.

`abandonedOperations` and `abandonmentRate` will drop sharply — that is the correction, not data loss.

A genuine usernameless sign-in that a user abandons is no longer recorded either. That is a real
trade-off, taken because the server currently cannot tell it apart from the speculative case.

Tests: 397 pass (three new — usernameless skipped, blank username skipped, mixed batch still sweeps the
named ceremony; two existing retargeted, as they used a usernameless ceremony to prove subtree coverage).

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usernameless passkey ceremonies are no longer incorrectly marked as abandoned or included in abandonment metrics.
  * Named-user ceremonies continue to be processed correctly, including when mixed with usernameless ceremonies.
  * Blank usernames are treated consistently as usernameless ceremonies.

* **Documentation**
  * Clarified abandonment retention settings and metric behavior.
  * Documented that conditional-UI ceremonies remain pending until normal cleanup and are excluded from abandonment sweeping and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->