### PR TITLE
feat(jans-cedarling): add minimal JavaScript SDK

### DIFF
--- a/jans-cedarling/Cargo.toml
+++ b/jans-cedarling/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
     "cedarling_pg_codegen",
     "test_utils",
 ]
-exclude = ["bindings/cedarling-java", "bindings/benchmarks", "custom-lints"]
+exclude = ["bindings/cedarling-java", "bindings/benchmarks", "custom-lints","bindings/cedarling_js",]
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/jans-cedarling/bindings/cedarling_js/.gitignore
+++ b/jans-cedarling/bindings/cedarling_js/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.test-dist/
+test-results/
+coverage/
+*.tgz
+*.log
+.DS_Store
+test-results

--- a/jans-cedarling/bindings/cedarling_js/.npmrc
+++ b/jans-cedarling/bindings/cedarling_js/.npmrc
@@ -1,0 +1,2 @@
+install-links=false
+save-exact=true

--- a/jans-cedarling/bindings/cedarling_js/README.md
+++ b/jans-cedarling/bindings/cedarling_js/README.md
@@ -1,0 +1,66 @@
+# Cedarling JavaScript SDK
+
+This directory contains the first independently runnable integration slice of
+`@janssenproject/cedarling`. The package remains private while the remaining SDK
+services, runtime qualification, and release automation are reviewed in later
+pull requests.
+
+## Included API
+
+- `createCedarling(options)`
+- `authorizeUnsigned(request)`
+- `authorizeMultiIssuer(request)`
+- `shutDown()`
+- One `CedarlingError` and `Result<T>` contract
+
+`authorizeMultiIssuer` is the token-validating authorization method. It accepts
+one or more mapped tokens; its name does not require multiple token issuers.
+
+## Development
+
+Node.js 20.19 or newer and the sibling Cedarling WASM package are required.
+
+```bash
+npm ci
+npm run check
+```
+
+The root export selects the Node or browser loader. This slice validates the
+Node path; broader runtime qualification is added by later SDK pull requests.
+
+## Unsigned authorization
+
+```ts
+import { createCedarling } from "@janssenproject/cedarling";
+
+const initialized = await createCedarling({
+  applicationName: "task-api",
+  policyStore: { type: "inline", document: policyStoreDocument },
+});
+
+if (!initialized.ok) throw initialized.error;
+const cedarling = initialized.value;
+
+try {
+  const result = await cedarling.authorizeUnsigned({
+    principal: { type: "User", id: "alice" },
+    action: { namespace: "Task", id: "Read" },
+    resource: { type: "Task", id: "task-1" },
+  });
+
+  if (!result.ok) throw result.error;
+  console.log(result.value.decision);
+} finally {
+  await cedarling.shutDown();
+}
+```
+
+Replace `policyStoreDocument` with a parsed Cedarling policy-store document.
+Every public operation returns `Result<T>`; a successful decision of `false` is
+a policy denial, not an SDK error.
+
+## Deferred from this slice
+
+Context data, retained logs, issuer observation, URL/archive/loader policy
+sources, CommonJS output, cross-runtime test runners, packaging, publication,
+and CI automation are introduced by the dependent pull requests.

--- a/jans-cedarling/bindings/cedarling_js/package-lock.json
+++ b/jans-cedarling/bindings/cedarling_js/package-lock.json
@@ -1,0 +1,496 @@
+{
+  "name": "@janssenproject/cedarling",
+  "version": "0.0.0-nightly",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@janssenproject/cedarling",
+      "version": "0.0.0-nightly",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@janssenproject/cedarling_wasm": "file:../cedarling_wasm/pkg"
+      },
+      "devDependencies": {
+        "@types/node": "24.13.3",
+        "@types/qunit": "2.19.14",
+        "qunit": "2.26.0",
+        "typescript": "7.0.2"
+      },
+      "engines": {
+        "node": ">=20.19"
+      }
+    },
+    "../cedarling_wasm/pkg": {
+      "name": "@janssenproject/cedarling_wasm",
+      "version": "0.0.0",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@janssenproject/cedarling_wasm": {
+      "resolved": "../cedarling_wasm/pkg",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/qunit": {
+      "version": "2.19.14",
+      "resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.19.14.tgz",
+      "integrity": "sha512-ou2RMtwyDnW1btrMnDMZeL6V5/yRRbuHKrRC6y8IuzDljjVzw6wPCVFb8p4qJD0NkUkf3BdZeJJIBzjK1BUUDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-watch": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qunit": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.26.0.tgz",
+      "integrity": "sha512-KSv16YomcYmiK90qTOJl3Bm5IvTf2upqQDdBQWCvSQWe94FWobnUgKOpvpvZdG7VkDt3TJSI8k8g9+GGGEd7Fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "7.2.0",
+        "node-watch": "0.7.3",
+        "tiny-glob": "0.2.9"
+      },
+      "bin": {
+        "qunit": "bin/qunit.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/jans-cedarling/bindings/cedarling_js/package.json
+++ b/jans-cedarling/bindings/cedarling_js/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@janssenproject/cedarling",
+  "version": "0.0.0-nightly",
+  "description": "Web-native JavaScript SDK for Cedarling authorization",
+  "type": "module",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JanssenProject/jans.git",
+    "directory": "jans-cedarling/bindings/cedarling_js"
+  },
+  "sideEffects": false,
+  "engines": { "node": ">=20.19" },
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "node": {
+        "types": "./dist/entries/node.d.ts",
+        "import": "./dist/entries/node.js"
+      },
+      "browser": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test:compile": "tsc -p tests/tsconfig.json",
+    "test:prepare": "npm run build && npm run test:compile",
+    "test:unit": "npm run test:prepare && node .test-dist/runners/node.js unit",
+    "test:contract": "npm run test:prepare && node .test-dist/runners/node.js contract",
+    "check": "npm run typecheck && npm run test:unit && npm run test:contract"
+  },
+  "dependencies": {
+    "@janssenproject/cedarling_wasm": "file:../cedarling_wasm/pkg"
+  },
+  "devDependencies": {
+    "@types/node": "24.13.3",
+    "@types/qunit": "2.19.14",
+    "qunit": "2.26.0",
+    "typescript": "7.0.2"
+  }
+}

--- a/jans-cedarling/bindings/cedarling_js/src/authorization/request.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/authorization/request.ts
@@ -77,10 +77,7 @@ function snapshotAction(
     return invalid(errorCode.inputInvalidType, ["action", "namespace"]);
   }
   const namespace = namespaceValue.split("::");
