### PR TITLE
docs(jans-cedarling): add policy annotation usage patterns

### DIFF
--- a/docs/cedarling/patterns/annotation-challenge.md
+++ b/docs/cedarling/patterns/annotation-challenge.md
@@ -12,7 +12,7 @@ tags:
 
 !!! note "Illustrative example"
 
-    Acme, ReportBot, and every annotation key below (`@challenge`, `@challenge_ttl`,
+    Acme, ReportBot, and every annotation key below (`@challenge`, `@challenge_ttl_seconds`,
     `@containment`, and the rest) are invented for this page. Cedarling attaches no meaning to
     them; they work only because the example application reads them. The scenario is simplified to
     show the mechanism, not to be copied as a security design. See
@@ -182,7 +182,7 @@ asked for. This condition is about the *nature of the accessor*, so it exists on
 @id("forbid_agent_read_sensitive_without_intent")
 @challenge("confirm_human_intent")
 @challenge_actor("controlling_human")
-@challenge_ttl("300")
+@challenge_ttl_seconds("300")
 @user_message_id("access.challenge.confirm_human_intent")
 forbid (
     principal is Acme::Agent,
@@ -204,6 +204,7 @@ differing only in how it reaches the human's assignments:
 @id("forbid_offscope_sensitive_read_by_agent")
 @challenge("data_owner_approval")
 @challenge_strength("high")
+@challenge_ttl_seconds("3600")
 @user_message_id("access.challenge.owner_approval")
 forbid (
     principal is Acme::Agent,
@@ -223,6 +224,7 @@ unless {
 @id("forbid_offscope_sensitive_read_by_user")
 @challenge("data_owner_approval")
 @challenge_strength("high")
+@challenge_ttl_seconds("3600")
 @user_message_id("access.challenge.owner_approval")
 forbid (
     principal is Acme::User,
@@ -269,9 +271,11 @@ Each `forbid` clears itself through `unless`. A `forbid` whose condition can nev
 hard block, not a challenge. The `unless` clause makes the denial resolvable, and it is why the
 second authorization call can legitimately return `Allow`.
 
-The guidance lives on `forbid`, not on `permit`. How decisions are reported forces this: on a
-`Deny`, only the satisfied `forbid` policies appear in `reason()`, and if nothing permitted the
-request at all, `reason()` is empty and there are no annotations to read. A broad `permit` with
+For a resolvable denial, the guidance lives on `forbid` rather than on `permit`. How decisions are
+reported forces this: on a `Deny`, only the satisfied `forbid` policies appear in `reason()`, and if
+nothing matched at all, `reason()` is empty and there are no annotations to read. Annotations on
+`permit` policies are not wasted, they simply speak on the allow path, which is what the
+[quota page](./annotation-quota.md) is built on. A broad `permit` with
 annotated `forbid` layers on top keeps hints available at the moment they are needed. See
 [Only the determining policies are reported](./annotation-patterns.md#only-the-determining-policies-are-reported).
 
@@ -290,7 +294,7 @@ and it is worth deciding once for the whole policy set rather than per policy.
 use std::collections::BTreeSet;
 
 // Server-issued records only, already filtered to this action and resource and to
-// records whose @challenge_ttl has not expired. Never the raw client context.
+// records whose @challenge_ttl_seconds has not expired. Never the raw client context.
 let mut completed: BTreeSet<String> = session.valid_challenges_for(&document, Action::Read);
 
 for attempt in 0..2 {
@@ -322,19 +326,35 @@ for attempt in 0..2 {
     let by_policy = cedarling.annotations_by_policy(reason.iter().copied());
     audit.record(&by_policy);
 
+    // An agent cannot answer a challenge, so the prompt goes to the human behind it.
+    let operator = &agent.operated_by;
+
     // Run the challenges. Results are attested server-side, never taken from the client.
-    // For an agent principal the prompt is addressed to `agent.operated_by`.
     for name in asked {
         match challenge_service.run(&name, &operator, &document).await? {
             Outcome::Passed => {
                 // Stored server-side, scoped to this resource and action, and stamped
-                // with the @challenge_ttl of the policy that asked for it.
+                // with the @challenge_ttl_seconds of the policy that asked for it.
                 session.record_challenge(&name, &document, Action::Read, ttl_of(&by_policy, &name))?;
                 completed.insert(name);
             }
             Outcome::Failed | Outcome::Abandoned => return Err(deny_and_escalate(name)),
         }
     }
+}
+
+/// The `@challenge_ttl_seconds` of the policy that asked for `name`.
+///
+/// `by_policy` is keyed by policy ID, so finding the TTL means finding the group
+/// whose `challenge` value is the one that was run. A policy that set no TTL gets
+/// the shortest one the application supports: never an unbounded grant.
+fn ttl_of(by_policy: &HashMap<String, HashMap<String, String>>, name: &str) -> u64 {
+    by_policy
+        .values()
+        .find(|a| a.get("challenge").map(String::as_str) == Some(name))
+        .and_then(|a| a.get("challenge_ttl_seconds"))
+        .and_then(|t| t.parse().ok())
+        .unwrap_or(MIN_CHALLENGE_TTL_SECONDS)
 }
 ```
 
@@ -349,7 +369,9 @@ if (!result.decision) {
     .filter((a) => a.challenge);
 
   if (asked.length === 0) {
-    return denyPlain(cedarling.annotations_map(reason).user_message_id);
+    return denyPlain(
+      cedarling.annotations_map(reason).user_message_id ?? "access.denied.generic",
+    );
   }
   return requestChallenges(asked);
 }
@@ -372,9 +394,11 @@ part of the implementation rather than as advice.
   challenge service and held in server-side session state, or in a signed, audience-bound token. If
   a browser or an agent can put `"security_key_touch"` into the context, the policy enforces
   nothing.
-- Enforce the TTL. `@challenge_ttl` is a hint the application has to act on: drop the completed
-  challenge from the context once it expires, so long-lived sessions cannot ride one touch forever.
-  Cedar has no concept of elapsed time here, so nothing enforces it if the application does not.
+- Enforce the TTL. `@challenge_ttl_seconds` is a hint the application has to act on: drop the
+  completed challenge from the context once it expires, so long-lived sessions cannot ride one touch
+  forever. Cedar has no concept of elapsed time here, so nothing enforces it if the application does
+  not. Treat a policy that carries no TTL as the shortest one you support rather than as unbounded.
+  Otherwise the one challenge somebody forgot to annotate is the one that never expires.
 - Bind the result to the request. A challenge passed for one document should not silently authorize
   a bulk export of a thousand others. Scope the stored result to the action and resource it was
   raised for, or to a short window, whichever your risk model justifies.
@@ -398,7 +422,7 @@ assistant:
 @id("forbid_agent_read_for_elevated_risk_operator")
 @challenge("security_key_touch")
 @challenge_actor("controlling_human")
-@challenge_ttl("60")
+@challenge_ttl_seconds("60")
 @user_message_id("access.challenge.security_key")
 forbid (
     principal is Acme::Agent,
@@ -436,10 +460,31 @@ forbid (
 when { principal.operated_by.risk_tier == "contained" };
 ```
 
-The application reads `containment` rather than `challenge`, shows the message, and does not
-prompt: there is no inline path from here back to `Allow`. Lifting it means changing the operator's
-`risk_tier`, which happens outside the request. A twin policy on `principal is Acme::User` contains
-the human's own sessions the same way.
+The human's own sessions need the twin, or containment stops an assistant and lets the operator
+carry on by hand:
+
+```cedar
+@id("forbid_contained_user")
+@containment("session_freeze")
+@user_message_id("access.contained.contact_security")
+@escalate_to("secops-oncall")
+forbid (
+    principal is Acme::User,
+    action,
+    resource
+)
+when { principal.risk_tier == "contained" };
+```
+
+The application reads `containment` rather than `challenge`, shows the message, and does not prompt:
+there is no inline path from here back to `Allow`. Lifting it means changing the `risk_tier`, which
+happens outside the request.
+
+Containment depends on an attribute being present, which is worth stating because it is the one
+policy here that must never quietly stop applying. Cedarling validates entities against the schema,
+so an operator entity built without `risk_tier` fails the request rather than slipping past the
+containment policy. That is the behavior you want, and it is a reason to keep the attribute required
+in the schema rather than optional.
 
 ## What This Buys You
 

--- a/docs/cedarling/patterns/annotation-challenge.md
+++ b/docs/cedarling/patterns/annotation-challenge.md
@@ -23,30 +23,29 @@ tags:
 Acme runs an internal assistant, `ReportBot`, that employees use to answer questions over company
 documents. It reads the same document store the employees can read, on their behalf.
 
-Dana works in the Northeast financial-services team. She asks ReportBot a broad question, and to
+Dana, who works in the Northeast financial-services team, asks ReportBot a broad question, and to
 answer it the assistant reaches for `Acme::Document::"strategy-fy27"`, a company-level strategy
 document classified `highly_confidential`, normally read only by the strategy and finance teams.
 
 Nothing here is obviously an attack. There are three plausible explanations:
 
 - Dana genuinely needs the document and nobody told the access system.
-- The assistant over-reached: it expanded a vague question into a search Dana never intended.
-  Dana never asked for that document and would be surprised to learn it was opened in her name.
+- The assistant over-reached and expanded a vague question into a search Dana never intended, so a
+  document Dana never asked for was opened under Dana's identity.
 - Dana's credentials are being used by somebody else.
 
 A binary access system has to pick one. Denying blocks legitimate work and trains people to route
-around the tool. Allowing means an agent quietly exfiltrates strategy documents at machine speed,
-and the security team finds out from a log review next week.
+around the tool. Allowing means an agent exfiltrates strategy documents at machine speed, and the
+security team finds out from a log review next week.
 
-The third option is to ask: confirm with the human that the access was intended, and get the data
-owner to confirm the need. [Beyond Zero](https://queue.acm.org/detail.cfm?id=3819083) calls this a
-*challenge*, friction applied in the moment and in proportion to the risk, instead of a flat
-denial.
+Neither has to be the answer. The system can ask instead: confirm with the human that the access
+was intended, and get the data owner to confirm the need.
+[Beyond Zero](https://queue.acm.org/detail.cfm?id=3819083) calls this a *challenge*, friction
+applied in the moment and in proportion to the risk, instead of a flat denial.
 
 ## Modeling the Agent
 
-The identity model has to be right before the policies make sense, because the policies are
-written against it.
+The policies below are written against the identity model, so the identity model comes first.
 
 The agent is a principal in its own right, not a flag on the human. `ReportBot` has its own entity,
 its own ID, and its own attributes, and it carries a reference to the human who operates it:
@@ -54,11 +53,11 @@ its own ID, and its own attributes, and it carries a reference to the human who 
 - `Acme::Agent::"reportbot-7f3"` is the accessor that made the request
 - `operated_by: Acme::User::"dana"` is the human accountable for it
 
-This matters for two reasons. The policies can tell "an agent did this" from "a human did this" by
-looking at the principal type, which is what Cedar is good at, instead of reading a string out of
-the context that nothing prevents the caller from setting. And losing the link to the operator is
-how agents end up with ambient authority nobody owns: the request has to stay attributable to a
-person even when no person typed it.
+Two consequences follow. Policies tell "an agent did this" from "a human did this" by the principal
+type, which is part of the policy scope and therefore enforced by the engine, rather than by reading
+a string out of the context that nothing prevents the caller from setting. And the reference to the
+operator keeps the request attributable to a person even when no person typed it. Lose that
+reference and the agent has ambient authority nobody owns.
 
 An agent-initiated request and a human-initiated request are therefore two different requests, with
 different principals, evaluated against different (though overlapping) policies.
@@ -66,7 +65,7 @@ different principals, evaluated against different (though overlapping) policies.
 ## Why Annotations Are the Right Place for the Remedy
 
 The decision is still binary. Cedar has `permit` and `forbid`, and adding a third outcome would
-mean forking the policy language. `Challenge` is not a decision. It is a status attached to a
+mean forking the policy language. `Challenge` is not a decision but a status attached to a
 denial, saying "denied for now, and here is what would change the answer."
 
 An annotation carries that well:
@@ -102,7 +101,7 @@ An annotation carries that well:
     │               │   "data_owner_approval"]                   │
     │               │◀────────────────────│                      │
     │               │                     │                      │
-    │               │  3. run both challenges, addressed to the operator
+    │               │  3. run both challenges, each to the actor its policy names
     │               │───────────────────────────────────────────▶│
     │  "ReportBot wants to open strategy-fy27. Did you ask for this?"
     │◀──────────────────────────────────────────────────────────│
@@ -121,13 +120,19 @@ An annotation carries that well:
 ```
 
 Step 4 is the important one. The challenge results go back in as context, and the same policies are
-evaluated again. No policy is bypassed and no verdict is overridden. The request genuinely became a
-different, better-evidenced request.
+evaluated again. No policy is bypassed and no verdict is overridden. The request became a different,
+better-evidenced request.
 
-Note who the challenge is addressed to. The principal is the agent, but an agent cannot confirm
-intent or touch a security key, so both prompts go to `principal.operated_by`. That routing is the
-application's job, and the `@challenge_actor` annotation below states it instead of leaving it
-implied.
+The principal is the agent, and an agent cannot confirm intent or touch a security key, so both
+prompt for either of those goes to `principal.operated_by`.
+
+Owner approval is the opposite case. Routing it to the operator would mean the operator approves
+their own off-scope read, and the control the policy was written for turns into a click. It goes to
+whoever owns the document, which the resource already records in `owner_team`.
+
+Routing is the application's job, and `@challenge_actor` is how each policy says where its prompt
+belongs: `controlling_human` for the two the operator answers, `data_owner` for the one they must
+not.
 
 ## Schema
 
@@ -203,6 +208,7 @@ differing only in how it reaches the human's assignments:
 ```cedar
 @id("forbid_offscope_sensitive_read_by_agent")
 @challenge("data_owner_approval")
+@challenge_actor("data_owner")
 @challenge_strength("high")
 @challenge_ttl_seconds("3600")
 @user_message_id("access.challenge.owner_approval")
@@ -223,6 +229,7 @@ unless {
 ```cedar
 @id("forbid_offscope_sensitive_read_by_user")
 @challenge("data_owner_approval")
+@challenge_actor("data_owner")
 @challenge_strength("high")
 @challenge_ttl_seconds("3600")
 @user_message_id("access.challenge.owner_approval")
@@ -247,7 +254,7 @@ DENY   reason: forbid_agent_read_sensitive_without_intent
                forbid_offscope_sensitive_read_by_agent
 ```
 
-Had Dana opened the document herself, only the scope rule would have fired: one challenge instead
+Had Dana opened the document directly, only the scope rule would have fired: one challenge instead
 of two, which is the proportionality the design is after.
 
 ```text
@@ -263,30 +270,34 @@ ALLOW  reason: permit_read_documents
 ### Notes on the Shape of This
 
 Each challenge is its own policy. Cedar rejects a duplicate annotation key on one policy, so
-`@challenge` appears once per policy. That constraint pushes the design somewhere useful:
-independent risk conditions stay independent policies, they are reviewed separately, and the ones
-that matched are the ones reported in `reason()`.
+`@challenge` appears once per policy. The constraint has a useful consequence: independent risk
+conditions stay independent policies, they are reviewed separately, and the ones that matched are
+the ones reported in `reason()`.
 
-Each `forbid` clears itself through `unless`. A `forbid` whose condition can never be satisfied is a
-hard block, not a challenge. The `unless` clause makes the denial resolvable, and it is why the
-second authorization call can legitimately return `Allow`.
+Each `forbid` clears itself through `unless`. A `forbid` with no way to clear it is a hard block,
+not a challenge. The `unless` clause makes the denial resolvable, and it is why the second
+authorization call can legitimately return `Allow`.
 
 For a resolvable denial, the guidance lives on `forbid` rather than on `permit`. How decisions are
 reported forces this: on a `Deny`, only the satisfied `forbid` policies appear in `reason()`, and if
 nothing matched at all, `reason()` is empty and there are no annotations to read. Annotations on
-`permit` policies are not wasted, they simply speak on the allow path, which is what the
-[quota page](./annotation-quota.md) is built on. A broad `permit` with
-annotated `forbid` layers on top keeps hints available at the moment they are needed. See
-[Only the determining policies are reported](./annotation-patterns.md#only-the-determining-policies-are-reported).
+`permit` policies are not wasted, they simply speak on the allow path, which is what the [quota
+page](./annotation-quota.md) is built on. A broad `permit` with annotated `forbid` layers on top
+keeps hints available at the moment they are needed. See [Only the determining policies are
+reported](./annotation-patterns.md#only-the-determining-policies-are-reported).
 
 One rule, two principal types, two policies. Cedar's scope cannot match a union of principal types,
-and `User` and `Agent` share no attribute interface, so a rule that applies to both is written
-twice. Keeping the `@challenge` value identical across the pair means the application still sees one
-challenge, whichever policy fired. If the duplication grows past a handful of pairs, mirror the
-operator's decision-relevant attributes onto the agent entity when it is built (`agent.assignments`
-copied from `operated_by`). That collapses each pair into a single policy at the cost of a
-denormalized entity. It is a trade between policy-store duplication and entity-builder complexity,
-and it is worth deciding once for the whole policy set rather than per policy.
+so a rule covering both is either written twice or written once with the type test moved into the
+`when` clause, narrowing on `principal is Acme::User` and `principal is Acme::Agent` in two branches
+of an `||`. That single-policy form validates. The pair is still worth the duplication here: each
+principal type gets its own `@id`, so `reason()` and the decision log say which shape fired, and a
+reviewer reads one condition at a time. Keeping the `@challenge` value identical across the pair
+means the application still sees one challenge, whichever policy fired. If the duplication grows
+past a handful of pairs, mirror the operator's decision-relevant attributes onto the agent entity
+when it is built (`agent.assignments` copied from `operated_by`). That collapses each pair into a
+single policy at the cost of a denormalized entity. It is a trade between policy-store duplication
+and entity-builder complexity, and it is worth deciding once for the whole policy set rather than
+per policy.
 
 ## Application Code
 
@@ -326,12 +337,19 @@ for attempt in 0..2 {
     let by_policy = cedarling.annotations_by_policy(reason.iter().copied());
     audit.record(&by_policy);
 
-    // An agent cannot answer a challenge, so the prompt goes to the human behind it.
-    let operator = &agent.operated_by;
-
     // Run the challenges. Results are attested server-side, never taken from the client.
     for name in asked {
-        match challenge_service.run(&name, &operator, &document).await? {
+        // Who answers is the policy's call, not this loop's: an agent cannot confirm
+        // its operator's intent, and an operator cannot approve their own off-scope read.
+        let responder = match actor_of(&by_policy, &name) {
+            "data_owner" => Responder::Team(&document.owner_team),
+            _ => Responder::User(&agent.operated_by),
+        };
+
+        match challenge_service
+            .run(&name, responder, strength_of(&by_policy, &name), &document)
+            .await?
+        {
             Outcome::Passed => {
                 // Stored server-side, scoped to this resource and action, and stamped
                 // with the @challenge_ttl_seconds of the policy that asked for it.
@@ -343,18 +361,46 @@ for attempt in 0..2 {
     }
 }
 
-/// The `@challenge_ttl_seconds` of the policy that asked for `name`.
-///
-/// `by_policy` is keyed by policy ID, so finding the TTL means finding the group
-/// whose `challenge` value is the one that was run. A policy that set no TTL gets
-/// the shortest one the application supports: never an unbounded grant.
-fn ttl_of(by_policy: &HashMap<String, HashMap<String, String>>, name: &str) -> u64 {
+/// Every group whose `challenge` is `name`. `by_policy` is keyed by policy ID, so
+/// the challenge name has to be looked up in the values.
+fn groups_for<'a>(
+    by_policy: &'a HashMap<String, HashMap<String, String>>,
+    name: &str,
+) -> impl Iterator<Item = &'a HashMap<String, String>> {
+    let name = name.to_string();
     by_policy
         .values()
-        .find(|a| a.get("challenge").map(String::as_str) == Some(name))
-        .and_then(|a| a.get("challenge_ttl_seconds"))
-        .and_then(|t| t.parse().ok())
+        .filter(move |a| a.get("challenge") == Some(&name))
+}
+
+/// The shortest TTL any matching policy asked for. Two policies can name the same
+/// challenge, `reason()` has no order, so taking the first one found would pick
+/// nondeterministically. A policy that set no TTL gets the application's floor.
+fn ttl_of(by_policy: &HashMap<String, HashMap<String, String>>, name: &str) -> u64 {
+    groups_for(by_policy, name)
+        .map(|a| {
+            a.get("challenge_ttl_seconds")
+                .and_then(|t| t.parse().ok())
+                .unwrap_or(MIN_CHALLENGE_TTL_SECONDS)
+        })
+        .min()
         .unwrap_or(MIN_CHALLENGE_TTL_SECONDS)
+}
+
+/// Who has to answer, and how hard the challenge should be. Both default to the
+/// strictest reading when a policy says nothing.
+fn actor_of<'a>(by_policy: &'a HashMap<String, HashMap<String, String>>, name: &str) -> &'a str {
+    groups_for(by_policy, name)
+        .find_map(|a| a.get("challenge_actor"))
+        .map_or("controlling_human", String::as_str)
+}
+
+fn strength_of(by_policy: &HashMap<String, HashMap<String, String>>, name: &str) -> Strength {
+    groups_for(by_policy, name)
+        .filter_map(|a| a.get("challenge_strength"))
+        .map(|s| Strength::parse(s))
+        .max()
+        .unwrap_or(Strength::High)
 }
 ```
 
@@ -402,9 +448,11 @@ part of the implementation rather than as advice.
 - Bind the result to the request. A challenge passed for one document should not silently authorize
   a bulk export of a thousand others. Scope the stored result to the action and resource it was
   raised for, or to a short window, whichever your risk model justifies.
-- Address the challenge to a human. A challenge that an agent can satisfy on its own is not a
-  challenge. `@challenge_actor("controlling_human")` states the requirement, and the application has
-  to route the prompt to `principal.operated_by` and record who answered.
+- Address the challenge to someone who can refuse it. A challenge an agent satisfies on its own is
+  not a challenge, and one the requester answers about their own request is not either.
+  `@challenge_actor` names the party per policy: `controlling_human` resolves to
+  `principal.operated_by`, `data_owner` to the team in `resource.owner_team`. Record who answered,
+  and reject an answer from the principal the challenge exists to constrain.
 - Log the failures. A challenge that is repeatedly abandoned is a signal in itself, and it belongs
   in the same stream as the decision logs.
 
@@ -480,11 +528,15 @@ The application reads `containment` rather than `challenge`, shows the message, 
 there is no inline path from here back to `Allow`. Lifting it means changing the `risk_tier`, which
 happens outside the request.
 
-Containment depends on an attribute being present, which is worth stating because it is the one
-policy here that must never quietly stop applying. Cedarling validates entities against the schema,
-so an operator entity built without `risk_tier` fails the request rather than slipping past the
-containment policy. That is the behavior you want, and it is a reason to keep the attribute required
-in the schema rather than optional.
+Containment depends on an attribute being present, and it is the one policy here that must never
+stop applying unnoticed. When the policy store carries a schema, Cedarling validates entities
+against it, so an operator entity built without `risk_tier` fails the request instead of slipping
+past the containment policy. Without a schema there is nothing to check: the policy errors at
+evaluation, drops out of the decision, and the denial it should have produced never happens. Ship a
+schema, and keep `risk_tier` required in it rather than optional.
+
+Containment is keyed on the human. Freezing one misbehaving agent while its operator keeps working
+would need `risk_tier` on `Agent` and a third policy; this example leaves that out.
 
 ## What This Buys You
 

--- a/docs/cedarling/patterns/annotation-challenge.md
+++ b/docs/cedarling/patterns/annotation-challenge.md
@@ -388,11 +388,19 @@ fn ttl_of(by_policy: &HashMap<String, HashMap<String, String>>, name: &str) -> u
 }
 
 /// Who has to answer, and how hard the challenge should be. Both default to the
-/// strictest reading when a policy says nothing.
+/// strictest reading when a policy says nothing, and disagreement resolves the same
+/// way: two policies naming different actors for one challenge is a policy bug, and
+/// picking whichever the iterator reached first would hide it behind a coin flip.
 fn actor_of<'a>(by_policy: &'a HashMap<String, HashMap<String, String>>, name: &str) -> &'a str {
-    groups_for(by_policy, name)
-        .find_map(|a| a.get("challenge_actor"))
-        .map_or("controlling_human", String::as_str)
+    let actors: BTreeSet<&str> = groups_for(by_policy, name)
+        .filter_map(|a| a.get("challenge_actor"))
+        .map(String::as_str)
+        .collect();
+
+    match actors.len() {
+        1 => actors.iter().next().copied().unwrap(),
+        _ => "controlling_human",
+    }
 }
 
 fn strength_of(by_policy: &HashMap<String, HashMap<String, String>>, name: &str) -> Strength {

--- a/docs/cedarling/patterns/annotation-challenge.md
+++ b/docs/cedarling/patterns/annotation-challenge.md
@@ -289,7 +289,9 @@ and it is worth deciding once for the whole policy set rather than per policy.
 ```rust
 use std::collections::BTreeSet;
 
-let mut completed: BTreeSet<String> = session.completed_challenges();
+// Server-issued records only, already filtered to this action and resource and to
+// records whose @challenge_ttl has not expired. Never the raw client context.
+let mut completed: BTreeSet<String> = session.valid_challenges_for(&document, Action::Read);
 
 for attempt in 0..2 {
     let result = cedarling
@@ -315,14 +317,21 @@ for attempt in 0..2 {
         return Err(deny(message_id));
     }
 
-    // Record which policy asked for what. This is the audit trail.
-    audit.record(cedarling.annotations_by_policy(reason.iter().copied()));
+    // Each policy's annotations stay grouped: the challenge it asked for, the TTL that
+    // applies to it, and the message that belongs with it. This is also the audit trail.
+    let by_policy = cedarling.annotations_by_policy(reason.iter().copied());
+    audit.record(&by_policy);
 
     // Run the challenges. Results are attested server-side, never taken from the client.
     // For an agent principal the prompt is addressed to `agent.operated_by`.
     for name in asked {
         match challenge_service.run(&name, &operator, &document).await? {
-            Outcome::Passed => { completed.insert(name); }
+            Outcome::Passed => {
+                // Stored server-side, scoped to this resource and action, and stamped
+                // with the @challenge_ttl of the policy that asked for it.
+                session.record_challenge(&name, &document, Action::Read, ttl_of(&by_policy, &name))?;
+                completed.insert(name);
+            }
             Outcome::Failed | Outcome::Abandoned => return Err(deny_and_escalate(name)),
         }
     }
@@ -334,15 +343,22 @@ const result = await cedarling.authorize_unsigned(JSON.stringify(request));
 
 if (!result.decision) {
   const reason = result.response.diagnostics.reason;
-  const asked = cedarling.annotation_values(reason, "challenge");
-  const ttl = cedarling.annotation_values(reason, "challenge_ttl");
+
+  // Grouped, so each challenge keeps its own TTL and message.
+  const asked = Object.values(cedarling.annotations_by_policy(reason))
+    .filter((a) => a.challenge);
 
   if (asked.length === 0) {
     return denyPlain(cedarling.annotations_map(reason).user_message_id);
   }
-  return requestChallenges(asked, ttl);
+  return requestChallenges(asked);
 }
 ```
+
+Nothing in that loop trusts the caller. The set fed into `context.completed_challenges` is rebuilt
+from server-side records that are scoped to this resource and action and dropped once their TTL has
+passed, which is what makes the policy's `unless` clause mean anything. The requirements below spell
+out why each of those properties matters.
 
 The retry is bounded on purpose. One re-evaluation after the challenges pass is enough. Looping
 until `Allow` turns a policy misconfiguration into an infinite challenge prompt.

--- a/docs/cedarling/patterns/annotation-challenge.md
+++ b/docs/cedarling/patterns/annotation-challenge.md
@@ -341,9 +341,9 @@ for attempt in 0..2 {
     for name in asked {
         // Who answers is the policy's call, not this loop's: an agent cannot confirm
         // its operator's intent, and an operator cannot approve their own off-scope read.
-        let responder = match actor_of(&by_policy, &name) {
-            "data_owner" => Responder::Team(&document.owner_team),
-            _ => Responder::User(&agent.operated_by),
+        let responder = match actor_of(&by_policy, &name)? {
+            Actor::DataOwner => Responder::Team(&document.owner_team),
+            Actor::ControllingHuman => Responder::User(&agent.operated_by),
         };
 
         match challenge_service
@@ -387,19 +387,24 @@ fn ttl_of(by_policy: &HashMap<String, HashMap<String, String>>, name: &str) -> u
         .unwrap_or(MIN_CHALLENGE_TTL_SECONDS)
 }
 
-/// Who has to answer, and how hard the challenge should be. Both default to the
-/// strictest reading when a policy says nothing, and disagreement resolves the same
-/// way: two policies naming different actors for one challenge is a policy bug, and
-/// picking whichever the iterator reached first would hide it behind a coin flip.
-fn actor_of<'a>(by_policy: &'a HashMap<String, HashMap<String, String>>, name: &str) -> &'a str {
+/// Who has to answer. Silence defaults to the strictest reading, but a value this
+/// code cannot route is a policy bug and so is a disagreement between two policies
+/// naming the same challenge. Neither may fall through to the operator: that is the
+/// party the challenge exists to check, so the quiet fallback weakens exactly the
+/// case it was meant to cover.
+fn actor_of(
+    by_policy: &HashMap<String, HashMap<String, String>>,
+    name: &str,
+) -> Result<Actor, Error> {
     let actors: BTreeSet<&str> = groups_for(by_policy, name)
         .filter_map(|a| a.get("challenge_actor"))
         .map(String::as_str)
         .collect();
 
-    match actors.len() {
-        1 => actors.iter().next().copied().unwrap(),
-        _ => "controlling_human",
+    match actors.into_iter().collect::<Vec<_>>().as_slice() {
+        [] | ["controlling_human"] => Ok(Actor::ControllingHuman),
+        ["data_owner"] => Ok(Actor::DataOwner),
+        other => Err(Error::MalformedAnnotation("challenge_actor", other.join(", "))),
     }
 }
 
@@ -459,8 +464,10 @@ part of the implementation rather than as advice.
 - Address the challenge to someone who can refuse it. A challenge an agent satisfies on its own is
   not a challenge, and one the requester answers about their own request is not either.
   `@challenge_actor` names the party per policy: `controlling_human` resolves to
-  `principal.operated_by`, `data_owner` to the team in `resource.owner_team`. Record who answered,
-  and reject an answer from the principal the challenge exists to constrain.
+  `principal.operated_by`, `data_owner` to the team in `resource.owner_team`. Those two are the
+  whole vocabulary: a third value, or two policies asking for different ones, is a policy bug, and
+  routing it to the operator anyway hands the challenge to the party it was meant to constrain.
+  Record who answered, and reject an answer from that principal.
 - Log the failures. A challenge that is repeatedly abandoned is a signal in itself, and it belongs
   in the same stream as the decision logs.
 

--- a/docs/cedarling/patterns/annotation-challenge.md
+++ b/docs/cedarling/patterns/annotation-challenge.md
@@ -1,0 +1,430 @@
+---
+tags:
+  - administration
+  - lock
+  - authorization / authz
+  - Cedar
+  - Cedarling
+  - annotations
+---
+
+# Pattern: Challenges and Step-Up
+
+!!! note "Illustrative example"
+
+    Acme, ReportBot, and every annotation key below (`@challenge`, `@challenge_ttl`,
+    `@containment`, and the rest) are invented for this page. Cedarling attaches no meaning to
+    them; they work only because the example application reads them. The scenario is simplified to
+    show the mechanism, not to be copied as a security design. See
+    [Policy Annotation Patterns](./annotation-patterns.md) for the ground rules.
+
+## The Scenario
+
+Acme runs an internal assistant, `ReportBot`, that employees use to answer questions over company
+documents. It reads the same document store the employees can read, on their behalf.
+
+Dana works in the Northeast financial-services team. She asks ReportBot a broad question, and to
+answer it the assistant reaches for `Acme::Document::"strategy-fy27"`, a company-level strategy
+document classified `highly_confidential`, normally read only by the strategy and finance teams.
+
+Nothing here is obviously an attack. There are three plausible explanations:
+
+- Dana genuinely needs the document and nobody told the access system.
+- The assistant over-reached: it expanded a vague question into a search Dana never intended.
+  Dana never asked for that document and would be surprised to learn it was opened in her name.
+- Dana's credentials are being used by somebody else.
+
+A binary access system has to pick one. Denying blocks legitimate work and trains people to route
+around the tool. Allowing means an agent quietly exfiltrates strategy documents at machine speed,
+and the security team finds out from a log review next week.
+
+The third option is to ask: confirm with the human that the access was intended, and get the data
+owner to confirm the need. [Beyond Zero](https://queue.acm.org/detail.cfm?id=3819083) calls this a
+*challenge*, friction applied in the moment and in proportion to the risk, instead of a flat
+denial.
+
+## Modeling the Agent
+
+The identity model has to be right before the policies make sense, because the policies are
+written against it.
+
+The agent is a principal in its own right, not a flag on the human. `ReportBot` has its own entity,
+its own ID, and its own attributes, and it carries a reference to the human who operates it:
+
+- `Acme::Agent::"reportbot-7f3"` is the accessor that made the request
+- `operated_by: Acme::User::"dana"` is the human accountable for it
+
+This matters for two reasons. The policies can tell "an agent did this" from "a human did this" by
+looking at the principal type, which is what Cedar is good at, instead of reading a string out of
+the context that nothing prevents the caller from setting. And losing the link to the operator is
+how agents end up with ambient authority nobody owns: the request has to stay attributable to a
+person even when no person typed it.
+
+An agent-initiated request and a human-initiated request are therefore two different requests, with
+different principals, evaluated against different (though overlapping) policies.
+
+## Why Annotations Are the Right Place for the Remedy
+
+The decision is still binary. Cedar has `permit` and `forbid`, and adding a third outcome would
+mean forking the policy language. `Challenge` is not a decision. It is a status attached to a
+denial, saying "denied for now, and here is what would change the answer."
+
+An annotation carries that well:
+
+- The policy that denied the request knows *why*, so it is the right place to record *what would
+  resolve it*. The condition and the remedy stay in one reviewable unit.
+- The set of challenges is a policy decision, not an application decision. Which risky combinations
+  deserve a security-key touch and which deserve owner approval is a question for the security
+  team, and it changes far more often than the application code.
+- The application only needs the *names* of the challenges it can run. It never needs to know under
+  which conditions each one applies.
+
+## The Flow
+
+```
+ ┌──────┐        ┌─────┐            ┌───────────┐      ┌───────────────────┐
+ │ Dana │        │ App │            │ Cedarling │      │ Challenge service │
+ └──┬───┘        └──┬──┘            └─────┬─────┘      └─────────┬─────────┘
+    │  prompt       │                     │                      │
+    │──────────────▶│                     │                      │
+    │               │  1. authorize_unsigned                      │
+    │               │  principal: Agent::"reportbot-7f3"          │
+    │               │  completed_challenges: []                   │
+    │               │────────────────────▶│                      │
+    │               │  Deny, reason: [    │                      │
+    │               │    forbid_agent_read_sensitive_without_intent,
+    │               │    forbid_offscope_sensitive_read_by_agent ]│
+    │               │◀────────────────────│                      │
+    │               │                     │                      │
+    │               │  2. annotation_values(reason, "challenge")  │
+    │               │────────────────────▶│                      │
+    │               │  ["confirm_human_intent",                  │
+    │               │   "data_owner_approval"]                   │
+    │               │◀────────────────────│                      │
+    │               │                     │                      │
+    │               │  3. run both challenges, addressed to the operator
+    │               │───────────────────────────────────────────▶│
+    │  "ReportBot wants to open strategy-fy27. Did you ask for this?"
+    │◀──────────────────────────────────────────────────────────│
+    │  confirm      │                     │                      │
+    │──────────────────────────────────────────────────────────▶│
+    │               │  attested results (server-side, TTL-bound)  │
+    │               │◀───────────────────────────────────────────│
+    │               │                     │                      │
+    │               │  4. re-authorize, same principal            │
+    │               │  completed_challenges: [both]               │
+    │               │────────────────────▶│                      │
+    │               │  Allow, reason: [permit_read_documents]     │
+    │               │◀────────────────────│                      │
+    │  answer       │                     │                      │
+    │◀──────────────│                     │                      │
+```
+
+Step 4 is the important one. The challenge results go back in as context, and the same policies are
+evaluated again. No policy is bypassed and no verdict is overridden. The request genuinely became a
+different, better-evidenced request.
+
+Note who the challenge is addressed to. The principal is the agent, but an agent cannot confirm
+intent or touch a security key, so both prompts go to `principal.operated_by`. That routing is the
+application's job, and the `@challenge_actor` annotation below states it instead of leaving it
+implied.
+
+## Schema
+
+Both principal types apply to the action, and the challenge results are part of the context so the
+policies can test them.
+
+```cedarschema
+namespace Acme {
+    entity User = {
+        "assignments": Set<String>,
+        "risk_tier": String,
+    };
+
+    entity Agent = {
+        "operated_by": User,
+        "model": String,
+    };
+
+    entity Document = {
+        "sensitivity": String,
+        "subject": String,
+        "owner_team": String,
+    };
+
+    action "Read" appliesTo {
+        principal: [User, Agent],
+        resource: [Document],
+        context: {
+            "completed_challenges": Set<String>,
+        }
+    };
+}
+```
+
+## Policies
+
+One broad `permit`, with the risk conditions layered on top as annotated `forbid` policies:
+
+```cedar
+@id("permit_read_documents")
+permit (
+    principal,
+    action == Acme::Action::"Read",
+    resource is Acme::Document
+);
+```
+
+An agent reading a highly confidential document must have the human confirm that this is what they
+asked for. This condition is about the *nature of the accessor*, so it exists only for `Agent`:
+
+```cedar
+@id("forbid_agent_read_sensitive_without_intent")
+@challenge("confirm_human_intent")
+@challenge_actor("controlling_human")
+@challenge_ttl("300")
+@user_message_id("access.challenge.confirm_human_intent")
+forbid (
+    principal is Acme::Agent,
+    action == Acme::Action::"Read",
+    resource is Acme::Document
+)
+when { resource.sensitivity == "highly_confidential" }
+unless {
+    context.completed_challenges.contains("confirm_human_intent")
+};
+```
+
+Reading a highly confidential document outside your work assignment needs the data owner's
+approval. This one is about the *human's scope of work*, and it applies whether the human reads
+the document directly or an agent reads it for them. So it exists twice, once per principal type,
+differing only in how it reaches the human's assignments:
+
+```cedar
+@id("forbid_offscope_sensitive_read_by_agent")
+@challenge("data_owner_approval")
+@challenge_strength("high")
+@user_message_id("access.challenge.owner_approval")
+forbid (
+    principal is Acme::Agent,
+    action == Acme::Action::"Read",
+    resource is Acme::Document
+)
+when {
+    resource.sensitivity == "highly_confidential" &&
+    !principal.operated_by.assignments.contains(resource.subject)
+}
+unless {
+    context.completed_challenges.contains("data_owner_approval")
+};
+```
+
+```cedar
+@id("forbid_offscope_sensitive_read_by_user")
+@challenge("data_owner_approval")
+@challenge_strength("high")
+@user_message_id("access.challenge.owner_approval")
+forbid (
+    principal is Acme::User,
+    action == Acme::Action::"Read",
+    resource is Acme::Document
+)
+when {
+    resource.sensitivity == "highly_confidential" &&
+    !principal.assignments.contains(resource.subject)
+}
+unless {
+    context.completed_challenges.contains("data_owner_approval")
+};
+```
+
+Evaluated against Dana's request, the agent principal trips both agent policies:
+
+```text
+DENY   reason: forbid_agent_read_sensitive_without_intent
+               forbid_offscope_sensitive_read_by_agent
+```
+
+Had Dana opened the document herself, only the scope rule would have fired: one challenge instead
+of two, which is the proportionality the design is after.
+
+```text
+DENY   reason: forbid_offscope_sensitive_read_by_user
+```
+
+And once both challenges are recorded in the context, the same policy set allows the request:
+
+```text
+ALLOW  reason: permit_read_documents
+```
+
+### Notes on the Shape of This
+
+Each challenge is its own policy. Cedar rejects a duplicate annotation key on one policy, so
+`@challenge` appears once per policy. That constraint pushes the design somewhere useful:
+independent risk conditions stay independent policies, they are reviewed separately, and the ones
+that matched are the ones reported in `reason()`.
+
+Each `forbid` clears itself through `unless`. A `forbid` whose condition can never be satisfied is a
+hard block, not a challenge. The `unless` clause makes the denial resolvable, and it is why the
+second authorization call can legitimately return `Allow`.
+
+The guidance lives on `forbid`, not on `permit`. How decisions are reported forces this: on a
+`Deny`, only the satisfied `forbid` policies appear in `reason()`, and if nothing permitted the
+request at all, `reason()` is empty and there are no annotations to read. A broad `permit` with
+annotated `forbid` layers on top keeps hints available at the moment they are needed. See
+[Only the determining policies are reported](./annotation-patterns.md#only-the-determining-policies-are-reported).
+
+One rule, two principal types, two policies. Cedar's scope cannot match a union of principal types,
+and `User` and `Agent` share no attribute interface, so a rule that applies to both is written
+twice. Keeping the `@challenge` value identical across the pair means the application still sees one
+challenge, whichever policy fired. If the duplication grows past a handful of pairs, mirror the
+operator's decision-relevant attributes onto the agent entity when it is built (`agent.assignments`
+copied from `operated_by`). That collapses each pair into a single policy at the cost of a
+denormalized entity. It is a trade between policy-store duplication and entity-builder complexity,
+and it is worth deciding once for the whole policy set rather than per policy.
+
+## Application Code
+
+```rust
+use std::collections::BTreeSet;
+
+let mut completed: BTreeSet<String> = session.completed_challenges();
+
+for attempt in 0..2 {
+    let result = cedarling
+        .authorize_unsigned(read_request(&agent, &document, &completed))
+        .await?;
+
+    if result.decision {
+        return Ok(serve(result));
+    }
+
+    let reason: Vec<_> = result.response.diagnostics().reason().collect();
+
+    // Every challenge asked for by a policy that actually matched.
+    let asked = cedarling.annotation_values(reason.iter().copied(), "challenge");
+
+    // No guidance, or the challenges were already attempted: a plain denial.
+    if asked.is_empty() || attempt == 1 {
+        let message_id = cedarling
+            .annotation_values(reason.iter().copied(), "user_message_id")
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| "access.denied.generic".to_string());
+        return Err(deny(message_id));
+    }
+
+    // Record which policy asked for what. This is the audit trail.
+    audit.record(cedarling.annotations_by_policy(reason.iter().copied()));
+
+    // Run the challenges. Results are attested server-side, never taken from the client.
+    // For an agent principal the prompt is addressed to `agent.operated_by`.
+    for name in asked {
+        match challenge_service.run(&name, &operator, &document).await? {
+            Outcome::Passed => { completed.insert(name); }
+            Outcome::Failed | Outcome::Abandoned => return Err(deny_and_escalate(name)),
+        }
+    }
+}
+```
+
+```javascript
+const result = await cedarling.authorize_unsigned(JSON.stringify(request));
+
+if (!result.decision) {
+  const reason = result.response.diagnostics.reason;
+  const asked = cedarling.annotation_values(reason, "challenge");
+  const ttl = cedarling.annotation_values(reason, "challenge_ttl");
+
+  if (asked.length === 0) {
+    return denyPlain(cedarling.annotations_map(reason).user_message_id);
+  }
+  return requestChallenges(asked, ttl);
+}
+```
+
+The retry is bounded on purpose. One re-evaluation after the challenges pass is enough. Looping
+until `Allow` turns a policy misconfiguration into an infinite challenge prompt.
+
+## Security Requirements
+
+The pattern is only as strong as the integrity of `context.completed_challenges`, so treat these as
+part of the implementation rather than as advice.
+
+- Never accept completed challenges from the client. A challenge result has to be produced by the
+  challenge service and held in server-side session state, or in a signed, audience-bound token. If
+  a browser or an agent can put `"security_key_touch"` into the context, the policy enforces
+  nothing.
+- Enforce the TTL. `@challenge_ttl` is a hint the application has to act on: drop the completed
+  challenge from the context once it expires, so long-lived sessions cannot ride one touch forever.
+  Cedar has no concept of elapsed time here, so nothing enforces it if the application does not.
+- Bind the result to the request. A challenge passed for one document should not silently authorize
+  a bulk export of a thousand others. Scope the stored result to the action and resource it was
+  raised for, or to a short window, whichever your risk model justifies.
+- Address the challenge to a human. A challenge that an agent can satisfy on its own is not a
+  challenge. `@challenge_actor("controlling_human")` states the requirement, and the application has
+  to route the prompt to `principal.operated_by` and record who answered.
+- Log the failures. A challenge that is repeatedly abandoned is a signal in itself, and it belongs
+  in the same stream as the decision logs.
+
+## Variation: Risk Carried by the Operator
+
+Risk attaches to the human, but the request arrives from the agent. Reaching through `operated_by`
+keeps the two connected, so an elevated-risk operator does not get a quieter path by sending an
+assistant:
+
+```cedar
+@id("forbid_agent_read_for_elevated_risk_operator")
+@challenge("security_key_touch")
+@challenge_actor("controlling_human")
+@challenge_ttl("60")
+@user_message_id("access.challenge.security_key")
+forbid (
+    principal is Acme::Agent,
+    action == Acme::Action::"Read",
+    resource is Acme::Document
+)
+when {
+    principal.operated_by.risk_tier == "elevated" &&
+    resource.sensitivity == "highly_confidential"
+}
+unless {
+    context.completed_challenges.contains("security_key_touch")
+};
+```
+
+## Variation: Containment
+
+A challenge is resolvable in the moment. Some outcomes should not be. After several failed
+challenges, or when an investigation has already flagged the account, the right answer is a durable
+block that a person has to lift.
+
+That is the same annotation mechanism with the `unless` clause removed, plus a different vocabulary
+so the application does not offer a way out that does not exist:
+
+```cedar
+@id("forbid_contained_operator")
+@containment("session_freeze")
+@user_message_id("access.contained.contact_security")
+@escalate_to("secops-oncall")
+forbid (
+    principal is Acme::Agent,
+    action,
+    resource
+)
+when { principal.operated_by.risk_tier == "contained" };
+```
+
+The application reads `containment` rather than `challenge`, shows the message, and does not
+prompt: there is no inline path from here back to `Allow`. Lifting it means changing the operator's
+`risk_tier`, which happens outside the request. A twin policy on `principal is Acme::User` contains
+the human's own sessions the same way.
+
+## What This Buys You
+
+The application ends up with no hardcoded knowledge of *when* to challenge. It knows how to run
+`confirm_human_intent`, `data_owner_approval`, and `security_key_touch`, it knows to address them to
+the operator, and it knows how to read annotations. Security engineers add a condition, retire one,
+or raise a challenge's strength by editing policies, and each of those changes is a diff you can
+review, test against recorded requests, and find later in the decision log.

--- a/docs/cedarling/patterns/annotation-challenge.md
+++ b/docs/cedarling/patterns/annotation-challenge.md
@@ -384,6 +384,10 @@ part of the implementation rather than as advice.
 - Log the failures. A challenge that is repeatedly abandoned is a signal in itself, and it belongs
   in the same stream as the decision logs.
 
+Because those records live on the server, a browser evaluating these same policies is working from a
+copy it cannot refresh, so its denials are provisional. See
+[Advisory denials in a client-side PDP](./annotation-client-authority.md).
+
 ## Variation: Risk Carried by the Operator
 
 Risk attaches to the human, but the request arrives from the agent. Reaching through `operated_by`

--- a/docs/cedarling/patterns/annotation-client-authority.md
+++ b/docs/cedarling/patterns/annotation-client-authority.md
@@ -56,6 +56,21 @@ The reverse must never exist. There is no annotation that lets a client skip the
 local `Allow`, and none that lets it disregard a denial from the server. Those would move the
 decision to the least trustworthy participant.
 
+The asymmetry is not free. It holds only while three things are true, and each of them is something
+you have to keep true:
+
+- Every guarded call is authorized again on the server, from inputs the server resolved itself. A
+  single endpoint that trusts the browser's decision, or that rebuilds the request from what the
+  browser sent, ends the guarantee for that endpoint.
+- The client renders denials and never enforces obligations. Annotations like `@mask` and
+  `@row_limit` from the [response shaping page](./annotation-response-shaping.md) are instructions
+  for whoever builds the response, which is the server. A browser that masks columns it received in
+  the clear is decorating data it already has.
+- Everything the browser evaluates is treated as public. The embedded PDP holds the policy store and
+  the entity attributes it reasons over, so thresholds, tier names, contract quotas, and risk tiers
+  are readable by anyone who opens the developer tools. Ship only what you are willing to show, and
+  keep policies whose contents are themselves sensitive on the server.
+
 ## Which Policies Deserve It
 
 Not the important ones. The ones whose conditions rest on facts the browser cannot hold fresh, which
@@ -151,8 +166,8 @@ so the next person to touch it can tell whether the marker is still warranted, a
     │                 │                   │                  │
     │                 │ Deny, reason: [forbid_..._quota_exhausted]
     │                 │                   │                  │
-    │                 │ annotation_values(reason, "revalidate")
-    │                 │ ["server"] → do not render this denial
+    │                 │ annotations_by_policy(reason)
+    │                 │ every denial marked → do not render it
     │  loader         │                   │                  │
     │◀────────────────│                   │                  │
     │                 │  POST /reports    │                  │
@@ -227,6 +242,15 @@ it is enforcing something.
 Declare the pair once, in a table the whole application shares:
 
 ```javascript
+// Built once, from the tokens the session already holds.
+const principal = {
+  cedar_entity_mapping: { entity_type: "Acme::User", id: user.id },
+  role: user.role,
+};
+
+// The stale counter this whole pattern is about: a snapshot taken at page load.
+const usage = usageSnapshot();
+
 const guardedActions = {
   generateReport: {
     action: 'Acme::Action::"GenerateReport"',

--- a/docs/cedarling/patterns/annotation-client-authority.md
+++ b/docs/cedarling/patterns/annotation-client-authority.md
@@ -1,0 +1,401 @@
+---
+tags:
+  - administration
+  - lock
+  - authorization / authz
+  - Cedar
+  - Cedarling
+  - annotations
+---
+
+# Pattern: Advisory Denials in a Client-Side PDP
+
+!!! note "Illustrative example"
+
+    Acme Reports and every annotation key below (`@revalidate`, `@stale_context`,
+    `@loading_message_id`) are invented for this page. Cedarling attaches no meaning to them; they
+    work only because the example application reads them. See
+    [Policy Annotation Patterns](./annotation-patterns.md) for the ground rules.
+
+## The Scenario
+
+Acme's reporting dashboard is a browser application with Cedarling embedded through the WASM
+package. It authorizes locally before it calls the API, which is what makes the interface feel
+immediate: buttons that would fail are disabled, and a click that cannot succeed is answered without
+a round trip.
+
+The API runs Cedarling too, over the same policy store, and re-evaluates every request. That is not
+redundancy. The browser copy exists for the interface, and the server copy is the one that actually
+protects the data.
+
+Now two different denials arrive at the same button.
+
+The user is a viewer, and viewers do not generate reports. The browser knows the user's role, the
+role is not going to change between the click and the request, and the server would say exactly the
+same thing. Rendering "you do not have access" locally is correct and costs nothing.
+
+The workspace has burned through its monthly quota. The browser is comparing against a counter it
+fetched when the page loaded, and the real figure lives in the metering service. That number may
+have moved in either direction: the month may have rolled over, an administrator may have raised the
+plan, or another tab may have consumed the remainder. A local denial here is a guess.
+
+Both are `Deny`. Only one of them is worth showing.
+
+## Why This Is Safe
+
+A client-side PDP can be wrong in exactly one direction. It cannot grant anything, because the
+server evaluates the same request again and grants nothing on the browser's say-so. What it can do
+is refuse something the server would have allowed, which is a correctness problem in the interface
+rather than a security problem.
+
+That asymmetry is what makes the pattern work. Sending the request anyway, after a local denial,
+gives away nothing: the authoritative answer is still the server's. The annotation only tells the
+browser that its own "no" is not worth rendering.
+
+The reverse must never exist. There is no annotation that lets a client skip the request after a
+local `Allow`, and none that lets it disregard a denial from the server. Those would move the
+decision to the least trustworthy participant.
+
+## Which Policies Deserve It
+
+Not the important ones. The ones whose conditions rest on facts the browser cannot hold fresh, which
+in practice means facts the server owns:
+
+- counters and quotas, like `context.reports_used`
+- approval records, like `context.approvals`
+- challenge results, like `context.completed_challenges`
+- validated incident or session state, like `context.incident_id`
+- risk attributes a backend investigation updates, like `principal.risk_tier`
+
+Those examples are the context fields from the other pages in this section, which is not a
+coincidence. Every one of them describes something the server established and the client merely
+carries a copy of. Their denials are the ones a browser should not render on its own.
+
+A denial that rests on the principal's role, the resource's type, or anything else the browser
+received with its tokens is in the opposite position. It is as good locally as it is remotely.
+
+## Schema
+
+```cedarschema
+namespace Acme {
+    entity User = {
+        "role": String,
+    };
+
+    entity Workspace;
+
+    action "GenerateReport" appliesTo {
+        principal: [User],
+        resource: [Workspace],
+        context: {
+            "reports_used": Long,
+        }
+    };
+}
+```
+
+## Policies
+
+The same three policies run in the browser and on the server. Only one of them carries the marker.
+
+```cedar
+@id("permit_generate_report")
+permit (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+);
+```
+
+```cedar
+@id("forbid_generate_report_wrong_role")
+@user_message_id("report.role.required")
+forbid (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+unless {
+    ["analyst", "admin"].contains(principal.role)
+};
+```
+
+```cedar
+@id("forbid_generate_report_quota_exhausted")
+@revalidate("server")
+@stale_context("reports_used")
+@loading_message_id("report.checking_quota")
+@user_message_id("quota.reports.exhausted")
+forbid (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when { context.reports_used >= 1000 };
+```
+
+`@stale_context("reports_used")` is not read by the runtime. It documents *why* the policy is marked,
+so the next person to touch it can tell whether the marker is still warranted, and so that removing
+`reports_used` from the context is visibly connected to removing the marker.
+
+## The Flow
+
+```text
+ ┌──────┐        ┌─────────┐        ┌───────────┐        ┌────────┐
+ │ User │        │ Browser │        │  API      │        │Metering│
+ └──┬───┘        └────┬────┘        └─────┬─────┘        └───┬────┘
+    │  click          │                   │                  │
+    │────────────────▶│                   │                  │
+    │                 │ local authorize_unsigned             │
+    │                 │ (reports_used from page load)        │
+    │                 │                   │                  │
+    │                 │ Deny, reason: [forbid_..._quota_exhausted]
+    │                 │                   │                  │
+    │                 │ annotation_values(reason, "revalidate")
+    │                 │ ["server"] → do not render this denial
+    │  loader         │                   │                  │
+    │◀────────────────│                   │                  │
+    │                 │  POST /reports    │                  │
+    │                 │──────────────────▶│                  │
+    │                 │                   │ fresh counter    │
+    │                 │                   │─────────────────▶│
+    │                 │                   │◀─────────────────│
+    │                 │                   │ authorize_unsigned
+    │                 │                   │ (authoritative)  │
+    │                 │  201, or 403 with its own message    │
+    │                 │◀──────────────────│                  │
+    │  report / error │                   │                  │
+    │◀────────────────│                   │                  │
+```
+
+The loader is the honest representation of the browser's state. It does not know the answer, and it
+says so.
+
+## Browser Code
+
+None of this belongs in a click handler. The decision of whether a local denial may be rendered is
+the same for every guarded action in the application, so it lives in two pieces that every action
+shares: a function that reads the decision, and a wrapper that runs the call.
+
+The first one is pure. Given a decision, it says what the browser is entitled to do with it:
+
+```javascript
+// The only place the UI interprets an authorization decision.
+function localOutcome(result) {
+  if (result.decision) {
+    return { proceed: true };
+  }
+
+  const denials = Object.values(
+    cedarling.annotations_by_policy(result.response.diagnostics.reason),
+  );
+
+  // A denial the browser is entitled to make, or nothing matched at all.
+  const local = denials.find((a) => a.revalidate !== "server");
+
+  if (local || denials.length === 0) {
+    return {
+      proceed: false,
+      messageId: local?.user_message_id ?? "access.denied.generic",
+    };
+  }
+
+  // Every denial rests on data the server owns, so this one is not ours to render.
+  return {
+    proceed: true,
+    pendingMessageId: denials[0].loading_message_id ?? "common.checking",
+  };
+}
+```
+
+Note that both an `Allow` and a fully provisional `Deny` return `proceed: true`. From the browser's
+side they are the same situation: it has nothing worth saying, and the server decides. The only
+difference is that one of them warns the interface to expect a wait.
+
+`localOutcome` is also what a render-time check calls. Disabling a button is the interface acting on
+a denial before any click, so it may only act on a denial the browser is entitled to make: `proceed:
+false` renders as disabled, and everything else renders as enabled and resolves when clicked.
+
+### Bind the Action to the Call It Guards
+
+The wrapper still needs a request to authorize and a call to make, and if a caller supplies those
+separately they are free to drift. The browser can authorize `Acme::Action::"GenerateReport"` and
+then post to an endpoint that exports raw rows, and nothing complains: the local check was real, it
+just answered a question nobody asked. The failure is quiet, because the interface still looks like
+it is enforcing something.
+
+Declare the pair once, in a table the whole application shares:
+
+```javascript
+const guardedActions = {
+  generateReport: {
+    action: 'Acme::Action::"GenerateReport"',
+    resource: (workspace) => ({
+      cedar_entity_mapping: { entity_type: "Acme::Workspace", id: workspace.id },
+    }),
+    context: (workspace) => ({ reports_used: usage.cached(workspace.id) }),
+    call: (workspace) => api.post("/reports", { workspace: workspace.id }),
+  },
+
+  exportRows: {
+    action: 'Acme::Action::"ExportRows"',
+    resource: (workspace) => ({
+      cedar_entity_mapping: { entity_type: "Acme::Workspace", id: workspace.id },
+    }),
+    context: () => ({}),
+    call: (workspace) => api.post("/exports", { workspace: workspace.id }),
+  },
+};
+
+// `target` is what the action operates on, the workspace here. Named `target`
+// rather than `subject`, which in authorization usually means the principal.
+async function guarded(name, target) {
+  const { action, resource, context, call } = guardedActions[name];
+
+  const result = await cedarling.authorize_unsigned(
+    JSON.stringify({
+      principal,
+      action,
+      resource: resource(target),
+      context: context(target),
+    }),
+  );
+
+  const outcome = localOutcome(result);
+
+  if (!outcome.proceed) {
+    return { status: "denied", messageId: outcome.messageId };
+  }
+
+  if (outcome.pendingMessageId) {
+    ui.setPendingMessage(outcome.pendingMessageId);
+  }
+
+  const response = await call(target);
+
+  return response.ok
+    ? { status: "ok", body: response.body }
+    : { status: "denied", messageId: response.messageId };  // the server's message
+}
+```
+
+A handler is then one line, names one thing, and knows nothing about annotations or policy IDs:
+
+```javascript
+const outcome = await guarded("generateReport", workspace);
+```
+
+Two caveats keep this from becoming a worse idea than it replaces.
+
+The mapping is a declaration, not a naming convention. Cedar actions describe what the user is
+doing, so they stay business-shaped: `Acme::Action::"GenerateReport"`, never
+`Acme::Action::"POST /reports"`. Naming actions after routes drags transport details into the policy
+vocabulary, and every URL change becomes a policy change.
+
+The relationship is not always one to one. A batch endpoint performs several actions, and a
+BFF or GraphQL resolver may serve one action through several calls. The rule that survives those
+cases is narrower than "one action per endpoint": every call site declares which action it is
+guarded by, in one place, next to the call.
+
+The server keeps its own version of this table, and derives the action from its routing rather than
+from anything the client sends. The client's binding exists so the interface asks the right
+question. The server's binding exists so the answer means something.
+
+The loader needs no special handling. `guarded` returns a promise, and the interface shows a pending
+state until it resolves, exactly as it does for any other request. `@loading_message_id` only
+supplies better wording for a wait the user was not expecting, since from their side the click
+appeared to do nothing locally.
+
+The four cases the browser has to tell apart:
+
+```text
+analyst, counter says 10     ALLOW  permit_generate_report
+analyst, counter says 1000   DENY   forbid_generate_report_quota_exhausted
+                                    marked, so ask the server
+viewer,  counter says 10     DENY   forbid_generate_report_wrong_role
+                                    unmarked, so render it
+viewer,  counter says 1000   DENY   forbid_generate_report_wrong_role
+                                    forbid_generate_report_quota_exhausted
+                                    one unmarked denial, so render it
+```
+
+The direction of that test matters. One unmarked denial is enough to render a refusal, because it
+holds regardless of what the server thinks about the others: the viewer without the right role stays
+refused even if the quota turns out to be fine. Only when *every* matched policy is marked does the
+browser have nothing worth saying.
+
+An empty `reason()` belongs on the same side as an unmarked denial. Nothing permitted the request,
+there is no policy to consult about staleness, and a round trip will not change that.
+
+## Server Code
+
+```rust
+// The API builds the context from what it owns, not from what the client sent.
+let request = report_request(&user, &workspace, metering.reports_used(&workspace)?);
+let result = cedarling.authorize_unsigned(request).await?;
+
+if !result.decision {
+    let annotations = cedarling.annotations_map(result.response.diagnostics().reason());
+    return Err(forbidden(
+        annotations
+            .get("user_message_id")
+            .cloned()
+            .unwrap_or_else(|| "access.denied.generic".to_string()),
+    ));
+}
+
+generate_report(&workspace)
+```
+
+The server never reads `@revalidate`. It has nobody to revalidate with. The marker is meaningful
+only to a PDP whose answer is provisional, and treating it as meaningful on the server would be a
+way of asking a policy to be optional.
+
+That is worth stating in a comment where your server PEP reads annotations, because the shared
+policy store makes it easy to assume both sides act on every key.
+
+## Rules That Keep This Honest
+
+**Read the decision in one place.** The rule for when a local denial may be rendered is a property
+of the application, not of the action, so it belongs in a single wrapper that every guarded call goes
+through. Spread across handlers it will be applied inconsistently, and the handler that forgets it is
+the one that shows a user a refusal the server would have overturned.
+
+**Keep the action and the call declared together.** A local check that authorizes one action while
+the handler performs another is worse than no check, because it looks like enforcement. Bind them in
+one table and let call sites name the binding.
+
+**A loader is not an optimistic yes.** The interface must not enable downstream state, start an
+upload, or show a success animation while the request is in flight. It knows nothing yet.
+
+**The final message comes from the server.** After the round trip, show what the server's decision
+carried. The local policy that fired may not even be the one that denies at the other end, and its
+message may describe a condition that turned out not to apply.
+
+**Do not mark everything.** Each marked policy is a round trip the client-side PDP was supposed to
+save. Mark enough policies and the embedded PDP becomes a latency cost with no benefit, at which
+point calling the server unconditionally would be simpler and more honest.
+
+**Keep the reason out of the annotation.** `@revalidate("server")` says what the client should do.
+Anything explaining *why* the request failed is visible in the browser, including to a user the
+policy was written to stop.
+
+**Re-check the marker when the context changes.** A policy marked because it reads a live counter
+should lose the marker when it stops reading one. `@stale_context` exists to make that connection
+reviewable.
+
+## When to Mark Actions Instead
+
+Marking policies is not the only option. An application can decide per action that a local denial is
+never rendered, which needs no annotations at all.
+
+That is the better choice when every denial for an action has the same provenance. Marking policies
+earns its keep when one action mixes both kinds, which is the case here: the same button can be
+refused for a role the browser knows and for a quota it does not.
+
+## What This Buys You
+
+The interface stops guessing about which failures it is allowed to render. Policy authors decide
+that, next to the condition that makes it true, and the same policy store answers both the browser
+and the API. A new policy that depends on server-owned data arrives with its own marker, and the
+front end handles it without a release.

--- a/docs/cedarling/patterns/annotation-client-authority.md
+++ b/docs/cedarling/patterns/annotation-client-authority.md
@@ -25,8 +25,7 @@ immediate: buttons that would fail are disabled, and a click that cannot succeed
 a round trip.
 
 The API runs Cedarling too, over the same policy store, and re-evaluates every request. That is not
-redundancy. The browser copy exists for the interface, and the server copy is the one that actually
-protects the data.
+redundancy: the browser copy exists for the interface, and the server copy protects the data.
 
 Now two different denials arrive at the same button.
 
@@ -43,21 +42,21 @@ Both are `Deny`. Only one of them is worth showing.
 
 ## Why This Is Safe
 
-A client-side PDP can be wrong in exactly one direction. It cannot grant anything, because the
-server evaluates the same request again and grants nothing on the browser's say-so. What it can do
-is refuse something the server would have allowed, which is a correctness problem in the interface
-rather than a security problem.
+A client-side PDP can be wrong in only one direction that matters. It cannot grant anything, because
+the server evaluates the same request again and grants nothing on the browser's say-so. What it can
+do is refuse something the server would have allowed, which is a correctness problem in the
+interface rather than a security problem.
 
-That asymmetry is what makes the pattern work. Sending the request anyway, after a local denial,
-gives away nothing: the authoritative answer is still the server's. The annotation only tells the
-browser that its own "no" is not worth rendering.
+The pattern rests on that asymmetry. Sending the request anyway, after a local denial, gives away
+nothing: the authoritative answer is still the server's. The annotation only tells the browser that
+its own "no" is not worth rendering.
 
 The reverse must never exist. There is no annotation that lets a client skip the request after a
 local `Allow`, and none that lets it disregard a denial from the server. Those would move the
 decision to the least trustworthy participant.
 
-The asymmetry is not free. It holds only while three things are true, and each of them is something
-you have to keep true:
+The asymmetry is not free. It holds only while three things are true, and each one has to be kept
+that way:
 
 - Every guarded call is authorized again on the server, from inputs the server resolved itself. A
   single endpoint that trusts the browser's decision, or that rebuilds the request from what the
@@ -70,6 +69,14 @@ you have to keep true:
   the entity attributes it reasons over, so thresholds, tier names, contract quotas, and risk tiers
   are readable by anyone who opens the developer tools. Ship only what you are willing to show, and
   keep policies whose contents are themselves sensitive on the server.
+- The action's effect is a server call. This pattern reasons about a request the server will
+  authorize again. An action the browser can carry out alone, revealing a field already on the page
+  or exporting rows it already downloaded, has no second check behind it, and there the local PDP is
+  the only PDP. Do not guard those this way.
+- The endpoint is safe to call when the answer is no. Every marked denial becomes a request that the
+  server is expected to refuse, so refusals must not start metered work, increment counters, or
+  leave half an effect behind, and the endpoint needs capacity for traffic the client used to
+  absorb.
 
 ## Which Policies Deserve It
 
@@ -83,8 +90,8 @@ in practice means facts the server owns:
 - risk attributes a backend investigation updates, like `principal.risk_tier`
 
 Those examples are the context fields from the other pages in this section, which is not a
-coincidence. Every one of them describes something the server established and the client merely
-carries a copy of. Their denials are the ones a browser should not render on its own.
+coincidence. Every one of them describes something the server established and the client carries a
+copy of. Their denials are the ones a browser should not render on its own.
 
 A denial that rests on the principal's role, the resource's type, or anything else the browser
 received with its tokens is in the opposite position. It is as good locally as it is remotely.
@@ -149,9 +156,9 @@ forbid (
 when { context.reports_used >= 1000 };
 ```
 
-`@stale_context("reports_used")` is not read by the runtime. It documents *why* the policy is marked,
-so the next person to touch it can tell whether the marker is still warranted, and so that removing
-`reports_used` from the context is visibly connected to removing the marker.
+`@stale_context("reports_used")` is not read by the runtime. It documents *why* the policy is
+marked, so the next person to touch it can tell whether the marker is still warranted, and so that
+removing `reports_used` from the context is visibly connected to removing the marker.
 
 ## The Flow
 
@@ -183,13 +190,12 @@ so the next person to touch it can tell whether the marker is still warranted, a
     │◀────────────────│                   │                  │
 ```
 
-The loader is the honest representation of the browser's state. It does not know the answer, and it
-says so.
+The pending state is an accurate report of what the browser knows, which at that point is nothing.
 
 ## Browser Code
 
-None of this belongs in a click handler. The decision of whether a local denial may be rendered is
-the same for every guarded action in the application, so it lives in two pieces that every action
+None of this belongs in a click handler. Whether a local denial may be rendered is the same question
+for every guarded action in the application, so the answer lives in two pieces that every action
 shares: a function that reads the decision, and a wrapper that runs the call.
 
 The first one is pure. Given a decision, it says what the browser is entitled to do with it:
@@ -201,9 +207,17 @@ function localOutcome(result) {
     return { proceed: true };
   }
 
-  const denials = Object.values(
-    cedarling.annotations_by_policy(result.response.diagnostics.reason),
-  );
+  const diagnostics = result.response.diagnostics;
+
+  // A policy that errored was dropped from the decision. In a browser the usual
+  // cause is an input this side failed to load, and the server evaluates the same
+  // policies over inputs it owns, so this denial is not ours to render.
+  if (diagnostics.errors.length > 0) {
+    report(diagnostics.errors);
+    return { proceed: true, pendingMessageId: "common.checking" };
+  }
+
+  const denials = Object.values(cedarling.annotations_by_policy(diagnostics.reason));
 
   // A denial the browser is entitled to make, or nothing matched at all.
   const local = denials.find((a) => a.revalidate !== "server");
@@ -216,20 +230,25 @@ function localOutcome(result) {
   }
 
   // Every denial rests on data the server owns, so this one is not ours to render.
-  return {
-    proceed: true,
-    pendingMessageId: denials[0].loading_message_id ?? "common.checking",
-  };
+  // reason() has no order, so sort rather than take whichever came first.
+  const pending = denials
+    .map((a) => a.loading_message_id)
+    .filter(Boolean)
+    .sort();
+
+  return { proceed: true, pendingMessageId: pending[0] ?? "common.checking" };
 }
 ```
 
-Note that both an `Allow` and a fully provisional `Deny` return `proceed: true`. From the browser's
-side they are the same situation: it has nothing worth saying, and the server decides. The only
-difference is that one of them warns the interface to expect a wait.
+Both an `Allow` and a fully provisional `Deny` return `proceed: true`. From the browser's side they
+are the same situation: it has nothing worth saying, and the server decides. The only difference is
+that one of them warns the interface to expect a wait.
 
-`localOutcome` is also what a render-time check calls. Disabling a button is the interface acting on
-a denial before any click, so it may only act on a denial the browser is entitled to make: `proceed:
-false` renders as disabled, and everything else renders as enabled and resolves when clicked.
+A render-time check calls `authorizeOnly` and stops there. Disabling a button is the interface
+acting on a denial before any click, so it may only act on a denial the browser is entitled to make:
+`proceed: false` renders as disabled, everything else renders as enabled and resolves when clicked.
+Going through the same function keeps the render check and the call on one binding, which is the
+drift the action registry exists to prevent.
 
 ### Bind the Action to the Call It Guards
 
@@ -273,8 +292,8 @@ const guardedActions = {
 
 // `target` is what the action operates on, the workspace here. Named `target`
 // rather than `subject`, which in authorization usually means the principal.
-async function guarded(name, target) {
-  const { action, resource, context, call } = guardedActions[name];
+async function authorizeOnly(name, target) {
+  const { action, resource, context } = guardedActions[name];
 
   const result = await cedarling.authorize_unsigned(
     JSON.stringify({
@@ -285,7 +304,11 @@ async function guarded(name, target) {
     }),
   );
 
-  const outcome = localOutcome(result);
+  return localOutcome(result);
+}
+
+async function guarded(name, target) {
+  const outcome = await authorizeOnly(name, target);
 
   if (!outcome.proceed) {
     return { status: "denied", messageId: outcome.messageId };
@@ -295,7 +318,7 @@ async function guarded(name, target) {
     ui.setPendingMessage(outcome.pendingMessageId);
   }
 
-  const response = await call(target);
+  const response = await guardedActions[name].call(target);
 
   return response.ok
     ? { status: "ok", body: response.body }
@@ -348,8 +371,15 @@ holds regardless of what the server thinks about the others: the viewer without 
 refused even if the quota turns out to be fine. Only when *every* matched policy is marked does the
 browser have nothing worth saying.
 
-An empty `reason()` belongs on the same side as an unmarked denial. Nothing permitted the request,
-there is no policy to consult about staleness, and a round trip will not change that.
+An empty `reason()` belongs on the same side as an unmarked denial, as long as it means what it
+looks like. Nothing matched, no policy has anything to say about staleness, and a round trip will
+not change that. The exception is the case the overview describes under [Only the determining
+policies are reported](./annotation-patterns.md#only-the-determining-policies-are-reported): a
+policy that errored is dropped from the decision and shows up in `errors()` instead. In a browser
+that error is usually the client's own doing, a counter that failed to load or an attribute the
+session never received, and the server would evaluate the same policies without trouble. So a
+non-empty `errors()` is the most provisional case there is, which is why `localOutcome` checks it
+before anything else.
 
 ## Server Code
 
@@ -371,19 +401,19 @@ if !result.decision {
 generate_report(&workspace)
 ```
 
-The server never reads `@revalidate`. It has nobody to revalidate with. The marker is meaningful
-only to a PDP whose answer is provisional, and treating it as meaningful on the server would be a
-way of asking a policy to be optional.
+The server never reads `@revalidate`. There is no second authority for it to consult. The marker
+means something only to a PDP whose answer is provisional, and acting on it server-side would amount
+to making a policy optional.
 
-That is worth stating in a comment where your server PEP reads annotations, because the shared
-policy store makes it easy to assume both sides act on every key.
+Record that in a comment where the server's enforcement point reads annotations. The shared policy
+store makes it easy to assume both sides act on every key.
 
 ## Rules That Keep This Honest
 
 **Read the decision in one place.** The rule for when a local denial may be rendered is a property
-of the application, not of the action, so it belongs in a single wrapper that every guarded call goes
-through. Spread across handlers it will be applied inconsistently, and the handler that forgets it is
-the one that shows a user a refusal the server would have overturned.
+of the application, not of the action, so it belongs in a single wrapper that every guarded call
+goes through. Spread across handlers it will be applied inconsistently, and the handler that forgets
+it is the one that shows a user a refusal the server would have overturned.
 
 **Keep the action and the call declared together.** A local check that authorizes one action while
 the handler performs another is worse than no check, because it looks like enforcement. Bind them in
@@ -400,9 +430,11 @@ message may describe a condition that turned out not to apply.
 save. Mark enough policies and the embedded PDP becomes a latency cost with no benefit, at which
 point calling the server unconditionally would be simpler and more honest.
 
-**Keep the reason out of the annotation.** `@revalidate("server")` says what the client should do.
-Anything explaining *why* the request failed is visible in the browser, including to a user the
-policy was written to stop.
+**Treat the annotation vocabulary as published.** The browser holds the policies and reads their
+annotations, so anything you put in a key is readable by the people the policy constrains. That is
+not a reason to hide the denial reason from the message, which the user is going to see anyway. It
+is a reason to keep internal identifiers, ticket numbers, and detection logic out of keys the client
+resolves.
 
 **Re-check the marker when the context changes.** A policy marked because it reads a live counter
 should lose the marker when it stops reading one. `@stale_context` exists to make that connection

--- a/docs/cedarling/patterns/annotation-client-authority.md
+++ b/docs/cedarling/patterns/annotation-client-authority.md
@@ -113,6 +113,11 @@ namespace Acme {
             "reports_used": Long,
         }
     };
+
+    action "ExportRows" appliesTo {
+        principal: [User],
+        resource: [Workspace],
+    };
 }
 ```
 

--- a/docs/cedarling/patterns/annotation-patterns.md
+++ b/docs/cedarling/patterns/annotation-patterns.md
@@ -46,12 +46,14 @@ The pages build on each other, so read them in this order if the mechanism is ne
 | [Multi-step flows and escalation](./annotation-workflow.md) | Onboarding steps, redirects, approval routing, break-glass |
 | [Challenges and step-up](./annotation-challenge.md) | A deny that says *how* to earn the allow: MFA, human confirmation, owner approval |
 | [Shaping the response and mapping controls](./annotation-response-shaping.md) | Masking, row limits, and compliance metadata on an allow |
+| [Advisory denials in a client-side PDP](./annotation-client-authority.md) | Telling a browser which of its own denials are worth rendering |
 
 The first two read annotations as hints the user can act on, which is the forgiving case: ignoring
 one costs you a worse experience and nothing more. Break-glass and response shaping treat them as
 obligations the application has to enforce, which is a stricter contract, so read
 [Obligations, not hints](./annotation-response-shaping.md#obligations-not-hints) before using that
-shape.
+shape. The last page is about consuming decisions rather than writing them, and it applies wherever
+Cedarling runs somewhere its answer is provisional.
 
 ## The Mental Model
 

--- a/docs/cedarling/patterns/annotation-patterns.md
+++ b/docs/cedarling/patterns/annotation-patterns.md
@@ -37,8 +37,8 @@ context. If that is new, read [Authorization](../reference/cedarling-authz.md) a
     The one exception is `@id`, which Cedarling uses as the policy ID.
 
     The same goes for the scenarios themselves. The companies, entities, schemas, and flows exist
-    to show what the mechanism makes possible. They are deliberately simplified, they are not
-    reference architectures, and they are not security advice for your system. Design your own
+    to show what the mechanism makes possible. They are deliberately simplified, and they are
+    neither reference architectures nor security advice for your system. Design your own
     vocabulary and your own policies around your own risk model, and treat these pages as a
     starting point for thinking rather than something to copy into production.
 
@@ -52,12 +52,13 @@ The pages build on each other, so read them in this order if the mechanism is ne
 | [Shaping the response and mapping controls](./annotation-response-shaping.md) | Masking, row limits, and compliance metadata on an allow |
 | [Advisory denials in a client-side PDP](./annotation-client-authority.md) | Telling a browser which of its own denials are worth rendering |
 
-The first two read annotations as hints the user can act on, which is the forgiving case: ignoring
-one costs you a worse experience and nothing more. Break-glass and response shaping treat them as
-obligations the application has to enforce, which is a stricter contract, so read
+The quota page and most of the workflow page read annotations as hints the user can act on, which is
+the forgiving case: ignoring one costs you a worse experience and nothing more. Break-glass, at the
+end of the workflow page, and all of response shaping treat them as obligations the application has
+to enforce. That is a stricter contract, so read
 [Obligations, not hints](./annotation-response-shaping.md#obligations-not-hints) before using that
-shape. The last page is about consuming decisions rather than writing them, and it applies wherever
-Cedarling runs somewhere its answer is provisional.
+shape. The last page is about consuming decisions rather than writing them, and it applies anywhere
+Cedarling's own answer is provisional because another PDP has the last word.
 
 ## The Mental Model
 
@@ -76,7 +77,7 @@ Cedarling runs somewhere its answer is provisional.
 Three properties follow from this, and every pattern in this section respects them.
 
 The decision stays binary. An annotation never changes `Allow` into `Deny` or the reverse.
-`Challenge`, `warn`, and `mask` are statuses carried alongside a decision, not a third decision.
+`Challenge`, `warn`, and `mask` travel alongside a decision. None of them is a third decision.
 
 The policy names the intent and the application implements it.
 `@challenge("security_key")` means the application knows a challenge called `security_key`. The
@@ -108,20 +109,27 @@ policy author wrote a rule that actively blocked the request, and that rule can 
 the second, no rule blocked anything and no rule allowed anything either: Cedar denies by default,
 and a default has no policy behind it to carry an annotation.
 
-Note also that `permit` annotations never survive a `Deny`. When a `forbid` overrides a matching
-`permit`, only the `forbid` appears in `reason()`, so a message you attached to the `permit` is not
-available to explain the denial.
+`permit` annotations also never survive a `Deny`. When a `forbid` overrides a matching `permit`,
+only the `forbid` appears in `reason()`, so a message you attached to the `permit` is not available
+to explain the denial.
 
-A fourth shape hides behind the third. A policy whose expression errors at evaluation time, on
+A fourth case looks just like the third. A policy whose expression errors at evaluation time, on
 integer overflow or on an attribute the entity does not carry, is dropped from the decision and
 reported in `diagnostics().errors()` instead of `reason()`. If that policy was the only `permit`,
 the result is a `Deny` with an empty `reason()`, indistinguishable from "nothing matched" to code
-that reads only `reason()`. Log `errors()` alongside the decision, or a broken policy will look like
-an ordinary default deny for as long as nobody checks.
+that reads only `reason()`. Log `errors()` alongside the decision, or a broken policy looks like an
+ordinary default deny for as long as nobody checks.
 
-The default-deny row is the one that catches people out. If you want a hint for a request that
+A fifth case fills `reason()` with policies that did not fire at all. `authorize_unsigned` with no
+principal runs Cedar's partial evaluation, and when residuals remain, Cedarling synthesizes a
+fail-closed `Deny` whose `reason()` holds the residual policy IDs. Those policies were neither
+satisfied nor rejected: the request lacked what they needed to decide. Annotations resolved from
+them describe rules that might have applied, so treat a principal-less denial as "undetermined"
+rather than reading its hints as the reason for a refusal.
+
+The default-deny row is the one that trips people up. If you want a hint for a request that
 simply matches no `permit`, an annotated `forbid` has to exist and match, as the quota example
-does with its `forbid` at 100%. Otherwise the application needs its own fallback message for
+does with its `forbid` at 100%. Otherwise, the application needs its own fallback message for
 "denied, no guidance available". Do not add a catch-all `forbid` just to hang an annotation on it:
 in Cedar `forbid` always wins, so a broad catch-all silently overrides every `permit` you have.
 
@@ -167,12 +175,17 @@ let by_policy = cedarling.annotations_by_policy(result.response.diagnostics().re
 let mut steps: Vec<(u32, &str)> = Vec::new();
 
 for (policy_id, a) in &by_policy {
+    // Policies that say nothing about steps are not this loop's business.
+    if !a.contains_key("wizard_step") && !a.contains_key("required_step") {
+        continue;
+    }
+
     match (
         a.get("wizard_step").and_then(|s| s.parse::<u32>().ok()),
         a.get("required_step"),
     ) {
         (Some(step), Some(name)) => steps.push((step, name.as_str())),
-        // A policy you cannot order is a bug to surface, not one to drop silently.
+        // A partial step description is a bug to surface, not one to drop.
         _ => return Err(Error::MalformedAnnotation(policy_id.clone())),
     }
 }
@@ -186,8 +199,13 @@ thing and is usually wrong.
 ### `@id` Is Reserved
 
 Cedarling uses the `@id("...")` annotation as the policy ID. Keep it as the identifier and do not
-overload it with other meaning. Every pattern here assumes stable, readable policy IDs, because
-those IDs are what appear in `reason()` and in the decision logs.
+overload it with other meaning.
+
+It is not stripped from the results. `annotations_map` returns an `id` key, and every group from
+`annotations_by_policy` carries one, because all three methods read a policy's annotations without
+filtering. Forwarding "all annotations" to a browser or a log therefore ships your policy IDs too.
+Every pattern here assumes stable, readable policy IDs, because those IDs are what appear in
+`reason()` and in the decision logs.
 
 ### The Lookup Is Independent of the Authorization Method
 
@@ -230,20 +248,23 @@ that a frontend restructure does not require a policy release.
 Do not put secrets or personal data in annotations. Annotations travel with the policy store and
 land in decision logs. They are policy metadata, readable by anyone who can read the policy.
 
-Do not let an annotation override the decision. A PEP that lets a `Deny` proceed because the policy
-carried `@enforcement("monitor")` has no enforcement at all. If you need a policy that observes
-without blocking, express that in the policy logic instead of ignoring its verdict.
+Do not let an annotation override the decision. An enforcement point that lets a `Deny` proceed
+because the policy carried `@enforcement("monitor")` is not enforcing anything. If you need a policy
+that observes without blocking, express that in the policy logic instead of ignoring its verdict.
 
-Do not encode structured data in one annotation. A JSON blob in a string is hard to review and easy
+Do not encode nested structure in one annotation. A JSON blob in a string is hard to review and easy
 to break. Prefer several flat keys (`@quota_scope("monthly")`, `@quota_threshold("80")`) over
-`@quota("{\"scope\":\"monthly\",\"threshold\":80}")`.
+`@quota("{\"scope\":\"monthly\",\"threshold\":80}")`. A flat delimited list is the exception,
+and only where the key genuinely repeats: `@mask("national_id,date_of_birth")` has to be one value,
+because Cedar allows the key once per policy.
 
 Do not invent keys per policy, and name the unit when a value has one. `@sla_hours`,
 `@retention_days`, and `@challenge_ttl_seconds` cannot be misread; a bare `@ttl` invites somebody to
-supply milliseconds. An annotation vocabulary is an interface between policy authors and application
-developers. Keep a short, documented list of keys and their allowed values, and treat
-adding a key as an API change: the application has to know how to handle it, and a key that no code
-reads is a silent no-op.
+supply milliseconds.
+
+An annotation vocabulary is an interface between policy authors and application developers, so keep
+a short, documented list of keys and their allowed values, and treat adding a key as an API change.
+The application has to know how to handle it, and a key that no code reads is a silent no-op.
 
 Do not assume an annotation will be there. Policies change independently of the application, so
 every lookup needs a sane default for "annotation absent".

--- a/docs/cedarling/patterns/annotation-patterns.md
+++ b/docs/cedarling/patterns/annotation-patterns.md
@@ -23,6 +23,10 @@ where it can be reviewed, versioned, and changed without a code release.
 This section collects patterns for doing that. Each page describes a scenario, the flow, the
 policies, and the application code that reads the annotations.
 
+The code samples assume you know how an authorization request carries its principal, resource, and
+context. If that is new, read [Authorization](../reference/cedarling-authz.md) and
+[Entities](../reference/cedarling-entities.md) first; nothing here changes how a request is built.
+
 !!! note "These are illustrative examples, not a specification"
 
     Cedarling gives annotations no built-in meaning. `@challenge`, `@warn`, `@redirect_route`,
@@ -108,6 +112,13 @@ Note also that `permit` annotations never survive a `Deny`. When a `forbid` over
 `permit`, only the `forbid` appears in `reason()`, so a message you attached to the `permit` is not
 available to explain the denial.
 
+A fourth shape hides behind the third. A policy whose expression errors at evaluation time, on
+integer overflow or on an attribute the entity does not carry, is dropped from the decision and
+reported in `diagnostics().errors()` instead of `reason()`. If that policy was the only `permit`,
+the result is a `Deny` with an empty `reason()`, indistinguishable from "nothing matched" to code
+that reads only `reason()`. Log `errors()` alongside the decision, or a broken policy will look like
+an ordinary default deny for as long as nobody checks.
+
 The default-deny row is the one that catches people out. If you want a hint for a request that
 simply matches no `permit`, an annotated `forbid` has to exist and match, as the quota example
 does with its `forbid` at 100%. Otherwise the application needs its own fallback message for
@@ -153,10 +164,18 @@ then sort them in the application.
 ```rust
 let by_policy = cedarling.annotations_by_policy(result.response.diagnostics().reason());
 
-let mut steps: Vec<(u32, &str)> = by_policy
-    .values()
-    .filter_map(|a| Some((a.get("wizard_step")?.parse().ok()?, a.get("required_step")?.as_str())))
-    .collect();
+let mut steps: Vec<(u32, &str)> = Vec::new();
+
+for (policy_id, a) in &by_policy {
+    match (
+        a.get("wizard_step").and_then(|s| s.parse::<u32>().ok()),
+        a.get("required_step"),
+    ) {
+        (Some(step), Some(name)) => steps.push((step, name.as_str())),
+        // A policy you cannot order is a bug to surface, not one to drop silently.
+        _ => return Err(Error::MalformedAnnotation(policy_id.clone())),
+    }
+}
 
 steps.sort();
 ```
@@ -219,8 +238,10 @@ Do not encode structured data in one annotation. A JSON blob in a string is hard
 to break. Prefer several flat keys (`@quota_scope("monthly")`, `@quota_threshold("80")`) over
 `@quota("{\"scope\":\"monthly\",\"threshold\":80}")`.
 
-Do not invent keys per policy. An annotation vocabulary is an interface between policy authors and
-application developers. Keep a short, documented list of keys and their allowed values, and treat
+Do not invent keys per policy, and name the unit when a value has one. `@sla_hours`,
+`@retention_days`, and `@challenge_ttl_seconds` cannot be misread; a bare `@ttl` invites somebody to
+supply milliseconds. An annotation vocabulary is an interface between policy authors and application
+developers. Keep a short, documented list of keys and their allowed values, and treat
 adding a key as an API change: the application has to know how to handle it, and a key that no code
 reads is a silent no-op.
 

--- a/docs/cedarling/patterns/annotation-patterns.md
+++ b/docs/cedarling/patterns/annotation-patterns.md
@@ -1,0 +1,235 @@
+---
+tags:
+  - administration
+  - lock
+  - authorization / authz
+  - Cedar
+  - Cedarling
+  - annotations
+---
+
+# Policy Annotation Patterns
+
+A Cedar policy answers one question: is this action on this resource allowed, yes or no. That
+answer alone is often not enough to build a product. The application also needs to know *what to
+do next*: which message to show, which step-up challenge to run, where to send the user, whether
+the response must be masked, or that the user is about to hit a quota.
+
+Cedar annotations (`@key("value")`) let the policy author attach that guidance to the policy
+itself, and Cedarling hands it back with the decision. Behavior that is normally hardcoded in the
+application (wizard steps, escalation paths, warning thresholds) moves into the policy store,
+where it can be reviewed, versioned, and changed without a code release.
+
+This section collects patterns for doing that. Each page describes a scenario, the flow, the
+policies, and the application code that reads the annotations.
+
+!!! note "These are illustrative examples, not a specification"
+
+    Cedarling gives annotations no built-in meaning. `@challenge`, `@warn`, `@redirect_route`,
+    `@user_message_id` and every other key on these pages were invented for the documentation:
+    they are not reserved, not validated, and nothing in Cedarling reacts to them. An annotation
+    only does something because *your* application reads that key and acts on it.
+
+    The one exception is `@id`, which Cedarling uses as the policy ID.
+
+    The same goes for the scenarios themselves. The companies, entities, schemas, and flows exist
+    to show what the mechanism makes possible. They are deliberately simplified, they are not
+    reference architectures, and they are not security advice for your system. Design your own
+    vocabulary and your own policies around your own risk model, and treat these pages as a
+    starting point for thinking rather than something to copy into production.
+
+The pages build on each other, so read them in this order if the mechanism is new to you.
+
+| Pattern | Problem it solves |
+|---|---|
+| [Quota and threshold warnings](./annotation-quota.md) | Warning the user before a limit turns into a denial |
+| [Multi-step flows and escalation](./annotation-workflow.md) | Onboarding steps, redirects, approval routing, break-glass |
+| [Challenges and step-up](./annotation-challenge.md) | A deny that says *how* to earn the allow: MFA, human confirmation, owner approval |
+| [Shaping the response and mapping controls](./annotation-response-shaping.md) | Masking, row limits, and compliance metadata on an allow |
+
+The first two read annotations as hints the user can act on, which is the forgiving case: ignoring
+one costs you a worse experience and nothing more. Break-glass and response shaping treat them as
+obligations the application has to enforce, which is a stricter contract, so read
+[Obligations, not hints](./annotation-response-shaping.md#obligations-not-hints) before using that
+shape.
+
+## The Mental Model
+
+```text
+                 ┌─────────────┐
+  request ──────▶│  Cedarling  │───▶ decision (Allow / Deny)
+                 │    (PDP)    │───▶ reason(): determining policy IDs
+                 └─────────────┘             │
+                                             ▼
+                                 annotations_map / annotation_values
+                                             │
+                                             ▼
+                        application (PEP) decides what to do with the hint
+```
+
+Three properties follow from this, and every pattern in this section respects them.
+
+The decision stays binary. An annotation never changes `Allow` into `Deny` or the reverse.
+`Challenge`, `warn`, and `mask` are statuses carried alongside a decision, not a third decision.
+
+The policy names the intent and the application implements it.
+`@challenge("security_key")` means the application knows a challenge called `security_key`. The
+policy does not know how it is performed.
+
+Annotations are static. The value is a literal string fixed at authoring time. It cannot
+interpolate context, entity attributes, or the current counter value. Anything dynamic is resolved
+by the application after it reads the hint.
+
+## Mechanics You Need to Know
+
+These constraints shape how the patterns are written, so read them before designing an annotation
+vocabulary.
+
+### Only the Determining Policies Are Reported
+
+`result.response.diagnostics().reason()` contains the policies that determined the outcome, and
+those are the only policies whose annotations you can resolve. Cedar reaches a decision in three
+ways, and each one reports something different:
+
+| Outcome | How it happened | `reason()` contains | Annotations you can read |
+|---|---|---|---|
+| `Allow` | at least one `permit` matched, no `forbid` did | the satisfied `permit` policies | the annotations on those `permit` policies |
+| `Deny` | a `forbid` matched, whether or not a `permit` also did | the satisfied `forbid` policies | the annotations on those `forbid` policies |
+| `Deny` | nothing matched at all, the default deny | nothing, `reason()` is empty | none |
+
+The two `Deny` rows are different situations, not conflicting statements about one. In the first, a
+policy author wrote a rule that actively blocked the request, and that rule can explain itself. In
+the second, no rule blocked anything and no rule allowed anything either: Cedar denies by default,
+and a default has no policy behind it to carry an annotation.
+
+Note also that `permit` annotations never survive a `Deny`. When a `forbid` overrides a matching
+`permit`, only the `forbid` appears in `reason()`, so a message you attached to the `permit` is not
+available to explain the denial.
+
+The default-deny row is the one that catches people out. If you want a hint for a request that
+simply matches no `permit`, an annotated `forbid` has to exist and match, as the quota example
+does with its `forbid` at 100%. Otherwise the application needs its own fallback message for
+"denied, no guidance available". Do not add a catch-all `forbid` just to hang an annotation on it:
+in Cedar `forbid` always wins, so a broad catch-all silently overrides every `permit` you have.
+
+### One Key per Policy, Several Values Means Several Policies
+
+Cedar rejects a duplicate annotation key on the same policy (`duplicate annotation: @challenge`),
+so a single policy carries at most one `@challenge`. Two challenges means two policies, each with
+its own annotation, and both have to be satisfied for both to appear in `reason()`.
+
+This works in your favor. Independent conditions stay independent policies, and
+`annotation_values(reason, "challenge")` collects every value that actually fired, duplicates
+preserved.
+
+```rust
+// Two forbid policies matched, each requesting a different challenge.
+let challenges =
+    cedarling.annotation_values(result.response.diagnostics().reason(), "challenge");
+// ["confirm_human_intent", "data_owner_approval"]
+```
+
+Use `annotations_map` only when you know the keys cannot collide across policies, since it keeps
+one arbitrary value per key. `annotations_by_policy` is the loss-free view, and it is the one you
+want for audit logging because it records which policy asked for what.
+
+### `reason()` Has No Order
+
+`reason()` is a set of policy IDs, so the policies come back in no particular order, and the lookup
+methods report values in whatever order they receive the IDs. Two consequences:
+
+- Never pair two `annotation_values` results by position. The first value of one list does not
+  necessarily come from the same policy as the first value of the other.
+- If several annotations on one policy only mean something together, read them with
+  `annotations_by_policy`, which keeps each policy's set intact.
+
+Anything that has to appear in a specific order has to say so in an annotation, such as
+`@wizard_step("2")`. That ordering key is only usable through `annotations_by_policy`, because it
+has to stay attached to the values it orders and the lossy views drop that link. Read the groups,
+then sort them in the application.
+
+```rust
+let by_policy = cedarling.annotations_by_policy(result.response.diagnostics().reason());
+
+let mut steps: Vec<(u32, &str)> = by_policy
+    .values()
+    .filter_map(|a| Some((a.get("wizard_step")?.parse().ok()?, a.get("required_step")?.as_str())))
+    .collect();
+
+steps.sort();
+```
+
+Sorting the output of `annotation_values` would sort the values themselves, which is not the same
+thing and is usually wrong.
+
+### `@id` Is Reserved
+
+Cedarling uses the `@id("...")` annotation as the policy ID. Keep it as the identifier and do not
+overload it with other meaning. Every pattern here assumes stable, readable policy IDs, because
+those IDs are what appear in `reason()` and in the decision logs.
+
+### The Lookup Is Independent of the Authorization Method
+
+Every pattern here is written against `authorize_unsigned`, but nothing in the mechanism depends on
+it. `authorize_multi_issuer` reports the determining policies the same way, and the same three
+lookup methods resolve their annotations. Only the principal and context construction differ.
+
+### Resolve Annotations Promptly
+
+Annotation lookup resolves IDs against the *current* policy store. A concurrent policy-store
+refresh may swap the store between the authorization call and the lookup, in which case IDs that
+no longer resolve are silently dropped. Resolve immediately after `authorize*()`, in the same
+request handler.
+
+## Use Message IDs, Not Message Text
+
+You can write the user-facing string straight into the policy:
+
+```cedar
+@user_message("Your export needs approval from the data owner.")
+```
+
+That works, and it is fine for a prototype or a single-locale internal tool. For anything
+user-facing, annotate a message ID instead and keep the text in your translation catalog:
+
+```cedar
+@user_message_id("access.export.owner_approval_required")
+```
+
+The message ID form keeps localization possible, lets the copy change without touching the policy
+store, and lets one message be reused by several policies. It also keeps product copy, and its
+review cycle, out of the authorization path.
+
+The same reasoning applies to routes. Prefer a logical target the application can resolve
+(`@redirect_route("kyc.documents")`) over a hardcoded path (`@redirect("/v2/kyc/documents")`), so
+that a frontend restructure does not require a policy release.
+
+## Anti-Patterns
+
+Do not put secrets or personal data in annotations. Annotations travel with the policy store and
+land in decision logs. They are policy metadata, readable by anyone who can read the policy.
+
+Do not let an annotation override the decision. A PEP that lets a `Deny` proceed because the policy
+carried `@enforcement("monitor")` has no enforcement at all. If you need a policy that observes
+without blocking, express that in the policy logic instead of ignoring its verdict.
+
+Do not encode structured data in one annotation. A JSON blob in a string is hard to review and easy
+to break. Prefer several flat keys (`@quota_scope("monthly")`, `@quota_threshold("80")`) over
+`@quota("{\"scope\":\"monthly\",\"threshold\":80}")`.
+
+Do not invent keys per policy. An annotation vocabulary is an interface between policy authors and
+application developers. Keep a short, documented list of keys and their allowed values, and treat
+adding a key as an API change: the application has to know how to handle it, and a key that no code
+reads is a silent no-op.
+
+Do not assume an annotation will be there. Policies change independently of the application, so
+every lookup needs a sane default for "annotation absent".
+
+## API Reference
+
+The three lookup methods have the same names in Rust, Python, and JavaScript, and are documented in
+the [Interfaces reference](../reference/cedarling-interfaces.md#annotation-lookup):
+
+- `annotations_map(policy_ids)` returns a merged map, lossy on duplicate keys
+- `annotation_values(policy_ids, key)` returns all values of one key, duplicates preserved
+- `annotations_by_policy(policy_ids)` returns them grouped by policy ID, loss-free

--- a/docs/cedarling/patterns/annotation-quota.md
+++ b/docs/cedarling/patterns/annotation-quota.md
@@ -439,6 +439,32 @@ interpolate the live numbers the policy does not have. See
 The same shape covers an autonomous agent burning through resources far faster than a human would,
 where the budget is gone by the time anyone notices.
 
+The same three jobs apply, so the budget needs a grant and a hard limit of its own before the
+warning means anything:
+
+```cedar
+@id("permit_run_inference")
+permit (
+    principal,
+    action == Acme::Action::"RunInference",
+    resource
+);
+```
+
+```cedar
+@id("forbid_run_inference_budget_exhausted")
+@user_message_id("budget.inference.exhausted")
+@notify("operator")
+@escalate_to("eng-ops")
+@quota_reset("monthly")
+forbid (
+    principal,
+    action == Acme::Action::"RunInference",
+    resource
+)
+when { context.budget_used >= resource.inference_budget };
+```
+
 ```cedar
 @id("permit_agent_inference_budget_warn")
 @warn("budget_80")

--- a/docs/cedarling/patterns/annotation-quota.md
+++ b/docs/cedarling/patterns/annotation-quota.md
@@ -523,6 +523,10 @@ when {
 };
 ```
 
+`context.budget_used` is projected usage: what the agent has already spent plus the cost of the
+request being authorized, computed server-side. Pass pre-request usage instead and the `>=`
+check lets through the request that carries the budget past its limit.
+
 The principal is the agent itself, and `@notify("operator")` tells the application to route the
 warning to `principal.operated_by`, the human accountable for the spend and the only one who can do
 anything about it. See

--- a/docs/cedarling/patterns/annotation-quota.md
+++ b/docs/cedarling/patterns/annotation-quota.md
@@ -35,11 +35,11 @@ already knows how close to the limit it is. The missing piece is a way for the p
 
 ## Annotations on Permit Policies
 
-Annotations are usually associated with denials, but a `permit` carries them just as well, and they
-are reported the same way: on an `Allow`, `reason()` contains the satisfied `permit` policies, so
-the application can read their annotations after a *successful* authorization.
+Annotations usually turn up on denials, but a `permit` carries them just as well, and Cedar reports
+them the same way: on an `Allow`, `reason()` contains the satisfied `permit` policies, so the
+application can read their annotations after a *successful* authorization.
 
-That covers a whole category of "allowed, with something to say":
+That covers a category of "allowed, with something to say":
 
 - approaching a quota or rate limit
 - an entitlement that expires soon
@@ -260,15 +260,15 @@ Those two IDs arrive in no particular order, since `reason()` is a set. It does 
 broad grant carries no annotations, the warning policy carries all of them, and the application
 reads one merged map without caring which policy contributed what.
 
-Three things are worth knowing about this shape.
+Three properties of this shape constrain how you extend it.
 
-The bands within a tier must not overlap. Annotation values are static strings and Cedar rejects two
-`@warn` annotations on one policy, so each band is its own policy. If two bands could hold at once,
-both would appear in `reason()` and `annotation_values(reason, "warn")` would return two warnings
-for one request, leaving the application to guess which is real.
+The bands within a tier must not overlap. Each band is its own policy, because an annotation value
+is a static string and Cedar rejects two `@warn` annotations on one policy. If two bands could hold
+at once, both would appear in `reason()` and `annotation_values(reason, "warn")` would return two
+warnings for one request, leaving the application to guess which is real.
 
 An annotation-only policy is still a real `permit`. It changes nothing only because the broad grant
-already allows the action. If someone later narrows that grant, these policies quietly become the
+already allows the action. If someone later narrows that grant, these policies become the
 thing that authorizes those requests. Keep their conditions no wider than the grant they shadow, and
 if that coupling makes you uncomfortable, put the warning annotations on the broad `permit` for the
 default case and accept fewer bands.
@@ -276,8 +276,8 @@ default case and accept fewer bands.
 The cost is duplication: tiers multiplied by bands. Three tiers with two bands each is six policies
 that differ only in numbers, and adding a third band means touching every tier. That is tolerable
 for a handful of plans and unpleasant for twenty. When the count gets uncomfortable, move the limit
-onto the entity, as the enterprise tier does next, and accept that the number then lives in your data
-rather than in your policies.
+onto the entity, as the enterprise tier does next, and accept that the number then lives in your
+data rather than in your policies.
 
 ## Negotiated Limits Read from the Entity
 
@@ -350,8 +350,8 @@ instead. The difference lives in the annotations rather than in the application'
 
 Cedar's `Long` arithmetic errors on overflow, and a policy that errors is dropped from the
 evaluation, so keep contract quotas to sane values. Multiplying a report counter by 100 leaves an
-enormous amount of headroom, but a number near the `Long` boundary takes exactly the cross-multiplied
-policies out of the decision while the rest of the set carries on:
+enormous amount of headroom, but a number near the `Long` boundary takes exactly the
+cross-multiplied policies out of the decision while the rest of the set carries on:
 
 ```text
 reports_used = 9000000000000000000, contract_quota = i64::MAX
@@ -363,7 +363,8 @@ reason: permit_generate_report
 
 The exhaustion `forbid` survives, because a plain `>=` cannot overflow, so enforcement holds and the
 warnings are what disappear. That is the better failure of the two, and it is still one you want to
-see: the errors are in `diagnostics().errors()`, not in `reason()`, so a PEP that only reads
+see: the errors are in `diagnostics().errors()`, not in `reason()`, so an enforcement point that
+only reads
 `reason()` will never notice.
 
 ## The Broad Grant Fails Open
@@ -372,9 +373,9 @@ Enforcement now lives entirely in the `forbid` policies, and every one of them i
 A workspace whose tier matches none of them is not denied. It is *allowed*, without limit, by the
 broad `permit`.
 
-That is the trade for the simpler structure, and it is the opposite of what a quota-gated grant would
-do. Both failure modes are bad, but they are bad in different ways: a set of narrow permits fails
-closed and silently, and a broad permit fails open and silently. Neither is acceptable, so close the
+That is the trade for the simpler structure. Narrow permits that each carry their own quota
+condition fail the other way: an unrecognized tier matches none of them, so the request is denied. A
+broad permit fails open instead. Both failures are silent, and neither is acceptable, so close the
 gap explicitly.
 
 ```cedar
@@ -397,7 +398,7 @@ rules, and an enterprise workspace whose `contract_quota` was never set. Adding 
 its policies *and* widening this guard, which is a change a reviewer can see. Without it, the same
 mistake ships unlimited free usage and nothing in the logs looks unusual.
 
-Note also what is *not* in the annotations: no counts, no reset date, no plan price. Those are
+What is *not* in the annotations matters as much: no counts, no reset date, no plan price. Those are
 per-tenant values that change every day, and annotations are static strings shared by every request
 that hits the policy. The policy says *which* message and *which* plan, and the application fills in
 "947 of 1,000, resets on 1 September".
@@ -411,10 +412,14 @@ let result = cedarling.authorize_unsigned(request).await?;
 let annotations = cedarling.annotations_map(result.response.diagnostics().reason());
 
 if !result.decision {
+    // Self-serve plans carry @upsell, contract plans carry @notify and @escalate_to.
+    // Reading all of them means the code does not need to know which tier it is.
     return Err(quota_error(
         annotations.get("user_message_id"),
         annotations.get("upsell"),
+        annotations.get("notify"),
         annotations.get("escalate_to"),
+        annotations.get("quota_reset"),
     ));
 }
 
@@ -440,7 +445,16 @@ Ok(response)
 const result = await cedarling.authorize_unsigned(JSON.stringify(request));
 const annotations = cedarling.annotations_map(result.response.diagnostics.reason);
 
-if (result.decision && annotations.warn) {
+// { used, limit, resetsOn } come from the metering response, not from the policy.
+if (!result.decision) {
+  return blocked({
+    text: t(annotations.user_message_id ?? "quota.generic.exhausted", { used, limit, resetsOn }),
+    action: annotations.upsell ? upgradeLink(annotations.upsell) : null,
+    contact: annotations.notify ?? null,
+  });
+}
+
+if (annotations.warn) {
   banner.show({
     level: annotations.warn_level ?? "info",
     text: t(annotations.user_message_id ?? "quota.generic.approaching", { used, limit, resetsOn }),
@@ -449,11 +463,12 @@ if (result.decision && annotations.warn) {
 }
 ```
 
-`annotations_map` is safe here because only one annotated policy can match at a time: the broad grant
-carries nothing, and the bands are gated on a tier and do not overlap within it. That property is
-worth stating in a test, because it is what the application code quietly depends on. If you later add
-an overlapping policy, such as a per-workspace warning alongside a per-user one, switch to
-`annotation_values` or `annotations_by_policy` and decide explicitly how to merge them.
+`annotations_map` is safe here because only one annotated policy can match at a time. The broad
+grant carries nothing, the report bands are gated on a tier and do not overlap within it, and the
+inference budget has a single band. The application code depends on that property, so state it in a
+test. If you later add an overlapping policy, such as a per-workspace warning alongside a per-user
+one, switch to `annotation_values` or `annotations_by_policy` and decide explicitly how to merge
+them.
 
 Using `user_message_id` instead of literal copy keeps the banner translatable and lets it
 interpolate the live numbers the policy does not have. See
@@ -461,10 +476,10 @@ interpolate the live numbers the policy does not have. See
 
 ## Variation: Agent Cost Budgets
 
-The same shape covers an autonomous agent burning through resources far faster than a human would,
-where the budget is gone by the time anyone notices.
+An autonomous agent consumes resources far faster than a human would, and the budget is usually
+gone by the time anyone notices. The same shape covers it.
 
-The same three jobs apply, so the budget needs a grant and a hard limit of its own before the
+The three jobs are unchanged, so the budget needs a grant and a hard limit of its own before the
 warning means anything:
 
 ```cedar
@@ -523,14 +538,16 @@ boundary and assert the decision *and* the exact `warn` value each time. For the
 Test every tier separately. The bands are written out per plan, so a typo in the business numbers
 cannot be caught by a passing team test, and the gap it leaves is quiet: a usage figure that matches
 no band is still allowed by the broad `permit`, so the request succeeds with no warning at all. That
-is a missing banner rather than a broken page, which is exactly why nobody notices it in staging.
+is a missing banner rather than a broken page, so it passes through staging unnoticed.
 
 Assert the `forbid` boundaries hardest. They are the only policies enforcing anything, so a wrong
 comparison there sells the plan for free.
 
-For the entity-driven tier, test an awkward contract quota such as 250, where the boundaries land at
-200 and 225. Cross-multiplied comparisons are exact, so there is no rounding to argue about, but an
-odd number is what catches a threshold written with the operands the wrong way round.
+For the entity-driven tier, pick a contract quota that is not divisible by 10. At 250 the
+boundaries land on 200 and 225 and nothing interesting happens, because 250 divides evenly by both
+thresholds. At 333 the 80% boundary is 267, not 266: cross-multiplication crosses as soon as
+`used * 100` reaches `quota * 80`, while integer division would have put it a request earlier. That
+one is the off-by-one an awkward quota catches.
 
 Test the unconfigured cases too: a tier nobody recognizes, and an enterprise workspace with no
 `contract_quota`. Both should reach `forbid_generate_report_unconfigured_plan`. If either one comes

--- a/docs/cedarling/patterns/annotation-quota.md
+++ b/docs/cedarling/patterns/annotation-quota.md
@@ -51,7 +51,9 @@ The quota case is the clearest of them, so it is the one worked through here.
 ## Where the Quota Number Lives
 
 Cedar cannot count, so the usage figure has to arrive with the request: the application reads it
-from its metering store, a counter, or a billing service, and passes it in as context. The *limit*
+from its metering store, a counter, or a billing service, and passes it in as context. A client-side
+PDP holding a stale copy of that counter is the subject of
+[Advisory denials in a client-side PDP](./annotation-client-authority.md). The *limit*
 is a different question, and it has two reasonable homes.
 
 Put the limit in the policy when it defines a plan. The team tier including 1,000 reports is a

--- a/docs/cedarling/patterns/annotation-quota.md
+++ b/docs/cedarling/patterns/annotation-quota.md
@@ -67,6 +67,15 @@ signed contract.
 
 This page uses both, because a real product usually has both.
 
+Wherever they come from, the application resolves them. `context.reports_used`, `resource.tier`, and
+`resource.contract_quota` are the only things the enforcing policies look at, so a service that
+forwards them from the caller has handed the caller its own quota: `reports_used: 0` on every
+request, or `tier: "enterprise"` with a generous `contract_quota` to slip past the guard at the end
+of this page. Read the counter from metering and the workspace from your own store, on the server,
+on every call. The same rule the [challenge page](./annotation-challenge.md#security-requirements)
+states for challenge results applies here, and it matters more, because these are the only policies
+enforcing anything.
+
 ## Schema
 
 ```cedarschema
@@ -339,9 +348,23 @@ those policies carry `@upsell`. An enterprise customer has a contract and an acc
 showing them an upgrade button is the wrong answer, so these carry `@notify` and `@escalate_to`
 instead. The difference lives in the annotations rather than in the application's `if` statements.
 
-Cedar's `Long` arithmetic errors on overflow, and a policy that errors is skipped, so keep contract
-quotas to sane values. Multiplying a report counter by 100 leaves an enormous amount of headroom,
-but a number near the `Long` boundary would take the request out of the policy set entirely.
+Cedar's `Long` arithmetic errors on overflow, and a policy that errors is dropped from the
+evaluation, so keep contract quotas to sane values. Multiplying a report counter by 100 leaves an
+enormous amount of headroom, but a number near the `Long` boundary takes exactly the cross-multiplied
+policies out of the decision while the rest of the set carries on:
+
+```text
+reports_used = 9000000000000000000, contract_quota = i64::MAX
+ALLOW
+error while evaluating policy `permit_generate_report_enterprise_quota_80`: integer overflow
+error while evaluating policy `permit_generate_report_enterprise_quota_90`: integer overflow
+reason: permit_generate_report
+```
+
+The exhaustion `forbid` survives, because a plain `>=` cannot overflow, so enforcement holds and the
+warnings are what disappear. That is the better failure of the two, and it is still one you want to
+see: the errors are in `diagnostics().errors()`, not in `reason()`, so a PEP that only reads
+`reason()` will never notice.
 
 ## The Broad Grant Fails Open
 
@@ -420,7 +443,7 @@ const annotations = cedarling.annotations_map(result.response.diagnostics.reason
 if (result.decision && annotations.warn) {
   banner.show({
     level: annotations.warn_level ?? "info",
-    text: t(annotations.user_message_id, { used, limit, resetsOn }),
+    text: t(annotations.user_message_id ?? "quota.generic.approaching", { used, limit, resetsOn }),
     action: annotations.upsell ? upgradeLink(annotations.upsell) : null,
   });
 }
@@ -470,6 +493,8 @@ when { context.budget_used >= resource.inference_budget };
 ```cedar
 @id("permit_agent_inference_budget_warn")
 @warn("budget_80")
+@warn_level("info")
+@user_message_id("budget.inference.approaching")
 @cost_center("eng-ops")
 @notify("operator")
 permit (

--- a/docs/cedarling/patterns/annotation-quota.md
+++ b/docs/cedarling/patterns/annotation-quota.md
@@ -1,0 +1,484 @@
+---
+tags:
+  - administration
+  - lock
+  - authorization / authz
+  - Cedar
+  - Cedarling
+  - annotations
+---
+
+# Pattern: Quota and Threshold Warnings
+
+!!! note "Illustrative example"
+
+    The tiers, thresholds, and annotation keys (`@warn`, `@upsell`, `@quota_reset`, and the rest)
+    are invented for this page. Cedarling attaches no meaning to them; they work only because the
+    example application reads them. Pick your own keys and your own thresholds. See
+    [Policy Annotation Patterns](./annotation-patterns.md) for the ground rules.
+
+## The Scenario
+
+Acme's reporting API is sold in tiers. The `team` tier includes 1,000 generated reports per month,
+`business` includes 25,000, and `enterprise` negotiates its own number in a contract. When the quota
+runs out, report generation stops.
+
+The denial itself is easy to get right. What is hard is everything before it: a customer whose first
+signal is a hard failure in the middle of their month-end close is a customer with a support ticket
+and a bad opinion of the product. They should have been told at 80%, told more loudly at 90%, and
+offered an upgrade before anything broke.
+
+That warning is not a separate feature. The authorization call already happens on every report
+generation, it already has the usage figure in context, and the policy that allows the request
+already knows how close to the limit it is. The missing piece is a way for the policy to say
+"allowed, but tell them", which is what an annotation on a `permit` does.
+
+## Annotations on Permit Policies
+
+Annotations are usually associated with denials, but a `permit` carries them just as well, and they
+are reported the same way: on an `Allow`, `reason()` contains the satisfied `permit` policies, so
+the application can read their annotations after a *successful* authorization.
+
+That covers a whole category of "allowed, with something to say":
+
+- approaching a quota or rate limit
+- an entitlement that expires soon
+- access granted under a temporary exception rather than a standing rule
+- a tier-limited response the customer could unlock by upgrading
+
+The quota case is the clearest of them, so it is the one worked through here.
+
+## Where the Quota Number Lives
+
+Cedar cannot count, so the usage figure has to arrive with the request: the application reads it
+from its metering store, a counter, or a billing service, and passes it in as context. The *limit*
+is a different question, and it has two reasonable homes.
+
+Put the limit in the policy when it defines a plan. The team tier including 1,000 reports is a
+product decision that applies to every team customer, changes rarely, and should be reviewable as a
+diff. Writing it as a literal means the policy store answers "what does the team plan include?"
+without joining against anything.
+
+Put the limit on the entity when it is negotiated per customer. An enterprise contract for 40,000
+reports is data about one account, and encoding it in a policy would mean a policy release for every
+signed contract.
+
+This page uses both, because a real product usually has both.
+
+## Schema
+
+```cedarschema
+namespace Acme {
+    entity User;
+
+    entity Agent = {
+        "operated_by": User,
+    };
+
+    entity Workspace = {
+        "tier": String,
+        "contract_quota"?: Long,
+        "inference_budget": Long,
+    };
+
+    action "GenerateReport" appliesTo {
+        principal: [User],
+        resource: [Workspace],
+        context: {
+            "reports_used": Long,
+        }
+    };
+
+    action "RunInference" appliesTo {
+        principal: [Agent],
+        resource: [Workspace],
+        context: {
+            "budget_used": Long,
+        }
+    };
+}
+```
+
+`contract_quota` is optional. Self-serve workspaces do not carry it, because their limit comes from
+the policies below.
+
+## Three Jobs, Three Kinds of Policy
+
+Splitting the policy set by *job* keeps each policy readable:
+
+- one broad `permit` that lets the action happen at all
+- one `forbid` per plan that stops it when the quota is gone
+- warning policies that exist only to carry annotations
+
+```cedar
+@id("permit_generate_report")
+permit (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+);
+```
+
+That grant says nothing about quotas, and it does not need to. Enforcement is the `forbid`'s job,
+and in Cedar a `forbid` always wins.
+
+## Plan Limits Written as Policy
+
+The team plan's limit is a literal, because 1,000 reports is what the plan includes:
+
+```cedar
+@id("forbid_generate_report_team_quota_exhausted")
+@user_message_id("quota.reports.exhausted.self_serve")
+@upsell("plan_business")
+@quota_reset("monthly")
+forbid (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "team" &&
+    context.reports_used >= 1000
+};
+```
+
+```cedar
+@id("forbid_generate_report_business_quota_exhausted")
+@user_message_id("quota.reports.exhausted.self_serve")
+@upsell("plan_enterprise")
+@quota_reset("monthly")
+forbid (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "business" &&
+    context.reports_used >= 25000
+};
+```
+
+Changing what a plan includes is now a policy change. Raising the team plan to 1,500 reports is one
+number in one file, reviewed like any other change, applied without a deployment of the billing
+code, and visible in the policy store's history. Nobody has to ask which service owns the number.
+
+## Annotation-Only Policies
+
+The warnings are not about access at all. Both bands are already allowed by the broad `permit`, so
+these policies change no decision. They exist so that their annotations appear in `reason()` when
+usage falls in their band:
+
+```cedar
+@id("permit_generate_report_team_quota_80")
+@warn("quota_80")
+@warn_level("info")
+@user_message_id("quota.reports.approaching")
+permit (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "team" &&
+    context.reports_used >= 800 &&
+    context.reports_used < 900
+};
+```
+
+```cedar
+@id("permit_generate_report_team_quota_90")
+@warn("quota_90")
+@warn_level("critical")
+@user_message_id("quota.reports.nearly_exhausted")
+@upsell("plan_business")
+permit (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "team" &&
+    context.reports_used >= 900 &&
+    context.reports_used < 1000
+};
+```
+
+The business plan gets the same two policies with its own numbers and its own upsell target:
+
+```cedar
+@id("permit_generate_report_business_quota_80")
+@warn("quota_80")
+@warn_level("info")
+@user_message_id("quota.reports.approaching")
+permit (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "business" &&
+    context.reports_used >= 20000 &&
+    context.reports_used < 22500
+};
+
+@id("permit_generate_report_business_quota_90")
+@warn("quota_90")
+@warn_level("critical")
+@user_message_id("quota.reports.nearly_exhausted")
+@upsell("plan_enterprise")
+permit (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "business" &&
+    context.reports_used >= 22500 &&
+    context.reports_used < 25000
+};
+```
+
+At 850 reports on a team workspace, two policies are satisfied and both appear in the decision:
+
+```text
+ALLOW  reason: permit_generate_report
+               permit_generate_report_team_quota_80
+```
+
+Those two IDs arrive in no particular order, since `reason()` is a set. It does not matter here: the
+broad grant carries no annotations, the warning policy carries all of them, and the application
+reads one merged map without caring which policy contributed what.
+
+Three things are worth knowing about this shape.
+
+The bands within a tier must not overlap. Annotation values are static strings and Cedar rejects two
+`@warn` annotations on one policy, so each band is its own policy. If two bands could hold at once,
+both would appear in `reason()` and `annotation_values(reason, "warn")` would return two warnings
+for one request, leaving the application to guess which is real.
+
+An annotation-only policy is still a real `permit`. It changes nothing only because the broad grant
+already allows the action. If someone later narrows that grant, these policies quietly become the
+thing that authorizes those requests. Keep their conditions no wider than the grant they shadow, and
+if that coupling makes you uncomfortable, put the warning annotations on the broad `permit` for the
+default case and accept fewer bands.
+
+The cost is duplication: tiers multiplied by bands. Three tiers with two bands each is six policies
+that differ only in numbers, and adding a third band means touching every tier. That is tolerable
+for a handful of plans and unpleasant for twenty. When the count gets uncomfortable, move the limit
+onto the entity, as the enterprise tier does next, and accept that the number then lives in your data
+rather than in your policies.
+
+## Negotiated Limits Read from the Entity
+
+An enterprise workspace carries its own number, so one set of policies covers every contract.
+Percentages have to be computed against it, and Cedar has no division operator, so cross-multiply:
+
+```text
+used / limit >= 80 / 100      becomes      used * 100 >= limit * 80
+```
+
+```cedar
+@id("forbid_generate_report_enterprise_quota_exhausted")
+@user_message_id("quota.reports.exhausted.enterprise")
+@notify("account_manager")
+@escalate_to("csm-oncall")
+@quota_reset("contract_term")
+forbid (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "enterprise" &&
+    resource has contract_quota &&
+    context.reports_used >= resource.contract_quota
+};
+```
+
+```cedar
+@id("permit_generate_report_enterprise_quota_80")
+@warn("quota_80")
+@warn_level("info")
+@user_message_id("quota.reports.approaching")
+permit (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "enterprise" &&
+    resource has contract_quota &&
+    context.reports_used * 100 >= resource.contract_quota * 80 &&
+    context.reports_used * 100 < resource.contract_quota * 90
+};
+```
+
+```cedar
+@id("permit_generate_report_enterprise_quota_90")
+@warn("quota_90")
+@warn_level("critical")
+@user_message_id("quota.reports.nearly_exhausted")
+@notify("account_manager")
+permit (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    resource.tier == "enterprise" &&
+    resource has contract_quota &&
+    context.reports_used * 100 >= resource.contract_quota * 90 &&
+    context.reports_used < resource.contract_quota
+};
+```
+
+Running out means something different here. A self-serve customer can fix it with a credit card, so
+those policies carry `@upsell`. An enterprise customer has a contract and an account manager, and
+showing them an upgrade button is the wrong answer, so these carry `@notify` and `@escalate_to`
+instead. The difference lives in the annotations rather than in the application's `if` statements.
+
+Cedar's `Long` arithmetic errors on overflow, and a policy that errors is skipped, so keep contract
+quotas to sane values. Multiplying a report counter by 100 leaves an enormous amount of headroom,
+but a number near the `Long` boundary would take the request out of the policy set entirely.
+
+## The Broad Grant Fails Open
+
+Enforcement now lives entirely in the `forbid` policies, and every one of them is gated on a tier.
+A workspace whose tier matches none of them is not denied. It is *allowed*, without limit, by the
+broad `permit`.
+
+That is the trade for the simpler structure, and it is the opposite of what a quota-gated grant would
+do. Both failure modes are bad, but they are bad in different ways: a set of narrow permits fails
+closed and silently, and a broad permit fails open and silently. Neither is acceptable, so close the
+gap explicitly.
+
+```cedar
+@id("forbid_generate_report_unconfigured_plan")
+@user_message_id("quota.reports.plan_unconfigured")
+@escalate_to("billing-oncall")
+forbid (
+    principal,
+    action == Acme::Action::"GenerateReport",
+    resource
+)
+when {
+    !(["team", "business"].contains(resource.tier)) &&
+    !(resource.tier == "enterprise" && resource has contract_quota)
+};
+```
+
+This is the policy that catches a new plan added to the price list before anyone wrote its quota
+rules, and an enterprise workspace whose `contract_quota` was never set. Adding a tier means adding
+its policies *and* widening this guard, which is a change a reviewer can see. Without it, the same
+mistake ships unlimited free usage and nothing in the logs looks unusual.
+
+Note also what is *not* in the annotations: no counts, no reset date, no plan price. Those are
+per-tenant values that change every day, and annotations are static strings shared by every request
+that hits the policy. The policy says *which* message and *which* plan, and the application fills in
+"947 of 1,000, resets on 1 September".
+
+## Application Code
+
+```rust
+let result = cedarling.authorize_unsigned(request).await?;
+
+// Read once, so the iterator goes straight in without collecting.
+let annotations = cedarling.annotations_map(result.response.diagnostics().reason());
+
+if !result.decision {
+    return Err(quota_error(
+        annotations.get("user_message_id"),
+        annotations.get("upsell"),
+        annotations.get("escalate_to"),
+    ));
+}
+
+let mut response = generate_report()?;
+
+// Allowed, but the policy may still have something to say.
+if let Some(warn) = annotations.get("warn") {
+    response.notice = Some(Notice {
+        message_id: annotations.get("user_message_id").cloned(),
+        level: annotations
+            .get("warn_level")
+            .cloned()
+            .unwrap_or_else(|| "info".to_string()),
+        upsell: annotations.get("upsell").cloned(),
+    });
+    metrics.increment("quota_warning", warn);
+}
+
+Ok(response)
+```
+
+```javascript
+const result = await cedarling.authorize_unsigned(JSON.stringify(request));
+const annotations = cedarling.annotations_map(result.response.diagnostics.reason);
+
+if (result.decision && annotations.warn) {
+  banner.show({
+    level: annotations.warn_level ?? "info",
+    text: t(annotations.user_message_id, { used, limit, resetsOn }),
+    action: annotations.upsell ? upgradeLink(annotations.upsell) : null,
+  });
+}
+```
+
+`annotations_map` is safe here because only one annotated policy can match at a time: the broad grant
+carries nothing, and the bands are gated on a tier and do not overlap within it. That property is
+worth stating in a test, because it is what the application code quietly depends on. If you later add
+an overlapping policy, such as a per-workspace warning alongside a per-user one, switch to
+`annotation_values` or `annotations_by_policy` and decide explicitly how to merge them.
+
+Using `user_message_id` instead of literal copy keeps the banner translatable and lets it
+interpolate the live numbers the policy does not have. See
+[Use message IDs, not message text](./annotation-patterns.md#use-message-ids-not-message-text).
+
+## Variation: Agent Cost Budgets
+
+The same shape covers an autonomous agent burning through resources far faster than a human would,
+where the budget is gone by the time anyone notices.
+
+```cedar
+@id("permit_agent_inference_budget_warn")
+@warn("budget_80")
+@cost_center("eng-ops")
+@notify("operator")
+permit (
+    principal,
+    action == Acme::Action::"RunInference",
+    resource
+)
+when {
+    context.budget_used * 100 >= resource.inference_budget * 80 &&
+    context.budget_used < resource.inference_budget
+};
+```
+
+The principal is the agent itself, and `@notify("operator")` tells the application to route the
+warning to `principal.operated_by`, the human accountable for the spend and the only one who can do
+anything about it. See
+[Modeling the agent](./annotation-challenge.md#modeling-the-agent) for why the agent is a principal
+in its own right rather than a flag on the human's request.
+
+## Testing
+
+Threshold policies are cheap to test exhaustively, so do it. Authorize on both sides of every
+boundary and assert the decision *and* the exact `warn` value each time. For the team plan that is
+799, 800, 899, 900, 999, and 1,000.
+
+Test every tier separately. The bands are written out per plan, so a typo in the business numbers
+cannot be caught by a passing team test, and the gap it leaves is quiet: a usage figure that matches
+no band is still allowed by the broad `permit`, so the request succeeds with no warning at all. That
+is a missing banner rather than a broken page, which is exactly why nobody notices it in staging.
+
+Assert the `forbid` boundaries hardest. They are the only policies enforcing anything, so a wrong
+comparison there sells the plan for free.
+
+For the entity-driven tier, test an awkward contract quota such as 250, where the boundaries land at
+200 and 225. Cross-multiplied comparisons are exact, so there is no rounding to argue about, but an
+odd number is what catches a threshold written with the operands the wrong way round.
+
+Test the unconfigured cases too: a tier nobody recognizes, and an enterprise workspace with no
+`contract_quota`. Both should reach `forbid_generate_report_unconfigured_plan`. If either one comes
+back as a plain `Allow`, the guard has a hole and that plan is running without a quota.

--- a/docs/cedarling/patterns/annotation-response-shaping.md
+++ b/docs/cedarling/patterns/annotation-response-shaping.md
@@ -51,6 +51,8 @@ Two rules follow from that, and they are the reason this pattern needs care:
 
 ```cedarschema
 namespace Acme {
+    entity Clearance enum ["standard", "elevated"];
+
     entity Analyst = {
         "clearance": String,
     };
@@ -59,7 +61,7 @@ namespace Acme {
         "classification": String,
         "special_category"?: {
             "regulation": String,
-            "min_clearance": String,
+            "min_clearance": Clearance,
         },
     };
 
@@ -79,6 +81,21 @@ dataset that holds nothing regulated simply does not carry the attribute, which 
 the clearance it demands travel with the dataset instead of being hardcoded in whichever policy
 happens to mention it.
 
+The two clearance fields are typed differently on purpose. `min_clearance` is an enumerated entity
+type, so the schema itself lists the legal values and a dataset labelled `"Elevated"` or
+`"top_secret"` is rejected before any policy runs:
+
+```text
+entity `Acme::Clearance::"top_secret"` is of an enumerated entity type,
+but "top_secret" is not declared as a valid eid
+help: valid entity eids: "standard", "elevated"
+```
+
+`Analyst.clearance` stays a `String`, because it arrives from an identity provider and you do not
+control what it sends. Typed as an enum, an unexpected claim would fail entity construction and the
+request would error out with nothing to show the user. Left as a string, it reaches the policies,
+and a guard policy can deny it with a message. Enumerate what you author; guard what you receive.
+
 The tradeoff is that every policy touching an optional attribute has to guard it. Cedar's validator
 enforces that, so a policy that reaches for `resource.special_category.regulation` without the
 `has` check is rejected at validation time rather than erroring at request time.
@@ -87,6 +104,11 @@ enforces that, so a policy that reaches for `resource.special_category.regulatio
 
 The baseline grant is deliberately narrow: standard clearance gets masked columns and a small page
 of rows.
+
+`@mask` carries a delimited list rather than one key per column, because Cedar allows a key to appear
+only once per policy. That is the one place where packing several values into a string is the right
+call, and it stays a flat list: still no nested structure, and still nothing the application has to
+parse beyond splitting on a comma.
 
 ```cedar
 @id("permit_query_standard")
@@ -115,7 +137,34 @@ permit (
     action == Acme::Action::"Query",
     resource
 )
-when { resource has special_category };
+when {
+    resource has special_category &&
+    ["standard", "elevated"].contains(principal.clearance)
+};
+```
+
+The clearance test in that policy is not decoration. Without it the permit fires for any principal
+at all, so an unrecognized clearance value would be allowed on the most sensitive datasets while
+still being denied on ordinary ones, which is the opposite of what anyone intends. A grant that
+turns on a property of the *resource* still has to say who it is for.
+
+Elevated clearance needs its own baseline, or an elevated analyst doing ordinary work matches no
+permit and falls to the default deny with nothing to show them:
+
+```cedar
+@id("permit_query_elevated")
+@mask("national_id")
+@row_limit("10000")
+@control("SOC2-CC6.1")
+permit (
+    principal,
+    action == Acme::Action::"Query",
+    resource
+)
+when {
+    principal.clearance == "elevated" &&
+    context.purpose != "incident_response"
+};
 ```
 
 Clearance below what the dataset demands is a denial rather than a narrower grant, and the dataset
@@ -132,34 +181,31 @@ forbid (
 )
 when {
     resource has special_category &&
-    resource.special_category.min_clearance == "elevated" &&
+    resource.special_category.min_clearance == Acme::Clearance::"elevated" &&
     principal.clearance != "elevated"
 };
 ```
 
-`min_clearance` is a plain `String`, and that policy only recognizes one value. A dataset asking for
-`"top_secret"`, or for `"Elevated"` with a stray capital, matches no denial and still matches the
-permits, so a stricter requirement would read as no requirement at all. Close that the same way the
-quota page closes an unrecognized tier:
+An unrecognized clearance on the principal is a plain default deny with nothing to show, so it needs
+a guard of its own:
 
 ```cedar
-@id("forbid_query_unrecognized_clearance_requirement")
-@user_message_id("query.clearance.unrecognized")
-@escalate_to("data-governance")
+@id("forbid_query_unrecognized_clearance")
+@user_message_id("query.clearance.unrecognized_principal")
+@escalate_to("identity-governance")
 forbid (
     principal,
     action == Acme::Action::"Query",
     resource
 )
 when {
-    resource has special_category &&
-    !(["standard", "elevated"].contains(resource.special_category.min_clearance))
+    !(["standard", "elevated"].contains(principal.clearance))
 };
 ```
 
-Any value the policy set does not know about now denies the query and tells someone to fix the
-dataset. The alternative is a closed vocabulary in the schema, which Cedar cannot express for a
-`String` attribute, so the guard policy is where that check has to live.
+The dataset side needs no such guard. `min_clearance` is an enumerated type, so a value outside the
+list never reaches a policy: it is rejected when the entity is built. That is the whole reason to
+spend an enum on it.
 
 Incident response gets the wider grant, and pays for it in audit:
 
@@ -182,8 +228,8 @@ when {
 
 ## Overlapping Permits Need a Restrictive Merge
 
-A standard analyst querying a dataset that carries `special_category` satisfies two of these
-policies, so both appear in the decision:
+A standard analyst querying a dataset that carries `special_category` with `min_clearance` of
+`"standard"` satisfies two of these policies, so both appear in the decision:
 
 ```text
 ALLOW  reason: permit_query_standard
@@ -198,32 +244,37 @@ the matched policies each describe a limit, and taking one of them means droppin
 annotations in play it would return one of them and silently discard the other, which in this case
 means shipping the health column in the clear.
 
-Merge restrictively instead: union the masks, take the smallest row limit, and treat any watermark
-or audit requirement as sticky.
+Merge restrictively instead: union the masks, take the smallest row limit, and treat a watermark
+requirement as sticky. Where no matching policy says anything, fall back to the application's own
+floor rather than to no limit at all.
 
 ```rust
 let reason: Vec<_> = result.response.diagnostics().reason().collect();
 
-// Union: every column any matching policy wants masked.
-let masked: BTreeSet<String> = cedarling
-    .annotation_values(reason.iter().copied(), "mask")
-    .iter()
-    .flat_map(|v| v.split(','))
-    .map(|c| c.trim().to_string())
-    .collect();
+// Union: the columns this deployment always masks, plus anything a matched policy adds.
+let mut masked: BTreeSet<String> = baseline_masked_columns();
+masked.extend(
+    cedarling
+        .annotation_values(reason.iter().copied(), "mask")
+        .iter()
+        .flat_map(|v| v.split(','))
+        .map(|c| c.trim().to_string()),
+);
 
-// Minimum: the tightest limit wins. A value that does not parse is a broken
-// obligation, not a reason to fall back to a wider default.
-let mut row_limit = HARD_ROW_CEILING;
+// Minimum of what the matched policies asked for. If none of them asked, the
+// application's default applies: an absent obligation must never widen anything.
+// A value that does not parse is a broken obligation, not a reason to fall back.
+let mut row_limit = None;
 for value in cedarling.annotation_values(reason.iter().copied(), "row_limit") {
     let parsed: usize = value
         .parse()
         .map_err(|_| Error::MalformedObligation("row_limit", value))?;
-    row_limit = row_limit.min(parsed);
+    row_limit = Some(row_limit.map_or(parsed, |current: usize| current.min(parsed)));
 }
+let row_limit = row_limit.unwrap_or(DEFAULT_ROW_LIMIT);
 
-// Sticky, but only a value we recognize counts. Anything else stops the response.
-let mut watermark = false;
+// Sticky, and only a value we recognize counts. Anything else stops the response.
+let mut watermark = WATERMARK_BY_DEFAULT;
 for value in cedarling.annotation_values(reason.iter().copied(), "watermark") {
     match value.as_str() {
         "true" => watermark = true,
@@ -236,6 +287,14 @@ let rows = run_query(&query, row_limit)?;
 Ok(shape(rows, &masked, watermark))
 ```
 
+The starting values are easy to get wrong. A union starts from the empty set, which masks nothing,
+and a minimum starts from an unbounded ceiling, which limits nothing. Start there and a request that
+matches one permit carrying no `@row_limit` walks away with no row limit at all. This policy set can
+produce that: an elevated analyst querying a special-category dataset matches only
+`permit_query_special_category`, which masks a column and says nothing about volume. With the
+fallbacks anchored in the application, a missing annotation leaves the floor where it is instead of
+lifting it.
+
 Both loops fail closed, which is the point. `unwrap_or(DEFAULT_ROW_LIMIT)` on a value that failed to
 parse would silently widen the response, and treating any non-empty `@watermark` as true would let
 `@watermark("false")` turn watermarking on. An obligation the application cannot interpret is a
@@ -243,10 +302,15 @@ policy the application is not implementing, so refuse the query and let the erro
 edits the policies.
 
 The incident-response policy shows why the direction of the merge matters. Its `@row_limit` of
-100,000 is wider than the standard 100, and if the analyst also matches the standard policy, the
-minimum keeps them at 100. Widening access has to come from *not* matching the narrow policy, not
-from adding a broader one alongside it. Write the wide grant so that the narrow one cannot match at
-the same time, or accept that the narrow limit wins.
+100,000 is wider than the 10,000 an elevated analyst normally gets, and a minimum merge cannot widen
+anything: if both policies matched, the analyst would be held at 10,000 no matter what the wider one
+says. That is why `permit_query_elevated` carries `context.purpose != "incident_response"`. The
+exclusion is what makes the wide grant reachable.
+
+Widening access therefore comes from *not* matching the narrow policy, never from adding a broader
+one alongside it. Whenever you write a permit that is meant to grant more, check what else the same
+request matches, because under a restrictive merge the narrowest matched policy is the one that
+decides.
 
 A useful sanity check when adding a `permit` with obligations: if this policy matched together with
 every other `permit`, would the merged result still be safe? If the answer depends on which policy

--- a/docs/cedarling/patterns/annotation-response-shaping.md
+++ b/docs/cedarling/patterns/annotation-response-shaping.md
@@ -251,6 +251,7 @@ requirement as sticky. Where no matching policy says anything, fall back to the 
 floor rather than to no limit at all.
 
 ```rust
+// Reached on an Allow. A Deny never gets here; the denial path is its own branch.
 let reason: Vec<_> = result.response.diagnostics().reason().collect();
 
 // Union: the columns this deployment always masks, plus anything a matched policy adds.

--- a/docs/cedarling/patterns/annotation-response-shaping.md
+++ b/docs/cedarling/patterns/annotation-response-shaping.md
@@ -137,6 +137,30 @@ when {
 };
 ```
 
+`min_clearance` is a plain `String`, and that policy only recognizes one value. A dataset asking for
+`"top_secret"`, or for `"Elevated"` with a stray capital, matches no denial and still matches the
+permits, so a stricter requirement would read as no requirement at all. Close that the same way the
+quota page closes an unrecognized tier:
+
+```cedar
+@id("forbid_query_unrecognized_clearance_requirement")
+@user_message_id("query.clearance.unrecognized")
+@escalate_to("data-governance")
+forbid (
+    principal,
+    action == Acme::Action::"Query",
+    resource
+)
+when {
+    resource has special_category &&
+    !(["standard", "elevated"].contains(resource.special_category.min_clearance))
+};
+```
+
+Any value the policy set does not know about now denies the query and tells someone to fix the
+dataset. The alternative is a closed vocabulary in the schema, which Cedar cannot express for a
+`String` attribute, so the guard policy is where that check has to live.
+
 Incident response gets the wider grant, and pays for it in audit:
 
 ```cedar
@@ -188,22 +212,35 @@ let masked: BTreeSet<String> = cedarling
     .map(|c| c.trim().to_string())
     .collect();
 
-// Minimum: the tightest limit wins.
-let row_limit = cedarling
-    .annotation_values(reason.iter().copied(), "row_limit")
-    .iter()
-    .filter_map(|v| v.parse::<usize>().ok())
-    .min()
-    .unwrap_or(DEFAULT_ROW_LIMIT);
+// Minimum: the tightest limit wins. A value that does not parse is a broken
+// obligation, not a reason to fall back to a wider default.
+let mut row_limit = HARD_ROW_CEILING;
+for value in cedarling.annotation_values(reason.iter().copied(), "row_limit") {
+    let parsed: usize = value
+        .parse()
+        .map_err(|_| Error::MalformedObligation("row_limit", value))?;
+    row_limit = row_limit.min(parsed);
+}
 
-// Sticky: one policy asking for a watermark is enough.
-let watermark = !cedarling
-    .annotation_values(reason.iter().copied(), "watermark")
-    .is_empty();
+// Sticky, but only a value we recognize counts. Anything else stops the response.
+let mut watermark = false;
+for value in cedarling.annotation_values(reason.iter().copied(), "watermark") {
+    match value.as_str() {
+        "true" => watermark = true,
+        "false" => {}
+        _ => return Err(Error::MalformedObligation("watermark", value)),
+    }
+}
 
 let rows = run_query(&query, row_limit)?;
 Ok(shape(rows, &masked, watermark))
 ```
+
+Both loops fail closed, which is the point. `unwrap_or(DEFAULT_ROW_LIMIT)` on a value that failed to
+parse would silently widen the response, and treating any non-empty `@watermark` as true would let
+`@watermark("false")` turn watermarking on. An obligation the application cannot interpret is a
+policy the application is not implementing, so refuse the query and let the error reach whoever
+edits the policies.
 
 The incident-response policy shows why the direction of the merge matters. Its `@row_limit` of
 100,000 is wider than the standard 100, and if the analyst also matches the standard policy, the

--- a/docs/cedarling/patterns/annotation-response-shaping.md
+++ b/docs/cedarling/patterns/annotation-response-shaping.md
@@ -1,0 +1,258 @@
+---
+tags:
+  - administration
+  - lock
+  - authorization / authz
+  - Cedar
+  - Cedarling
+  - annotations
+---
+
+# Pattern: Shaping the Response and Mapping Controls
+
+!!! note "Illustrative example"
+
+    Acme Analytics and every annotation key below (`@mask`, `@row_limit`, `@control`, and the rest)
+    are invented for this page. Cedarling attaches no meaning to them; they work only because the
+    example application reads them. See
+    [Policy Annotation Patterns](./annotation-patterns.md) for the ground rules.
+
+## The Scenario
+
+Acme Analytics lets internal staff query customer datasets. Access is not really a yes or no
+question. A support agent looking up one account should see the account, but not the customer's
+national ID. An analyst studying churn needs a hundred thousand rows and no personal identifiers at
+all. An on-call engineer during an incident needs the raw record, and the company needs a record of
+the fact.
+
+Answering with `Deny` in all the awkward cases pushes people toward CSV exports and shared logins.
+Answering with an unrestricted `Allow` gives away more than the request needed. What the system
+actually wants to say is "allowed, in this shape": these columns masked, this many rows, watermarked
+on the way out.
+
+Cedar decides *whether*. The annotations carry *in what shape*, and the application enforces it.
+
+## Obligations, Not Hints
+
+The earlier patterns use annotations as hints on a denial. Something the user can act on, and the
+worst case of ignoring one is a poor experience. This pattern is different. A `@mask("national_id")`
+on a `permit` is an obligation: if the application ignores it, the data goes out unmasked and the
+policy that looked like a control did nothing.
+
+Two rules follow from that, and they are the reason this pattern needs care:
+
+- Enforce obligations in one place, close to where the response is built. An obligation applied in
+  three handlers is an obligation missing from the fourth.
+- Fail closed on an unknown key. If a policy carries `@mask` and the application does not recognize
+  the column name, mask everything or refuse, and never return the row unmasked because the
+  instruction was unfamiliar.
+
+## Schema
+
+```cedarschema
+namespace Acme {
+    entity Analyst = {
+        "clearance": String,
+    };
+
+    entity Dataset = {
+        "classification": String,
+        "special_category"?: {
+            "regulation": String,
+            "min_clearance": String,
+        },
+    };
+
+    action "Query" appliesTo {
+        principal: [Analyst],
+        resource: [Dataset],
+        context: {
+            "purpose": String,
+        }
+    };
+}
+```
+
+`special_category` is optional, and the policies test it with `resource has special_category`. A
+dataset that holds nothing regulated simply does not carry the attribute, which reads better than a
+`Bool` flag and gives the extra fields somewhere to live: the regulation the data falls under and
+the clearance it demands travel with the dataset instead of being hardcoded in whichever policy
+happens to mention it.
+
+The tradeoff is that every policy touching an optional attribute has to guard it. Cedar's validator
+enforces that, so a policy that reaches for `resource.special_category.regulation` without the
+`has` check is rejected at validation time rather than erroring at request time.
+
+## Policies
+
+The baseline grant is deliberately narrow: standard clearance gets masked columns and a small page
+of rows.
+
+```cedar
+@id("permit_query_standard")
+@mask("national_id,date_of_birth")
+@row_limit("100")
+@watermark("true")
+@control("SOC2-CC6.1")
+permit (
+    principal,
+    action == Acme::Action::"Query",
+    resource
+)
+when { principal.clearance == "standard" };
+```
+
+Special-category data carries its own rule, and it applies no matter who is asking:
+
+```cedar
+@id("permit_query_special_category")
+@mask("diagnosis_code")
+@regulation("GDPR-Art9")
+@retention_days("30")
+@control("SOC2-CC6.1")
+permit (
+    principal,
+    action == Acme::Action::"Query",
+    resource
+)
+when { resource has special_category };
+```
+
+Clearance below what the dataset demands is a denial rather than a narrower grant, and the dataset
+states the requirement itself:
+
+```cedar
+@id("forbid_query_below_required_clearance")
+@user_message_id("query.clearance.insufficient")
+@request_access_route("access.request_clearance")
+forbid (
+    principal,
+    action == Acme::Action::"Query",
+    resource
+)
+when {
+    resource has special_category &&
+    resource.special_category.min_clearance == "elevated" &&
+    principal.clearance != "elevated"
+};
+```
+
+Incident response gets the wider grant, and pays for it in audit:
+
+```cedar
+@id("permit_query_incident_response")
+@row_limit("100000")
+@audit("full_query_text")
+@notify("data_protection_officer")
+@control("SOC2-CC7.2")
+permit (
+    principal,
+    action == Acme::Action::"Query",
+    resource
+)
+when {
+    principal.clearance == "elevated" &&
+    context.purpose == "incident_response"
+};
+```
+
+## Overlapping Permits Need a Restrictive Merge
+
+A standard analyst querying a dataset that carries `special_category` satisfies two of these
+policies, so both appear in the decision:
+
+```text
+ALLOW  reason: permit_query_standard
+               permit_query_special_category
+```
+
+This is where obligations differ sharply from hints. On a denial, reading any one annotation is
+usually fine, because every matched `forbid` describes something the user has to do. On an `Allow`,
+the matched policies each describe a limit, and taking one of them means dropping the others.
+
+`annotations_map` is the wrong tool here. It keeps one arbitrary value per key, so with two `@mask`
+annotations in play it would return one of them and silently discard the other, which in this case
+means shipping the health column in the clear.
+
+Merge restrictively instead: union the masks, take the smallest row limit, and treat any watermark
+or audit requirement as sticky.
+
+```rust
+let reason: Vec<_> = result.response.diagnostics().reason().collect();
+
+// Union: every column any matching policy wants masked.
+let masked: BTreeSet<String> = cedarling
+    .annotation_values(reason.iter().copied(), "mask")
+    .iter()
+    .flat_map(|v| v.split(','))
+    .map(|c| c.trim().to_string())
+    .collect();
+
+// Minimum: the tightest limit wins.
+let row_limit = cedarling
+    .annotation_values(reason.iter().copied(), "row_limit")
+    .iter()
+    .filter_map(|v| v.parse::<usize>().ok())
+    .min()
+    .unwrap_or(DEFAULT_ROW_LIMIT);
+
+// Sticky: one policy asking for a watermark is enough.
+let watermark = !cedarling
+    .annotation_values(reason.iter().copied(), "watermark")
+    .is_empty();
+
+let rows = run_query(&query, row_limit)?;
+Ok(shape(rows, &masked, watermark))
+```
+
+The incident-response policy shows why the direction of the merge matters. Its `@row_limit` of
+100,000 is wider than the standard 100, and if the analyst also matches the standard policy, the
+minimum keeps them at 100. Widening access has to come from *not* matching the narrow policy, not
+from adding a broader one alongside it. Write the wide grant so that the narrow one cannot match at
+the same time, or accept that the narrow limit wins.
+
+A useful sanity check when adding a `permit` with obligations: if this policy matched together with
+every other `permit`, would the merged result still be safe? If the answer depends on which policy
+the application happens to read, the merge logic is not restrictive enough.
+
+## Mapping Policies to Controls
+
+The keys in these policies are not all for the runtime. `@control("SOC2-CC6.1")`,
+`@regulation("GDPR-Art9")`, and `@retention_days("30")` are read by people and by tooling that never
+makes an authorization call.
+
+This is a different use of the same mechanism, and it is worth naming because it changes what the
+annotation is for. The runtime keys tell the application what to do with one response. The
+compliance keys describe the policy itself, so that:
+
+- an auditor asking "show me the controls that enforce CC6.1" gets an answer from the policy store,
+  by grepping for `@control("SOC2-CC6.1")`, rather than from a spreadsheet somebody maintains by
+  hand
+- the decision log records which control was exercised, because the annotations resolve from the
+  same `reason()` the log already carries
+- retention tooling reads `@retention_days` from the policy that authorized the query, instead of
+  inferring a retention class from the dataset name
+
+```rust
+// Written to the audit trail alongside the decision.
+audit.record(Access {
+    decision: result.decision,
+    controls: cedarling.annotation_values(reason.iter().copied(), "control"),
+    regulations: cedarling.annotation_values(reason.iter().copied(), "regulation"),
+    by_policy: cedarling.annotations_by_policy(reason.iter().copied()),
+});
+```
+
+`annotations_by_policy` is the right call for the audit record. It keeps the attribution intact, so
+the log says *which* policy claimed CC6.1 rather than merely that something did.
+
+Keep the compliance vocabulary as disciplined as the runtime vocabulary. A control ID that no longer
+exists in the control framework, attached to a policy nobody has reviewed, is worse than no
+annotation: it produces a confident, wrong answer at audit time.
+
+## What This Buys You
+
+The data-handling rules stop being scattered through query builders and serializers. Which columns
+are sensitive, how many rows a clearance level may pull, what gets watermarked, and which control
+each rule implements are all stated in the policy that grants the access. The application keeps one
+implementation of masking, limiting, and watermarking, and applies whatever the decision asked for.

--- a/docs/cedarling/patterns/annotation-response-shaping.md
+++ b/docs/cedarling/patterns/annotation-response-shaping.md
@@ -27,14 +27,14 @@ the fact.
 
 Answering with `Deny` in all the awkward cases pushes people toward CSV exports and shared logins.
 Answering with an unrestricted `Allow` gives away more than the request needed. What the system
-actually wants to say is "allowed, in this shape": these columns masked, this many rows, watermarked
-on the way out.
+needs to say is "allowed, in this shape": these columns masked, this many rows, watermarked on the
+way out.
 
 Cedar decides *whether*. The annotations carry *in what shape*, and the application enforces it.
 
 ## Obligations, Not Hints
 
-The earlier patterns use annotations as hints on a denial. Something the user can act on, and the
+The earlier patterns use annotations as hints on a denial, something the user can act on, where the
 worst case of ignoring one is a poor experience. This pattern is different. A `@mask("national_id")`
 on a `permit` is an obligation: if the application ignores it, the data goes out unmasked and the
 policy that looked like a control did nothing.
@@ -82,12 +82,12 @@ the clearance it demands travel with the dataset instead of being hardcoded in w
 happens to mention it.
 
 The two clearance fields are typed differently on purpose. `min_clearance` is an enumerated entity
-type, so the schema itself lists the legal values and a dataset labelled `"Elevated"` or
+type, so the schema itself lists the legal values and a dataset labeled `"Elevated"` or
 `"top_secret"` is rejected before any policy runs:
 
 ```text
 entity `Acme::Clearance::"top_secret"` is of an enumerated entity type,
-but "top_secret" is not declared as a valid eid
+but `"top_secret"` is not declared as a valid eid
 help: valid entity eids: "standard", "elevated"
 ```
 
@@ -96,19 +96,20 @@ control what it sends. Typed as an enum, an unexpected claim would fail entity c
 request would error out with nothing to show the user. Left as a string, it reaches the policies,
 and a guard policy can deny it with a message. Enumerate what you author; guard what you receive.
 
-The tradeoff is that every policy touching an optional attribute has to guard it. Cedar's validator
-enforces that, so a policy that reaches for `resource.special_category.regulation` without the
-`has` check is rejected at validation time rather than erroring at request time.
+The tradeoff is that every policy touching an optional attribute has to guard it. `cedar validate`
+rejects a policy that reaches for `resource.special_category.regulation` without the `has` check, so
+run it in CI. Cedarling does not validate policies when it authorizes: an unguarded policy errors at
+request time, drops out of the decision, and takes its annotations with it.
 
 ## Policies
 
 The baseline grant is deliberately narrow: standard clearance gets masked columns and a small page
 of rows.
 
-`@mask` carries a delimited list rather than one key per column, because Cedar allows a key to appear
-only once per policy. That is the one place where packing several values into a string is the right
-call, and it stays a flat list: still no nested structure, and still nothing the application has to
-parse beyond splitting on a comma.
+`@mask` carries a delimited list rather than one key per column, because Cedar allows a key to
+appear only once per policy. That is the one place where packing several values into a string is the
+right call. It stays a flat list: no nested structure, and nothing for the application to parse
+beyond splitting on a comma.
 
 ```cedar
 @id("permit_query_standard")
@@ -143,7 +144,7 @@ when {
 };
 ```
 
-The clearance test in that policy is not decoration. Without it the permit fires for any principal
+The clearance test in that policy is doing real work. Without it the permit fires for any principal
 at all, so an unrecognized clearance value would be allowed on the most sensitive datasets while
 still being denied on ordinary ones, which is the opposite of what anyone intends. A grant that
 turns on a property of the *resource* still has to say who it is for.
@@ -182,6 +183,7 @@ forbid (
 when {
     resource has special_category &&
     resource.special_category.min_clearance == Acme::Clearance::"elevated" &&
+    ["standard", "elevated"].contains(principal.clearance) &&
     principal.clearance != "elevated"
 };
 ```
@@ -241,8 +243,8 @@ usually fine, because every matched `forbid` describes something the user has to
 the matched policies each describe a limit, and taking one of them means dropping the others.
 
 `annotations_map` is the wrong tool here. It keeps one arbitrary value per key, so with two `@mask`
-annotations in play it would return one of them and silently discard the other, which in this case
-means shipping the health column in the clear.
+annotations in play it returns one of them and drops the other, and which one it drops is
+arbitrary, so the health column may be the one that ships in the clear.
 
 Merge restrictively instead: union the masks, take the smallest row limit, and treat a watermark
 requirement as sticky. Where no matching policy says anything, fall back to the application's own
@@ -252,14 +254,17 @@ floor rather than to no limit at all.
 let reason: Vec<_> = result.response.diagnostics().reason().collect();
 
 // Union: the columns this deployment always masks, plus anything a matched policy adds.
+// A column name the response builder does not know is a broken obligation: masking
+// it would be a no-op, and the column would ship in the clear.
 let mut masked: BTreeSet<String> = baseline_masked_columns();
-masked.extend(
-    cedarling
-        .annotation_values(reason.iter().copied(), "mask")
-        .iter()
-        .flat_map(|v| v.split(','))
-        .map(|c| c.trim().to_string()),
-);
+for value in cedarling.annotation_values(reason.iter().copied(), "mask") {
+    for column in value.split(',').map(str::trim) {
+        if !KNOWN_COLUMNS.contains(column) {
+            return Err(Error::MalformedObligation("mask", column.to_string()));
+        }
+        masked.insert(column.to_string());
+    }
+}
 
 // Minimum of what the matched policies asked for. If none of them asked, the
 // application's default applies: an absent obligation must never widen anything.
@@ -288,15 +293,17 @@ Ok(shape(rows, &masked, watermark))
 ```
 
 The starting values are easy to get wrong. A union starts from the empty set, which masks nothing,
-and a minimum starts from an unbounded ceiling, which limits nothing. Start there and a request that
-matches one permit carrying no `@row_limit` walks away with no row limit at all. This policy set can
-produce that: an elevated analyst querying a special-category dataset matches only
-`permit_query_special_category`, which masks a column and says nothing about volume. With the
-fallbacks anchored in the application, a missing annotation leaves the floor where it is instead of
-lifting it.
+and a minimum starts from an unbounded ceiling, which limits nothing. Start there and any request
+that matches one permit carrying no `@row_limit` is served with no row limit at all.
 
-Both loops fail closed, which is the point. `unwrap_or(DEFAULT_ROW_LIMIT)` on a value that failed to
-parse would silently widen the response, and treating any non-empty `@watermark` as true would let
+This policy set does not produce that, and only because every clearance has a baseline grant that
+carries a limit. Delete `permit_query_elevated` and an elevated analyst on a special-category
+dataset matches `permit_query_special_category` alone, which masks a column and says nothing about
+volume. A single missing baseline produces it. With the fallbacks anchored in the application, a
+missing annotation leaves the floor where it is instead of lifting it.
+
+Both loops fail closed. `unwrap_or(DEFAULT_ROW_LIMIT)` on a value that failed to parse would
+silently widen the response, and treating any non-empty `@watermark` as true would let
 `@watermark("false")` turn watermarking on. An obligation the application cannot interpret is a
 policy the application is not implementing, so refuse the query and let the error reach whoever
 edits the policies.
@@ -322,9 +329,9 @@ The keys in these policies are not all for the runtime. `@control("SOC2-CC6.1")`
 `@regulation("GDPR-Art9")`, and `@retention_days("30")` are read by people and by tooling that never
 makes an authorization call.
 
-This is a different use of the same mechanism, and it is worth naming because it changes what the
-annotation is for. The runtime keys tell the application what to do with one response. The
-compliance keys describe the policy itself, so that:
+This is a different use of the same mechanism, and it changes what the annotation is for. The
+runtime keys tell the application what to do with one response. The compliance keys describe the
+policy itself, so that:
 
 - an auditor asking "show me the controls that enforce CC6.1" gets an answer from the policy store,
   by grepping for `@control("SOC2-CC6.1")`, rather than from a spreadsheet somebody maintains by

--- a/docs/cedarling/patterns/annotation-workflow.md
+++ b/docs/cedarling/patterns/annotation-workflow.md
@@ -69,11 +69,16 @@ namespace Acme {
 }
 ```
 
-## Part 1: A State Graph Made of Policies
+## Part 1: Prerequisites as Policies
 
-Onboarding is a graph: each step unlocks the next, and the merchant cannot accept payments until
-every step is done. Instead of encoding that order in the wizard, give each step its own `forbid`
-policy that names itself.
+Onboarding has three prerequisites, and the merchant cannot accept payments until all of them are
+done. Instead of encoding them in the wizard, give each one its own `forbid` policy that names
+itself.
+
+Nothing here orders the prerequisites: the three policies are independent, and a merchant can clear
+them in any order. `@wizard_step` orders the *display*, so the interface can present a sequence over
+a set. If a step genuinely has to come after another, that belongs in the policy condition, not in
+the annotation.
 
 ```cedar
 @id("permit_accept_payments")
@@ -140,7 +145,7 @@ DENY   reason: forbid_accept_payments_without_bank_account
                forbid_accept_payments_without_identity_check
 ```
 
-Three annotations describe each missing step, and they only mean anything together, so read them
+Four annotations describe each missing step, and they only mean anything together, so read them
 with `annotations_by_policy` and keep each policy's set intact:
 
 ```rust
@@ -167,18 +172,18 @@ remaining.sort();
 //  (3, "identity_check", "onboarding.identity_check")]
 ```
 
-Collecting with `filter_map` and a chain of `?` reads better and is wrong. A new `forbid` that
-carries `@required_step` but no `@redirect_route` drops out of the list, so the user sees two
-remaining steps while three policies deny them, completes both, and is refused again with no
-explanation. The whole selling point of this pattern is that adding a policy is enough;
-that only holds if a policy the application cannot render is loud rather than invisible.
+A `filter_map` with a chain of `?` reads better and discards every group it cannot parse. A new
+`forbid` that carries `@required_step` but no `@redirect_route` falls out of the list, so the user
+sees two remaining steps while three policies deny them, completes both, and is refused again with
+no explanation. This pattern pays off because adding a policy is enough, and that only holds when a
+policy the application cannot render fails loudly instead of disappearing.
 
-The sort is not optional. `reason()` is a set of policy IDs with no defined iteration order, so the
-policies come back in whatever order the set yields, and two separate `annotation_values` calls
-cannot be zipped by position: the first value of one list does not necessarily belong to the same
-policy as the first value of the other. Anything that has to stay paired belongs in
-`annotations_by_policy`, and anything that has to stay ordered has to say so in an annotation and be
-sorted by the application.
+The sort is required. `reason()` is a set of policy IDs with no defined iteration
+order, so the policies come back in whatever order the set yields, and two separate
+`annotation_values` calls cannot be zipped by position: the first value of one list does not
+necessarily belong to the same policy as the first value of the other. Anything that has to stay
+paired belongs in `annotations_by_policy`, and anything that has to stay ordered has to say so in an
+annotation and be sorted by the application.
 
 With that in hand, the application has a checklist rather than a single error. It can show the whole
 remaining path instead of revealing one obstacle at a time, redirect to the lowest-numbered step,
@@ -187,7 +192,7 @@ and render the rest as upcoming.
 `annotation_values` is still the right call when the values are independent and order does not
 matter, such as collecting every `@challenge` a decision asked for.
 
-Two properties make this worth doing:
+This shape has two practical benefits:
 
 - Adding a step means adding one policy, not editing a state machine. Nothing else has to know the
   new step exists.
@@ -233,9 +238,11 @@ when { context.amount_cents > 1000000 }
 unless { context.approvals.contains("finance_lead") };
 ```
 
-The policy decides who approves. That is the part worth moving out of the code: thresholds and
-approver groups change with company policy, audit findings, and regulation, while the mechanics of
-raising an approval request do not.
+Two keys do different jobs here. `@approver_group` names who to ask, `@approval_required` names the
+token the policy tests for, so the application asks `finance-leads` and, when they answer, records
+`finance_lead` in `context.approvals`. Both come from the policy, so the code holds no mapping
+between the two. Thresholds and approver groups change with company policy, audit findings, and
+regulation, while the mechanics of raising an approval request do not.
 
 ```rust
 let reason: Vec<_> = result.response.diagnostics().reason().collect();
@@ -251,7 +258,7 @@ for annotations in by_policy.values() {
         Some(value) => Some(
             value
                 .parse::<u32>()
-                .map_err(|_| Error::MalformedAnnotation("sla_hours"))?,
+                .map_err(|_| Error::MalformedAnnotation("sla_hours".to_string()))?,
         ),
         None => None,
     };
@@ -260,7 +267,7 @@ for annotations in by_policy.values() {
 }
 ```
 
-Two details in that loop are the difference between it working and only appearing to. It reads
+Two details in that loop decide whether it works or only looks like it does. It reads
 `annotations_by_policy`, so a group is never paired with an SLA from a different policy and no
 approval is dropped when two policies ask. And a malformed `@sla_hours` is an error rather than
 `None`: a typo would otherwise produce an approval request with no deadline, and nothing surfaces
@@ -270,9 +277,9 @@ Once the approval is recorded, the request is re-evaluated with `approvals` in t
 same policy set allows it. As with challenges, the approval record has to be produced server-side.
 A client that can put `"finance_lead"` into `context.approvals` has approved its own withdrawal.
 
-Server-side is necessary and not sufficient. `context.approvals` is a set of role names, so on its
-own it says that *somebody* with that role approved *something*. Three properties have to come from
-the record behind it, and none of them are visible in the policy:
+A server-side record is necessary and not enough on its own. `context.approvals` is a set of role
+names, so by itself it says that *somebody* with that role approved *something*. Three properties
+have to come from the record behind it, and none of them are visible in the policy:
 
 - who approved. The record has to name the approver, and the application has to refuse an approval
   whose approver is the principal making the request. Without that, a finance lead approves their
@@ -281,15 +288,23 @@ the record behind it, and none of them are visible in the policy:
   it against the session instead and the first approval covers every withdrawal after it.
 - when. Expire it, for the same reason a challenge expires.
 
-If you want any of that enforced by the policy rather than around it, put it in the context and test
-it there: an `approvals` set of `"finance_lead:<withdrawal-id>"` values is crude but reviewable, and
-a policy can compare it against the withdrawal being authorized.
+To have the policy enforce the binding rather than trust the application to, put the binding in the
+context as a value the policy can compare. Cedar has no string concatenation, so the policy cannot
+assemble `"finance_lead:<withdrawal-id>"` itself: the application resolves the approval record for
+*this* withdrawal and passes what it found, for instance
+`context.approvals` holding only the roles whose stored approval matches this withdrawal's id and
+amount. The set then means "approved, for this request", and `contains("finance_lead")` is a claim
+the policy can trust.
 
-Several independent conditions can escalate to different people. If a second `forbid` covered, say,
-a newly added destination account, a withdrawal that is both large and newly routed would trip both
+Several independent conditions can escalate to different people. If a second `forbid` covered a
+newly added destination account, a withdrawal that is both large and newly routed would trip both
 policies, and `annotations_by_policy` hands back both groups with their own SLAs, so the application
-requests both approvals rather than picking one. `annotations_map` cannot do that: it keeps one
-`approver_group`, and the withdrawal proceeds once a single approval lands.
+requests both approvals at once.
+
+`annotations_map` does not let it: one `approver_group` survives, so the application asks for one
+approval. Cedar still refuses the retry, because the second `forbid` is untouched, and the user
+waits out an approval only to be denied again by an obstacle nobody mentioned. The failure is a
+stuck flow rather than an over-authorization, and it is invisible until somebody sits through it.
 
 ## Part 3: Break-Glass Access
 
@@ -303,7 +318,7 @@ The middle option is to allow it under conditions the application has to enforce
 @break_glass("true")
 @requires_justification("true")
 @grant_ttl_seconds("900")
-@audit("dual_control")
+@audit("second_reviewer")
 @notify("merchant_owner")
 @user_message_id("support.break_glass.notice")
 permit (
@@ -318,20 +333,23 @@ when {
 ```
 
 This is an `Allow`, so the annotations arrive on the success path. They are obligations rather than
-hints: the application has to collect a justification, expire the grant after 15 minutes, write a
-dual-control audit record, and notify the merchant. An `Allow` whose obligations are ignored is a
-worse outcome than a `Deny`, because it looks accountable and is not.
+hints: the application has to collect a justification, expire the grant after 15 minutes, write an
+audit record naming a second reviewer, and notify the merchant. An `Allow` whose obligations are
+ignored is worse than a `Deny`, because it leaves a trail that looks accountable while nothing was
+enforced.
 
-Notice which of those the policy actually gates on. `context.incident_id` is a precondition: no
-incident, no permit. `@requires_justification` is not. It is collected after the decision, so a
-support engineer with a valid incident reads the record whether or not anyone ever types a reason,
-and the only thing that fails is a log line. If the justification has to be a real gate, feed it
+The policy does not gate on all of that. `context.incident_id` is a precondition: no incident, no
+permit. `@requires_justification` is not. It is collected after the decision, so a support engineer
+with a valid incident reads the record whether or not anyone ever types a reason, and the only thing
+that fails is a log line. If the justification has to be a real gate, feed it
 back the way challenges are fed back: record it server-side, put `justification_id` in the context,
 and add it to the `when` clause. Otherwise be clear with yourself that it is an audit obligation.
 
-`@grant_ttl_seconds` deserves the same scrutiny. A decision is a point in time, so nothing expires
-on its own: the application has to re-authorize while the session continues, and may treat one
-`Allow` as permission for the next 15 minutes only because it will ask again.
+`@grant_ttl_seconds` deserves the same scrutiny. `permit_support_break_glass` carries no time term,
+so re-authorizing the same request returns the same `Allow` forever, and the 900 seconds means
+nothing until something acts on it. Either the application drops the grant when it expires and stops
+serving the records, or the server re-resolves the incident and refuses one that has been closed.
+Re-authorization alone changes nothing.
 
 `context.incident_id` has to be built server-side from a validated incident record, exactly like the
 approvals above. The policy only checks that the value is non-empty, so if a client can put a string
@@ -356,9 +374,18 @@ if (!result.decision) {
   const byPolicy = Object.values(cedarling.annotations_by_policy(reason));
 
   // Each entry keeps its own step, route, and message together.
-  const steps = byPolicy
-    .filter((a) => a.required_step && a.wizard_step)
-    .sort((a, b) => Number(a.wizard_step) - Number(b.wizard_step));
+  const stepPolicies = byPolicy.filter((a) => a.required_step || a.wizard_step);
+  const broken = stepPolicies.filter(
+    (a) => !a.required_step || !a.wizard_step || !a.redirect_route,
+  );
+
+  if (broken.length > 0) {
+    throw new MalformedAnnotation(broken);
+  }
+
+  const steps = stepPolicies.sort(
+    (a, b) => Number(a.wizard_step) - Number(b.wizard_step),
+  );
 
   if (steps.length > 0) {
     return showChecklist(steps);
@@ -386,13 +413,14 @@ The last line is the one case where an arbitrary pick is acceptable: several pol
 `user_message_id`, and any of them is a reasonable thing to show. If that is not true for your
 messages, rank them explicitly rather than taking the first.
 
-The order of these branches is a product decision: a request can be missing an onboarding step
-*and* need an approval, and the application decides which obstacle to show first. Policies do not
-rank themselves.
+The order of these branches is a product decision. One request carries one action, so onboarding
+steps and withdrawal approvals never arrive together. Two obstacles for one action do collide once a
+second approval rule exists, and policies do not rank themselves, so the application decides what to
+show first.
 
 ## What This Buys You
 
 The onboarding order, the approval threshold, the approver group, and the break-glass conditions
 all live in the policy store, in policies that say what they require. The wizard renders a
 checklist it did not author, and adding a fourth onboarding step or lowering the approval threshold
-to five thousand is a policy diff that ships without touching the application.
+to $5,000 is a policy diff that ships without touching the application.

--- a/docs/cedarling/patterns/annotation-workflow.md
+++ b/docs/cedarling/patterns/annotation-workflow.md
@@ -1,0 +1,317 @@
+---
+tags:
+  - administration
+  - lock
+  - authorization / authz
+  - Cedar
+  - Cedarling
+  - annotations
+---
+
+# Pattern: Multi-Step Flows and Escalation
+
+!!! note "Illustrative example"
+
+    Acme Payments and every annotation key below (`@required_step`, `@redirect_route`,
+    `@approval_required`, and the rest) are invented for this page. Cedarling attaches no meaning
+    to them; they work only because the example application reads them. See
+    [Policy Annotation Patterns](./annotation-patterns.md) for the ground rules.
+
+## The Scenario
+
+Acme Payments onboards merchants in stages. A new merchant can log in immediately, but before they
+can accept a card payment they have to submit business details, connect a bank account, and pass an
+identity check. Later, once they are trading, a large withdrawal needs a second pair of eyes, and
+support staff occasionally need to open a merchant's records during an incident.
+
+Each of these is the same shape: an action the user is not allowed to perform *yet*, where the
+system knows exactly what would make it allowed. Written the usual way, that knowledge ends up
+spread across the codebase. The onboarding wizard hardcodes the order of steps, the withdrawal
+handler hardcodes the approval threshold, and the support tool hardcodes what counts as a valid
+break-glass. All three then drift apart from the policies that supposedly govern them.
+
+Annotations let each rule state its own remedy, so the application can render a next step without
+knowing which rule produced it.
+
+## Schema
+
+```cedarschema
+namespace Acme {
+    entity User = {
+        "completed_steps": Set<String>,
+        "role": String,
+    };
+
+    entity Merchant;
+
+    action "AcceptPayments" appliesTo {
+        principal: [User],
+        resource: [Merchant],
+        context: {}
+    };
+
+    action "Withdraw" appliesTo {
+        principal: [User],
+        resource: [Merchant],
+        context: {
+            "amount_cents": Long,
+            "approvals": Set<String>,
+        }
+    };
+
+    action "ViewMerchantRecords" appliesTo {
+        principal: [User],
+        resource: [Merchant],
+        context: {
+            "incident_id": String,
+        }
+    };
+}
+```
+
+## Part 1: A State Graph Made of Policies
+
+Onboarding is a graph: each step unlocks the next, and the merchant cannot accept payments until
+every step is done. Instead of encoding that order in the wizard, give each step its own `forbid`
+policy that names itself.
+
+```cedar
+@id("permit_accept_payments")
+permit (
+    principal,
+    action == Acme::Action::"AcceptPayments",
+    resource
+);
+```
+
+```cedar
+@id("forbid_accept_payments_without_business_details")
+@required_step("business_details")
+@wizard_step("1")
+@redirect_route("onboarding.business_details")
+@user_message_id("onboarding.business_details.required")
+forbid (
+    principal,
+    action == Acme::Action::"AcceptPayments",
+    resource
+)
+unless {
+    principal.completed_steps.contains("business_details")
+};
+```
+
+```cedar
+@id("forbid_accept_payments_without_bank_account")
+@required_step("bank_account")
+@wizard_step("2")
+@redirect_route("onboarding.bank_account")
+@user_message_id("onboarding.bank_account.required")
+forbid (
+    principal,
+    action == Acme::Action::"AcceptPayments",
+    resource
+)
+unless {
+    principal.completed_steps.contains("bank_account")
+};
+```
+
+```cedar
+@id("forbid_accept_payments_without_identity_check")
+@required_step("identity_check")
+@wizard_step("3")
+@redirect_route("onboarding.identity_check")
+@user_message_id("onboarding.identity_check.required")
+forbid (
+    principal,
+    action == Acme::Action::"AcceptPayments",
+    resource
+)
+unless {
+    principal.completed_steps.contains("identity_check")
+};
+```
+
+A merchant who has submitted business details but nothing else gets both remaining steps back in
+one call:
+
+```text
+DENY   reason: forbid_accept_payments_without_bank_account
+               forbid_accept_payments_without_identity_check
+```
+
+Three annotations describe each missing step, and they only mean anything together, so read them
+with `annotations_by_policy` and keep each policy's set intact:
+
+```rust
+let by_policy = cedarling.annotations_by_policy(result.response.diagnostics().reason());
+
+let mut remaining: Vec<(u32, &str, &str)> = by_policy
+    .values()
+    .filter_map(|a| {
+        Some((
+            a.get("wizard_step")?.parse().ok()?,
+            a.get("required_step")?.as_str(),
+            a.get("redirect_route")?.as_str(),
+        ))
+    })
+    .collect();
+
+remaining.sort();
+// [(2, "bank_account",   "onboarding.bank_account"),
+//  (3, "identity_check", "onboarding.identity_check")]
+```
+
+The sort is not optional. `reason()` is a set of policy IDs with no defined iteration order, so the
+policies come back in whatever order the set yields, and two separate `annotation_values` calls
+cannot be zipped by position: the first value of one list does not necessarily belong to the same
+policy as the first value of the other. Anything that has to stay paired belongs in
+`annotations_by_policy`, and anything that has to stay ordered has to say so in an annotation and be
+sorted by the application.
+
+With that in hand, the application has a checklist rather than a single error. It can show the whole
+remaining path instead of revealing one obstacle at a time, redirect to the lowest-numbered step,
+and render the rest as upcoming.
+
+`annotation_values` is still the right call when the values are independent and order does not
+matter, such as collecting every `@challenge` a decision asked for.
+
+Two properties make this worth doing:
+
+- Adding a step means adding one policy, not editing a state machine. Nothing else has to know the
+  new step exists.
+- The same policies answer for every entry point. An API call, the dashboard, and a mobile client
+  all get the same list of remaining steps, because the list comes from the decision rather than
+  from each client's copy of the flow.
+
+### Where the Redirect Should Point
+
+`@redirect_route("onboarding.bank_account")` names a route, not a URL. A logical name survives a
+frontend restructure and lets a mobile client resolve it to a screen instead of a path. It also
+keeps the policy store free of deployment details such as locale prefixes and version segments.
+
+## Part 2: Escalation and Approval
+
+A large withdrawal is not blocked outright. It needs someone else to agree, which is a resolvable
+denial in exactly the way a challenge is.
+
+Withdrawals need their own `permit`, or clearing the approval would leave the request matching
+nothing at all and Cedar would deny it by default, with no annotations to explain why:
+
+```cedar
+@id("permit_withdraw")
+permit (
+    principal,
+    action == Acme::Action::"Withdraw",
+    resource
+);
+```
+
+```cedar
+@id("forbid_large_withdrawal_without_approval")
+@approval_required("finance_lead")
+@approver_group("finance-leads")
+@sla_hours("4")
+@user_message_id("withdrawal.approval_required")
+forbid (
+    principal,
+    action == Acme::Action::"Withdraw",
+    resource
+)
+when { context.amount_cents > 1000000 }
+unless { context.approvals.contains("finance_lead") };
+```
+
+The policy decides who approves. That is the part worth moving out of the code: thresholds and
+approver groups change with company policy, audit findings, and regulation, while the mechanics of
+raising an approval request do not.
+
+```rust
+let reason: Vec<_> = result.response.diagnostics().reason().collect();
+let annotations = cedarling.annotations_map(reason.iter().copied());
+
+if let Some(group) = annotations.get("approver_group") {
+    approvals.request(
+        group,
+        annotations.get("sla_hours").and_then(|h| h.parse::<u32>().ok()),
+        &withdrawal,
+    )?;
+}
+```
+
+Once the approval is recorded, the request is re-evaluated with `approvals` in the context, and the
+same policy set allows it. As with challenges, the approval record has to be produced server-side.
+A client that can put `"finance_lead"` into `context.approvals` has approved its own withdrawal.
+
+Several independent conditions can escalate to different people. A withdrawal that is both large
+and going to a newly added bank account trips two policies, and `annotation_values` returns both
+approver groups, so the application requests both approvals rather than picking one.
+
+## Part 3: Break-Glass Access
+
+Support staff sometimes need to open a merchant's records during an incident. Denying that outright
+means incidents take longer. Allowing it silently means an unmonitored path into customer data.
+
+The middle option is to allow it under conditions the application has to enforce afterwards:
+
+```cedar
+@id("permit_support_break_glass")
+@break_glass("true")
+@requires_justification("true")
+@ttl_seconds("900")
+@audit("dual_control")
+@notify("merchant_owner")
+@user_message_id("support.break_glass.notice")
+permit (
+    principal,
+    action == Acme::Action::"ViewMerchantRecords",
+    resource
+)
+when {
+    principal.role == "support_oncall" &&
+    context.incident_id != ""
+};
+```
+
+This is an `Allow`, so the annotations arrive on the success path. They are obligations rather than
+hints: the application has to collect a justification, expire the grant after 15 minutes, write a
+dual-control audit record, and notify the merchant. An `Allow` whose obligations are ignored is a
+worse outcome than a `Deny`, because it looks accountable and is not.
+
+Keep break-glass a separate, narrow policy rather than a relaxation of the normal one. It is the
+policy an auditor will ask about first, and it is far easier to answer when it stands alone with a
+single `@id`, its own conditions, and its own annotations.
+
+## Reading the Annotations Generically
+
+Once several patterns share a vocabulary, the application can handle them in one place rather than
+one branch per key:
+
+```javascript
+const reason = result.response.diagnostics.reason;
+const annotations = cedarling.annotations_map(reason);
+
+if (!result.decision) {
+  const steps = cedarling.annotation_values(reason, "required_step");
+  const routes = cedarling.annotation_values(reason, "redirect_route");
+
+  if (steps.length > 0) {
+    return showChecklist(steps, routes, annotations.user_message_id);
+  }
+  if (annotations.approver_group) {
+    return requestApproval(annotations.approver_group, annotations.sla_hours);
+  }
+  return denyPlain(annotations.user_message_id ?? "access.denied.generic");
+}
+```
+
+The order of these branches is a product decision: a request can be missing an onboarding step
+*and* need an approval, and the application decides which obstacle to show first. Policies do not
+rank themselves.
+
+## What This Buys You
+
+The onboarding order, the approval threshold, the approver group, and the break-glass conditions
+all live in the policy store, in policies that say what they require. The wizard renders a
+checklist it did not author, and adding a fourth onboarding step or lowering the approval threshold
+to five thousand is a policy diff that ships without touching the application.

--- a/docs/cedarling/patterns/annotation-workflow.md
+++ b/docs/cedarling/patterns/annotation-workflow.md
@@ -278,6 +278,13 @@ hints: the application has to collect a justification, expire the grant after 15
 dual-control audit record, and notify the merchant. An `Allow` whose obligations are ignored is a
 worse outcome than a `Deny`, because it looks accountable and is not.
 
+`context.incident_id` has to be built server-side from a validated incident record, exactly like the
+approvals above. The policy only checks that the value is non-empty, so if a client can put a string
+there, every support account holds a permanent break-glass key and the audit trail fills up with
+incident IDs that never existed. Resolve the incident before authorizing, reject the request when it
+is unknown or already closed, and pass in what the server resolved rather than what the caller
+sent.
+
 Keep break-glass a separate, narrow policy rather than a relaxation of the normal one. It is the
 policy an auditor will ask about first, and it is far easier to answer when it stands alone with a
 single `@id`, its own conditions, and its own annotations.
@@ -289,21 +296,40 @@ one branch per key:
 
 ```javascript
 const reason = result.response.diagnostics.reason;
-const annotations = cedarling.annotations_map(reason);
 
 if (!result.decision) {
-  const steps = cedarling.annotation_values(reason, "required_step");
-  const routes = cedarling.annotation_values(reason, "redirect_route");
+  const byPolicy = Object.values(cedarling.annotations_by_policy(reason));
+
+  // Each entry keeps its own step, route, and message together.
+  const steps = byPolicy
+    .filter((a) => a.required_step && a.wizard_step)
+    .sort((a, b) => Number(a.wizard_step) - Number(b.wizard_step));
 
   if (steps.length > 0) {
-    return showChecklist(steps, routes, annotations.user_message_id);
+    return showChecklist(steps);
   }
-  if (annotations.approver_group) {
-    return requestApproval(annotations.approver_group, annotations.sla_hours);
+
+  // Every policy that asked for an approval, not just the first one.
+  const approvals = byPolicy.filter((a) => a.approver_group);
+
+  if (approvals.length > 0) {
+    return requestApprovals(approvals);
   }
-  return denyPlain(annotations.user_message_id ?? "access.denied.generic");
+
+  const messages = cedarling.annotation_values(reason, "user_message_id");
+  return denyPlain(messages[0] ?? "access.denied.generic");
 }
 ```
+
+Everything here goes through `annotations_by_policy`, because both branches need the annotations of
+one policy to stay together: a step belongs with its own route, and an approver group belongs with
+its own SLA. `annotations_map` would keep one `approver_group` and drop the rest, which turns the
+two-approval case from the previous section into a single request that silently authorizes less than
+it should.
+
+The last line is the one case where an arbitrary pick is acceptable: several policies may carry a
+`user_message_id`, and any of them is a reasonable thing to show. If that is not true for your
+messages, rank them explicitly rather than taking the first.
 
 The order of these branches is a product decision: a request can be missing an onboarding step
 *and* need an approval, and the application decides which obstacle to show first. Policies do not

--- a/docs/cedarling/patterns/annotation-workflow.md
+++ b/docs/cedarling/patterns/annotation-workflow.md
@@ -292,9 +292,9 @@ To have the policy enforce the binding rather than trust the application to, put
 context as a value the policy can compare. Cedar has no string concatenation, so the policy cannot
 assemble `"finance_lead:<withdrawal-id>"` itself: the application resolves the approval record for
 *this* withdrawal and passes what it found, for instance
-`context.approvals` holding only the roles whose stored approval matches this withdrawal's id and
-amount. The set then means "approved, for this request", and `contains("finance_lead")` is a claim
-the policy can trust.
+`context.approvals` holding only the roles whose stored approval matches this withdrawal's id,
+amount, and destination. The set then means "approved, for this request", and
+`contains("finance_lead")` is a claim the policy can trust.
 
 Several independent conditions can escalate to different people. If a second `forbid` covered a
 newly added destination account, a withdrawal that is both large and newly routed would trip both
@@ -347,9 +347,11 @@ and add it to the `when` clause. Otherwise be clear with yourself that it is an 
 
 `@grant_ttl_seconds` deserves the same scrutiny. `permit_support_break_glass` carries no time term,
 so re-authorizing the same request returns the same `Allow` forever, and the 900 seconds means
-nothing until something acts on it. Either the application drops the grant when it expires and stops
-serving the records, or the server re-resolves the incident and refuses one that has been closed.
-Re-authorization alone changes nothing.
+nothing until something acts on it. The application has to drop the grant when it expires and stop
+serving the records, *and* the server has to re-resolve the incident on every request and refuse one
+that has been closed. Neither covers the other: an incident that stays open never expires the grant,
+and an expiry check says nothing about an incident closed after it was opened. Re-authorization
+alone changes nothing.
 
 `context.incident_id` has to be built server-side from a validated incident record, exactly like the
 approvals above. The policy only checks that the value is non-empty, so if a client can put a string

--- a/docs/cedarling/patterns/annotation-workflow.md
+++ b/docs/cedarling/patterns/annotation-workflow.md
@@ -146,21 +146,32 @@ with `annotations_by_policy` and keep each policy's set intact:
 ```rust
 let by_policy = cedarling.annotations_by_policy(result.response.diagnostics().reason());
 
-let mut remaining: Vec<(u32, &str, &str)> = by_policy
-    .values()
-    .filter_map(|a| {
-        Some((
-            a.get("wizard_step")?.parse().ok()?,
-            a.get("required_step")?.as_str(),
-            a.get("redirect_route")?.as_str(),
-        ))
-    })
-    .collect();
+let mut remaining: Vec<(u32, &str, &str)> = Vec::new();
+
+for (policy_id, a) in &by_policy {
+    match (
+        a.get("wizard_step").and_then(|s| s.parse::<u32>().ok()),
+        a.get("required_step"),
+        a.get("redirect_route"),
+    ) {
+        (Some(step), Some(name), Some(route)) => {
+            remaining.push((step, name.as_str(), route.as_str()))
+        }
+        // A blocking policy that cannot be rendered is a bug to surface, not one to skip.
+        _ => return Err(Error::MalformedAnnotation(policy_id.clone())),
+    }
+}
 
 remaining.sort();
 // [(2, "bank_account",   "onboarding.bank_account"),
 //  (3, "identity_check", "onboarding.identity_check")]
 ```
+
+Collecting with `filter_map` and a chain of `?` reads better and is wrong. A new `forbid` that
+carries `@required_step` but no `@redirect_route` drops out of the list, so the user sees two
+remaining steps while three policies deny them, completes both, and is refused again with no
+explanation. The whole selling point of this pattern is that adding a policy is enough;
+that only holds if a policy the application cannot render is loud rather than invisible.
 
 The sort is not optional. `reason()` is a set of policy IDs with no defined iteration order, so the
 policies come back in whatever order the set yields, and two separate `annotation_values` calls
@@ -228,24 +239,57 @@ raising an approval request do not.
 
 ```rust
 let reason: Vec<_> = result.response.diagnostics().reason().collect();
-let annotations = cedarling.annotations_map(reason.iter().copied());
+let by_policy = cedarling.annotations_by_policy(reason.iter().copied());
 
-if let Some(group) = annotations.get("approver_group") {
-    approvals.request(
-        group,
-        annotations.get("sla_hours").and_then(|h| h.parse::<u32>().ok()),
-        &withdrawal,
-    )?;
+// Every policy that asked for an approval, each with the SLA that belongs to it.
+for annotations in by_policy.values() {
+    let Some(group) = annotations.get("approver_group") else {
+        continue;
+    };
+
+    let sla_hours = match annotations.get("sla_hours") {
+        Some(value) => Some(
+            value
+                .parse::<u32>()
+                .map_err(|_| Error::MalformedAnnotation("sla_hours"))?,
+        ),
+        None => None,
+    };
+
+    approvals.request(group, sla_hours, &withdrawal)?;
 }
 ```
+
+Two details in that loop are the difference between it working and only appearing to. It reads
+`annotations_by_policy`, so a group is never paired with an SLA from a different policy and no
+approval is dropped when two policies ask. And a malformed `@sla_hours` is an error rather than
+`None`: a typo would otherwise produce an approval request with no deadline, and nothing surfaces
+that until somebody asks why the escalation never fired.
 
 Once the approval is recorded, the request is re-evaluated with `approvals` in the context, and the
 same policy set allows it. As with challenges, the approval record has to be produced server-side.
 A client that can put `"finance_lead"` into `context.approvals` has approved its own withdrawal.
 
-Several independent conditions can escalate to different people. A withdrawal that is both large
-and going to a newly added bank account trips two policies, and `annotation_values` returns both
-approver groups, so the application requests both approvals rather than picking one.
+Server-side is necessary and not sufficient. `context.approvals` is a set of role names, so on its
+own it says that *somebody* with that role approved *something*. Three properties have to come from
+the record behind it, and none of them are visible in the policy:
+
+- who approved. The record has to name the approver, and the application has to refuse an approval
+  whose approver is the principal making the request. Without that, a finance lead approves their
+  own withdrawals and the policy cannot tell the difference.
+- what they approved. Tie the record to one withdrawal: its id, its amount, its destination. Store
+  it against the session instead and the first approval covers every withdrawal after it.
+- when. Expire it, for the same reason a challenge expires.
+
+If you want any of that enforced by the policy rather than around it, put it in the context and test
+it there: an `approvals` set of `"finance_lead:<withdrawal-id>"` values is crude but reviewable, and
+a policy can compare it against the withdrawal being authorized.
+
+Several independent conditions can escalate to different people. If a second `forbid` covered, say,
+a newly added destination account, a withdrawal that is both large and newly routed would trip both
+policies, and `annotations_by_policy` hands back both groups with their own SLAs, so the application
+requests both approvals rather than picking one. `annotations_map` cannot do that: it keeps one
+`approver_group`, and the withdrawal proceeds once a single approval lands.
 
 ## Part 3: Break-Glass Access
 
@@ -258,7 +302,7 @@ The middle option is to allow it under conditions the application has to enforce
 @id("permit_support_break_glass")
 @break_glass("true")
 @requires_justification("true")
-@ttl_seconds("900")
+@grant_ttl_seconds("900")
 @audit("dual_control")
 @notify("merchant_owner")
 @user_message_id("support.break_glass.notice")
@@ -277,6 +321,17 @@ This is an `Allow`, so the annotations arrive on the success path. They are obli
 hints: the application has to collect a justification, expire the grant after 15 minutes, write a
 dual-control audit record, and notify the merchant. An `Allow` whose obligations are ignored is a
 worse outcome than a `Deny`, because it looks accountable and is not.
+
+Notice which of those the policy actually gates on. `context.incident_id` is a precondition: no
+incident, no permit. `@requires_justification` is not. It is collected after the decision, so a
+support engineer with a valid incident reads the record whether or not anyone ever types a reason,
+and the only thing that fails is a log line. If the justification has to be a real gate, feed it
+back the way challenges are fed back: record it server-side, put `justification_id` in the context,
+and add it to the `when` clause. Otherwise be clear with yourself that it is an audit obligation.
+
+`@grant_ttl_seconds` deserves the same scrutiny. A decision is a point in time, so nothing expires
+on its own: the application has to re-authorize while the session continues, and may treat one
+`Allow` as permission for the next 15 minutes only because it will ask again.
 
 `context.incident_id` has to be built server-side from a validated incident record, exactly like the
 approvals above. The policy only checks that the value is non-empty, so if a client can put a string

--- a/docs/cedarling/reference/cedarling-authz.md
+++ b/docs/cedarling/reference/cedarling-authz.md
@@ -625,4 +625,4 @@ After an authorization call, the policies that determined the decision are repor
 
 Unknown policy IDs are silently skipped. Resolve annotations promptly after the authorization call; a concurrent policy-store refresh may swap the store, dropping IDs that no longer resolve.
 
-See the [Interfaces](./cedarling-interfaces.md#annotation-lookup) reference for signatures and examples.
+See the [Interfaces](./cedarling-interfaces.md#annotation-lookup) reference for signatures and examples, and [Policy Annotation Patterns](../patterns/annotation-patterns.md) for worked scenarios — step-up challenges, quota warnings, and the design constraints behind them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -606,6 +606,12 @@ nav:
     - Java: cedarling/tutorials/java.md
     - Kotlin: cedarling/tutorials/kotlin.md
     - Swift: cedarling/tutorials/swift.md
+  - Patterns:
+    - Policy Annotations: cedarling/patterns/annotation-patterns.md
+    - Quota Warnings: cedarling/patterns/annotation-quota.md
+    - Multi-Step Flows: cedarling/patterns/annotation-workflow.md
+    - Challenges and Step-Up: cedarling/patterns/annotation-challenge.md
+    - Response Shaping: cedarling/patterns/annotation-response-shaping.md
   - Reference:
     - Authorization: cedarling/reference/cedarling-authz.md
     - Multi-Issuer: cedarling/reference/cedarling-multi-issuer.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -612,6 +612,7 @@ nav:
     - Multi-Step Flows: cedarling/patterns/annotation-workflow.md
     - Challenges and Step-Up: cedarling/patterns/annotation-challenge.md
     - Response Shaping: cedarling/patterns/annotation-response-shaping.md
+    - Client-Side Denials: cedarling/patterns/annotation-client-authority.md
   - Reference:
     - Authorization: cedarling/reference/cedarling-authz.md
     - Multi-Issuer: cedarling/reference/cedarling-multi-issuer.md


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14795

#### Implementation Details

New `docs/cedarling/patterns/` section, added to the mkdocs nav between Tutorials and Reference, with a link to it from the annotation lookup section of `cedarling-authz.md`.

`annotation-patterns.md` is the overview. It covers the mental model (the policy names the intent, the application implements it) and the mechanics everything else depends on: only determining policies appear in `reason()`, the three ways a decision is reached and what each one reports, one annotation key per policy, `reason()` has no order so pairing and sorting go through `annotations_by_policy`, and `@id` is reserved. It closes with message IDs instead of literal copy for i18n, and a list of anti-patterns.

`annotation-quota.md` covers threshold warnings on `permit`: a broad grant, a per-tier `forbid` that does the enforcing, and annotation-only policies that carry `@warn` and `@upsell` without changing any decision. It also works through where the limit belongs, as a literal in the policy for plan limits and as an entity attribute for negotiated contracts, using cross-multiplication because Cedar has no division operator.

`annotation-workflow.md` models onboarding as a state graph of `forbid` policies (`@required_step`, `@wizard_step`, `@redirect_route`), then covers approval routing and break-glass obligations.

`annotation-challenge.md` covers step-up challenges for the Beyond Zero case. The agent is a first-class principal carrying `operated_by`, and challenge results come back as context for reevaluation, so the decision stays binary.

`annotation-response-shaping.md` treats `@mask` and `@row_limit` as obligations rather than hints, shows how to merge restrictively when several `permit` policies match, and maps policies to compliance controls.

Every annotation key is presented as invented for the docs, and each page states that Cedarling gives annotations no built-in meaning apart from `@id`. Pages run simplest first: quota, then workflow, then challenge, then response shaping.

Verification: all schemas and policies were extracted from the pages and run through the `cedar` CLI, `validate` on each set plus `authorize` at both sides of every threshold, for all three tiers and for the unconfigured-plan cases. 


-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14797, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Cedarling patterns for policy annotations, step-up challenges, quota warnings, multi-step workflows, response shaping, and client-side authorization handling.
  - Documented annotation semantics, denial messaging, server revalidation, audit considerations, escalation, and restrictive response controls with Rust, JavaScript, and Cedar examples.
  - Expanded authorization reference guidance with links to the new pattern examples.
  - Added a dedicated Patterns section to the documentation navigation for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->