### PR TITLE
ci(sandbox): send the VM key to Zulip

### DIFF
--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -292,7 +292,6 @@ jobs:
             echo "- Persistence: $PERSISTENCE (db \`jansdb\`)"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # MSG carries the base64 private key + decode instructions (like flex), so the dev has the key inline.
       - name: Report VM access to Zulip
         if: always() && steps.create_env.outputs.MSG != ''
         continue-on-error: true

--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -292,9 +292,9 @@ jobs:
             echo "- Persistence: $PERSISTENCE (db \`jansdb\`)"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Host/IP only — the private key (in easycloud's MSG) is not broadcast; devs get it from the PR.
+      # MSG carries the base64 private key + decode instructions (like flex), so the dev has the key inline.
       - name: Report VM access to Zulip
-        if: always() && steps.create_env.outputs.host != ''
+        if: always() && steps.create_env.outputs.MSG != ''
         continue-on-error: true
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1
         with:
@@ -304,4 +304,6 @@ jobs:
           to: "bot_reporter"
           type: "stream"
           topic: "jans-sandbox"
-          content: "jans sandbox `${{ steps.create_env.outputs.host }}` (${{ steps.create_env.outputs.ip }}) provisioned for @${{ github.actor }} — SSH key + details in the easycloud PR this run opened."
+          content: |
+            jans sandbox `${{ steps.create_env.outputs.host }}` (${{ steps.create_env.outputs.ip }}) for @${{ github.actor }}
+            ${{ steps.create_env.outputs.MSG }}


### PR DESCRIPTION
Report easycloud's `MSG` (base64 private key + decode steps) in the Zulip message, prefixed with host/IP — so the dev gets the key inline instead of digging through the easycloud PR (flex build-admin-ui parity). Gated on `MSG != ''` (only when a VM was actually created).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Notifications**
  * Updated VM creation notifications to include the VM host, IP address, triggering actor, and setup message.
  * Notifications are now sent only when VM setup provides a non-empty message, ensuring recipients receive complete and relevant status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->