-  if (
-    namespace.length === 0 ||
-    namespace.some((part) => !CEDAR_IDENTIFIER_PATTERN.test(part))
-  ) {
+  if (namespace.some((part) => !CEDAR_IDENTIFIER_PATTERN.test(part))) {
     return invalid(errorCode.inputInvalidFormat, ["action", "namespace"]);
   }
 
@@ -227,8 +224,8 @@ function snapshotTokens(
   }
 
   const tokens: TokenInput[] = [];
-  for (const [index, value] of inspected.values.entries()) {
-    const token = record(value, ["tokens", index]);
+  for (const [index, tokenValue] of inspected.values.entries()) {
+    const token = record(tokenValue, ["tokens", index]);
     exactFields(token, INPUT_FIELDS.token, ["tokens", index]);
     tokens.push({
       mapping: requiredString(

--- a/jans-cedarling/bindings/cedarling_js/src/authorization/request.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/authorization/request.ts
@@ -1,0 +1,260 @@
+import type {
+  CedarEntity,
+  MultiIssuerAuthorizationRequest,
+  TokenInput,
+  UnsignedAuthorizationRequest,
+} from "./types.js";
+import { normalizeInputError } from "../errors/errors.js";
+import { errorCode, type CedarlingOperation } from "../errors/types.js";
+import { snapshotCedarObject } from "../values/snapshot.js";
+import {
+  inspectDenseArray,
+  type DataRecord,
+} from "../helpers/records.js";
+import { INPUT_FIELDS } from "../helpers/constants.js";
+import { createInputValidator } from "../helpers/validation.js";
+
+const CEDAR_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+const FORMAL_ACTION_PATTERN =
+  /^(?:[A-Za-z_][A-Za-z0-9_]*::)*Action::("(?:[^"\\\u0000-\u001F]|\\(?:["\\/bfnrt]|u[0-9A-Fa-f]{4}))*")$/u;
+
+function validator(
+  operation: Extract<
+    CedarlingOperation,
+    "authorizeUnsigned" | "authorizeMultiIssuer"
+  >,
+) {
+  return createInputValidator(operation, { allowNullPrototype: true });
+}
+
+/** Validates and normalizes either public action representation to one UID. */
+function snapshotAction(
+  value: unknown,
+  operation: Extract<
+    CedarlingOperation,
+    "authorizeUnsigned" | "authorizeMultiIssuer"
+  >,
+): string {
+  const { exactFields, field, invalid, record, requiredString } =
+    validator(operation);
+  if (value === undefined) {
+    return invalid(errorCode.inputRequired, ["action"]);
+  }
+
+  if (typeof value === "string") {
+    const match = FORMAL_ACTION_PATTERN.exec(value);
+    if (match === null) {
+      return invalid(
+        value.trim().length === 0
+          ? errorCode.inputRequired
+          : errorCode.inputInvalidFormat,
+        ["action"],
+      );
+    }
+    try {
+      const id = JSON.parse(match[1] as string) as unknown;
+      if (typeof id !== "string" || id.trim().length === 0) {
+        return invalid(errorCode.inputRequired, ["action"]);
+      }
+    } catch {
+      return invalid(errorCode.inputInvalidFormat, ["action"]);
+    }
+    return value;
+  }
+
+  const action = record(value, ["action"]);
+  exactFields(action, INPUT_FIELDS.action, ["action"]);
+
+  const id = requiredString(field(action, "id", ["action"]), [
+    "action",
+    "id",
+  ]);
+  const namespaceValue = field(action, "namespace", ["action"]);
+  if (namespaceValue === undefined) {
+    return `Action::${JSON.stringify(id)}`;
+  }
+  if (typeof namespaceValue !== "string") {
+    return invalid(errorCode.inputInvalidType, ["action", "namespace"]);
+  }
+  const namespace = namespaceValue.split("::");
+  if (
+    namespace.length === 0 ||
+    namespace.some((part) => !CEDAR_IDENTIFIER_PATTERN.test(part))
+  ) {
+    return invalid(errorCode.inputInvalidFormat, ["action", "namespace"]);
+  }
+
+  return `${namespace.join("::")}::Action::${JSON.stringify(id)}`;
+}
+
+/** Runs a nested value snapshot while retaining its public request path. */
+function snapshotAtPath<T>(
+  path: readonly (string | number)[],
+  operation: Extract<
+    CedarlingOperation,
+    "authorizeUnsigned" | "authorizeMultiIssuer"
+  >,
+  snapshot: () => T,
+): T {
+  try {
+    return snapshot();
+  } catch (error: unknown) {
+    throw normalizeInputError(error, operation, path);
+  }
+}
+
+/** Creates an SDK-owned entity snapshot before crossing the engine Seam. */
+function snapshotEntity(
+  value: unknown,
+  path: readonly (string | number)[],
+  operation: Extract<
+    CedarlingOperation,
+    "authorizeUnsigned" | "authorizeMultiIssuer"
+  >,
+): CedarEntity {
+  const { exactFields, field, invalid, record, requiredString } =
+    validator(operation);
+  const entity = record(value, path);
+  exactFields(entity, INPUT_FIELDS.entity, path);
+  const type = requiredString(field(entity, "type", path), [...path, "type"]);
+  const id = requiredString(field(entity, "id", path), [...path, "id"]);
+  const attributes = field(entity, "attributes", path);
+
+  if (
+    attributes !== undefined &&
+    typeof attributes === "object" &&
+    attributes !== null &&
+    Object.hasOwn(attributes, "cedar_entity_mapping")
+  ) {
+    return invalid(errorCode.inputUnknownField, [
+      ...path,
+      "attributes",
+      "cedar_entity_mapping",
+    ]);
+  }
+
+  return {
+    type,
+    id,
+    ...(attributes === undefined
+      ? {}
+      : {
+          attributes: snapshotAtPath(
+            [...path, "attributes"],
+            operation,
+            () => snapshotCedarObject(attributes, operation),
+          ),
+        }),
+  };
+}
+
+/** Detaches the action, resource, and context shared by both trust models. */
+function snapshotAuthorizationTarget(
+  request: DataRecord,
+  operation: Extract<
+    CedarlingOperation,
+    "authorizeUnsigned" | "authorizeMultiIssuer"
+  >,
+): Pick<
+  UnsignedAuthorizationRequest,
+  "action" | "resource" | "context"
+> {
+  const { field } = validator(operation);
+  const context = field(request, "context", []);
+
+  return {
+    action: snapshotAction(field(request, "action", []), operation),
+    resource: snapshotEntity(
+      field(request, "resource", []),
+      ["resource"],
+      operation,
+    ),
+    ...(context === undefined
+      ? {}
+      : {
+          context: snapshotAtPath(
+            ["context"],
+            operation,
+            () => snapshotCedarObject(context, operation),
+          ),
+        }),
+  };
+}
+
+/** Detaches all value-bearing parts of an unsigned authorization request. */
+export function snapshotUnsignedRequest(
+  value: UnsignedAuthorizationRequest,
+): UnsignedAuthorizationRequest {
+  const operation = "authorizeUnsigned";
+  const { exactFields, field, record } = validator(operation);
+  const request = record(value, []);
+  exactFields(request, INPUT_FIELDS.unsignedAuthorizationRequest, []);
+  const principal = field(request, "principal", []);
+
+  return {
+    ...(principal === undefined
+      ? {}
+      : { principal: snapshotEntity(principal, ["principal"], operation) }),
+    ...snapshotAuthorizationTarget(request, operation),
+  };
+}
+
+/** Validates and detaches a non-empty ordered token input array. */
+function snapshotTokens(
+  value: unknown,
+  operation: "authorizeMultiIssuer",
+): readonly TokenInput[] {
+  const { exactFields, field, invalid, record, requiredString } =
+    validator(operation);
+  if (!Array.isArray(value)) {
+    return invalid(
+      value === undefined
+        ? errorCode.inputRequired
+        : errorCode.inputInvalidType,
+      ["tokens"],
+    );
+  }
+  if (value.length === 0) {
+    return invalid(errorCode.inputOutOfRange, ["tokens"]);
+  }
+
+  const inspected = inspectDenseArray(value);
+  if (inspected.kind === "invalid") {
+    return invalid(
+      errorCode.inputInvalidType,
+      inspected.index === undefined ? ["tokens"] : ["tokens", inspected.index],
+    );
+  }
+
+  const tokens: TokenInput[] = [];
+  for (const [index, value] of inspected.values.entries()) {
+    const token = record(value, ["tokens", index]);
+    exactFields(token, INPUT_FIELDS.token, ["tokens", index]);
+    tokens.push({
+      mapping: requiredString(
+        field(token, "mapping", ["tokens", index]),
+        ["tokens", index, "mapping"],
+      ),
+      payload: requiredString(
+        field(token, "payload", ["tokens", index]),
+        ["tokens", index, "payload"],
+      ),
+    });
+  }
+  return tokens;
+}
+
+/** Detaches all value-bearing parts of a multi-issuer request. */
+export function snapshotMultiIssuerRequest(
+  value: MultiIssuerAuthorizationRequest,
+): MultiIssuerAuthorizationRequest {
+  const operation = "authorizeMultiIssuer";
+  const { exactFields, field, record } = validator(operation);
+  const request = record(value, []);
+  exactFields(request, INPUT_FIELDS.multiIssuerAuthorizationRequest, []);
+
+  return {
+    tokens: snapshotTokens(field(request, "tokens", []), operation),
+    ...snapshotAuthorizationTarget(request, operation),
+  };
+}

--- a/jans-cedarling/bindings/cedarling_js/src/authorization/types.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/authorization/types.ts
@@ -1,0 +1,63 @@
+import type { CedarObject } from "../values/types.js";
+import type { CedarlingError } from "../errors/types.js";
+
+export interface CedarEntity {
+  readonly type: string;
+  readonly id: string;
+  readonly attributes?: CedarObject;
+}
+
+/**
+ * Structured Cedar action accepted as an alternative to a formal action UID.
+ *
+ * The SDK converts `{ namespace: "Task", id: "Read" }` to
+ * `Task::Action::"Read"`. Omit `namespace` for the root `Action` entity type.
+ */
+export interface CedarAction {
+  readonly namespace?: string;
+  readonly id: string;
+}
+
+/**
+ * Application-asserted authorization request that does not require tokens.
+ *
+ * The principal is optional to support Cedar partial evaluation. Request data
+ * is validated and detached before reaching WebAssembly.
+ */
+export interface UnsignedAuthorizationRequest {
+  readonly principal?: CedarEntity;
+  readonly action: string | CedarAction;
+  readonly resource: CedarEntity;
+  readonly context?: CedarObject;
+}
+
+export interface TokenInput {
+  readonly mapping: string;
+  readonly payload: string;
+}
+
+/**
+ * Token-validating authorization request. The method name distinguishes this
+ * flow from unsigned authorization; it does not require multiple tokens or
+ * issuers.
+ */
+export interface MultiIssuerAuthorizationRequest {
+  readonly tokens: readonly TokenInput[];
+  readonly action: string | CedarAction;
+  readonly resource: CedarEntity;
+  readonly context?: CedarObject;
+}
+
+/**
+ * Detached result of one authorization evaluation.
+ *
+ * A `false` decision is a normal successful result, not an operational error.
+ */
+export interface AuthorizationDecision {
+  readonly decision: boolean;
+  readonly requestId: string;
+  readonly diagnostics: {
+    readonly reasons: readonly string[];
+    readonly errors: readonly CedarlingError[];
+  };
+}

--- a/jans-cedarling/bindings/cedarling_js/src/client/client.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/client/client.ts
@@ -1,0 +1,170 @@
+import type {
+  AuthorizationDecision,
+  MultiIssuerAuthorizationRequest,
+  UnsignedAuthorizationRequest,
+} from "../authorization/types.js";
+import type { CedarlingClient } from "./types.js";
+import type { CedarlingOptions } from "../configuration/types.js";
+import type {
+  CedarlingError,
+  CedarlingOperation,
+  Result,
+} from "../errors/types.js";
+import {
+  snapshotMultiIssuerRequest,
+  snapshotUnsignedRequest,
+} from "../authorization/request.js";
+import type { CedarlingEngine, EngineFactory } from "../engine/engine.js";
+import {
+  createSdkError,
+  normalizeInputError,
+  normalizeOperationError,
+} from "../errors/errors.js";
+import { errorCode } from "../errors/types.js";
+import {
+  prepareCedarlingOptions,
+  type PreparedClientCapabilities,
+} from "../configuration/prepare.js";
+
+const ok = <T>(value: T): Result<T> => ({ ok: true, value });
+const failed = (error: CedarlingError): Result<never> => ({ ok: false, error });
+
+class CedarlingClientImplementation implements CedarlingClient {
+  readonly #engine: CedarlingEngine;
+  readonly #capabilities: PreparedClientCapabilities;
+  #open = true;
+  #inFlight = 0;
+  #idle:
+    | { readonly promise: Promise<void>; readonly resolve: () => void }
+    | undefined;
+  #shutDownResult: Promise<Result<void>> | undefined;
+
+  constructor(
+    engine: CedarlingEngine,
+    capabilities: PreparedClientCapabilities,
+  ) {
+    this.#engine = engine;
+    this.#capabilities = capabilities;
+  }
+
+  async #run<T, Prepared>(
+    operation: CedarlingOperation,
+    prepare: () => Prepared,
+    work: (prepared: Prepared) => Promise<T>,
+  ): Promise<Result<T>> {
+    if (!this.#open) {
+      return failed(createSdkError(errorCode.clientClosed, operation));
+    }
+    let prepared: Prepared;
+    try {
+      prepared = prepare();
+    } catch (error: unknown) {
+      return failed(normalizeInputError(error, operation));
+    }
+    this.#inFlight += 1;
+    try {
+      return ok(await work(prepared));
+    } catch (error: unknown) {
+      return failed(normalizeOperationError(
+        error,
+        operation,
+        this.#capabilities.exposeRawErrors,
+      ));
+    } finally {
+      this.#inFlight -= 1;
+      if (this.#inFlight === 0 && this.#idle !== undefined) {
+        const idle = this.#idle;
+        this.#idle = undefined;
+        idle.resolve();
+      }
+    }
+  }
+
+  authorizeUnsigned(
+    request: UnsignedAuthorizationRequest,
+  ): Promise<Result<AuthorizationDecision>> {
+    return this.#run(
+      "authorizeUnsigned",
+      () => snapshotUnsignedRequest(request),
+      (snapshot) => this.#engine.authorizeUnsigned(snapshot),
+    );
+  }
+
+  authorizeMultiIssuer(
+    request: MultiIssuerAuthorizationRequest,
+  ): Promise<Result<AuthorizationDecision>> {
+    return this.#run(
+      "authorizeMultiIssuer",
+      () => snapshotMultiIssuerRequest(request),
+      (snapshot) => this.#engine.authorizeMultiIssuer(snapshot),
+    );
+  }
+
+  #waitUntilIdle(): Promise<void> {
+    if (this.#inFlight === 0) return Promise.resolve();
+    if (this.#idle === undefined) {
+      let resolveIdle: (() => void) | undefined;
+      const promise = new Promise<void>((resolve) => {
+        resolveIdle = resolve;
+      });
+      this.#idle = { promise, resolve: () => resolveIdle?.() };
+    }
+    return this.#idle.promise;
+  }
+
+  async #finishShutDown(): Promise<Result<void>> {
+    try {
+      await this.#waitUntilIdle();
+      await this.#engine.shutDown();
+      return ok(undefined);
+    } catch (error: unknown) {
+      return failed(normalizeOperationError(
+        error,
+        "shutDown",
+        this.#capabilities.exposeRawErrors,
+      ));
+    }
+  }
+
+  shutDown(): Promise<Result<void>> {
+    if (this.#shutDownResult === undefined) {
+      this.#open = false;
+      this.#shutDownResult = this.#finishShutDown();
+    }
+    return this.#shutDownResult;
+  }
+}
+
+export function createClientForEngine(
+  engine: CedarlingEngine,
+  capabilities: Partial<PreparedClientCapabilities> = {},
+): CedarlingClient {
+  return new CedarlingClientImplementation(engine, {
+    exposeRawErrors: capabilities.exposeRawErrors ?? false,
+  });
+}
+
+export function createCedarlingForEngine(
+  createEngine: EngineFactory,
+): (options: CedarlingOptions) => Promise<Result<CedarlingClient>> {
+  return async function createCedarling(options: CedarlingOptions) {
+    let snapshot;
+    try {
+      snapshot = prepareCedarlingOptions(options);
+    } catch (error: unknown) {
+      return failed(normalizeInputError(error, "initialize"));
+    }
+    try {
+      return ok(createClientForEngine(
+        await createEngine(snapshot),
+        snapshot.clientCapabilities,
+      ));
+    } catch (error: unknown) {
+      return failed(normalizeOperationError(
+        error,
+        "initialize",
+        snapshot.clientCapabilities.exposeRawErrors,
+      ));
+    }
+  };
+}

--- a/jans-cedarling/bindings/cedarling_js/src/client/types.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/client/types.ts
@@ -1,0 +1,16 @@
+import type {
+  AuthorizationDecision,
+  MultiIssuerAuthorizationRequest,
+  UnsignedAuthorizationRequest,
+} from "../authorization/types.js";
+import type { Result } from "../errors/types.js";
+
+export interface CedarlingClient {
+  authorizeUnsigned(
+    request: UnsignedAuthorizationRequest,
+  ): Promise<Result<AuthorizationDecision>>;
+  authorizeMultiIssuer(
+    request: MultiIssuerAuthorizationRequest,
+  ): Promise<Result<AuthorizationDecision>>;
+  shutDown(): Promise<Result<void>>;
+}

--- a/jans-cedarling/bindings/cedarling_js/src/configuration/bootstrap.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/configuration/bootstrap.ts
@@ -35,9 +35,11 @@ export function applyTypedBootstrap(
     DEFAULTS.authorization.disableSchemaValidation,
     authorization.path("dangerouslyDisableSchemaValidation"),
   ) ? "disabled" : "enabled";
+  const decisionLogTokenIdClaim = authorization.read("decisionLogTokenIdClaim");
   bootstrap.CEDARLING_DECISION_LOG_DEFAULT_JWT_ID = requiredString(
-    authorization.read("decisionLogTokenIdClaim") ??
-      DEFAULTS.authorization.decisionLogTokenIdClaim,
+    decisionLogTokenIdClaim === undefined
+      ? DEFAULTS.authorization.decisionLogTokenIdClaim
+      : decisionLogTokenIdClaim,
     authorization.path("decisionLogTokenIdClaim"),
   );
 
@@ -53,8 +55,9 @@ export function applyTypedBootstrap(
     jwt.path("dangerouslyDisableStatusValidation"),
   ) ? "disabled" : "enabled";
   const algorithms = jwt.read("allowedAlgorithms");
-  bootstrap.CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED =
+  bootstrap.CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED = Object.freeze(
     algorithms === undefined
       ? [...JWT_ALGORITHMS]
-      : [...jwtAlgorithms(algorithms, jwt.path("allowedAlgorithms"))];
+      : [...jwtAlgorithms(algorithms, jwt.path("allowedAlgorithms"))],
+  );
 }

--- a/jans-cedarling/bindings/cedarling_js/src/configuration/bootstrap.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/configuration/bootstrap.ts
@@ -1,0 +1,60 @@
+import {
+  DEFAULTS,
+  INPUT_FIELDS,
+  JWT_ALGORITHMS,
+} from "../helpers/constants.js";
+import {
+  field,
+  jwtAlgorithms,
+  optionalBoolean,
+  record,
+  rejectUnknown,
+  requiredString,
+} from "./validation.js";
+
+function section(value: unknown, name: string, fields: readonly string[]) {
+  const options = value === undefined ? {} : record(value, [name]);
+  rejectUnknown(options, fields, [name]);
+  return {
+    read: (fieldName: string) => field(options, fieldName, [name]),
+    path: (fieldName: string) => [name, fieldName] as const,
+  };
+}
+
+export function applyTypedBootstrap(
+  options: Record<string, unknown>,
+  bootstrap: Record<string, unknown>,
+): void {
+  const authorization = section(
+    field(options, "authorization", []),
+    "authorization",
+    INPUT_FIELDS.authorization,
+  );
+  bootstrap.CEDARLING_STRICT_SCHEMA_VALIDATION = optionalBoolean(
+    authorization.read("dangerouslyDisableSchemaValidation"),
+    DEFAULTS.authorization.disableSchemaValidation,
+    authorization.path("dangerouslyDisableSchemaValidation"),
+  ) ? "disabled" : "enabled";
+  bootstrap.CEDARLING_DECISION_LOG_DEFAULT_JWT_ID = requiredString(
+    authorization.read("decisionLogTokenIdClaim") ??
+      DEFAULTS.authorization.decisionLogTokenIdClaim,
+    authorization.path("decisionLogTokenIdClaim"),
+  );
+
+  const jwt = section(field(options, "jwt", []), "jwt", INPUT_FIELDS.jwt);
+  bootstrap.CEDARLING_JWT_SIG_VALIDATION = optionalBoolean(
+    jwt.read("dangerouslyDisableSignatureValidation"),
+    DEFAULTS.jwt.disableSignatureValidation,
+    jwt.path("dangerouslyDisableSignatureValidation"),
+  ) ? "disabled" : "enabled";
+  bootstrap.CEDARLING_JWT_STATUS_VALIDATION = optionalBoolean(
+    jwt.read("dangerouslyDisableStatusValidation"),
+    DEFAULTS.jwt.disableStatusValidation,
+    jwt.path("dangerouslyDisableStatusValidation"),
+  ) ? "disabled" : "enabled";
+  const algorithms = jwt.read("allowedAlgorithms");
+  bootstrap.CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED =
+    algorithms === undefined
+      ? [...JWT_ALGORITHMS]
+      : [...jwtAlgorithms(algorithms, jwt.path("allowedAlgorithms"))];
+}

--- a/jans-cedarling/bindings/cedarling_js/src/configuration/policy-source.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/configuration/policy-source.ts
@@ -1,0 +1,44 @@
+import type { JsonObject } from "../values/types.js";
+import { INPUT_FIELDS } from "../helpers/constants.js";
+import { snapshotJsonObject } from "../values/snapshot.js";
+import {
+  field,
+  invalid,
+  record,
+  rejectUnknown,
+} from "./validation.js";
+import { errorCode } from "../errors/types.js";
+
+export interface PreparedPolicySource {
+  readonly type: "inline";
+  readonly document: JsonObject;
+}
+
+export function preparePolicyStore(
+  sourceValue: unknown,
+  bootstrap: Record<string, unknown>,
+): PreparedPolicySource {
+  const source = record(sourceValue, ["policyStore"]);
+  rejectUnknown(source, INPUT_FIELDS.policyInline, ["policyStore"]);
+  const type = field(source, "type", ["policyStore"]);
+  if (type !== "inline") {
+    return invalid(
+      type === undefined
+        ? errorCode.inputRequired
+        : errorCode.inputUnsupported,
+      ["policyStore", "type"],
+    );
+  }
+  const document = field(source, "document", ["policyStore"]);
+  if (document === undefined) {
+    return invalid(errorCode.inputRequired, ["policyStore", "document"]);
+  }
+  let snapshot: JsonObject;
+  try {
+    snapshot = snapshotJsonObject(document, "initialize");
+  } catch {
+    return invalid(errorCode.inputInvalidType, ["policyStore", "document"]);
+  }
+  bootstrap.CEDARLING_POLICY_STORE_LOCAL = JSON.stringify(snapshot);
+  return { type, document: snapshot };
+}

--- a/jans-cedarling/bindings/cedarling_js/src/configuration/policy-source.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/configuration/policy-source.ts
@@ -9,15 +9,10 @@ import {
 } from "./validation.js";
 import { errorCode } from "../errors/types.js";
 
-export interface PreparedPolicySource {
-  readonly type: "inline";
-  readonly document: JsonObject;
-}
-
 export function preparePolicyStore(
   sourceValue: unknown,
   bootstrap: Record<string, unknown>,
-): PreparedPolicySource {
+): void {
   const source = record(sourceValue, ["policyStore"]);
   rejectUnknown(source, INPUT_FIELDS.policyInline, ["policyStore"]);
   const type = field(source, "type", ["policyStore"]);
@@ -40,5 +35,4 @@ export function preparePolicyStore(
     return invalid(errorCode.inputInvalidType, ["policyStore", "document"]);
   }
   bootstrap.CEDARLING_POLICY_STORE_LOCAL = JSON.stringify(snapshot);
-  return { type, document: snapshot };
 }

--- a/jans-cedarling/bindings/cedarling_js/src/configuration/prepare.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/configuration/prepare.ts
@@ -1,0 +1,52 @@
+import type { CedarlingOptions } from "./types.js";
+import { INPUT_FIELDS } from "../helpers/constants.js";
+import { applyTypedBootstrap } from "./bootstrap.js";
+import {
+  preparePolicyStore,
+  type PreparedPolicySource,
+} from "./policy-source.js";
+import {
+  field,
+  prepareDebug,
+  record,
+  rejectUnknown,
+  requiredString,
+} from "./validation.js";
+
+export interface PreparedClientCapabilities {
+  readonly exposeRawErrors: boolean;
+}
+
+export interface PreparedEngineOptions {
+  readonly bootstrapConfig: Readonly<Record<string, unknown>>;
+  readonly policyStore: PreparedPolicySource;
+}
+
+export interface PreparedCedarlingOptions extends PreparedEngineOptions {
+  readonly clientCapabilities: PreparedClientCapabilities;
+}
+
+export function prepareCedarlingOptions(
+  input: CedarlingOptions,
+): PreparedCedarlingOptions {
+  const options = record(input, []);
+  rejectUnknown(options, INPUT_FIELDS.webNativeOptions, []);
+  const bootstrap: Record<string, unknown> = {
+    CEDARLING_APPLICATION_NAME: requiredString(
+      field(options, "applicationName", []),
+      ["applicationName"],
+    ),
+  };
+  const policyStore = preparePolicyStore(
+    field(options, "policyStore", []),
+    bootstrap,
+  );
+  applyTypedBootstrap(options, bootstrap);
+  return {
+    bootstrapConfig: Object.freeze(bootstrap),
+    policyStore,
+    clientCapabilities: Object.freeze({
+      exposeRawErrors: prepareDebug(field(options, "debug", [])),
+    }),
+  };
+}

--- a/jans-cedarling/bindings/cedarling_js/src/configuration/prepare.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/configuration/prepare.ts
@@ -1,10 +1,7 @@
 import type { CedarlingOptions } from "./types.js";
 import { INPUT_FIELDS } from "../helpers/constants.js";
 import { applyTypedBootstrap } from "./bootstrap.js";
-import {
-  preparePolicyStore,
-  type PreparedPolicySource,
-} from "./policy-source.js";
+import { preparePolicyStore } from "./policy-source.js";
 import {
   field,
   prepareDebug,
@@ -19,7 +16,6 @@ export interface PreparedClientCapabilities {
 
 export interface PreparedEngineOptions {
   readonly bootstrapConfig: Readonly<Record<string, unknown>>;
-  readonly policyStore: PreparedPolicySource;
 }
 
 export interface PreparedCedarlingOptions extends PreparedEngineOptions {
@@ -37,14 +33,13 @@ export function prepareCedarlingOptions(
       ["applicationName"],
     ),
   };
-  const policyStore = preparePolicyStore(
+  preparePolicyStore(
     field(options, "policyStore", []),
     bootstrap,
   );
   applyTypedBootstrap(options, bootstrap);
   return {
     bootstrapConfig: Object.freeze(bootstrap),
-    policyStore,
     clientCapabilities: Object.freeze({
       exposeRawErrors: prepareDebug(field(options, "debug", [])),
     }),

--- a/jans-cedarling/bindings/cedarling_js/src/configuration/types.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/configuration/types.ts
@@ -1,0 +1,30 @@
+import type { JsonObject } from "../values/types.js";
+import type { JWT_ALGORITHMS } from "../helpers/constants.js";
+
+export type JwtAlgorithm = (typeof JWT_ALGORITHMS)[number];
+
+export interface AuthorizationOptions {
+  readonly dangerouslyDisableSchemaValidation?: boolean;
+  readonly decisionLogTokenIdClaim?: string;
+}
+
+export interface JwtValidationOptions {
+  readonly dangerouslyDisableSignatureValidation?: boolean;
+  readonly dangerouslyDisableStatusValidation?: boolean;
+  readonly allowedAlgorithms?: readonly JwtAlgorithm[];
+}
+
+export interface CedarlingDebugOptions {
+  readonly dangerouslyExposeRawErrors?: boolean;
+}
+
+export interface CedarlingOptions {
+  readonly applicationName: string;
+  readonly policyStore: {
+    readonly type: "inline";
+    readonly document: JsonObject;
+  };
+  readonly authorization?: AuthorizationOptions;
+  readonly jwt?: JwtValidationOptions;
+  readonly debug?: CedarlingDebugOptions;
+}

--- a/jans-cedarling/bindings/cedarling_js/src/configuration/validation.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/configuration/validation.ts
@@ -1,0 +1,66 @@
+import type { JwtAlgorithm } from "./types.js";
+import {
+  DEFAULTS,
+  INPUT_FIELDS,
+  JWT_ALGORITHM_SET,
+} from "../helpers/constants.js";
+import { createInputValidator } from "../helpers/validation.js";
+import { snapshotJsonValue } from "../values/snapshot.js";
+import { errorCode } from "../errors/types.js";
+
+export const {
+  exactFields: rejectUnknown,
+  field,
+  invalid,
+  record,
+  requiredString,
+} = createInputValidator("initialize", {
+  stringNormalization: "trim",
+});
+
+export function optionalBoolean(
+  value: unknown,
+  fallback: boolean,
+  path: readonly string[],
+): boolean {
+  if (value === undefined) return fallback;
+  return typeof value === "boolean"
+    ? value
+    : invalid(errorCode.inputInvalidType, path);
+}
+
+export function prepareDebug(value: unknown): boolean {
+  if (value === undefined) return DEFAULTS.client.exposeRawErrors;
+  const options = record(value, ["debug"]);
+  rejectUnknown(options, INPUT_FIELDS.debug, ["debug"]);
+  return optionalBoolean(
+    field(options, "dangerouslyExposeRawErrors", ["debug"]),
+    DEFAULTS.client.exposeRawErrors,
+    ["debug", "dangerouslyExposeRawErrors"],
+  );
+}
+
+export function jwtAlgorithms(
+  value: unknown,
+  path: readonly string[],
+): readonly JwtAlgorithm[] {
+  let snapshot: unknown;
+  try {
+    snapshot = snapshotJsonValue(value, "initialize");
+  } catch {
+    return invalid(errorCode.inputInvalidFormat, path);
+  }
+  if (
+    !Array.isArray(snapshot) ||
+    snapshot.length === 0 ||
+    !snapshot.every(
+      (algorithm) =>
+        typeof algorithm === "string" &&
+        JWT_ALGORITHM_SET.has(algorithm),
+    ) ||
+    new Set(snapshot).size !== snapshot.length
+  ) {
+    return invalid(errorCode.inputInvalidFormat, path);
+  }
+  return snapshot as readonly JwtAlgorithm[];
+}

--- a/jans-cedarling/bindings/cedarling_js/src/engine/engine.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/engine.ts
@@ -1,0 +1,20 @@
+import type {
+  AuthorizationDecision,
+  MultiIssuerAuthorizationRequest,
+  UnsignedAuthorizationRequest,
+} from "../authorization/types.js";
+import type { PreparedEngineOptions } from "../configuration/prepare.js";
+
+export interface CedarlingEngine {
+  authorizeUnsigned(
+    request: UnsignedAuthorizationRequest,
+  ): Promise<AuthorizationDecision>;
+  authorizeMultiIssuer(
+    request: MultiIssuerAuthorizationRequest,
+  ): Promise<AuthorizationDecision>;
+  shutDown(): Promise<void>;
+}
+
+export type EngineFactory = (
+  options: PreparedEngineOptions,
+) => Promise<CedarlingEngine>;

--- a/jans-cedarling/bindings/cedarling_js/src/engine/factory.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/factory.ts
@@ -1,0 +1,122 @@
+import type { PreparedEngineOptions } from "../configuration/prepare.js";
+import { createSdkError, isSdkErrorCode } from "../errors/errors.js";
+import { errorCode } from "../errors/types.js";
+import type { EngineFactory } from "./engine.js";
+import {
+  createGeneratedEngine,
+  hasGeneratedModuleOutput,
+} from "./generated.js";
+
+export interface EngineDependencies {
+  readonly hasRequiredWebAssembly: () => boolean;
+  readonly initializeGeneratedModule: () => Promise<unknown>;
+  readonly initializeGeneratedClient: (
+    config: Readonly<Record<string, unknown>>,
+  ) => Promise<unknown>;
+}
+
+export function hasWebAssemblyConstructors(): boolean {
+  return (
+    typeof WebAssembly === "object" &&
+    typeof WebAssembly.Module === "function" &&
+    typeof WebAssembly.Instance === "function"
+  );
+}
+
+function hasDependencyProtocol(
+  dependencies: EngineDependencies,
+): boolean {
+  try {
+    return (
+      typeof dependencies.hasRequiredWebAssembly === "function" &&
+      typeof dependencies.initializeGeneratedModule === "function" &&
+      typeof dependencies.initializeGeneratedClient === "function"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function createEngineFactory(
+  dependencies: EngineDependencies,
+): EngineFactory {
+  const dependencyProtocolValid = hasDependencyProtocol(dependencies);
+  let moduleInitialization: Promise<void> | undefined;
+
+  async function initializeModuleOnce(): Promise<void> {
+    if (moduleInitialization === undefined) {
+      const attempt = (async () => {
+        let output: unknown;
+        try {
+          output = await dependencies.initializeGeneratedModule();
+        } catch (error: unknown) {
+          if (isSdkErrorCode(error, [errorCode.wasmLoadFailed])) throw error;
+          throw createSdkError(errorCode.wasmLoadFailed, "initialize", {
+            rawCause: error,
+          });
+        }
+        if (!hasGeneratedModuleOutput(output)) {
+          throw createSdkError(errorCode.generatedProtocolError, "initialize");
+        }
+      })();
+      moduleInitialization = attempt.catch((error: unknown) => {
+        moduleInitialization = undefined;
+        if (
+          isSdkErrorCode(error, [
+            errorCode.unsupportedRuntimeCapability,
+            errorCode.wasmLoadFailed,
+            errorCode.generatedProtocolError,
+          ])
+        ) {
+          throw error;
+        }
+        throw createSdkError(errorCode.wasmLoadFailed, "initialize", {
+          rawCause: error,
+        });
+      });
+    }
+    return moduleInitialization;
+  }
+
+  return async (options: PreparedEngineOptions) => {
+    if (!dependencyProtocolValid) {
+      throw createSdkError(errorCode.generatedProtocolError, "initialize");
+    }
+    let hasWebAssembly = false;
+    let capabilityFailure: unknown;
+    try {
+      hasWebAssembly = dependencies.hasRequiredWebAssembly();
+    } catch (error: unknown) {
+      capabilityFailure = error;
+    }
+    if (!hasWebAssembly) {
+      throw createSdkError(
+        errorCode.unsupportedRuntimeCapability,
+        "initialize",
+        {
+          details: { runtimeCapability: "webAssembly" },
+          ...(capabilityFailure === undefined
+            ? {}
+            : { rawCause: capabilityFailure }),
+        },
+      );
+    }
+    await initializeModuleOnce();
+
+    let generatedValue: unknown;
+    try {
+      generatedValue = await dependencies.initializeGeneratedClient(
+        options.bootstrapConfig,
+      );
+    } catch (error: unknown) {
+      throw createSdkError(errorCode.initializationFailed, "initialize", {
+        rawCause: error,
+      });
+    }
+    const engine = createGeneratedEngine(generatedValue);
+    if (engine === undefined) {
+      throw createSdkError(errorCode.generatedProtocolError, "initialize");
+    }
+    return engine;
+  };
+}

--- a/jans-cedarling/bindings/cedarling_js/src/engine/factory.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/factory.ts
@@ -109,6 +109,12 @@ export function createEngineFactory(
         options.bootstrapConfig,
       );
     } catch (error: unknown) {
+      if (isSdkErrorCode(error, [
+          errorCode.initializationFailed,
+          errorCode.unsupportedRuntimeCapability,
+          errorCode.wasmLoadFailed,
+          errorCode.generatedProtocolError,
+      ])) throw error;
       throw createSdkError(errorCode.initializationFailed, "initialize", {
         rawCause: error,
       });

--- a/jans-cedarling/bindings/cedarling_js/src/engine/generated-authorization.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/generated-authorization.ts
@@ -1,0 +1,175 @@
+import type {
+  AuthorizationDecision,
+  CedarEntity,
+  MultiIssuerAuthorizationRequest,
+  UnsignedAuthorizationRequest,
+} from "../authorization/types.js";
+import {
+  createPolicyEvaluationError,
+  createSdkError,
+} from "../errors/errors.js";
+import {
+  errorCode,
+  type CedarlingError,
+} from "../errors/types.js";
+import { isObjectRecord, ownDataProperty } from "../helpers/records.js";
+
+interface GeneratedAuthorizationResult {
+  readonly decision: boolean;
+
+  readonly requestId: string;
+
+  readonly reasons: readonly string[];
+
+  readonly errors: readonly CedarlingError[];
+}
+function copyStringArray(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    return undefined;
+  }
+  return [...value];
+}
+
+function copyPolicyErrors(
+  value: unknown,
+  operation: "authorizeUnsigned" | "authorizeMultiIssuer",
+): readonly CedarlingError[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const copied: CedarlingError[] = [];
+  for (const item of value) {
+    if (!isObjectRecord(item)) {
+      return undefined;
+    }
+    const id = ownDataProperty(item, "id");
+    const error = ownDataProperty(item, "error");
+    if (typeof id !== "string" || typeof error !== "string") {
+      return undefined;
+    }
+    copied.push(createPolicyEvaluationError(id, error, operation));
+  }
+  return copied;
+}
+
+/**
+ * Validates the binding's serialized result protocol.
+ *
+ * Malformed JSON is a conversion failure. Valid JSON with an incompatible
+ * generated field layout is an adapter protocol failure.
+ */
+export function parseGeneratedResult(
+  serialized: string,
+  operation: "authorizeUnsigned" | "authorizeMultiIssuer",
+): GeneratedAuthorizationResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(serialized) as unknown;
+  } catch (error: unknown) {
+    throw createSdkError(
+      errorCode.resultConversionFailed,
+      operation,
+      { rawCause: error },
+    );
+  }
+
+  if (!isObjectRecord(value)) {
+    throw createSdkError(
+      errorCode.generatedProtocolError,
+      operation,
+    );
+  }
+
+  const decision = ownDataProperty(value, "decision");
+  const requestId = ownDataProperty(value, "request_id");
+  const response = ownDataProperty(value, "response");
+  if (
+    typeof decision !== "boolean" ||
+    typeof requestId !== "string" ||
+    !isObjectRecord(response)
+  ) {
+    throw createSdkError(
+      errorCode.generatedProtocolError,
+      operation,
+    );
+  }
+
+  const diagnostics = ownDataProperty(response, "diagnostics");
+  if (!isObjectRecord(diagnostics)) {
+    throw createSdkError(
+      errorCode.generatedProtocolError,
+      operation,
+    );
+  }
+
+  const reasons = copyStringArray(ownDataProperty(diagnostics, "reason"));
+  const errors = copyPolicyErrors(
+    ownDataProperty(diagnostics, "errors"),
+    operation,
+  );
+  if (reasons === undefined || errors === undefined) {
+    throw createSdkError(
+      errorCode.generatedProtocolError,
+      operation,
+    );
+  }
+
+  return { decision, requestId, reasons, errors };
+}
+
+export function toAuthorizationDecision(
+  parsed: GeneratedAuthorizationResult,
+): AuthorizationDecision {
+  return {
+    decision: parsed.decision,
+    requestId: parsed.requestId,
+    diagnostics: {
+      reasons: [...parsed.reasons],
+      errors: [...parsed.errors],
+    },
+  };
+}
+
+function toGeneratedEntity(entity: CedarEntity): Record<string, unknown> {
+  return {
+    ...entity.attributes,
+    cedar_entity_mapping: {
+      entity_type: entity.type,
+      id: entity.id,
+    },
+  };
+}
+
+function toGeneratedAuthorizationTarget(
+  request: UnsignedAuthorizationRequest | MultiIssuerAuthorizationRequest,
+): Record<string, unknown> {
+  return {
+    action: request.action,
+    resource: toGeneratedEntity(request.resource),
+    context: request.context ?? {},
+  };
+}
+
+export function toGeneratedRequest(
+  request: UnsignedAuthorizationRequest,
+): Record<string, unknown> {
+  return {
+    ...(request.principal === undefined
+      ? {}
+      : { principal: toGeneratedEntity(request.principal) }),
+    ...toGeneratedAuthorizationTarget(request),
+  };
+}
+
+export function toGeneratedMultiIssuerRequest(
+  request: MultiIssuerAuthorizationRequest,
+): Record<string, unknown> {
+  return {
+    tokens: request.tokens.map((token) => ({
+      mapping: token.mapping,
+      payload: token.payload,
+    })),
+    ...toGeneratedAuthorizationTarget(request),
+  };
+}

--- a/jans-cedarling/bindings/cedarling_js/src/engine/generated-wrapper.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/generated-wrapper.ts
@@ -1,0 +1,126 @@
+import { errorCode, type CedarlingOperation } from "../errors/types.js";
+import { createSdkError } from "../errors/errors.js";
+
+export interface GeneratedClientBoundary {
+  authorizeUnsigned(request: string): Promise<unknown>;
+  authorizeMultiIssuer(request: string): Promise<unknown>;
+  shutDown(): Promise<unknown>;
+  dispose(): void;
+}
+
+export interface GeneratedResultBoundary {
+  jsonString(): unknown;
+  dispose(): void;
+}
+
+function isObjectLike(value: unknown): value is object {
+  return (
+    (typeof value === "object" && value !== null) ||
+    typeof value === "function"
+  );
+}
+
+export function hasGeneratedModuleOutput(value: unknown): boolean {
+  if (!isObjectLike(value)) return false;
+  try {
+    return Reflect.has(value, "memory");
+  } catch {
+    return false;
+  }
+}
+
+function readMethod(
+  value: object,
+  name: PropertyKey,
+): ((...arguments_: unknown[]) => unknown) | undefined {
+  try {
+    const method = Reflect.get(value, name) as unknown;
+    return typeof method === "function"
+      ? method as (...arguments_: unknown[]) => unknown
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function withGeneratedWrapper<T>(
+  wrapper: { dispose(): void },
+  operation: CedarlingOperation,
+  convert: () => T,
+): T {
+  try {
+    return convert();
+  } finally {
+    try {
+      wrapper.dispose();
+    } catch (error: unknown) {
+      throw createSdkError(errorCode.generatedProtocolError, operation, {
+        rawCause: error,
+      });
+    }
+  }
+}
+
+export function adaptGeneratedClient(
+  value: unknown,
+): GeneratedClientBoundary | undefined {
+  if (!isObjectLike(value)) return undefined;
+  const authorizeUnsigned = readMethod(value, "authorize_unsigned");
+  const authorizeMultiIssuer = readMethod(value, "authorize_multi_issuer");
+  const shutDown = readMethod(value, "shut_down");
+  const dispose = readMethod(value, "free");
+  if (
+    authorizeUnsigned === undefined ||
+    authorizeMultiIssuer === undefined ||
+    shutDown === undefined ||
+    dispose === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    async authorizeUnsigned(request: string): Promise<unknown> {
+      return authorizeUnsigned.call(value, request);
+    },
+    async authorizeMultiIssuer(request: string): Promise<unknown> {
+      return authorizeMultiIssuer.call(value, request);
+    },
+    async shutDown(): Promise<unknown> {
+      return shutDown.call(value);
+    },
+    dispose(): void {
+      dispose.call(value);
+    },
+  };
+}
+
+export function disposeUnadaptedGeneratedClient(value: unknown): void {
+  if (!isObjectLike(value)) return;
+  const dispose = readMethod(value, "free");
+  if (dispose === undefined) return;
+  try {
+    dispose.call(value);
+  } catch {
+    // The incompatible generated protocol remains the reported failure.
+  }
+}
+
+export function adaptGeneratedResult(
+  value: unknown,
+  operation: "authorizeUnsigned" | "authorizeMultiIssuer",
+): GeneratedResultBoundary | undefined {
+  if (!isObjectLike(value)) return undefined;
+  const jsonString = readMethod(value, "json_string");
+  const dispose = readMethod(value, "free");
+  if (dispose === undefined) return undefined;
+  return {
+    jsonString(): unknown {
+      if (jsonString === undefined) {
+        throw createSdkError(errorCode.generatedProtocolError, operation);
+      }
+      return jsonString.call(value);
+    },
+    dispose(): void {
+      dispose.call(value);
+    },
+  };
+}

--- a/jans-cedarling/bindings/cedarling_js/src/engine/generated-wrapper.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/generated-wrapper.ts
@@ -48,17 +48,23 @@ export function withGeneratedWrapper<T>(
   operation: CedarlingOperation,
   convert: () => T,
 ): T {
+  let outcome: { readonly value: T } | { readonly error: unknown };
   try {
-    return convert();
-  } finally {
-    try {
-      wrapper.dispose();
-    } catch (error: unknown) {
+    outcome = { value: convert() };
+  } catch (error: unknown) {
+    outcome = { error };
+  }
+  try {
+    wrapper.dispose();
+  } catch (error: unknown) {
+    if ("value" in outcome) {
       throw createSdkError(errorCode.generatedProtocolError, operation, {
         rawCause: error,
       });
     }
   }
+  if ("error" in outcome) throw outcome.error;
+  return outcome.value;
 }
 
 export function adaptGeneratedClient(

--- a/jans-cedarling/bindings/cedarling_js/src/engine/generated.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/generated.ts
@@ -1,0 +1,125 @@
+import type {
+  AuthorizationDecision,
+  MultiIssuerAuthorizationRequest,
+  UnsignedAuthorizationRequest,
+} from "../authorization/types.js";
+import type { CedarlingEngine } from "./engine.js";
+import { errorCode } from "../errors/types.js";
+import {
+  createSdkError,
+  isSdkErrorCode,
+} from "../errors/errors.js";
+import {
+  adaptGeneratedClient,
+  adaptGeneratedResult,
+  disposeUnadaptedGeneratedClient,
+  type GeneratedClientBoundary,
+  withGeneratedWrapper,
+} from "./generated-wrapper.js";
+import {
+  parseGeneratedResult,
+  toAuthorizationDecision,
+  toGeneratedMultiIssuerRequest,
+  toGeneratedRequest,
+} from "./generated-authorization.js";
+
+export { hasGeneratedModuleOutput } from "./generated-wrapper.js";
+
+class GeneratedCedarlingEngine implements CedarlingEngine {
+  readonly #generated: GeneratedClientBoundary;
+
+  constructor(generated: GeneratedClientBoundary) {
+    this.#generated = generated;
+  }
+
+  async #authorize(
+    operation: "authorizeUnsigned" | "authorizeMultiIssuer",
+    invoke: () => Promise<unknown>,
+  ): Promise<AuthorizationDecision> {
+    let generatedValue: unknown;
+    try {
+      generatedValue = await invoke();
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw createSdkError(errorCode.authorizationFailed, operation, {
+        details: { wasmMessage: message },
+        rawCause: error,
+      });
+    }
+    const result = adaptGeneratedResult(generatedValue, operation);
+    if (result === undefined) {
+      throw createSdkError(errorCode.generatedProtocolError, operation);
+    }
+    return withGeneratedWrapper(result, operation, () => {
+      let serialized: unknown;
+      try {
+        serialized = result.jsonString();
+      } catch (error: unknown) {
+        if (isSdkErrorCode(error, [errorCode.generatedProtocolError])) {
+          throw error;
+        }
+        throw createSdkError(errorCode.resultConversionFailed, operation, {
+          rawCause: error,
+        });
+      }
+      if (typeof serialized !== "string") {
+        throw createSdkError(errorCode.generatedProtocolError, operation);
+      }
+      return toAuthorizationDecision(
+        parseGeneratedResult(serialized, operation),
+      );
+    });
+  }
+
+  authorizeUnsigned(
+    request: UnsignedAuthorizationRequest,
+  ): Promise<AuthorizationDecision> {
+    return this.#authorize(
+      "authorizeUnsigned",
+      () => this.#generated.authorizeUnsigned(
+        JSON.stringify(toGeneratedRequest(request)),
+      ),
+    );
+  }
+
+  authorizeMultiIssuer(
+    request: MultiIssuerAuthorizationRequest,
+  ): Promise<AuthorizationDecision> {
+    return this.#authorize(
+      "authorizeMultiIssuer",
+      () => this.#generated.authorizeMultiIssuer(
+        JSON.stringify(toGeneratedMultiIssuerRequest(request)),
+      ),
+    );
+  }
+
+  async shutDown(): Promise<void> {
+    const failures: unknown[] = [];
+    try {
+      await this.#generated.shutDown();
+    } catch (error: unknown) {
+      failures.push(error);
+    }
+    try {
+      this.#generated.dispose();
+    } catch (error: unknown) {
+      failures.push(error);
+    }
+    if (failures.length > 0) {
+      throw createSdkError(errorCode.lifecycleFailed, "shutDown", {
+        rawCause: failures.length === 1 ? failures[0] : Object.freeze(failures),
+      });
+    }
+  }
+}
+
+export function createGeneratedEngine(
+  generatedValue: unknown,
+): CedarlingEngine | undefined {
+  const generated = adaptGeneratedClient(generatedValue);
+  if (generated === undefined) {
+    disposeUnadaptedGeneratedClient(generatedValue);
+    return undefined;
+  }
+  return new GeneratedCedarlingEngine(generated);
+}

--- a/jans-cedarling/bindings/cedarling_js/src/engine/generated.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/generated.ts
@@ -40,9 +40,7 @@ class GeneratedCedarlingEngine implements CedarlingEngine {
     try {
       generatedValue = await invoke();
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
       throw createSdkError(errorCode.authorizationFailed, operation, {
-        details: { wasmMessage: message },
         rawCause: error,
       });
     }

--- a/jans-cedarling/bindings/cedarling_js/src/engine/node.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/node.ts
@@ -1,0 +1,122 @@
+/// <reference types="node" />
+
+/**
+ * Node-family construction boundary for the generated `cedarling_wasm`
+ * package.
+ *
+ * This adapter resolves the generated dependency from the installed SDK,
+ * reads its adjacent WASM asset, and passes those bytes to the generated
+ * synchronous initializer. It does not depend on a consumer working directory,
+ * a global `fetch` patch, or repository-relative paths.
+ *
+ * `createRequire(import.meta.url)` is Node's documented ESM mechanism for
+ * module-relative CommonJS resolution:
+ * https://nodejs.org/api/module.html#modulecreaterequirefilename
+ */
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { EngineFactory } from "./engine.js";
+import { createSdkError } from "../errors/errors.js";
+import { errorCode } from "../errors/types.js";
+import {
+  createEngineFactory,
+  hasWebAssemblyConstructors,
+} from "./factory.js";
+
+/**
+ * Module reference for dependency resolution.
+ *
+ * The ESM build supplies `import.meta.url`; the bundled CommonJS build supplies
+ * `__filename`. In both formats resolution begins at the installed SDK rather
+ * than the application working directory.
+ */
+const moduleReference =
+  typeof __filename !== "undefined" ? __filename : import.meta.url;
+
+const localRequire = createRequire(moduleReference);
+
+/** Absolute generated-package locations resolved by the host module loader. */
+interface ResolvedGeneratedPackage {
+  readonly gluePath: string;
+
+  readonly wasmPath: string;
+}
+
+/** Resolves the generated package without exposing host resolver details. */
+function resolveRequiredGeneratedPackage(): ResolvedGeneratedPackage {
+  let gluePath: string;
+  try {
+    gluePath = localRequire.resolve("@janssenproject/cedarling_wasm");
+  } catch {
+    throw createSdkError(errorCode.wasmLoadFailed, "initialize");
+  }
+  return {
+    gluePath,
+    wasmPath: path.join(
+      path.dirname(gluePath),
+      "cedarling_wasm_bg.wasm",
+    ),
+  };
+}
+
+/** Generated module methods consumed by this runtime adapter. */
+interface CedarlingWasmModule {
+  readonly __wasm: unknown;
+  initSync(module: { module: Uint8Array }): unknown;
+  init(config: Readonly<Record<string, unknown>>): Promise<unknown>;
+}
+
+/**
+ * Imports generated ESM glue through a file URL.
+ *
+ * Node's ESM loader accepts `file:` URLs, and conversion avoids platform-
+ * specific path syntax in dynamic `import()`:
+ * https://nodejs.org/api/esm.html#urls
+ *
+ * Passing an already resolved package lets module initialization verify the
+ * adjacent WASM asset before importing generated glue.
+ */
+async function importGeneratedPackage(
+  resolved = resolveRequiredGeneratedPackage(),
+): Promise<CedarlingWasmModule> {
+  return (await import(
+    pathToFileURL(resolved.gluePath).href
+  )) as CedarlingWasmModule;
+}
+
+/**
+ * Reads the installed WASM asset into detached bytes.
+ *
+ * `undefined` deliberately hides filesystem and package-layout details from
+ * public initialization errors.
+ */
+function readGeneratedWasmBytes(
+  resolved: ResolvedGeneratedPackage,
+): Uint8Array | undefined {
+  try {
+    return new Uint8Array(readFileSync(resolved.wasmPath));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Once-per-realm Node-family engine factory used by the Node entry. */
+export const createNodeEngine: EngineFactory = createEngineFactory({
+  hasRequiredWebAssembly: hasWebAssemblyConstructors,
+  initializeGeneratedModule: async () => {
+    const resolved = resolveRequiredGeneratedPackage();
+    const wasmBytes = readGeneratedWasmBytes(resolved);
+    if (wasmBytes === undefined || wasmBytes.byteLength === 0) {
+      throw createSdkError(errorCode.wasmLoadFailed, "initialize");
+    }
+    const module = await importGeneratedPackage(resolved);
+    return module.__wasm ?? module.initSync({ module: wasmBytes });
+  },
+  initializeGeneratedClient: async (config) => {
+    const module = await importGeneratedPackage();
+    return module.init(config);
+  },
+});

--- a/jans-cedarling/bindings/cedarling_js/src/engine/web.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/engine/web.ts
@@ -1,0 +1,27 @@
+/**
+ * Browser construction boundary for the generated `cedarling_wasm` package.
+ *
+ * The wasm-bindgen Web target resolves its adjacent `.wasm` asset relative to
+ * the generated JavaScript module and fetches it through the standard Web
+ * loader contract. The SDK therefore delegates browser asset delivery to the
+ * generated package rather than patching `fetch` or deriving filesystem paths.
+ *
+ * Authoritative loader reference:
+ * https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html
+ */
+import initializeGeneratedModule, {
+  init as initializeGeneratedClient,
+} from "@janssenproject/cedarling_wasm";
+
+import { createEngineFactory } from "./factory.js";
+import type { EngineFactory } from "./engine.js";
+
+/** Once-per-realm browser engine factory used by the package root. */
+export const createWebEngine: EngineFactory = createEngineFactory({
+  hasRequiredWebAssembly: () =>
+    typeof WebAssembly === "object" &&
+    typeof WebAssembly.instantiate === "function" &&
+    typeof WebAssembly.Instance === "function",
+  initializeGeneratedModule,
+  initializeGeneratedClient,
+});

--- a/jans-cedarling/bindings/cedarling_js/src/entries/node.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/entries/node.ts
@@ -1,0 +1,5 @@
+import { createCedarlingForEngine } from "../client/client.js";
+import { createNodeEngine } from "../engine/node.js";
+
+export const createCedarling = createCedarlingForEngine(createNodeEngine);
+export type * from "../index.js";

--- a/jans-cedarling/bindings/cedarling_js/src/errors/errors.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/errors/errors.ts
@@ -14,7 +14,7 @@ const SAFE_DETAIL_FIELDS = [
   "runtimeCapability",
   "sourceType",
   "requestId",
-  "wasmMessage",
+  "policyId",
 ] as const;
 const SAFE_DETAIL_STRING_PATTERN = /^[A-Za-z][A-Za-z0-9._-]{0,79}$/u;
 const SAFE_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,80}$/u;
@@ -149,11 +149,10 @@ export function createPolicyEvaluationError(
     "authorizeUnsigned" | "authorizeMultiIssuer"
   >,
 ): CedarlingError {
-  return buildSdkError(
+  return createSdkError(
     errorCode.policyEvaluationFailed,
     operation,
-    message,
-    { details: Object.freeze({ policyId }) },
+    { details: { policyId }, rawCause: message },
   );
 }
 

--- a/jans-cedarling/bindings/cedarling_js/src/errors/errors.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/errors/errors.ts
@@ -1,0 +1,260 @@
+import type {
+  CedarlingError,
+  CedarlingErrorCode,
+  CedarlingOperation,
+} from "./types.js";
+import { errorCode } from "./types.js";
+import type { JsonObject, JsonValue } from "../values/types.js";
+import {
+  isPlainDataRecord,
+  ownEnumerableDataProperty,
+} from "../helpers/records.js";
+
+const SAFE_DETAIL_FIELDS = [
+  "runtimeCapability",
+  "sourceType",
+  "requestId",
+  "wasmMessage",
+] as const;
+const SAFE_DETAIL_STRING_PATTERN = /^[A-Za-z][A-Za-z0-9._-]{0,79}$/u;
+const SAFE_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,80}$/u;
+
+const ERROR_MESSAGES: Readonly<Record<CedarlingErrorCode, string>> = {
+  [errorCode.inputRequired]: "A required Cedarling input value is missing.",
+  [errorCode.inputInvalidType]:
+    "A Cedarling input value has an invalid type.",
+  [errorCode.inputInvalidFormat]:
+    "A Cedarling input value has an invalid format.",
+  [errorCode.inputOutOfRange]:
+    "A Cedarling input value is outside the supported range.",
+  [errorCode.inputUnknownField]: "A Cedarling input field is not supported.",
+  [errorCode.inputConflict]:
+    "A Cedarling input value conflicts with another field.",
+  [errorCode.inputUnsupported]: "A Cedarling input value is not supported.",
+  [errorCode.unsupportedRuntimeCapability]:
+    "The runtime does not support a required Cedarling capability.",
+  [errorCode.wasmLoadFailed]:
+    "The Cedarling WebAssembly module could not be loaded.",
+  [errorCode.initializationFailed]: "Cedarling initialization failed.",
+  [errorCode.authorizationFailed]: "Cedarling authorization failed.",
+  [errorCode.policyEvaluationFailed]: "A Cedar policy evaluation failed.",
+  [errorCode.clientClosed]: "The Cedarling client is closed.",
+  [errorCode.lifecycleFailed]: "The Cedarling lifecycle operation failed.",
+  [errorCode.resultConversionFailed]:
+    "A Cedarling result could not be converted.",
+  [errorCode.generatedProtocolError]:
+    "The Cedarling generated protocol is incompatible.",
+};
+
+const safeErrors = new WeakSet<object>();
+const rawErrorCauses = new WeakMap<object, unknown>();
+const exposedRawErrors = new WeakSet<object>();
+
+function sanitizeDetails(
+  details: Readonly<Record<string, unknown>> | undefined,
+): JsonObject | undefined {
+  if (details === undefined || !isPlainDataRecord(details, false)) {
+    return undefined;
+  }
+  const sanitized: Record<string, JsonValue> = {};
+  for (const key of SAFE_DETAIL_FIELDS) {
+    const value = ownEnumerableDataProperty(details, key);
+    if (typeof value === "string" && SAFE_DETAIL_STRING_PATTERN.test(value)) {
+      sanitized[key] = value;
+    }
+  }
+  return Object.keys(sanitized).length === 0
+    ? undefined
+    : Object.freeze(sanitized);
+}
+
+function sanitizePath(
+  path: readonly (string | number)[] | undefined,
+): readonly (string | number)[] | undefined {
+  if (path === undefined) return undefined;
+  const sanitized: (string | number)[] = [];
+  for (const segment of path) {
+    if (
+      (typeof segment === "number" &&
+        Number.isSafeInteger(segment) &&
+        segment >= 0) ||
+      (typeof segment === "string" && SAFE_PATH_SEGMENT_PATTERN.test(segment))
+    ) {
+      sanitized.push(segment);
+    }
+  }
+  return Object.freeze(sanitized);
+}
+
+const createErrorEnvelope = (
+  message: string,
+  code: CedarlingErrorCode,
+  operation: CedarlingOperation,
+) => Object.assign(new Error(message), {
+  name: "CedarlingError" as const,
+  code,
+  operation,
+});
+
+function buildSdkError(
+  code: CedarlingErrorCode,
+  operation: CedarlingOperation,
+  message: string,
+  options: {
+    readonly path?: readonly (string | number)[];
+    readonly details?: JsonObject;
+    readonly cause?: unknown;
+    readonly rawCause?: unknown;
+  } = {},
+): CedarlingError {
+  const error = createErrorEnvelope(message, code, operation);
+  if (options.path !== undefined) Object.assign(error, { path: options.path });
+  if (options.details !== undefined) {
+    Object.assign(error, { details: options.details });
+  }
+  if (
+    typeof options.cause === "object" &&
+    options.cause !== null &&
+    safeErrors.has(options.cause)
+  ) {
+    Object.assign(error, { cause: options.cause });
+  }
+  if ("rawCause" in options) rawErrorCauses.set(error, options.rawCause);
+  safeErrors.add(error);
+  return Object.freeze(error);
+}
+
+export function createSdkError(
+  code: CedarlingErrorCode,
+  operation: CedarlingOperation,
+  options: {
+    readonly path?: readonly (string | number)[];
+    readonly details?: Readonly<Record<string, unknown>>;
+    readonly cause?: unknown;
+    readonly rawCause?: unknown;
+  } = {},
+): CedarlingError {
+  return buildSdkError(code, operation, ERROR_MESSAGES[code], {
+    ...options,
+    path: sanitizePath(options.path),
+    details: sanitizeDetails(options.details),
+  });
+}
+
+export function createPolicyEvaluationError(
+  policyId: string,
+  message: string,
+  operation: Extract<
+    CedarlingOperation,
+    "authorizeUnsigned" | "authorizeMultiIssuer"
+  >,
+): CedarlingError {
+  return buildSdkError(
+    errorCode.policyEvaluationFailed,
+    operation,
+    message,
+    { details: Object.freeze({ policyId }) },
+  );
+}
+
+export function exposeSdkErrorCause(
+  error: CedarlingError,
+): CedarlingError {
+  if (exposedRawErrors.has(error) || !rawErrorCauses.has(error)) {
+    return error;
+  }
+  const exposed = createErrorEnvelope(
+    error.message,
+    error.code,
+    error.operation,
+  );
+  if (error.path !== undefined) Object.assign(exposed, { path: error.path });
+  if (error.details !== undefined) {
+    Object.assign(exposed, { details: error.details });
+  }
+  Object.defineProperty(exposed, "cause", {
+    configurable: false,
+    enumerable: false,
+    value: rawErrorCauses.get(error),
+    writable: false,
+  });
+  safeErrors.add(exposed);
+  exposedRawErrors.add(exposed);
+  return Object.freeze(exposed);
+}
+
+function isSdkError(error: unknown): error is CedarlingError {
+  return typeof error === "object" && error !== null && safeErrors.has(error);
+}
+
+export function isSdkErrorCode(
+  error: unknown,
+  codes: readonly CedarlingErrorCode[],
+): error is CedarlingError {
+  return isSdkError(error) && codes.some((code) => code === error.code);
+}
+
+const isInputErrorCode = (code: CedarlingErrorCode): boolean =>
+  code.startsWith("INPUT_");
+
+export function createInputError(
+  code: CedarlingErrorCode,
+  operation: CedarlingOperation,
+  path: readonly (string | number)[] = [],
+): CedarlingError {
+  return createSdkError(
+    isInputErrorCode(code) ? code : errorCode.inputInvalidType,
+    operation,
+    { path },
+  );
+}
+
+export function normalizeInputError(
+  error: unknown,
+  operation: CedarlingOperation,
+  path: readonly (string | number)[] = [],
+): CedarlingError {
+  return isSdkError(error) && isInputErrorCode(error.code)
+    ? createInputError(error.code, operation, [...path, ...(error.path ?? [])])
+    : createInputError(errorCode.inputInvalidType, operation, path);
+}
+
+function operationErrorPolicy(operation: CedarlingOperation) {
+  const shared = [
+    errorCode.resultConversionFailed,
+    errorCode.generatedProtocolError,
+  ] as const;
+  if (operation.startsWith("authorize")) {
+    return {
+      fallback: errorCode.authorizationFailed,
+      allowed: [errorCode.authorizationFailed, ...shared],
+    } as const;
+  }
+  if (operation === "shutDown") {
+    return {
+      fallback: errorCode.lifecycleFailed,
+      allowed: [errorCode.lifecycleFailed, ...shared],
+    } as const;
+  }
+  return {
+    fallback: errorCode.initializationFailed,
+    allowed: [
+      errorCode.initializationFailed,
+      errorCode.unsupportedRuntimeCapability,
+      errorCode.wasmLoadFailed,
+      ...shared,
+    ],
+  } as const;
+}
+
+export function normalizeOperationError(
+  error: unknown,
+  operation: CedarlingOperation,
+  exposeRawErrors: boolean,
+): CedarlingError {
+  const policy = operationErrorPolicy(operation);
+  const normalized = isSdkErrorCode(error, policy.allowed)
+    ? error
+    : createSdkError(policy.fallback, operation, { rawCause: error });
+  return exposeRawErrors ? exposeSdkErrorCause(normalized) : normalized;
+}

--- a/jans-cedarling/bindings/cedarling_js/src/errors/types.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/errors/types.ts
@@ -1,0 +1,46 @@
+import type { JsonObject } from "../values/types.js";
+
+export type Result<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: CedarlingError };
+
+export type CedarlingOperation =
+  | "initialize"
+  | "authorizeUnsigned"
+  | "authorizeMultiIssuer"
+  | "shutDown";
+
+export const errorCode = Object.freeze({
+  inputRequired: "INPUT_REQUIRED",
+  inputInvalidType: "INPUT_INVALID_TYPE",
+  inputInvalidFormat: "INPUT_INVALID_FORMAT",
+  inputOutOfRange: "INPUT_OUT_OF_RANGE",
+  inputUnknownField: "INPUT_UNKNOWN_FIELD",
+  inputConflict: "INPUT_CONFLICT",
+  inputUnsupported: "INPUT_UNSUPPORTED",
+
+  unsupportedRuntimeCapability: "UNSUPPORTED_RUNTIME_CAPABILITY",
+  wasmLoadFailed: "WASM_LOAD_FAILED",
+  initializationFailed: "INITIALIZATION_FAILED",
+
+  authorizationFailed: "AUTHORIZATION_FAILED",
+  policyEvaluationFailed: "POLICY_EVALUATION_FAILED",
+
+  clientClosed: "CLIENT_CLOSED",
+  lifecycleFailed: "LIFECYCLE_FAILED",
+
+  resultConversionFailed: "RESULT_CONVERSION_FAILED",
+  generatedProtocolError: "GENERATED_PROTOCOL_ERROR",
+} as const);
+
+export type CedarlingErrorCode =
+  (typeof errorCode)[keyof typeof errorCode];
+
+export interface CedarlingError extends Error {
+  readonly name: "CedarlingError";
+  readonly code: CedarlingErrorCode;
+  readonly operation: CedarlingOperation;
+  readonly path?: readonly (string | number)[];
+  readonly details?: JsonObject;
+  readonly cause?: unknown;
+}

--- a/jans-cedarling/bindings/cedarling_js/src/helpers/constants.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/helpers/constants.ts
@@ -1,0 +1,67 @@
+export const DEFAULTS = Object.freeze({
+  authorization: {
+    decisionLogTokenIdClaim: "jti",
+    disableSchemaValidation: false,
+  },
+  client: {
+    exposeRawErrors: false,
+  },
+  jwt: {
+    disableSignatureValidation: false,
+    disableStatusValidation: false,
+  },
+} as const);
+
+export const JWT_ALGORITHMS = [
+  "HS256",
+  "HS384",
+  "HS512",
+  "ES256",
+  "ES384",
+  "RS256",
+  "RS384",
+  "RS512",
+  "PS256",
+  "PS384",
+  "PS512",
+  "EdDSA",
+] as const;
+
+export const JWT_ALGORITHM_SET: ReadonlySet<string> =
+  new Set(JWT_ALGORITHMS);
+
+export const CEDAR_EXTENSION_FUNCTIONS = [
+  "decimal",
+  "ip",
+  "datetime",
+  "duration",
+] as const;
+
+export const CEDAR_EXTENSION_FUNCTION_SET: ReadonlySet<string> =
+  new Set(CEDAR_EXTENSION_FUNCTIONS);
+
+export const INPUT_FIELDS = Object.freeze({
+  action: ["namespace", "id"],
+  authorization: [
+    "dangerouslyDisableSchemaValidation",
+    "decisionLogTokenIdClaim",
+  ],
+  debug: ["dangerouslyExposeRawErrors"],
+  entity: ["type", "id", "attributes"],
+  jwt: [
+    "dangerouslyDisableSignatureValidation",
+    "dangerouslyDisableStatusValidation",
+    "allowedAlgorithms",
+  ],
+  multiIssuerAuthorizationRequest: ["tokens", "action", "resource", "context"],
+  policyInline: ["type", "document"],
+  token: ["mapping", "payload"],
+  webNativeOptions: [
+    "applicationName",
+    "policyStore",
+    "debug",
+    "authorization",
+    "jwt",
+  ],
+  unsignedAuthorizationRequest: ["principal", "action", "resource", "context"],
+} as const);

--- a/jans-cedarling/bindings/cedarling_js/src/helpers/constants.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/helpers/constants.ts
@@ -1,4 +1,9 @@
-export const DEFAULTS = Object.freeze({
+function freezeValues<T extends Record<string, object>>(record: T): Readonly<T> {
+  for (const value of Object.values(record)) Object.freeze(value);
+  return Object.freeze(record);
+}
+
+export const DEFAULTS = freezeValues({
   authorization: {
     decisionLogTokenIdClaim: "jti",
     disableSchemaValidation: false,
@@ -40,7 +45,7 @@ export const CEDAR_EXTENSION_FUNCTIONS = [
 export const CEDAR_EXTENSION_FUNCTION_SET: ReadonlySet<string> =
   new Set(CEDAR_EXTENSION_FUNCTIONS);
 
-export const INPUT_FIELDS = Object.freeze({
+export const INPUT_FIELDS = freezeValues({
   action: ["namespace", "id"],
   authorization: [
     "dangerouslyDisableSchemaValidation",

--- a/jans-cedarling/bindings/cedarling_js/src/helpers/records.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/helpers/records.ts
@@ -1,0 +1,115 @@
+/** Host-neutral structural inspection of caller- and adapter-owned values. */
+
+export type DataRecord = Readonly<Record<string, unknown>>;
+
+/** Neutral classification of one own JavaScript property descriptor. */
+export type OwnPropertyInspection =
+  | { readonly kind: "missing" }
+  | { readonly kind: "accessor"; readonly enumerable: boolean }
+  | {
+      readonly kind: "data";
+      readonly enumerable: boolean;
+      readonly value: unknown;
+    };
+
+/** Reports whether a value is a non-null, non-array object record. */
+export function isObjectRecord(
+  value: unknown,
+): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Reports whether a value is an ordinary data record. */
+export function isPlainDataRecord(
+  value: unknown,
+  allowNullPrototype: boolean,
+): value is DataRecord {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  const prototype: unknown = Object.getPrototypeOf(value);
+  return (
+    prototype === Object.prototype ||
+    (allowNullPrototype && prototype === null)
+  );
+}
+
+/** Classifies a descriptor without evaluating an accessor. */
+export function inspectPropertyDescriptor(
+  descriptor: PropertyDescriptor | undefined,
+): OwnPropertyInspection {
+  if (descriptor === undefined) {
+    return { kind: "missing" };
+  }
+  if (!("value" in descriptor)) {
+    return {
+      kind: "accessor",
+      enumerable: descriptor.enumerable === true,
+    };
+  }
+  return {
+    kind: "data",
+    enumerable: descriptor.enumerable === true,
+    value: descriptor.value,
+  };
+}
+
+/** Reads and classifies one own property without evaluating an accessor. */
+export function inspectOwnProperty(
+  value: object,
+  key: PropertyKey,
+): OwnPropertyInspection {
+  return inspectPropertyDescriptor(Object.getOwnPropertyDescriptor(value, key));
+}
+
+/** Lists own enumerable string keys without evaluating accessors. */
+export function ownEnumerableStringKeys(value: object): readonly string[] {
+  return Object.keys(value);
+}
+
+/** Reads one own data property, including a non-enumerable property. */
+export function ownDataProperty(value: object, key: PropertyKey): unknown {
+  const property = inspectOwnProperty(value, key);
+  return property.kind === "data" ? property.value : undefined;
+}
+
+/** Result of descriptor-safe dense-array inspection. */
+export type DenseArrayInspection =
+  | { readonly kind: "values"; readonly values: readonly unknown[] }
+  | { readonly kind: "invalid"; readonly index?: number };
+
+/** Reads a dense array without invoking accessors. */
+export function inspectDenseArray(
+  value: readonly unknown[],
+): DenseArrayInspection {
+  const ownKeys = Reflect.ownKeys(value);
+  if (
+    ownKeys.some((key) => typeof key === "symbol") ||
+    ownKeys.length !== value.length + 1
+  ) {
+    return { kind: "invalid" };
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const values: unknown[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const property = inspectPropertyDescriptor(descriptors[String(index)]);
+    if (property.kind !== "data" || !property.enumerable) {
+      return { kind: "invalid", index };
+    }
+    values.push(property.value);
+  }
+  return { kind: "values", values };
+}
+
+/** Reads one own enumerable data property without invoking accessors. */
+export function ownEnumerableDataProperty(
+  value: object,
+  key: PropertyKey,
+): unknown {
+  const property = inspectOwnProperty(value, key);
+  return property.kind === "data" && property.enumerable
+    ? property.value
+    : undefined;
+}

--- a/jans-cedarling/bindings/cedarling_js/src/helpers/validation.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/helpers/validation.ts
@@ -1,0 +1,141 @@
+/** Reusable validation mechanics for untrusted JavaScript input records. */
+import { createInputError } from "../errors/errors.js";
+import type {
+  CedarlingErrorCode,
+  CedarlingOperation,
+} from "../errors/types.js";
+import { errorCode } from "../errors/types.js";
+import {
+  inspectOwnProperty,
+  isPlainDataRecord,
+  ownEnumerableStringKeys,
+  type DataRecord,
+} from "./records.js";
+
+/** Descriptor handling policies shared by feature input validators. */
+export const FIELD_BEHAVIORS = Object.freeze({
+  rejectAccessors: {
+    accessor: "alwaysInvalid",
+  },
+  strictEnumerableData: {
+    accessor: "alwaysInvalid",
+    nonEnumerableData: "invalid",
+  },
+} as const);
+
+/** Creates one validator scoped to an exact public operation. */
+export function createInputValidator(
+  operation: CedarlingOperation,
+  defaults: {
+    readonly allowNullPrototype?: boolean;
+    readonly stringNormalization?: "preserve" | "trim";
+  } = {},
+) {
+  function invalid(
+    code: CedarlingErrorCode,
+    path: readonly (string | number)[] = [],
+  ): never {
+    throw createInputError(code, operation, path);
+  }
+
+  function record(
+    value: unknown,
+    path: readonly (string | number)[],
+  ): DataRecord {
+    return isPlainDataRecord(value, defaults.allowNullPrototype === true)
+      ? value
+      : invalid(errorCode.inputInvalidType, path);
+  }
+
+  function field(
+    value: DataRecord,
+    key: string,
+    path: readonly (string | number)[],
+    behavior: {
+      readonly accessor?: "alwaysInvalid" | "invalidWhenEnumerable";
+      readonly nonEnumerableData?: "invalid" | "missing";
+    } = {},
+  ): unknown {
+    const property = inspectOwnProperty(value, key);
+    if (property.kind === "missing") {
+      return undefined;
+    }
+    if (property.kind === "accessor") {
+      const invalidAccessor =
+        behavior.accessor === "alwaysInvalid" || property.enumerable;
+      return invalidAccessor
+        ? invalid(errorCode.inputInvalidType, [...path, key])
+        : undefined;
+    }
+    if (!property.enumerable) {
+      return behavior.nonEnumerableData === "invalid"
+        ? invalid(errorCode.inputInvalidType, [...path, key])
+        : undefined;
+    }
+    return property.value;
+  }
+
+  function exactFields(
+    value: DataRecord,
+    allowed: readonly string[],
+    path: readonly (string | number)[],
+  ): void {
+    for (const key of ownEnumerableStringKeys(value)) {
+      if (!allowed.includes(key)) {
+        invalid(errorCode.inputUnknownField, [...path, key]);
+      }
+    }
+  }
+
+  function requiredString(
+    value: unknown,
+    path: readonly (string | number)[],
+    behavior: {
+      readonly empty?: "empty" | "blank";
+      readonly normalize?: "preserve" | "trim";
+      readonly missingIsInvalidType?: boolean;
+    } = {},
+  ): string {
+    if (typeof value !== "string") {
+      return invalid(
+        value === undefined
+          ? behavior.missingIsInvalidType === true
+            ? errorCode.inputInvalidType
+            : errorCode.inputRequired
+          : errorCode.inputInvalidType,
+        path,
+      );
+    }
+    const blank = behavior.empty === "empty"
+      ? value.length === 0
+      : value.trim().length === 0;
+    if (blank) {
+      return invalid(errorCode.inputRequired, path);
+    }
+    return (behavior.normalize ?? defaults.stringNormalization) === "trim"
+      ? value.trim()
+      : value;
+  }
+
+  return Object.freeze({
+    exactFields,
+    field,
+    invalid,
+    record,
+    requiredString,
+  });
+}
+
+/** Reports whether a value is a safe integer inside an inclusive range. */
+export function isSafeIntegerInRange(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= minimum &&
+    value <= maximum
+  );
+}

--- a/jans-cedarling/bindings/cedarling_js/src/index.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/index.ts
@@ -1,0 +1,37 @@
+import { createCedarlingForEngine } from "./client/client.js";
+import { createWebEngine } from "./engine/web.js";
+
+export const createCedarling = createCedarlingForEngine(createWebEngine);
+
+export type {
+  AuthorizationOptions,
+  CedarlingDebugOptions,
+  CedarlingOptions,
+  JwtAlgorithm,
+  JwtValidationOptions,
+} from "./configuration/types.js";
+export type {
+  CedarObject,
+  CedarExtensionFunction,
+  CedarExtensionValue,
+  CedarEntityReference,
+  JsonObject,
+  JsonValue,
+  CedarValue,
+  ContextDataValue,
+} from "./values/types.js";
+export type {
+  CedarAction,
+  CedarEntity,
+  TokenInput,
+  UnsignedAuthorizationRequest,
+  MultiIssuerAuthorizationRequest,
+  AuthorizationDecision,
+} from "./authorization/types.js";
+export type { CedarlingClient } from "./client/types.js";
+export type {
+  CedarlingOperation,
+  Result,
+  CedarlingError,
+  CedarlingErrorCode,
+} from "./errors/types.js";

--- a/jans-cedarling/bindings/cedarling_js/src/values/snapshot.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/values/snapshot.ts
@@ -1,0 +1,437 @@
+/**
+ * SDK-owned validation and snapshot helpers for every JSON-shaped public value.
+ *
+ * Traversal uses property descriptors instead of normal property access so
+ * accessors are rejected without executing application code.
+ */
+import type {
+  CedarEntityReference,
+  CedarExtensionFunction,
+  CedarExtensionValue,
+  CedarObject,
+  CedarValue,
+  JsonObject,
+  JsonValue,
+} from "./types.js";
+import { createInputError } from "../errors/errors.js";
+import { errorCode, type CedarlingOperation } from "../errors/types.js";
+import { CEDAR_EXTENSION_FUNCTION_SET } from "../helpers/constants.js";
+import {
+  inspectDenseArray,
+  inspectPropertyDescriptor,
+  isPlainDataRecord,
+} from "../helpers/records.js";
+
+/** Raises the single public error shape without retaining the rejected value. */
+function invalidValue(operation: CedarlingOperation): never {
+  throw createInputError(errorCode.inputInvalidType, operation);
+}
+
+/** Returns an enumerable data-property value without invoking accessors. */
+function dataPropertyValue(
+  descriptor: PropertyDescriptor | undefined,
+  operation: CedarlingOperation,
+): unknown {
+  const property = inspectPropertyDescriptor(descriptor);
+  if (property.kind !== "data" || !property.enumerable) {
+    return invalidValue(operation);
+  }
+
+  return property.value;
+}
+
+/** Recursive snapshot function shared by array and object traversal. */
+type SnapshotValue<T> = (
+  value: unknown,
+  ancestors: WeakSet<object>,
+  operation: CedarlingOperation,
+) => T;
+
+/**
+ * Copies a dense array using descriptors.
+ *
+ * Sparse arrays, symbol properties, accessors, and extra own properties are
+ * rejected because they do not have a lossless Cedar/JSON representation.
+ */
+function snapshotArray<T>(
+  value: readonly unknown[],
+  ancestors: WeakSet<object>,
+  snapshotValue: SnapshotValue<T>,
+  operation: CedarlingOperation,
+): readonly T[] {
+  const inspected = inspectDenseArray(value);
+  if (inspected.kind === "invalid") {
+    return invalidValue(operation);
+  }
+
+  const snapshot: T[] = [];
+  for (const item of inspected.values) {
+    snapshot.push(snapshotValue(item, ancestors, operation));
+  }
+
+  return snapshot;
+}
+
+/**
+ * Enumerates a plain data object without evaluating getters.
+ *
+ * Only ordinary or null prototypes are accepted; class instances and other
+ * behavior-bearing objects must be converted by the caller first.
+ */
+function plainObjectEntries(
+  value: object,
+  operation: CedarlingOperation,
+): readonly (readonly [string, unknown])[] {
+  if (!isPlainDataRecord(value, true)) {
+    return invalidValue(operation);
+  }
+
+  const ownKeys = Reflect.ownKeys(value);
+
+  if (ownKeys.some((key) => typeof key === "symbol")) {
+    return invalidValue(operation);
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const entries: [string, unknown][] = [];
+
+  for (const key of ownKeys) {
+    if (typeof key !== "string") {
+      return invalidValue(operation);
+    }
+
+    entries.push([key, dataPropertyValue(descriptors[key], operation)]);
+  }
+
+  return entries;
+}
+
+/** Recursively copies entries from a previously validated plain object. */
+function snapshotObject<T>(
+  value: object,
+  ancestors: WeakSet<object>,
+  snapshotValue: SnapshotValue<T>,
+  operation: CedarlingOperation,
+): Readonly<Record<string, T>> {
+  const snapshot: Record<string, T> = Object.create(null) as Record<string, T>;
+
+  for (const [key, item] of plainObjectEntries(value, operation)) {
+    snapshot[key] = snapshotValue(item, ancestors, operation);
+  }
+
+  return snapshot;
+}
+
+/** Validates a root object and starts cycle tracking for recursive traversal. */
+function snapshotRootObject<T>(
+  value: unknown,
+  snapshotValue: SnapshotValue<T>,
+  operation: CedarlingOperation,
+): Readonly<Record<string, T>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return invalidValue(operation);
+  }
+
+  const ancestors = new WeakSet<object>();
+  ancestors.add(value);
+
+  try {
+    return snapshotObject(value, ancestors, snapshotValue, operation);
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+/**
+ * Canonically validates and copies one Cedar-compatible value.
+ *
+ * Entity attributes, request context, and retained context data share one
+ * representation and traversal policy.
+ */
+const snapshotCedarValueInner: SnapshotValue<CedarValue> =
+  (value, ancestors, operation) => {
+    if (typeof value === "boolean" || typeof value === "string") {
+      return value;
+    }
+
+    if (typeof value === "number") {
+      if (!Number.isSafeInteger(value)) {
+        return invalidValue(operation);
+      }
+
+      return value;
+    }
+
+    if (value === null || typeof value !== "object") {
+      return invalidValue(operation);
+    }
+
+    if (ancestors.has(value)) {
+      return invalidValue(operation);
+    }
+
+    ancestors.add(value);
+
+    try {
+      if (Array.isArray(value)) {
+        return snapshotArray(
+          value,
+          ancestors,
+          snapshotCedarValueInner,
+          operation,
+        );
+      }
+
+      if (Reflect.ownKeys(value).includes("__entity")) {
+        return snapshotCedarEntityReference(value, operation);
+      }
+
+      if (Reflect.ownKeys(value).includes("__extn")) {
+        return snapshotCedarExtension(value, operation);
+      }
+
+      if (Reflect.ownKeys(value).includes("cedar_entity_mapping")) {
+        return invalidValue(operation);
+      }
+
+      return snapshotObject(
+        value,
+        ancestors,
+        snapshotCedarValueInner,
+        operation,
+      );
+    } finally {
+      ancestors.delete(value);
+    }
+  };
+
+/**
+ * Validates and detaches one Cedar entity-attribute value.
+ *
+ * @param value - Untrusted JavaScript input.
+ * @returns An SDK-owned Cedar value.
+ * @throws A branded Cedarling error when the value is not losslessly
+ * representable.
+ */
+export function snapshotCedarValue(
+  value: unknown,
+  operation: CedarlingOperation,
+): CedarValue {
+  return snapshotCedarValueInner(value, new WeakSet<object>(), operation);
+}
+
+/**
+ * Validates and detaches a root Cedar entity-attributes object.
+ *
+ * @param value - Untrusted JavaScript input.
+ * @returns An SDK-owned Cedar object.
+ */
+export function snapshotCedarObject(
+  value: unknown,
+  operation: CedarlingOperation,
+): CedarObject {
+  return snapshotRootObject(
+    value,
+    snapshotCedarValueInner,
+    operation,
+  );
+}
+
+/** Narrows a string to a supported Cedar extension function. */
+function isCedarExtensionFunction(
+  value: string,
+): value is CedarExtensionFunction {
+  return CEDAR_EXTENSION_FUNCTION_SET.has(value);
+}
+
+/**
+ * Validates an exact `{ __extn: { fn, arg } }` marker.
+ *
+ * Extra outer or inner fields are rejected so ordinary context objects cannot
+ * be confused with extension values.
+ */
+function snapshotCedarExtension(
+  value: object,
+  operation: CedarlingOperation,
+): CedarExtensionValue {
+  const outerEntries = plainObjectEntries(value, operation);
+
+  if (
+    outerEntries.length !== 1 ||
+    outerEntries[0]?.[0] !== "__extn" ||
+    outerEntries[0][1] === null ||
+    typeof outerEntries[0][1] !== "object" ||
+    Array.isArray(outerEntries[0][1])
+  ) {
+    return invalidValue(operation);
+  }
+
+  const innerEntries = plainObjectEntries(outerEntries[0][1], operation);
+  const inner = new Map(innerEntries);
+
+  if (
+    innerEntries.length !== 2 ||
+    !inner.has("fn") ||
+    !inner.has("arg")
+  ) {
+    return invalidValue(operation);
+  }
+
+  const fn = inner.get("fn");
+  const arg = inner.get("arg");
+
+  if (
+    typeof fn !== "string" ||
+    !isCedarExtensionFunction(fn) ||
+    typeof arg !== "string" ||
+    arg.trim().length === 0
+  ) {
+    return invalidValue(operation);
+  }
+
+  return {
+    __extn: {
+      fn,
+      arg,
+    },
+  };
+}
+
+/**
+ * Validates an exact `{ __entity: { type, id } }` marker.
+ *
+ * Extra outer or inner fields are rejected so ordinary context objects cannot
+ * be confused with entity references.
+ */
+function snapshotCedarEntityReference(
+  value: object,
+  operation: CedarlingOperation,
+): CedarEntityReference {
+  const outerEntries = plainObjectEntries(value, operation);
+
+  if (
+    outerEntries.length !== 1 ||
+    outerEntries[0]?.[0] !== "__entity"
+  ) {
+    return invalidValue(operation);
+  }
+
+  const entityValue = outerEntries[0][1];
+  if (
+    entityValue === null ||
+    typeof entityValue !== "object" ||
+    Array.isArray(entityValue)
+  ) {
+    return invalidValue(operation);
+  }
+
+  const innerEntries = plainObjectEntries(entityValue, operation);
+  const inner = new Map(innerEntries);
+
+  if (
+    innerEntries.length !== 2 ||
+    !inner.has("type") ||
+    !inner.has("id")
+  ) {
+    return invalidValue(operation);
+  }
+
+  const type = inner.get("type");
+  const id = inner.get("id");
+
+  if (
+    typeof type !== "string" ||
+    type.trim().length === 0 ||
+    typeof id !== "string" ||
+    id.trim().length === 0
+  ) {
+    return invalidValue(operation);
+  }
+
+  return {
+    __entity: {
+      type,
+      id,
+    },
+  };
+}
+
+/**
+ * Validates one JSON value while preserving nested `null` and finite
+ * fractional numbers.
+ */
+function snapshotJsonValueInner(
+  value: unknown,
+  ancestors: WeakSet<object>,
+  operation: CedarlingOperation,
+): JsonValue {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "string"
+  ) {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return invalidValue(operation);
+    }
+
+    if (Number.isInteger(value) && !Number.isSafeInteger(value)) {
+      return invalidValue(operation);
+    }
+
+    return value;
+  }
+
+  if (typeof value !== "object") {
+    return invalidValue(operation);
+  }
+
+  if (ancestors.has(value)) {
+    return invalidValue(operation);
+  }
+
+  ancestors.add(value);
+
+  try {
+    if (Array.isArray(value)) {
+      return snapshotArray(value, ancestors, snapshotJsonValueInner, operation);
+    }
+
+    return snapshotObject(value, ancestors, snapshotJsonValueInner, operation);
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+/**
+ * Validates and detaches one JSON-compatible value.
+ *
+ * @param value - Untrusted JavaScript input.
+ * @returns An SDK-owned JSON value.
+ */
+export function snapshotJsonValue(
+  value: unknown,
+  operation: CedarlingOperation,
+): JsonValue {
+  return snapshotJsonValueInner(value, new WeakSet<object>(), operation);
+}
+
+/**
+ * Validates and detaches a root JSON object.
+ *
+ * @param value - Untrusted JavaScript input.
+ * @returns An SDK-owned JSON object.
+ */
+export function snapshotJsonObject(
+  value: unknown,
+  operation: CedarlingOperation,
+): JsonObject {
+  return snapshotRootObject(
+    value,
+    snapshotJsonValueInner,
+    operation,
+  );
+}

--- a/jans-cedarling/bindings/cedarling_js/src/values/types.ts
+++ b/jans-cedarling/bindings/cedarling_js/src/values/types.ts
@@ -1,0 +1,74 @@
+import type { CEDAR_EXTENSION_FUNCTIONS } from "../helpers/constants.js";
+
+/**
+ * Readonly JSON-compatible value.
+ *
+ * Runtime validation additionally rejects non-finite and unsafe numbers,
+ * cyclic structures, sparse arrays, accessors, symbols, and behavior-bearing
+ * prototypes.
+ */
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export type JsonObject = Readonly<Record<string, JsonValue>>;
+
+/**
+ * Recursive value accepted in Cedar entity attributes.
+ *
+ * Plain numbers must be safe integers. Fractional and specialized values use
+ * an explicit {@link CedarExtensionValue}.
+ */
+export type CedarValue =
+  | boolean
+  | number
+  | string
+  | CedarExtensionValue
+  | CedarEntityReference
+  | readonly CedarValue[]
+  | { readonly [key: string]: CedarValue };
+
+export type CedarObject = Readonly<Record<string, CedarValue>>;
+
+export type CedarExtensionFunction =
+  (typeof CEDAR_EXTENSION_FUNCTIONS)[number];
+
+/**
+ * Explicit Cedar extension marker for request context.
+ *
+ * Plain request-context numbers must be safe integers. Use a `"decimal"`
+ * marker when a fractional Cedar value is required. The argument must be a
+ * non-empty canonical string.
+ */
+export interface CedarExtensionValue {
+  readonly __extn: {
+    readonly fn: CedarExtensionFunction;
+    readonly arg: string;
+  };
+}
+
+/**
+ * Cedar entity reference marker embedded in context or entity attributes.
+ *
+ * Cedar JSON represents entity references with a `{ __entity: { type, id } }`
+ * wrapper. The SDK validates the marker and passes it through to the core.
+ */
+export interface CedarEntityReference {
+  readonly __entity: {
+    readonly type: string;
+    readonly id: string;
+  };
+}
+
+/**
+ * Cedar-compatible value stored for later injection below `context.data`.
+ *
+ * The SDK validates only generic Cedar representation. The application remains
+ * responsible for defining the key and its exact type in the active policy
+ * store schema.
+ */
+export type ContextDataValue = CedarValue;

--- a/jans-cedarling/bindings/cedarling_js/tests/contract/authorize-multi-issuer.test.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/contract/authorize-multi-issuer.test.ts
@@ -1,0 +1,284 @@
+import type QUnitApi from "qunit";
+import {
+  type CedarlingClient,
+  type JsonObject,
+  type MultiIssuerAuthorizationRequest,
+} from "@janssenproject/cedarling";
+import { withCedarling } from "../run.js";
+import { createMultiIssuerPolicyStore } from "../fixtures/multi-issuer-policy-store.js";
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+/**
+ * Produces one well-formed HMAC-signed JWT for token-processing contracts.
+ *
+ * This suite deliberately disables signature verification; cryptographic
+ * verification is covered by the dedicated signature-validation E2E suite.
+ */
+async function signToken(claims: JsonObject): Promise<string> {
+  const encoder = new TextEncoder();
+  const header = base64Url(
+    encoder.encode(JSON.stringify({ alg: "HS256", typ: "JWT" })),
+  );
+  const payload = base64Url(encoder.encode(JSON.stringify(claims)));
+  const input = `${header}.${payload}`;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode("cedarling-js-contract-signing-key"),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(input),
+  );
+  return `${input}.${base64Url(new Uint8Array(signature))}`;
+}
+
+export default function registerMultiIssuerAuthorizationTests(
+  QUnit: QUnitApi,
+): void {
+  QUnit.module("authorize-multi-issuer");
+
+  async function withClient(
+    assert: Assert,
+    applicationName: string,
+    work: (client: CedarlingClient) => Promise<void>,
+  ): Promise<void> {
+    await withCedarling(assert, {
+      applicationName,
+      authorization: {
+        dangerouslyDisableSchemaValidation: true,
+      },
+      jwt: {
+        dangerouslyDisableSignatureValidation: true,
+        dangerouslyDisableStatusValidation: true,
+      },
+      policyStore: {
+        type: "inline",
+        document: createMultiIssuerPolicyStore(),
+      },
+    }, work);
+  }
+
+  async function accessToken(
+    id: string,
+    claims: JsonObject = {},
+  ): Promise<string> {
+    return await signToken({
+      iss: "https://issuer.example",
+      sub: "alice",
+      jti: id,
+      iat: 1_700_000_000,
+      exp: 4_000_000_000,
+      ...claims,
+    });
+  }
+
+  function request(
+    payloads: readonly string[],
+    action = 'Authorization::Action::"Read"',
+  ): MultiIssuerAuthorizationRequest {
+    return {
+      tokens: payloads.map((payload) => ({
+        mapping: "Authorization::AccessToken",
+        payload,
+      })),
+      action,
+      resource: {
+        type: "Authorization::Resource",
+        id: "document",
+      },
+    };
+  }
+
+  QUnit.test("authorizes one well-formed token set", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-multi-issuer-valid",
+      async (client) => {
+        const authorized = await client.authorizeMultiIssuer(
+          request([await accessToken("valid-token")]),
+        );
+
+        assert.true(authorized.ok, "the well-formed token set is processed");
+        if (authorized.ok) {
+          assert.true(authorized.value.decision);
+          assert.deepEqual(authorized.value.diagnostics.reasons, [
+            "token_present",
+          ]);
+        }
+      },
+    );
+  });
+
+  QUnit.test("expired and not-yet-valid token sets fail closed", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-multi-issuer-time",
+      async (client) => {
+        const expired = await accessToken("expired-token", { exp: 1 });
+        const future = await accessToken("future-token", {
+          nbf: 4_000_000_000,
+        });
+
+        for (
+          const [name, token] of [
+            ["expired", expired],
+            ["not-yet-valid", future],
+          ] as const
+        ) {
+          const authorized = await client.authorizeMultiIssuer(
+            request([token]),
+          );
+          assert.false(authorized.ok, `${name} token is rejected`);
+          if (!authorized.ok) {
+            assert.strictEqual(
+              authorized.error.code,
+              "AUTHORIZATION_FAILED",
+            );
+            assert.strictEqual(
+              authorized.error.operation,
+              "authorizeMultiIssuer",
+            );
+            assert.false(
+              JSON.stringify(authorized.error).includes(token),
+              "the rejected token is not disclosed",
+            );
+          }
+        }
+      },
+    );
+  });
+
+  QUnit.test("malformed and unknown-issuer token sets fail closed", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-multi-issuer-invalid",
+      async (client) => {
+        const unknownIssuer = await signToken({
+          iss: "https://unknown.example",
+          sub: "mallory",
+          jti: "unknown-issuer",
+          exp: 4_000_000_000,
+        });
+
+        for (
+          const [name, token] of [
+            ["malformed", "not-a-jwt"],
+            ["unknown issuer", unknownIssuer],
+          ] as const
+        ) {
+          const authorized = await client.authorizeMultiIssuer(
+            request([token]),
+          );
+          assert.false(authorized.ok, `${name} token is rejected`);
+          if (!authorized.ok) {
+            assert.strictEqual(
+              authorized.error.code,
+              "AUTHORIZATION_FAILED",
+            );
+            assert.false(
+              JSON.stringify(authorized.error).includes(token),
+              "the rejected token is not disclosed",
+            );
+          }
+        }
+      },
+    );
+  });
+
+  QUnit.test("a well-formed token survives a partially invalid token set", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-multi-issuer-partial",
+      async (client) => {
+        const authorized = await client.authorizeMultiIssuer(
+          request([await accessToken("valid-among-invalid"), "not-a-jwt"]),
+        );
+
+        assert.true(authorized.ok, "Cedarling ignores the malformed token");
+        if (authorized.ok) {
+          assert.true(authorized.value.decision);
+          assert.deepEqual(authorized.value.diagnostics.reasons, [
+            "token_present",
+          ]);
+        }
+      },
+    );
+  });
+
+  QUnit.test("duplicate mapped tokens are handled gracefully", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-multi-issuer-duplicate",
+      async (client) => {
+        const first = await accessToken("duplicate-first", {
+          scope: ["allow"],
+        });
+        const second = await accessToken("duplicate-second", {
+          scope: ["deny"],
+        });
+        const authorized = await client.authorizeMultiIssuer(
+          request([first, second]),
+        );
+
+        assert.true(authorized.ok, "duplicates are handled by Cedarling");
+        if (authorized.ok) {
+          assert.true(
+            authorized.value.decision,
+            "a duplicate does not erase the valid mapped token",
+          );
+          assert.deepEqual(authorized.value.diagnostics.reasons, [
+            "token_present",
+          ]);
+        }
+      },
+    );
+  });
+
+  QUnit.test("policy-store defaults override a colliding request resource", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-multi-issuer-default",
+      async (client) => {
+        const input = request(
+          [await accessToken("default-entity-token")],
+          'Authorization::Action::"Default"',
+        );
+        const authorized = await client.authorizeMultiIssuer({
+          ...input,
+          resource: {
+            type: "Authorization::Resource",
+            id: "default",
+            attributes: {
+              owner: "attacker",
+            },
+          },
+        });
+
+        assert.true(authorized.ok, "authorization completes");
+        if (authorized.ok) {
+          assert.true(
+            authorized.value.decision,
+            "policy-store entity data takes precedence",
+          );
+          assert.deepEqual(authorized.value.diagnostics.reasons, [
+            "default_entity",
+          ]);
+        }
+      },
+    );
+  });
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/contract/authorize-unsigned.test.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/contract/authorize-unsigned.test.ts
@@ -1,0 +1,336 @@
+import type QUnitApi from "qunit";
+import type { CedarlingClient } from "@janssenproject/cedarling";
+import {
+  tracerExtensionPolicyStore,
+  tracerPolicyStore,
+} from "../fixtures/tracer-policy-store.js";
+import { withCedarling } from "../run.js";
+
+function containsGeneratedSurface(
+  value: unknown,
+  visited = new Set<object>(),
+): boolean {
+  if (typeof value === "bigint" || value instanceof Map) {
+    return true;
+  }
+  if (typeof value !== "object" || value === null || visited.has(value)) {
+    return false;
+  }
+
+  visited.add(value);
+  if (
+    "free" in value ||
+    "memory" in value ||
+    (Symbol.dispose !== undefined && Symbol.dispose in value)
+  ) {
+    return true;
+  }
+
+  return Reflect.ownKeys(value).some((key) =>
+    containsGeneratedSurface(Reflect.get(value, key), visited)
+  );
+}
+
+export default function registerUnsignedAuthorizationTests(
+  QUnit: QUnitApi,
+): void {
+  QUnit.module("authorize-unsigned");
+
+  async function withClient(
+    assert: Assert,
+    applicationName: string,
+    work: (client: CedarlingClient) => Promise<void>,
+  ): Promise<void> {
+    await withCedarling(
+      assert,
+      {
+        applicationName,
+        policyStore: {
+          type: "inline",
+          document: tracerPolicyStore,
+        },
+      },
+      work,
+    );
+  }
+
+  QUnit.test("returns allow and deny as successful decisions", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-unsigned-decisions",
+      async (client) => {
+        const principal = {
+          type: "Tracer::User",
+          id: "alice",
+        };
+        const resource = {
+          type: "Tracer::Resource",
+          id: "document",
+        };
+
+        const allowed = await client.authorizeUnsigned({
+          principal,
+          action: 'Tracer::Action::"Read"',
+          resource,
+        });
+        const denied = await client.authorizeUnsigned({
+          principal,
+          action: 'Tracer::Action::"Deny"',
+          resource,
+        });
+
+        assert.true(allowed.ok, "allow is a successful authorization");
+        if (allowed.ok) {
+          assert.true(allowed.value.decision);
+          assert.false(
+            "allowed" in allowed,
+            "the canonical result has no flat allow shortcut",
+          );
+          assert.false(
+            "denied" in allowed,
+            "the canonical result has no flat deny shortcut",
+          );
+          assert.false(
+            "decision" in allowed,
+            "the decision remains under result.value",
+          );
+          assert.false(
+            "err" in allowed,
+            "errors use the canonical error field",
+          );
+          assert.deepEqual(allowed.value.diagnostics.reasons, ["allow"]);
+          assert.propEqual(
+            structuredClone(allowed.value),
+            allowed.value,
+            "the decision is ordinary structured-cloneable data",
+          );
+          assert.strictEqual(
+            Object.getPrototypeOf(allowed.value),
+            Object.prototype,
+            "the decision has a plain object prototype",
+          );
+          assert.false(
+            containsGeneratedSurface(allowed.value),
+            "no wrapper, disposal hook, memory, Map, or bigint escapes",
+          );
+        }
+        assert.true(denied.ok, "deny is not an operational failure");
+        if (denied.ok) {
+          assert.false(denied.value.decision);
+          assert.deepEqual(denied.value.diagnostics.reasons, []);
+        }
+      },
+    );
+  });
+
+  QUnit.test("accepts a structured Cedar action without exposing UID syntax", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-structured-action",
+      async (client) => {
+        const authorized = await client.authorizeUnsigned({
+          principal: {
+            type: "Tracer::User",
+            id: "alice",
+          },
+          action: {
+            namespace: "Tracer",
+            id: "Read",
+          },
+          resource: {
+            type: "Tracer::Resource",
+            id: "document",
+          },
+        });
+
+        assert.true(authorized.ok, "the SDK constructs the Cedar action UID");
+        if (authorized.ok) {
+          assert.true(authorized.value.decision);
+          assert.deepEqual(authorized.value.diagnostics.reasons, ["allow"]);
+        }
+      },
+    );
+  });
+
+  QUnit.test("omitted principals preserve partial evaluation and fail closed", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-unsigned-partial",
+      async (client) => {
+        const resource = {
+          type: "Tracer::Resource",
+          id: "document",
+        };
+
+        const publicResult = await client.authorizeUnsigned({
+          action: 'Tracer::Action::"Public"',
+          resource,
+        });
+        const protectedResult = await client.authorizeUnsigned({
+          action: 'Tracer::Action::"Protected"',
+          resource,
+        });
+
+        assert.true(publicResult.ok, "principal-independent policy resolves");
+        if (publicResult.ok) {
+          assert.true(publicResult.value.decision);
+          assert.deepEqual(publicResult.value.diagnostics.reasons, ["public"]);
+        }
+        assert.true(
+          protectedResult.ok,
+          "a residual is a decision, not an error",
+        );
+        if (protectedResult.ok) {
+          assert.false(protectedResult.value.decision);
+          assert.true(
+            protectedResult.value.diagnostics.reasons.includes("residual"),
+            "the residual policy ID is preserved",
+          );
+        }
+      },
+    );
+  });
+
+  QUnit.test("entity attributes are converted from a detached request snapshot", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-unsigned-entities",
+      async (client) => {
+        const principal = {
+          type: "Tracer::User",
+          id: "alice",
+          attributes: {
+            role: "editor",
+            labels: ["stable"],
+          },
+        };
+        const resource = {
+          type: "Tracer::Resource",
+          id: "document",
+          attributes: {
+            owner: "alice",
+          },
+        };
+
+        const pending = client.authorizeUnsigned({
+          principal,
+          action: 'Tracer::Action::"Edit"',
+          resource,
+        });
+
+        principal.attributes.role = "viewer";
+        principal.attributes.labels[0] = "mutated";
+        resource.attributes.owner = "mallory";
+
+        const authorized = await pending;
+        assert.true(authorized.ok, "authorization uses the accepted snapshot");
+        if (authorized.ok) {
+          assert.true(authorized.value.decision);
+          assert.deepEqual(authorized.value.diagnostics.reasons, [
+            "entity_attributes",
+          ]);
+        }
+      },
+    );
+  });
+
+  QUnit.test("canonical Cedar extension markers reach the engine unchanged", async (assert) => {
+    await withCedarling(assert, {
+      applicationName: "cedarling-js-unsigned-extension",
+      authorization: {
+        dangerouslyDisableSchemaValidation: true,
+      },
+      policyStore: {
+        type: "inline",
+        document: tracerExtensionPolicyStore,
+      },
+    }, async (client) => {
+      const authorized = await client.authorizeUnsigned({
+        principal: {
+          type: "Tracer::User",
+          id: "alice",
+        },
+        action: 'Tracer::Action::"Connect"',
+        resource: {
+          type: "Tracer::Resource",
+          id: "gateway",
+        },
+        context: {
+          network: {
+            __extn: {
+              fn: "ip",
+              arg: "192.0.2.42",
+            },
+          },
+        },
+      });
+
+      assert.true(authorized.ok, "the extension is accepted by Cedarling");
+      if (authorized.ok) {
+        assert.true(authorized.value.decision);
+        assert.deepEqual(authorized.value.diagnostics.reasons, ["network"]);
+      }
+    });
+  });
+
+  QUnit.test("an attribute-free resource resolves its policy-store default entity", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-unsigned-default-entity",
+      async (client) => {
+        const authorized = await client.authorizeUnsigned({
+          principal: {
+            type: "Tracer::User",
+            id: "alice",
+          },
+          action: 'Tracer::Action::"UseDefault"',
+          resource: {
+            type: "Tracer::Resource",
+            id: "default",
+          },
+        });
+
+        assert.true(authorized.ok, "the default entity is usable");
+        if (authorized.ok) {
+          assert.true(authorized.value.decision);
+          assert.deepEqual(authorized.value.diagnostics.reasons, [
+            "default_entity",
+          ]);
+        }
+      },
+    );
+  });
+
+  QUnit.test("rejects a whitespace-only entity type before authorization", async (assert) => {
+    await withClient(
+      assert,
+      "cedarling-js-unsigned-validation",
+      async (client) => {
+        const authorized = await client.authorizeUnsigned({
+          principal: {
+            type: " ",
+            id: "alice",
+          },
+          action: 'Tracer::Action::"Read"',
+          resource: {
+            type: "Tracer::Resource",
+            id: "document",
+          },
+        });
+
+        assert.false(authorized.ok, "the SDK rejects the invalid entity");
+        if (!authorized.ok) {
+          assert.strictEqual(authorized.error.code, "INPUT_REQUIRED");
+          assert.strictEqual(
+            authorized.error.operation,
+            "authorizeUnsigned",
+          );
+          assert.deepEqual(authorized.error.path, [
+            "principal",
+            "type",
+          ]);
+        }
+      },
+    );
+  });
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/contract/index.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/contract/index.ts
@@ -1,0 +1,6 @@
+import type { SuiteLoader } from "../run.js";
+
+export const contractSuites: readonly SuiteLoader[] = [
+  () => import("./authorize-unsigned.test.js"),
+  () => import("./authorize-multi-issuer.test.js"),
+];

