### PR TITLE
fix(docs): fix broken links and anchor

### DIFF
--- a/docs/janssen-server/auth-server/endpoints/global-token-revocation.md
+++ b/docs/janssen-server/auth-server/endpoints/global-token-revocation.md
@@ -66,7 +66,7 @@ HTTP/1.1 204
 
 ## Disabling The Endpoint Using Feature Flag
 
-`Global Token Revocation` endpoint can be enabled or disable using [GLOBAL_TOKEN_REVOCATION feature flag](../../reference/json/feature-flags/janssenauthserver-feature-flags.md#globaltokenrevocation).
+`Global Token Revocation` endpoint can be enabled or disable using [GLOBAL_TOKEN_REVOCATION feature flag](../../reference/json/feature-flags/janssenauthserver-feature-flags.md#global_token_revocation).
 Use [Janssen Text-based UI(TUI)](../../config-guide/config-tools/jans-tui/README.md) or [Janssen command-line interface](../../config-guide/config-tools/jans-cli/README.md) to perform this task.
 
 When using TUI, navigate via `Auth Server`->`Properties`->`enabledFeatureFlags` to screen below. From here, enable or

--- a/docs/janssen-server/auth-server/endpoints/global-token-revocation.md
+++ b/docs/janssen-server/auth-server/endpoints/global-token-revocation.md
@@ -66,7 +66,7 @@ HTTP/1.1 204
 
 ## Disabling The Endpoint Using Feature Flag
 
-`Global Token Revocation` endpoint can be enabled or disable using [GLOBAL_TOKEN_REVOCATION feature flag](../../reference/json/feature-flags/janssenauthserver-feature-flags.md#global_token_revocation).
+`Global Token Revocation` endpoint can be enabled or disabled using [GLOBAL_TOKEN_REVOCATION feature flag](../../reference/json/feature-flags/janssenauthserver-feature-flags.md#global_token_revocation).
 Use [Janssen Text-based UI(TUI)](../../config-guide/config-tools/jans-tui/README.md) or [Janssen command-line interface](../../config-guide/config-tools/jans-cli/README.md) to perform this task.
 
 When using TUI, navigate via `Auth Server`->`Properties`->`enabledFeatureFlags` to screen below. From here, enable or

--- a/docs/janssen-server/auth-server/tokens/logout-status-jwt.md
+++ b/docs/janssen-server/auth-server/tokens/logout-status-jwt.md
@@ -93,7 +93,7 @@ If Token Status List has `INVALID` (`1` - at `idx` index for 2 bits) then RP mus
 
 ## Disabling Logout Status JWT Using Feature Flag
 
-`Logout Status JWT` can be enabled or disabled using [logout_status_jwt feature flag](../../../script-catalog/logout_status_jwt/logout-status-jwt.md).
+`Logout Status JWT` can be enabled or disabled using [logout_status_jwt feature flag](../../reference/json/feature-flags/janssenauthserver-feature-flags.md#logout_status_jwt).
 Use [Janssen Text-based UI(TUI)](../../config-guide/config-tools/jans-tui/README.md) or [Janssen command-line interface](../../config-guide/config-tools/jans-cli/README.md) to perform this task.
 
 When using TUI, navigate via `Auth Server`->`Properties`->`enabledFeatureFlags` to screen below. From here, enable or


### PR DESCRIPTION
### Prepare

- [X] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [X] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description
Fix broken feature-flag links in the Auth Server documentation. The `GLOBAL_TOKEN_REVOCATION` link was updated to use the correct `#global_token_revocation` anchor, and the `Logout Status JWT` link was updated to use the correct `#logout_status_jwt` anchor.


#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #13560 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the feature-flag documentation link for global token revocation.
  * Updated the Logout Status JWT feature-flag link to reference the Janssen Auth Server documentation.
  * Improved documentation navigation for configuring and managing these authentication features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->