--- a/jans-cedarling/bindings/cedarling_js/tests/fixtures/multi-issuer-policy-store.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/fixtures/multi-issuer-policy-store.ts
@@ -1,0 +1,52 @@
+export function createMultiIssuerPolicyStore(
+  openidConfigurationEndpoint =
+    "https://issuer.example/.well-known/openid-configuration",
+) {
+  return {
+    cedar_version: "v4.0.0",
+    policy_stores: {
+      multi_issuer: {
+        cedar_version: "v4.0.0",
+        name: "Multi issuer",
+        trusted_issuers: {
+          TestIssuer: {
+            name: "TestIssuer",
+            description: "Synthetic SDK contract issuer",
+            openid_configuration_endpoint: openidConfigurationEndpoint,
+            token_metadata: {
+              access_token: {
+                entity_type_name: "Authorization::AccessToken",
+              },
+            },
+          },
+        },
+        policies: {
+          token_present: {
+            description: "allow when the mapped access token is present",
+            creation_date: "2026-07-23T00:00:00Z",
+            policy_content: {
+              encoding: "none",
+              content_type: "cedar",
+              body:
+                'permit(principal, action == Authorization::Action::"Read", resource) when { context has tokens && context.tokens has testissuer_accesstoken };',
+            },
+          },
+          default_entity: {
+            description: "require policy-store-owned default resource data",
+            creation_date: "2026-07-23T00:00:00Z",
+            policy_content: {
+              encoding: "none",
+              content_type: "cedar",
+              body:
+                'permit(principal, action == Authorization::Action::"Default", resource) when { resource.owner == "trusted" };',
+            },
+          },
+        },
+        default_entities: {
+          default:
+            "eyJ1aWQiOnsidHlwZSI6IkF1dGhvcml6YXRpb246OlJlc291cmNlIiwiaWQiOiJkZWZhdWx0In0sImF0dHJzIjp7Im93bmVyIjoidHJ1c3RlZCJ9LCJwYXJlbnRzIjpbXX0=",
+        },
+      },
+    },
+  } as const;
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/fixtures/tracer-policy-store.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/fixtures/tracer-policy-store.ts
@@ -1,0 +1,102 @@
+export const tracerPolicyStore = {
+  cedar_version: "v4.0.0",
+  policy_stores: {
+    tracer: {
+      cedar_version: "v4.0.0",
+      name: "Tracer",
+      policies: {
+        allow: {
+          description: "allow the public tracer",
+          creation_date: "2026-07-23T00:00:00Z",
+          policy_content: {
+            encoding: "none",
+            content_type: "cedar",
+            body: 'permit(principal, action == Tracer::Action::"Read", resource);',
+          },
+        },
+        public: {
+          description: "allow a principal-independent public action",
+          creation_date: "2026-07-23T00:00:00Z",
+          policy_content: {
+            encoding: "none",
+            content_type: "cedar",
+            body:
+              'permit(principal, action == Tracer::Action::"Public", resource);',
+          },
+        },
+        residual: {
+          description: "require a principal attribute for a protected action",
+          creation_date: "2026-07-23T00:00:00Z",
+          policy_content: {
+            encoding: "none",
+            content_type: "cedar",
+            body:
+              'permit(principal, action == Tracer::Action::"Protected", resource) when { principal.is_ok };',
+          },
+        },
+        entity_attributes: {
+          description: "authorize detached entity attributes",
+          creation_date: "2026-07-23T00:00:00Z",
+          policy_content: {
+            encoding: "none",
+            content_type: "cedar",
+            body:
+              'permit(principal, action == Tracer::Action::"Edit", resource) when { principal.role == "editor" && principal.labels.contains("stable") && resource.owner == "alice" };',
+          },
+        },
+        default_entity: {
+          description: "authorize a policy-store-owned default resource",
+          creation_date: "2026-07-23T00:00:00Z",
+          policy_content: {
+            encoding: "none",
+            content_type: "cedar",
+            body:
+              'permit(principal, action == Tracer::Action::"UseDefault", resource) when { resource.owner == "trusted" };',
+          },
+        },
+      },
+      schema: {
+        encoding: "none",
+        content_type: "cedar",
+        body:
+          "namespace Tracer {\n" +
+          "entity User = { is_ok?: Bool, role?: String, labels?: Set<String> };\n" +
+          "entity Any;\n" +
+          "entity Resource = { owner?: String };\n" +
+          'action "Read" appliesTo { principal: [User], resource: [Resource], context: {} };\n' +
+          'action "Deny" appliesTo { principal: [User], resource: [Resource], context: {} };\n' +
+          'action "Public" appliesTo { principal: [Any], resource: [Resource], context: {} };\n' +
+          'action "Protected" appliesTo { principal: [User], resource: [Resource], context: {} };\n' +
+          'action "Edit" appliesTo { principal: [User], resource: [Resource], context: {} };\n' +
+          'action "UseDefault" appliesTo { principal: [User], resource: [Resource], context: {} };\n' +
+          "}",
+      },
+      default_entities: {
+        default:
+          "eyJ1aWQiOnsidHlwZSI6IlRyYWNlcjo6UmVzb3VyY2UiLCJpZCI6ImRlZmF1bHQifSwiYXR0cnMiOnsib3duZXIiOiJ0cnVzdGVkIn0sInBhcmVudHMiOltdfQ==",
+      },
+    },
+  },
+} as const;
+
+export const tracerExtensionPolicyStore = {
+  cedar_version: "v4.0.0",
+  policy_stores: {
+    tracer_extensions: {
+      cedar_version: "v4.0.0",
+      name: "Tracer extensions",
+      policies: {
+        network: {
+          description: "allow callers from the documentation network",
+          creation_date: "2026-07-23T00:00:00Z",
+          policy_content: {
+            encoding: "none",
+            content_type: "cedar",
+            body:
+              'permit(principal, action == Tracer::Action::"Connect", resource) when { context.network.isInRange(ip("192.0.2.0/24")) };',
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/jans-cedarling/bindings/cedarling_js/tests/run.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/run.ts
@@ -1,0 +1,51 @@
+import type QUnitApi from "qunit";
+import {
+  type CedarlingClient,
+  type CedarlingOptions,
+  createCedarling,
+} from "@janssenproject/cedarling";
+
+export type TestGroup = "unit" | "contract";
+export type TestSuite = (QUnit: QUnitApi) => void | Promise<void>;
+export type SuiteLoader = () => Promise<{ default: TestSuite }>;
+
+export async function withCedarling(
+  assert: Assert,
+  options: CedarlingOptions,
+  work: (client: CedarlingClient) => Promise<void>,
+): Promise<void> {
+  const created = await createCedarling(options);
+  assert.true(created.ok, "the real WASM client initializes");
+  if (!created.ok) return;
+  try {
+    await work(created.value);
+  } finally {
+    assert.true((await created.value.shutDown()).ok, "the client shuts down");
+  }
+}
+
+export async function runTestSuites(
+  QUnit: QUnitApi,
+  suiteLoaders: readonly SuiteLoader[],
+  filter?: string,
+): Promise<{ readonly failed: number }> {
+  QUnit.config.autostart = false;
+  QUnit.config.testTimeout = 60_000;
+  (QUnit.config as QUnitApi["config"] & {
+    reporters: { tap: boolean };
+  }).reporters.tap = true;
+  if (filter !== undefined) QUnit.config.filter = filter;
+
+  const completion = new Promise<{ readonly failed: number }>((resolve) => {
+    QUnit.done((details) => resolve({ failed: details.failed }));
+  });
+  for (const loadSuite of suiteLoaders) {
+    try {
+      (await loadSuite()).default(QUnit);
+    } catch (error: unknown) {
+      QUnit.onUncaughtException(error);
+    }
+  }
+  QUnit.start();
+  return completion;
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/run.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/run.ts
@@ -41,7 +41,7 @@ export async function runTestSuites(
   });
   for (const loadSuite of suiteLoaders) {
     try {
-      (await loadSuite()).default(QUnit);
+      await (await loadSuite()).default(QUnit);
     } catch (error: unknown) {
       QUnit.onUncaughtException(error);
     }

--- a/jans-cedarling/bindings/cedarling_js/tests/runners/node.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/runners/node.ts
@@ -1,0 +1,19 @@
+import QUnit from "qunit";
+import {
+  runTestSuites,
+  type SuiteLoader,
+  type TestGroup,
+} from "../run.js";
+import { unitSuites } from "../unit/index.js";
+import { contractSuites } from "../contract/index.js";
+
+const groups: Readonly<Record<TestGroup, readonly SuiteLoader[]>> = {
+  unit: unitSuites,
+  contract: contractSuites,
+};
+const [, , requestedGroup, filter] = process.argv;
+if (requestedGroup !== "unit" && requestedGroup !== "contract") {
+  throw new Error("Expected a test group: unit or contract.");
+}
+const summary = await runTestSuites(QUnit, groups[requestedGroup], filter);
+process.exitCode = summary.failed === 0 ? 0 : 1;

--- a/jans-cedarling/bindings/cedarling_js/tests/tsconfig.json
+++ b/jans-cedarling/bindings/cedarling_js/tests/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": false,
+    "outDir": "../.test-dist",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "rootDir": ".",
+    "sourceMap": false,
+    "types": [
+      "node",
+      "qunit"
+    ]
+  },
+  "include": [
+    "run.ts",
+    "runners/**/*.ts",
+    "fixtures/**/*.ts",
+    "unit/**/*.ts",
+    "contract/**/*.ts",
+    "e2e/**/*.ts"
+  ]
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/unit/authorization-kernel.test.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/unit/authorization-kernel.test.ts
@@ -1,6 +1,10 @@
 import type QUnitApi from "qunit";
 import { createClientForEngine } from "../../dist/client/client.js";
 import type { CedarlingEngine } from "../../dist/engine/engine.js";
+import { prepareCedarlingOptions } from "../../dist/configuration/prepare.js";
+import { createGeneratedEngine } from "../../dist/engine/generated.js";
+import { parseGeneratedResult } from "../../dist/engine/generated-authorization.js";
+import { withGeneratedWrapper } from "../../dist/engine/generated-wrapper.js";
 
 export default function registerAuthorizationKernelTests(
   QUnit: QUnitApi,
@@ -110,5 +114,70 @@ export default function registerAuthorizationKernelTests(
     assert.true((await authorization).ok);
     assert.true((await shutdown).ok);
     assert.strictEqual(await client.shutDown(), await shutdown);
+  });
+
+  QUnit.test("configuration rejects null decision-log claims", (assert) => {
+    assert.throws(
+      () => prepareCedarlingOptions({
+        applicationName: "review-test",
+        policyStore: { type: "inline", document: {} },
+        authorization: { decisionLogTokenIdClaim: null as never },
+      }),
+      (error: unknown) =>
+        (error as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+    );
+  });
+
+  QUnit.test("wrapper disposal preserves conversion failures", (assert) => {
+    const conversionFailure = new Error("conversion");
+    let disposals = 0;
+    assert.throws(
+      () => withGeneratedWrapper(
+        { dispose() { disposals += 1; throw new Error("dispose"); } },
+        "authorizeUnsigned",
+        () => { throw conversionFailure; },
+      ),
+      (error: unknown) => error === conversionFailure,
+    );
+    assert.strictEqual(disposals, 1);
+  });
+
+  QUnit.test("generated failures redact raw diagnostics by default", async (assert) => {
+    const rawFailure = new Error("raw-wasm-secret");
+    const engine = createGeneratedEngine({
+      authorize_unsigned() { throw rawFailure; },
+      authorize_multi_issuer() { throw rawFailure; },
+      shut_down() {},
+      free() {},
+    });
+    assert.ok(engine);
+    if (engine === undefined) return;
+    const request = {
+      action: 'Action::"Read"',
+      resource: { type: "Task", id: "one" },
+    };
+    const hidden = await createClientForEngine(engine).authorizeUnsigned(request);
+    assert.false(hidden.ok);
+    if (!hidden.ok) {
+      assert.strictEqual(hidden.error.details, undefined);
+      assert.false("cause" in hidden.error);
+    }
+    const exposed = await createClientForEngine(
+      engine,
+      { exposeRawErrors: true },
+    ).authorizeUnsigned(request);
+    assert.false(exposed.ok);
+    if (!exposed.ok) assert.strictEqual(exposed.error.cause, rawFailure);
+
+    const policyError = parseGeneratedResult(
+      JSON.stringify({
+        decision: false,
+        request_id: "request",
+        response: { diagnostics: { reason: [], errors: [{ id: "unsafe policy id", error: "secret" }] } },
+      }),
+      "authorizeUnsigned",
+    ).errors[0];
+    assert.strictEqual(policyError?.message, "A Cedar policy evaluation failed.");
+    assert.strictEqual(policyError?.details, undefined);
   });
 }

--- a/jans-cedarling/bindings/cedarling_js/tests/unit/authorization-kernel.test.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/unit/authorization-kernel.test.ts
@@ -1,0 +1,114 @@
+import type QUnitApi from "qunit";
+import { createClientForEngine } from "../../dist/client/client.js";
+import type { CedarlingEngine } from "../../dist/engine/engine.js";
+
+export default function registerAuthorizationKernelTests(
+  QUnit: QUnitApi,
+): void {
+  QUnit.module("authorization kernel");
+
+  QUnit.test("snapshots inputs and preserves the result contract", async (assert) => {
+    let receivedId = "";
+    const engine: CedarlingEngine = {
+      async authorizeUnsigned(request) {
+        receivedId = request.resource.id;
+        return {
+          decision: true,
+          requestId: "request-1",
+          diagnostics: { reasons: ["allow"], errors: [] },
+        };
+      },
+      async authorizeMultiIssuer() {
+        return {
+          decision: true,
+          requestId: "request-2",
+          diagnostics: { reasons: ["token"], errors: [] },
+        };
+      },
+      async shutDown() {},
+    };
+    const client = createClientForEngine(engine);
+    const resource = { type: "Task", id: "original" };
+    const pending = client.authorizeUnsigned({
+      action: 'Action::"Read"',
+      resource,
+    });
+    resource.id = "mutated";
+
+    const result = await pending;
+    assert.true(result.ok);
+    assert.strictEqual(receivedId, "original");
+    if (result.ok) {
+      assert.true(result.value.decision);
+      assert.strictEqual(result.value.requestId, "request-1");
+    }
+    assert.true((await client.shutDown()).ok);
+  });
+
+  QUnit.test("returns validation and closed-client failures", async (assert) => {
+    const engine: CedarlingEngine = {
+      async authorizeUnsigned() {
+        throw new Error("must not run");
+      },
+      async authorizeMultiIssuer() {
+        throw new Error("must not run");
+      },
+      async shutDown() {},
+    };
+    const client = createClientForEngine(engine);
+    const invalid = await client.authorizeMultiIssuer({
+      tokens: [],
+      action: 'Action::"Read"',
+      resource: { type: "Task", id: "one" },
+    });
+    assert.false(invalid.ok);
+    if (!invalid.ok) {
+      assert.strictEqual(invalid.error.code, "INPUT_OUT_OF_RANGE");
+      assert.deepEqual(invalid.error.path, ["tokens"]);
+    }
+
+    assert.true((await client.shutDown()).ok);
+    const closed = await client.authorizeUnsigned(
+      new Proxy({} as never, {
+        get() {
+          assert.true(false, "closed clients must not inspect input");
+        },
+      }),
+    );
+    assert.false(closed.ok);
+    if (!closed.ok) {
+      assert.strictEqual(closed.error.code, "CLIENT_CLOSED");
+    }
+  });
+
+  QUnit.test("shutdown waits for admitted authorization", async (assert) => {
+    let release = () => {};
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const engine: CedarlingEngine = {
+      async authorizeUnsigned() {
+        await blocked;
+        return {
+          decision: true,
+          requestId: "request-3",
+          diagnostics: { reasons: [], errors: [] },
+        };
+      },
+      async authorizeMultiIssuer() {
+        throw new Error("unused");
+      },
+      async shutDown() {},
+    };
+    const client = createClientForEngine(engine);
+    const authorization = client.authorizeUnsigned({
+      action: 'Action::"Read"',
+      resource: { type: "Task", id: "one" },
+    });
+    const shutdown = client.shutDown();
+    release();
+    assert.true((await authorization).ok);
+    assert.true((await shutdown).ok);
+    assert.strictEqual(await client.shutDown(), await shutdown);
+  });
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/unit/authorize-unsigned.test.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/unit/authorize-unsigned.test.ts
@@ -1,0 +1,255 @@
+import type QUnitApi from "qunit";
+
+import { createClientForEngine } from "../../dist/client/client.js";
+import { createTestEngine } from "./engine-fixture.js";
+
+const decision = {
+  decision: true,
+  requestId: "unsigned-unit",
+  diagnostics: { reasons: ["allow"], errors: [] },
+};
+
+export default function registerUnsignedAuthorizationUnitTests(
+  QUnit: QUnitApi,
+): void {
+  QUnit.module("authorize-unsigned");
+
+  function createRecordingClient() {
+    let calls = 0;
+    const engine = createTestEngine({
+      async authorizeUnsigned() {
+        calls += 1;
+        return decision;
+      },
+    });
+    return {
+      client: createClientForEngine(engine),
+      calls: () => calls,
+    };
+  }
+
+  QUnit.test("rejects malformed request structure before the engine", async (assert) => {
+    const recording = createRecordingClient();
+    const cases: readonly {
+      readonly name: string;
+      readonly value: unknown;
+      readonly path: readonly (string | number)[];
+      readonly code: string;
+    }[] = [
+      {
+        name: "non-object request",
+        value: null,
+        path: [],
+        code: "INPUT_INVALID_TYPE",
+      },
+      {
+        name: "missing action",
+        value: { resource: { type: "Example::Resource", id: "document" } },
+        path: ["action"],
+        code: "INPUT_REQUIRED",
+      },
+      {
+        name: "empty action",
+        value: {
+          action: " ",
+          resource: { type: "Example::Resource", id: "document" },
+        },
+        path: ["action"],
+        code: "INPUT_REQUIRED",
+      },
+      {
+        name: "missing resource",
+        value: { action: 'Example::Action::"Read"' },
+        path: ["resource"],
+        code: "INPUT_INVALID_TYPE",
+      },
+      {
+        name: "empty resource identifier",
+        value: {
+          action: 'Example::Action::"Read"',
+          resource: { type: "Example::Resource", id: "" },
+        },
+        path: ["resource", "id"],
+        code: "INPUT_REQUIRED",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = await recording.client.authorizeUnsigned(
+        testCase.value as never,
+      );
+      assert.false(result.ok, testCase.name);
+      if (!result.ok) {
+        assert.strictEqual(result.error.code, testCase.code);
+        assert.deepEqual(result.error.path, testCase.path);
+      }
+    }
+
+    assert.strictEqual(recording.calls(), 0, "no invalid request reaches the engine");
+    await recording.client.shutDown();
+  });
+
+  QUnit.test("rejects unknown fields without reading accessors", async (assert) => {
+    const recording = createRecordingClient();
+    const baseRequest = {
+      principal: { type: "Example::User", id: "alice" },
+      action: 'Example::Action::"Read"',
+      resource: { type: "Example::Resource", id: "document" },
+    };
+    const cases = [
+      {
+        name: "top-level field",
+        value: { ...baseRequest, ressource: baseRequest.resource },
+        path: ["ressource"],
+      },
+      {
+        name: "principal field",
+        value: {
+          ...baseRequest,
+          principal: { ...baseRequest.principal, role: "admin" },
+        },
+        path: ["principal", "role"],
+      },
+      {
+        name: "resource field",
+        value: {
+          ...baseRequest,
+          resource: { ...baseRequest.resource, owner: "alice" },
+        },
+        path: ["resource", "owner"],
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const result = await recording.client.authorizeUnsigned(
+        testCase.value as never,
+      );
+      assert.false(result.ok, testCase.name);
+      if (!result.ok) {
+        assert.strictEqual(result.error.code, "INPUT_UNKNOWN_FIELD");
+        assert.deepEqual(result.error.path, testCase.path);
+      }
+    }
+
+    let accessorReads = 0;
+    const requestWithAccessor = { ...baseRequest } as Record<string, unknown>;
+    Object.defineProperty(requestWithAccessor, "ressource", {
+      enumerable: true,
+      get() {
+        accessorReads += 1;
+        return baseRequest.resource;
+      },
+    });
+    const accessorResult = await recording.client.authorizeUnsigned(
+      requestWithAccessor as never,
+    );
+    assert.false(accessorResult.ok);
+    if (!accessorResult.ok) {
+      assert.deepEqual(accessorResult.error.path, ["ressource"]);
+      assert.strictEqual(accessorResult.error.code, "INPUT_UNKNOWN_FIELD");
+    }
+    assert.strictEqual(accessorReads, 0, "unknown accessors are not executed");
+    assert.strictEqual(recording.calls(), 0, "no invalid request reaches the engine");
+    await recording.client.shutDown();
+  });
+
+  QUnit.test("rejects unsafe Cedar values before the engine", async (assert) => {
+    const recording = createRecordingClient();
+    const cases: readonly {
+      readonly name: string;
+      readonly value: unknown;
+      readonly path: readonly (string | number)[];
+      readonly code: "INPUT_INVALID_TYPE" | "INPUT_UNKNOWN_FIELD";
+    }[] = [
+      {
+        name: "reserved generated mapping",
+        value: {
+          principal: {
+            type: "Example::User",
+            id: "alice",
+            attributes: {
+              cedar_entity_mapping: "attacker-controlled",
+            },
+          },
+          action: 'Example::Action::"Read"',
+          resource: { type: "Example::Resource", id: "document" },
+        },
+        path: ["principal", "attributes", "cedar_entity_mapping"],
+        code: "INPUT_UNKNOWN_FIELD",
+      },
+      {
+        name: "unsafe entity integer",
+        value: {
+          principal: {
+            type: "Example::User",
+            id: "alice",
+            attributes: {
+              count: Number.MAX_SAFE_INTEGER + 1,
+            },
+          },
+          action: 'Example::Action::"Read"',
+          resource: { type: "Example::Resource", id: "document" },
+        },
+        path: ["principal", "attributes"],
+        code: "INPUT_INVALID_TYPE",
+      },
+      {
+        name: "implicit fractional entity number",
+        value: {
+          principal: {
+            type: "Example::User",
+            id: "alice",
+            attributes: {
+              score: 1.25,
+            },
+          },
+          action: 'Example::Action::"Read"',
+          resource: { type: "Example::Resource", id: "document" },
+        },
+        path: ["principal", "attributes"],
+        code: "INPUT_INVALID_TYPE",
+      },
+      {
+        name: "raw fractional context number",
+        value: {
+          action: 'Example::Action::"Read"',
+          resource: { type: "Example::Resource", id: "document" },
+          context: { score: 1.25 },
+        },
+        path: ["context"],
+        code: "INPUT_INVALID_TYPE",
+      },
+      {
+        name: "malformed extension marker",
+        value: {
+          action: 'Example::Action::"Read"',
+          resource: { type: "Example::Resource", id: "document" },
+          context: {
+            network: {
+              __extn: {
+                fn: "ip",
+                arg: "",
+              },
+            },
+          },
+        },
+        path: ["context"],
+        code: "INPUT_INVALID_TYPE",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = await recording.client.authorizeUnsigned(
+        testCase.value as never,
+      );
+      assert.false(result.ok, testCase.name);
+      if (!result.ok) {
+        assert.strictEqual(result.error.code, testCase.code);
+        assert.deepEqual(result.error.path, testCase.path);
+      }
+    }
+
+    assert.strictEqual(recording.calls(), 0, "no invalid value reaches the engine");
+    await recording.client.shutDown();
+  });
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/unit/common-values.test.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/unit/common-values.test.ts
@@ -8,9 +8,26 @@ import {
   ownEnumerableDataProperty,
   ownEnumerableStringKeys,
 } from "../../dist/helpers/records.js";
-import { snapshotCedarValue } from "../../dist/values/snapshot.js";
+import {
+  snapshotCedarObject,
+  snapshotCedarValue,
+  snapshotJsonObject,
+  snapshotJsonValue,
+} from "../../dist/values/snapshot.js";
 
-export default function registerCommonValueTests(QUnit: QUnitApi): void {
+function rejectionCode(work: () => unknown): unknown {
+  try {
+    work();
+  } catch (error: unknown) {
+    return typeof error === "object" && error !== null
+      ? ownDataProperty(error, "code")
+      : error;
+  }
+  return "NO_ERROR";
+}
+
+export default async function registerCommonValueTests(QUnit: QUnitApi): Promise<void> {
+  await Promise.resolve();
   QUnit.module("common-values");
 
   QUnit.test("plain-record inspection honors null prototypes", (assert) => {
@@ -78,6 +95,16 @@ export default function registerCommonValueTests(QUnit: QUnitApi): void {
     assert.strictEqual(reads, 0);
   });
 
+  QUnit.test("JSON and Cedar root snapshots preserve their contracts", (assert) => {
+    assert.deepEqual(snapshotJsonValue({ empty: null, ratio: 1.5 }, "initialize"), { empty: null, ratio: 1.5 });
+    assert.deepEqual(snapshotJsonObject({ ratio: 1.5 }, "initialize"), { ratio: 1.5 });
+    assert.deepEqual(snapshotCedarObject({ enabled: true }, "authorizeUnsigned"), { enabled: true });
+    for (const invalid of [Number.NaN, Infinity, Number.MAX_SAFE_INTEGER + 1])
+      assert.strictEqual(rejectionCode(() => snapshotJsonValue(invalid, "initialize")), "INPUT_INVALID_TYPE");
+    for (const snapshot of [snapshotJsonObject, snapshotCedarObject])
+      for (const invalid of [null, [], "not an object"])
+        assert.strictEqual(rejectionCode(() => snapshot(invalid, "initialize")), "INPUT_INVALID_TYPE");
+  });
   QUnit.test("entity values are detached and decimals stay explicit", (assert) => {
     const source = {
       score: {
@@ -162,15 +189,9 @@ export default function registerCommonValueTests(QUnit: QUnitApi): void {
     ];
 
     for (const [index, invalid] of invalidValues.entries()) {
-      let thrown: unknown;
-      try {
-        snapshotCedarValue(invalid, "authorizeUnsigned");
-      } catch (error: unknown) {
-        thrown = error;
-      }
-
-      assert.true(
-        (thrown as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+      assert.strictEqual(
+        rejectionCode(() => snapshotCedarValue(invalid, "authorizeUnsigned")),
+        "INPUT_INVALID_TYPE",
         `invalid value ${index + 1} rejects with an input error`,
       );
     }
@@ -214,15 +235,9 @@ export default function registerCommonValueTests(QUnit: QUnitApi): void {
     ];
 
     for (const [index, invalid] of invalidValues.entries()) {
-      let thrown: unknown;
-      try {
-        snapshotCedarValue(invalid, "authorizeUnsigned");
-      } catch (error: unknown) {
-        thrown = error;
-      }
-
-      assert.true(
-        (thrown as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+      assert.strictEqual(
+        rejectionCode(() => snapshotCedarValue(invalid, "authorizeUnsigned")),
+        "INPUT_INVALID_TYPE",
         `invalid context value ${index + 1} rejects with an input error`,
       );
     }
@@ -289,15 +304,9 @@ export default function registerCommonValueTests(QUnit: QUnitApi): void {
     ];
 
     for (const [index, invalid] of invalidValues.entries()) {
-      let thrown: unknown;
-      try {
-        snapshotCedarValue(invalid, "authorizeUnsigned");
-      } catch (error: unknown) {
-        thrown = error;
-      }
-
-      assert.true(
-        (thrown as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+      assert.strictEqual(
+        rejectionCode(() => snapshotCedarValue(invalid, "authorizeUnsigned")),
+        "INPUT_INVALID_TYPE",
         `invalid entity reference ${index + 1} rejects with an input error`,
       );
     }
@@ -315,15 +324,9 @@ export default function registerCommonValueTests(QUnit: QUnitApi): void {
     ];
 
     for (const [index, invalid] of invalidValues.entries()) {
-      let thrown: unknown;
-      try {
-        snapshotCedarValue(invalid, "authorizeUnsigned");
-      } catch (error: unknown) {
-        thrown = error;
-      }
-
-      assert.true(
-        (thrown as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+      assert.strictEqual(
+        rejectionCode(() => snapshotCedarValue(invalid, "authorizeUnsigned")),
+        "INPUT_INVALID_TYPE",
         `reserved key ${index + 1} rejects with an input error`,
       );
     }

--- a/jans-cedarling/bindings/cedarling_js/tests/unit/common-values.test.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/unit/common-values.test.ts
@@ -1,0 +1,332 @@
+import type QUnitApi from "qunit";
+
+import {
+  inspectDenseArray,
+  inspectOwnProperty,
+  isPlainDataRecord,
+  ownDataProperty,
+  ownEnumerableDataProperty,
+  ownEnumerableStringKeys,
+} from "../../dist/helpers/records.js";
+import { snapshotCedarValue } from "../../dist/values/snapshot.js";
+
+export default function registerCommonValueTests(QUnit: QUnitApi): void {
+  QUnit.module("common-values");
+
+  QUnit.test("plain-record inspection honors null prototypes", (assert) => {
+    const nullPrototype = Object.create(null) as Record<string, unknown>;
+    nullPrototype.value = 1;
+
+    assert.false(isPlainDataRecord(nullPrototype, false));
+    assert.true(isPlainDataRecord(nullPrototype, true));
+  });
+
+  QUnit.test("property inspection never invokes accessors", (assert) => {
+    let getterInvoked = false;
+    const value: Record<PropertyKey, unknown> = {
+      first: 1,
+      [Symbol("symbol")]: "symbol",
+    };
+    Object.defineProperty(value, "computed", {
+      enumerable: true,
+      get() {
+        getterInvoked = true;
+        return "computed";
+      },
+    });
+    Object.defineProperty(value, "hidden", {
+      enumerable: false,
+      value: 2,
+    });
+
+    assert.deepEqual(inspectOwnProperty(value, "first"), {
+      kind: "data",
+      enumerable: true,
+      value: 1,
+    });
+    assert.deepEqual(inspectOwnProperty(value, "computed"), {
+      kind: "accessor",
+      enumerable: true,
+    });
+    assert.deepEqual(ownEnumerableStringKeys(value), ["first", "computed"]);
+    assert.strictEqual(ownDataProperty(value, "hidden"), 2);
+    assert.strictEqual(ownEnumerableDataProperty(value, "hidden"), undefined);
+    assert.false(getterInvoked);
+  });
+
+  QUnit.test("dense-array inspection rejects sparse and accessor elements", (assert) => {
+    const sparse = new Array<unknown>(1);
+    let reads = 0;
+    const accessor = ["placeholder"];
+    Object.defineProperty(accessor, "0", {
+      enumerable: true,
+      get() {
+        reads += 1;
+        return "secret";
+      },
+    });
+
+    assert.deepEqual(inspectDenseArray(["a", "b"]), {
+      kind: "values",
+      values: ["a", "b"],
+    });
+    assert.deepEqual(inspectDenseArray(sparse), { kind: "invalid" });
+    assert.deepEqual(inspectDenseArray(accessor), {
+      kind: "invalid",
+      index: 0,
+    });
+    assert.strictEqual(reads, 0);
+  });
+
+  QUnit.test("entity values are detached and decimals stay explicit", (assert) => {
+    const source = {
+      score: {
+        __extn: {
+          fn: "decimal" as const,
+          arg: "1.23456",
+        },
+      },
+      labels: ["initial"],
+    };
+
+    const snapshot = snapshotCedarValue(source, "authorizeUnsigned");
+
+    source.score.__extn.arg = "9.0";
+    source.labels[0] = "mutated";
+
+    assert.deepEqual(snapshot, {
+      score: {
+        __extn: {
+          fn: "decimal",
+          arg: "1.23456",
+        },
+      },
+      labels: ["initial"],
+    });
+  });
+
+  QUnit.test("non-data and lossy JavaScript structures are rejected", (assert) => {
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+
+    const sparse = new Array<unknown>(1);
+
+    let getterInvoked = false;
+    const accessor = {};
+    Object.defineProperty(accessor, "secret", {
+      enumerable: true,
+      get() {
+        getterInvoked = true;
+        return "secret";
+      },
+    });
+
+    const customPrototype = Object.create({ inherited: true }) as Record<
+      string,
+      unknown
+    >;
+    customPrototype.value = true;
+
+    const symbolProperty = {
+      value: true,
+      [Symbol("hidden")]: "hidden",
+    };
+
+    const nonEnumerableProperty = { value: true };
+    Object.defineProperty(nonEnumerableProperty, "hidden", {
+      value: "hidden",
+    });
+
+    const invalidValues: readonly unknown[] = [
+      null,
+      undefined,
+      () => undefined,
+      Symbol("value"),
+      1n,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER + 1,
+      cycle,
+      sparse,
+      accessor,
+      customPrototype,
+      symbolProperty,
+      nonEnumerableProperty,
+      new Uint8Array(0),
+      new ArrayBuffer(0),
+      new Date(),
+      /regex/,
+      new Map(),
+      new Set(),
+      Promise.resolve(),
+    ];
+
+    for (const [index, invalid] of invalidValues.entries()) {
+      let thrown: unknown;
+      try {
+        snapshotCedarValue(invalid, "authorizeUnsigned");
+      } catch (error: unknown) {
+        thrown = error;
+      }
+
+      assert.true(
+        (thrown as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+        `invalid value ${index + 1} rejects with an input error`,
+      );
+    }
+
+    assert.false(getterInvoked, "accessors are rejected without invocation");
+  });
+
+  QUnit.test("request context requires integers or exact extension markers", (assert) => {
+    const extension = {
+      __extn: {
+        fn: "decimal",
+        arg: "1.2346",
+      },
+    };
+
+    const snapshot = snapshotCedarValue(
+      { count: 4, price: extension },
+      "authorizeUnsigned",
+    );
+
+    extension.__extn.arg = "mutated";
+
+    assert.deepEqual(snapshot, {
+      count: 4,
+      price: {
+        __extn: {
+          fn: "decimal",
+          arg: "1.2346",
+        },
+      },
+    });
+
+    const invalidValues: readonly unknown[] = [
+      1.5,
+      null,
+      { __extn: { fn: "unknown", arg: "value" } },
+      { __extn: { fn: "ip", arg: "" } },
+      { __extn: { fn: "ip", arg: "192.0.2.1", extra: true } },
+      { __extn: { fn: "ip", arg: "192.0.2.1" }, extra: true },
+      { __extn: "192.0.2.1" },
+    ];
+
+    for (const [index, invalid] of invalidValues.entries()) {
+      let thrown: unknown;
+      try {
+        snapshotCedarValue(invalid, "authorizeUnsigned");
+      } catch (error: unknown) {
+        thrown = error;
+      }
+
+      assert.true(
+        (thrown as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+        `invalid context value ${index + 1} rejects with an input error`,
+      );
+    }
+  });
+
+  QUnit.test("extension marker fields are independent of insertion order", (assert) => {
+    const snapshot = snapshotCedarValue(
+      {
+        __extn: {
+          arg: "192.0.2.1",
+          fn: "ip",
+        },
+      },
+      "authorizeUnsigned",
+    );
+
+    assert.deepEqual(snapshot, {
+      __extn: {
+        fn: "ip",
+        arg: "192.0.2.1",
+      },
+    });
+  });
+
+  QUnit.test("entity reference markers are detached and preserved", (assert) => {
+    const source = {
+      owner: {
+        __entity: {
+          type: "Jans::User",
+          id: "alice",
+        },
+      },
+    };
+
+    const snapshot = snapshotCedarValue(source, "authorizeUnsigned");
+    source.owner.__entity.type = "Mutated::User";
+
+    assert.deepEqual(snapshot, {
+      owner: {
+        __entity: {
+          type: "Jans::User",
+          id: "alice",
+        },
+      },
+    });
+  });
+
+  QUnit.test("entity reference markers require an exact shape", (assert) => {
+    const invalidValues: readonly unknown[] = [
+      { __entity: { type: "Jans::User" } },
+      { __entity: { id: "alice" } },
+      { __entity: { type: "Jans::User", id: "alice", extra: true } },
+      { __entity: { type: "", id: "alice" } },
+      { __entity: { type: "Jans::User", id: "" } },
+      { __entity: { type: 1, id: "alice" } },
+      { __entity: { type: "Jans::User", id: 1 } },
+      { __entity: "Jans::User" },
+      { __entity: ["Jans::User", "alice"] },
+      { __entity: { type: "Jans::User", id: "alice" }, extra: true },
+      {
+        __entity: { type: "Jans::User", id: "alice" },
+        __extn: { fn: "ip", arg: "192.0.2.1" },
+      },
+    ];
+
+    for (const [index, invalid] of invalidValues.entries()) {
+      let thrown: unknown;
+      try {
+        snapshotCedarValue(invalid, "authorizeUnsigned");
+      } catch (error: unknown) {
+        thrown = error;
+      }
+
+      assert.true(
+        (thrown as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+        `invalid entity reference ${index + 1} rejects with an input error`,
+      );
+    }
+  });
+
+  QUnit.test("reserved cedar_entity_mapping key is rejected in Cedar values", (assert) => {
+    const invalidValues: readonly unknown[] = [
+      { cedar_entity_mapping: { entity_type: "Jans::User", id: "alice" } },
+      {
+        nested: {
+          cedar_entity_mapping: { entity_type: "Jans::User", id: "alice" },
+        },
+      },
+      [{ cedar_entity_mapping: "attacker-controlled" }],
+    ];
+
+    for (const [index, invalid] of invalidValues.entries()) {
+      let thrown: unknown;
+      try {
+        snapshotCedarValue(invalid, "authorizeUnsigned");
+      } catch (error: unknown) {
+        thrown = error;
+      }
+
+      assert.true(
+        (thrown as { code?: unknown }).code === "INPUT_INVALID_TYPE",
+        `reserved key ${index + 1} rejects with an input error`,
+      );
+    }
+  });
+
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/unit/engine-fixture.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/unit/engine-fixture.ts
@@ -1,0 +1,16 @@
+import type { CedarlingEngine } from "../../dist/engine/engine.js";
+
+export function createTestEngine(
+  overrides: Partial<CedarlingEngine> = {},
+): CedarlingEngine {
+  return {
+    async authorizeUnsigned() {
+      throw new Error("unsigned authorization is outside this test");
+    },
+    async authorizeMultiIssuer() {
+      throw new Error("multi-issuer authorization is outside this test");
+    },
+    async shutDown() {},
+    ...overrides,
+  };
+}

--- a/jans-cedarling/bindings/cedarling_js/tests/unit/index.ts
+++ b/jans-cedarling/bindings/cedarling_js/tests/unit/index.ts
@@ -1,0 +1,7 @@
+import type { SuiteLoader } from "../run.js";
+
+export const unitSuites: readonly SuiteLoader[] = [
+  () => import("./authorization-kernel.test.js"),
+  () => import("./authorize-unsigned.test.js"),
+  () => import("./common-values.test.js"),
+];

--- a/jans-cedarling/bindings/cedarling_js/tsconfig.build.json
+++ b/jans-cedarling/bindings/cedarling_js/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist"
+  }
+}

--- a/jans-cedarling/bindings/cedarling_js/tsconfig.json
+++ b/jans-cedarling/bindings/cedarling_js/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "ESNext.Disposable"
+    ],
+    "types": [],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "noEmitOnError": true,
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
### Prepare

  - [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
  - [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

  -------------------

  ### Description

  #### Target issue

  Part of #14582

  This is the first PR in the dependency-ordered Cedarling JavaScript SDK integration. It intentionally does not close
  #14582 because additional SDK services, runtime qualification, CI, and examples will follow in separate PRs.

  #### Implementation Details

  This PR introduces the smallest independently runnable and reviewable `@janssenproject/cedarling` package.

  It includes:

  - The `createCedarling()` factory.
  - The explicit `authorizeUnsigned()` authorization method.
  - The explicit token-validating `authorizeMultiIssuer()` method.
  - Idempotent `shutDown()` lifecycle handling.
  - A single `CedarlingError`, `CedarlingErrorCode`, and `Result<T>` contract.
  - Inline policy-store configuration.
  - ESM package-root exports for Node.js and browser loading.
  - Node.js WASM loading through the sibling `@janssenproject/cedarling_wasm` package.
  - Descriptor-safe input validation that does not invoke getters or accessors.
  - Detached authorization request snapshots.
  - Generated-result conversion, error redaction, and deterministic wrapper disposal.
  - Focused unit tests and real-WASM authorization contracts.
  - A scoped README documenting only the functionality included in this PR.

  The JavaScript binding directory is excluded from the parent Cargo workspace because it is built and tested through
  its npm toolchain.

  This PR deliberately does not introduce:

  - Context data services.
  - Retained log services.
  - Issuer-readiness services.
  - URL, archive-byte, or application-loader policy sources.
  - CommonJS output.
  - Bun, Deno, or browser qualification runners.
  - Packaging, publication, or CI automation.
  - Demo applications.

  Those capabilities are reserved for the dependent follow-up PRs.

  -------------------

  ### Test and Document the changes

  - [x] Static code analysis has been run locally and issues have been fixed
  - [x] Relevant unit and integration tests have been added/updated
  - [x] Relevant documentation has been updated where applicable

  #### Local validation

  ```bash
  cd jans-cedarling/bindings/cedarling_js
  npm ci
  npm run check
``` 
  The validation covers TypeScript type checking, focused unit tests, and real-WASM authorization contracts.

  Documentation impact exists: this PR adds the initial package README for the limited authorization-kernel surface.

  - [ ] I confirm that there is no impact on the docs due to the code changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a JavaScript/TypeScript Cedarling SDK for browser and Node.js environments.
  * Supports unsigned and multi-issuer authorization, inline policy stores, JWT configuration, structured results, and managed client shutdown.
  * Added standardized errors, strict input validation, and safe value handling.
* **Documentation**
  * Added SDK setup, API, runtime behavior, and security-scanning documentation.
* **Tests**
  * Added unit and contract coverage for authorization, validation, policy behavior, errors, and lifecycle management.
* **Chores**
  * Improved penetration-test scanning and consolidated security reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->