### PR TITLE
feat(jans-fido2): honour forwarded end-user IP and user agent in passkey metrics

### DIFF
--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -32,6 +32,7 @@ The following properties represent the dynamic configuration for the Janssen FID
 | `fido2MetricsAggregationInterval` | `60` | Interval in minutes driving the passkey metrics aggregation scheduler (default `60` = hourly). |
 | `fido2MetricsRetentionDays` | `90` | Retention period in days for passkey metric entries and aggregations before automatic cleanup. |
 | `fido2DeviceInfoCollection` | `true` | Whether device info (browser, OS, device type) is collected and stored with passkey metrics. |
+| `fido2TrustedClientContextSources` | `[]` | Callers whose `X-Jans-Client-IP` and `X-Jans-Client-User-Agent` headers are honoured, listed by remote address. Empty (the default) ignores the headers. See [Passkey Telemetry & Metrics](passkey-telemetry.md). |
 | `fido2ErrorCategorization` | `true` | Whether passkey operation failures are categorized for the error-analysis endpoint. |
 | `fido2PerformanceMetrics` | `true` | Whether passkey operation durations are tracked for performance analytics. |
 | `fido2Configuration` | Object | Nested object containing FIDO2 protocol-specific details (see structure below). |

--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -139,9 +139,9 @@ Beyond the outcome itself, each raw entry records where the operation came from:
 
 | Field | Source |
 |---|---|
-| `ipAddress` | First valid address from `X-Forwarded-For` and the other common proxy headers, otherwise the socket remote address. |
-| `userAgent` | The `User-Agent` request header, up to 512 characters. |
-| `deviceInfo` | Browser, OS and device type parsed from the user agent, plus a copy of the user agent itself. The only field `fido2DeviceInfoCollection` suppresses — every other field here is written regardless. |
+| `ipAddress` | The `X-Jans-Client-IP` header when it comes from a trusted caller, otherwise the first valid address from `X-Forwarded-For` and the other common proxy headers, otherwise the socket remote address. |
+| `userAgent` | The `X-Jans-Client-User-Agent` header when it comes from a trusted caller, otherwise the `User-Agent` request header. Up to 512 characters. |
+| `deviceInfo` | Browser, OS and device type parsed from the user agent above, plus a copy of the user agent itself. The only field `fido2DeviceInfoCollection` suppresses — every other field here is written regardless. |
 | `sessionId` | The `session_id` cookie set by the Authorization Server, falling back to the servlet session when one exists. Empty for requests that carry neither. |
 | `metricType` | The metric name of the event, e.g. `fido2_registration_success`. |
 | `nodeId` | Identifier of the cluster node that served the request. |
@@ -159,6 +159,36 @@ Beyond the outcome itself, each raw entry records where the operation came from:
     your deployment terminates TLS at a proxy, make sure it sets `X-Forwarded-For` and
     strips any client-supplied value; otherwise the recorded address can be spoofed by the
     caller.
+
+#### Whose device is recorded
+
+The FIDO2 endpoints are not called by the browser. The Authorization Server, Casa and the
+person-authentication script relay to them over a server-to-server HTTP client, so the only
+client the FIDO2 server can observe on its own is that caller — `ipAddress` is the calling
+service's address and `userAgent` is its HTTP client, not a browser.
+
+A caller that does hold the browser's request can forward the end user's details on
+`X-Jans-Client-IP` and `X-Jans-Client-User-Agent`. These are honoured only when the request
+comes from an address listed in `fido2TrustedClientContextSources`; from anywhere else they
+are ordinary headers and are ignored, so a client reaching the server directly cannot dictate
+what is recorded about it. The list is empty by default, which means the headers are ignored
+everywhere until you configure it:
+
+```json
+"fido2TrustedClientContextSources": ["192.0.2.10"]
+```
+
+Use the caller's remote address as the FIDO2 server sees it. Where callers have no stable
+address — containerised deployments, mostly — a single entry of `"*"` trusts every caller;
+only do this where the FIDO2 server is not reachable by end users, since it removes the check
+entirely.
+
+!!! note "Until callers forward it"
+    Sending the headers is the calling side's half of this and is tracked separately. Until a
+    caller sends them, `ipAddress` and the `deviceInfo` breakdowns continue to describe the
+    relaying service. A user agent that matches no known platform is reported with
+    `deviceType` of `UNKNOWN` rather than being assumed to be a desktop, so these entries are
+    visibly absent from the device breakdown instead of silently inflating `DESKTOP`.
 
 ### Aggregation schedule and retention
 
@@ -184,6 +214,7 @@ as listed below:
 | `fido2DeviceInfoCollection` | `true` | Whether device info (browser, OS, device type) is collected and stored. Entries are still written when this is `false` — only the `deviceInfo` field is omitted. Use `fido2MetricsEnabled` to stop writing entries altogether. |
 | `fido2ErrorCategorization` | `true` | Whether failures are categorized for the error-analysis endpoint. |
 | `fido2PerformanceMetrics` | `true` | Whether operation durations are tracked. |
+| `fido2TrustedClientContextSources` | `[]` | Remote addresses of callers whose `X-Jans-Client-IP` and `X-Jans-Client-User-Agent` headers are honoured. Empty ignores the headers everywhere; `["*"]` trusts every caller. See [Whose device is recorded](#whose-device-is-recorded). |
 
 !!! warning "Don't confuse these with `metricReporter*`"
     The `metricReporterEnabled` / `metricReporterInterval` / `metricReporterKeepDataDays`

--- a/docs/janssen-server/reference/json/properties/fido2-properties.md
+++ b/docs/janssen-server/reference/json/properties/fido2-properties.md
@@ -31,6 +31,7 @@ tags:
 | fido2MetricsEnabled | Boolean value specifying whether FIDO2 passkey metrics collection is enabled | [Details](#fido2metricsenabled) |
 | fido2MetricsRetentionDays | Number of days to keep FIDO2 passkey metrics data | [Details](#fido2metricsretentiondays) |
 | fido2PerformanceMetrics | Boolean value specifying whether to collect detailed performance metrics for FIDO2 operations | [Details](#fido2performancemetrics) |
+| fido2TrustedClientContextSources | Callers whose forwarded client-context headers (X-Jans-Client-IP, X-Jans-Client-User-Agent) are honoured, given as remote addresses. Empty means the headers are ignored; a single entry of * trusts every caller and must only be used where the FIDO2 server is not reachable by end users | [Details](#fido2trustedclientcontextsources) |
 | hints | Hints to the RP - security-key, client-device, hybrid | [Details](#hints) |
 | issuer | URL using the https scheme for Issuer identifier | [Details](#issuer) |
 | loggingLayout | Logging layout used for Fido2 | [Details](#logginglayout) |
@@ -239,6 +240,15 @@ tags:
 - Required: No
 
 - Default value: true
+
+
+## fido2TrustedClientContextSources
+
+- Description: Callers whose forwarded client-context headers (X-Jans-Client-IP, X-Jans-Client-User-Agent) are honoured, given as remote addresses. Empty means the headers are ignored; a single entry of * trusts every caller and must only be used where the FIDO2 server is not reachable by end users
+
+- Required: No
+
+- Default value: empty list
 
 
 ## hints

--- a/jans-fido2/client/src/main/java/io/jans/fido2/client/AssertionService.java
+++ b/jans-fido2/client/src/main/java/io/jans/fido2/client/AssertionService.java
@@ -9,7 +9,9 @@ package io.jans.fido2.client;
 import io.jans.fido2.model.assertion.AssertionOptions;
 import io.jans.fido2.model.assertion.AssertionOptionsGenerate;
 import io.jans.fido2.model.assertion.AssertionResult;
+import io.jans.fido2.model.common.ClientContextHeaders;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -29,11 +31,48 @@ public interface AssertionService {
     @Path("/options")
     public Response authenticate(AssertionOptions assertionOptions);
 
-  
+    /**
+     * As {@link #authenticate(AssertionOptions)}, additionally forwarding the end user's
+     * connection details so metrics describe the user rather than this client.
+     *
+     * Pass null for either value when the caller does not hold the browser's request; the
+     * header is then omitted and the server falls back to what it can observe itself.
+     *
+     * @param assertionOptions assertion options
+     * @param clientIp end user's IP address, or null
+     * @param clientUserAgent end user's browser user agent, or null
+     * @return assertion options response
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Path("/options")
+    public Response authenticate(AssertionOptions assertionOptions,
+            @HeaderParam(ClientContextHeaders.CLIENT_IP) String clientIp,
+            @HeaderParam(ClientContextHeaders.CLIENT_USER_AGENT) String clientUserAgent);
+
+
     @POST
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @Path("/result")
     public Response verify(AssertionResult assertionResult);
+
+    /**
+     * As {@link #verify(AssertionResult)}, additionally forwarding the end user's
+     * connection details so metrics describe the user rather than this client.
+     *
+     * @param assertionResult assertion result
+     * @param clientIp end user's IP address, or null
+     * @param clientUserAgent end user's browser user agent, or null
+     * @return assertion verification response
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Path("/result")
+    public Response verify(AssertionResult assertionResult,
+            @HeaderParam(ClientContextHeaders.CLIENT_IP) String clientIp,
+            @HeaderParam(ClientContextHeaders.CLIENT_USER_AGENT) String clientUserAgent);
 
 }

--- a/jans-fido2/client/src/main/java/io/jans/fido2/client/AttestationService.java
+++ b/jans-fido2/client/src/main/java/io/jans/fido2/client/AttestationService.java
@@ -8,7 +8,9 @@ package io.jans.fido2.client;
 
 import io.jans.fido2.model.attestation.AttestationOptions;
 import io.jans.fido2.model.attestation.AttestationResult;
+import io.jans.fido2.model.common.ClientContextHeaders;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -28,10 +30,47 @@ public interface AttestationService {
     @Path("/options")
     public Response register(AttestationOptions attestationOptions);
 
+    /**
+     * As {@link #register(AttestationOptions)}, additionally forwarding the end user's
+     * connection details so metrics describe the user rather than this client.
+     *
+     * Pass null for either value when the caller does not hold the browser's request; the
+     * header is then omitted and the server falls back to what it can observe itself.
+     *
+     * @param attestationOptions attestation options
+     * @param clientIp end user's IP address, or null
+     * @param clientUserAgent end user's browser user agent, or null
+     * @return attestation options response
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Path("/options")
+    public Response register(AttestationOptions attestationOptions,
+            @HeaderParam(ClientContextHeaders.CLIENT_IP) String clientIp,
+            @HeaderParam(ClientContextHeaders.CLIENT_USER_AGENT) String clientUserAgent);
+
     @POST
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @Path("/result")
     public Response verify(AttestationResult attestationResult);
+
+    /**
+     * As {@link #verify(AttestationResult)}, additionally forwarding the end user's
+     * connection details so metrics describe the user rather than this client.
+     *
+     * @param attestationResult attestation result
+     * @param clientIp end user's IP address, or null
+     * @param clientUserAgent end user's browser user agent, or null
+     * @return attestation verification response
+     */
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @Path("/result")
+    public Response verify(AttestationResult attestationResult,
+            @HeaderParam(ClientContextHeaders.CLIENT_IP) String clientIp,
+            @HeaderParam(ClientContextHeaders.CLIENT_USER_AGENT) String clientUserAgent);
 
 }

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/common/ClientContextHeaders.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/common/ClientContextHeaders.java
@@ -1,0 +1,36 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.model.common;
+
+/**
+ * Headers carrying the end user's connection details across a server-to-server hop.
+ *
+ * The FIDO2 endpoints are never called by the browser - the Authorization Server, Casa
+ * and the person-authentication script relay to them - so the only client the server can
+ * observe on its own is the calling service. A caller that does hold the browser's request
+ * sends these headers so metrics describe the user rather than the relay.
+ *
+ * They are only honoured from a caller listed in {@code fido2TrustedClientContextSources};
+ * anywhere else they are ordinary request headers and are ignored.
+ *
+ * @author Janssen Project
+ */
+public final class ClientContextHeaders {
+
+    /**
+     * End user's IP address, as observed by the calling service.
+     */
+    public static final String CLIENT_IP = "X-Jans-Client-IP";
+
+    /**
+     * End user's browser user agent, as observed by the calling service.
+     */
+    public static final String CLIENT_USER_AGENT = "X-Jans-Client-User-Agent";
+
+    private ClientContextHeaders() {
+    }
+}

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/AppConfiguration.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/AppConfiguration.java
@@ -80,6 +80,9 @@ public class AppConfiguration implements Configuration, Serializable {
 	@DocProperty(description = "Boolean value specifying whether to collect device information in FIDO2 metrics", defaultValue = "true")
     private boolean fido2DeviceInfoCollection = true;
 	
+	@DocProperty(description = "Callers whose forwarded client-context headers (X-Jans-Client-IP, X-Jans-Client-User-Agent) are honoured, given as remote addresses. Empty means the headers are ignored; a single entry of * trusts every caller and must only be used where the FIDO2 server is not reachable by end users", defaultValue = "empty list")
+    private List<String> fido2TrustedClientContextSources;
+
 	@DocProperty(description = "Boolean value specifying whether to categorize errors in FIDO2 metrics", defaultValue = "true")
     private boolean fido2ErrorCategorization = true;
 	
@@ -228,6 +231,14 @@ public class AppConfiguration implements Configuration, Serializable {
 
 	public void setFido2DeviceInfoCollection(boolean fido2DeviceInfoCollection) {
 		this.fido2DeviceInfoCollection = fido2DeviceInfoCollection;
+	}
+
+	public List<String> getFido2TrustedClientContextSources() {
+		return fido2TrustedClientContextSources;
+	}
+
+	public void setFido2TrustedClientContextSources(List<String> fido2TrustedClientContextSources) {
+		this.fido2TrustedClientContextSources = fido2TrustedClientContextSources;
 	}
 
 	public boolean isFido2ErrorCategorization() {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/shared/MetricService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/shared/MetricService.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
+import io.jans.fido2.model.common.ClientContextHeaders;
 import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.metric.Fido2MetricsConstants;
 import io.jans.fido2.model.metric.Fido2MetricsData;
@@ -91,6 +92,7 @@ public class MetricService extends io.jans.service.metric.MetricService {
     private static final String ATTEMPT_STATUS = "ATTEMPT";
     private static final String SUCCESS_STATUS = "SUCCESS";
     private static final String SESSION_ID_COOKIE = "session_id";
+    private static final String TRUST_ANY_CLIENT_CONTEXT_SOURCE = "*";
     
     // Cache for username-to-userId mapping to reduce database load
     // TTL: 1 hour (3600000 ms) - balances performance with data freshness
@@ -493,8 +495,9 @@ public class MetricService extends io.jans.service.metric.MetricService {
         Fido2MetricsData.DeviceInfo deviceInfo = null;
 
         try {
-            ipAddress = extractIpAddress(request);
-            userAgent = request.getHeader("User-Agent");
+            boolean trustedCaller = isTrustedClientContextSource(request);
+            ipAddress = resolveClientIpAddress(request, trustedCaller);
+            userAgent = resolveClientUserAgent(request, trustedCaller);
             sessionId = extractSessionId(request);
         } catch (Exception e) {
             // A request-scoped proxy outside of an active request lands here
@@ -504,7 +507,7 @@ public class MetricService extends io.jans.service.metric.MetricService {
 
         if (appConfiguration.isFido2DeviceInfoCollection()) {
             try {
-                deviceInfo = deviceInfoExtractor.extractDeviceInfo(request);
+                deviceInfo = deviceInfoExtractor.extractDeviceInfo(userAgent);
             } catch (Exception e) {
                 log.debug("Failed to extract device info: {}", e.getMessage());
                 deviceInfo = deviceInfoExtractor.createMinimalDeviceInfo();
@@ -708,6 +711,73 @@ public class MetricService extends io.jans.service.metric.MetricService {
         // For now, we'll log the FIDO2 timer metrics
         // In a production environment, you might want to integrate with the base metric system
         log.debug("FIDO2 Timer updated: {} - {} ms", fido2MetricType.getMetricName(), duration);
+    }
+
+    /**
+     * Whether this request comes from a caller allowed to speak for the end user.
+     *
+     * The FIDO2 endpoints are reached from the Authorization Server, Casa or the
+     * person-authentication script rather than from the browser, so a caller that does hold
+     * the browser's request can forward its IP and user agent. Honouring those headers from
+     * anyone else would let a client dictate what gets recorded about it, so trust is granted
+     * per remote address through {@code fido2TrustedClientContextSources} and is empty by
+     * default.
+     *
+     * @param request HTTP servlet request
+     * @return true when the forwarded client-context headers on this request may be used
+     */
+    private boolean isTrustedClientContextSource(HttpServletRequest request) {
+        List<String> trustedSources = appConfiguration.getFido2TrustedClientContextSources();
+        if (trustedSources == null || trustedSources.isEmpty()) {
+            return false;
+        }
+
+        if (trustedSources.contains(TRUST_ANY_CLIENT_CONTEXT_SOURCE)) {
+            return true;
+        }
+
+        String remoteAddr = request.getRemoteAddr();
+        return remoteAddr != null && trustedSources.contains(remoteAddr);
+    }
+
+    /**
+     * Resolve the end user's IP address for this operation.
+     *
+     * Prefers the address forwarded by a trusted caller, since that caller is the only party
+     * that saw the browser. Falls back to what this request itself carries, which for a
+     * service-to-service call is the calling service rather than the user.
+     *
+     * @param request HTTP servlet request
+     * @param trustedCaller whether forwarded client context may be used
+     * @return end user's IP address where known, otherwise the requesting address
+     */
+    private String resolveClientIpAddress(HttpServletRequest request, boolean trustedCaller) {
+        if (trustedCaller) {
+            String forwardedIp = request.getHeader(ClientContextHeaders.CLIENT_IP);
+            if (forwardedIp != null && isValidIpAddress(forwardedIp.trim())) {
+                return forwardedIp.trim();
+            }
+        }
+
+        return extractIpAddress(request);
+    }
+
+    /**
+     * Resolve the end user's user agent for this operation.
+     *
+     * @param request HTTP servlet request
+     * @param trustedCaller whether forwarded client context may be used
+     * @return end user's user agent where known, otherwise this request's own User-Agent
+     */
+    private String resolveClientUserAgent(HttpServletRequest request, boolean trustedCaller) {
+        if (trustedCaller) {
+            String forwardedUserAgent = request.getHeader(ClientContextHeaders.CLIENT_USER_AGENT);
+            if (forwardedUserAgent != null && !forwardedUserAgent.trim().isEmpty()) {
+                return forwardedUserAgent.trim();
+            }
+        }
+
+        return request.getHeader("User-Agent");
     }
 
     /**

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/util/DeviceInfoExtractor.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/util/DeviceInfoExtractor.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 public class DeviceInfoExtractor {
     
     private static final String UNKNOWN_VALUE = "Unknown";
+    private static final String UNKNOWN_DEVICE_TYPE = "UNKNOWN";
 
     @Inject
     private Logger log;
@@ -55,9 +56,21 @@ public class DeviceInfoExtractor {
             return null;
         }
 
+        return extractDeviceInfo(request.getHeader("User-Agent"));
+    }
+
+    /**
+     * Extract device information from an already-resolved user agent
+     *
+     * Takes the string rather than the request so the caller can supply the end user's
+     * user agent forwarded by a trusted service, which is not the one on this request.
+     *
+     * @param userAgent user agent to parse, may be null
+     * @return DeviceInfo object with extracted information, fields left unset when userAgent is null
+     */
+    public DeviceInfo extractDeviceInfo(String userAgent) {
         DeviceInfo deviceInfo = new DeviceInfo();
-        String userAgent = request.getHeader("User-Agent");
-        
+
         if (userAgent != null) {
             deviceInfo.setUserAgent(userAgent);
             extractBrowserInfo(deviceInfo, userAgent);
@@ -167,17 +180,39 @@ public class DeviceInfoExtractor {
 
     /**
      * Determine device type based on user agent
+     *
+     * A user agent that matches no known platform is reported as UNKNOWN rather than
+     * assumed to be a desktop. Non-browser callers - a service-to-service HTTP client,
+     * for one - would otherwise be counted as desktops, which makes the device breakdown
+     * wrong rather than merely incomplete.
      */
     private void determineDeviceType(DeviceInfo deviceInfo, String userAgent) {
         String userAgentLower = userAgent.toLowerCase();
-        
+
         if (userAgentLower.contains("mobile") || userAgentLower.contains("android") || userAgentLower.contains("iphone")) {
             deviceInfo.setDeviceType("MOBILE");
         } else if (userAgentLower.contains("tablet") || userAgentLower.contains("ipad")) {
             deviceInfo.setDeviceType("TABLET");
-        } else {
+        } else if (isDesktopUserAgent(userAgentLower)) {
             deviceInfo.setDeviceType("DESKTOP");
+        } else {
+            deviceInfo.setDeviceType(UNKNOWN_DEVICE_TYPE);
         }
+    }
+
+    /**
+     * Whether the user agent names a desktop platform
+     *
+     * Checked only after the mobile and tablet tests, so the Linux marker shared with
+     * Android is not reached by an Android user agent.
+     */
+    private boolean isDesktopUserAgent(String userAgentLower) {
+        return userAgentLower.contains("windows")
+                || userAgentLower.contains("macintosh")
+                || userAgentLower.contains("mac os x")
+                || userAgentLower.contains("x11")
+                || userAgentLower.contains("linux")
+                || userAgentLower.contains("cros");
     }
 
     /**
@@ -189,7 +224,7 @@ public class DeviceInfoExtractor {
         deviceInfo.setBrowserVersion(UNKNOWN_VALUE);
         deviceInfo.setOperatingSystem(UNKNOWN_VALUE);
         deviceInfo.setOsVersion(UNKNOWN_VALUE);
-        deviceInfo.setDeviceType("UNKNOWN");
+        deviceInfo.setDeviceType(UNKNOWN_DEVICE_TYPE);
         return deviceInfo;
     }
 }

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/shared/MetricServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/shared/MetricServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.slf4j.Logger;
 
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,6 +40,11 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class MetricServiceTest {
+
+    /** What the FIDO2 server sees today: the relaying service, not the browser. */
+    private static final String APACHE_HTTP_CLIENT = "Apache-HttpClient/4.5.14 (Java/17.0.20)";
+    private static final String BROWSER_USER_AGENT =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
 
     @Mock
     private AppConfiguration appConfiguration;
@@ -249,6 +255,126 @@ class MetricServiceTest {
         assertFalse(metricService.isValidIpAddress("1.2.3."));
         assertFalse(metricService.isValidIpAddress("a.b.c.d"));
         assertFalse(metricService.isValidIpAddress("0000.1.1.1"));
+    }
+
+    /**
+     * The forwarded headers are only meaningful from a caller that saw the browser. With no
+     * trusted sources configured - the default - they are ordinary request headers and must be
+     * ignored, leaving the values this request carries.
+     */
+    @Test
+    void testForwardedClientContextIgnoredWhenNoTrustedSourceConfigured() {
+        // Given
+        when(appConfiguration.getFido2TrustedClientContextSources()).thenReturn(Collections.emptyList());
+        when(httpRequest.getRemoteAddr()).thenReturn("10.0.0.5");
+        when(httpRequest.getHeader("User-Agent")).thenReturn(APACHE_HTTP_CLIENT);
+        when(httpRequest.getHeader("X-Jans-Client-IP")).thenReturn("203.0.113.7");
+        when(httpRequest.getHeader("X-Jans-Client-User-Agent")).thenReturn(BROWSER_USER_AGENT);
+
+        // When
+        metricService.recordPasskeyAuthenticationSuccess("testuser", httpRequest,
+                System.currentTimeMillis(), "platform");
+
+        // Then
+        Fido2MetricsData stored = captureStoredMetrics();
+        assertEquals("10.0.0.5", stored.getIpAddress());
+        assertEquals(APACHE_HTTP_CLIENT, stored.getUserAgent());
+    }
+
+    /**
+     * A caller listed as trusted speaks for the end user, so its forwarded values win over
+     * the relayed request's own address and user agent.
+     */
+    @Test
+    void testForwardedClientContextUsedWhenCallerIsTrusted() {
+        // Given
+        when(appConfiguration.getFido2TrustedClientContextSources())
+                .thenReturn(Collections.singletonList("10.0.0.5"));
+        when(httpRequest.getRemoteAddr()).thenReturn("10.0.0.5");
+        when(httpRequest.getHeader("User-Agent")).thenReturn(APACHE_HTTP_CLIENT);
+        when(httpRequest.getHeader("X-Jans-Client-IP")).thenReturn("203.0.113.7");
+        when(httpRequest.getHeader("X-Jans-Client-User-Agent")).thenReturn(BROWSER_USER_AGENT);
+
+        // When
+        metricService.recordPasskeyAuthenticationSuccess("testuser", httpRequest,
+                System.currentTimeMillis(), "platform");
+
+        // Then
+        Fido2MetricsData stored = captureStoredMetrics();
+        assertEquals("203.0.113.7", stored.getIpAddress());
+        assertEquals(BROWSER_USER_AGENT, stored.getUserAgent());
+        verify(deviceInfoExtractor).extractDeviceInfo(BROWSER_USER_AGENT);
+    }
+
+    /**
+     * Trust is granted per remote address, so headers from anywhere else are ignored - a
+     * client that reaches the server directly cannot dictate what is recorded about it.
+     */
+    @Test
+    void testForwardedClientContextIgnoredFromUntrustedCaller() {
+        // Given
+        when(appConfiguration.getFido2TrustedClientContextSources())
+                .thenReturn(Collections.singletonList("10.0.0.5"));
+        when(httpRequest.getRemoteAddr()).thenReturn("198.51.100.9");
+        when(httpRequest.getHeader("User-Agent")).thenReturn(APACHE_HTTP_CLIENT);
+        when(httpRequest.getHeader("X-Jans-Client-IP")).thenReturn("203.0.113.7");
+        when(httpRequest.getHeader("X-Jans-Client-User-Agent")).thenReturn(BROWSER_USER_AGENT);
+
+        // When
+        metricService.recordPasskeyAuthenticationSuccess("testuser", httpRequest,
+                System.currentTimeMillis(), "platform");
+
+        // Then
+        Fido2MetricsData stored = captureStoredMetrics();
+        assertEquals("198.51.100.9", stored.getIpAddress());
+        assertEquals(APACHE_HTTP_CLIENT, stored.getUserAgent());
+    }
+
+    /**
+     * Deployments where the callers have no stable address - containers, mostly - can opt in
+     * with a wildcard, which is only safe because the FIDO2 server is not reachable by end
+     * users there.
+     */
+    @Test
+    void testWildcardTrustsAnyCaller() {
+        // Given
+        when(appConfiguration.getFido2TrustedClientContextSources())
+                .thenReturn(Collections.singletonList("*"));
+        when(httpRequest.getRemoteAddr()).thenReturn("198.51.100.9");
+        when(httpRequest.getHeader("X-Jans-Client-IP")).thenReturn("203.0.113.7");
+        when(httpRequest.getHeader("X-Jans-Client-User-Agent")).thenReturn(BROWSER_USER_AGENT);
+
+        // When
+        metricService.recordPasskeyAuthenticationSuccess("testuser", httpRequest,
+                System.currentTimeMillis(), "platform");
+
+        // Then
+        Fido2MetricsData stored = captureStoredMetrics();
+        assertEquals("203.0.113.7", stored.getIpAddress());
+    }
+
+    /**
+     * A forwarded address is still caller-supplied text. If it does not parse, the request's
+     * own address is recorded rather than the malformed value, and the user agent - which has
+     * no format to violate - is unaffected.
+     */
+    @Test
+    void testMalformedForwardedIpFallsBackToRequestAddress() {
+        // Given
+        when(appConfiguration.getFido2TrustedClientContextSources())
+                .thenReturn(Collections.singletonList("10.0.0.5"));
+        when(httpRequest.getRemoteAddr()).thenReturn("10.0.0.5");
+        when(httpRequest.getHeader("X-Jans-Client-IP")).thenReturn("not-an-ip");
+        when(httpRequest.getHeader("X-Jans-Client-User-Agent")).thenReturn(BROWSER_USER_AGENT);
+
+        // When
+        metricService.recordPasskeyAuthenticationSuccess("testuser", httpRequest,
+                System.currentTimeMillis(), "platform");
+
+        // Then
+        Fido2MetricsData stored = captureStoredMetrics();
+        assertEquals("10.0.0.5", stored.getIpAddress());
+        assertEquals(BROWSER_USER_AGENT, stored.getUserAgent());
     }
 
     /**

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/util/DeviceInfoExtractorTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/util/DeviceInfoExtractorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.service.util;
+
+import io.jans.fido2.model.metric.Fido2MetricsData.DeviceInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class for DeviceInfoExtractor
+ *
+ * @author Janssen Project
+ * @version 1.0
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DeviceInfoExtractorTest {
+
+    private static final String CHROME_WINDOWS =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    private static final String SAFARI_MACOS =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+    private static final String SAFARI_IPHONE =
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+    private static final String SAFARI_IPAD =
+            "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+    private static final String FIREFOX_LINUX =
+            "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0";
+
+    /**
+     * The user agent the FIDO2 server actually sees today, since the Authorization Server
+     * relays to it over a service-to-service HTTP client rather than the browser calling in.
+     */
+    private static final String APACHE_HTTP_CLIENT = "Apache-HttpClient/4.5.14 (Java/17.0.20)";
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private HttpServletRequest httpRequest;
+
+    @InjectMocks
+    private DeviceInfoExtractor deviceInfoExtractor;
+
+    /**
+     * A non-browser caller must not be counted as a desktop. Before the UNKNOWN branch every
+     * relayed call fell through to DESKTOP, so the device breakdown was populated entirely by
+     * the calling service and looked plausible rather than empty.
+     */
+    @Test
+    void testServiceToServiceUserAgentIsUnknownNotDesktop() {
+        DeviceInfo deviceInfo = deviceInfoExtractor.extractDeviceInfo(APACHE_HTTP_CLIENT);
+
+        assertEquals("UNKNOWN", deviceInfo.getDeviceType());
+        assertEquals("Unknown", deviceInfo.getBrowser());
+        assertEquals("Unknown", deviceInfo.getOperatingSystem());
+        assertEquals(APACHE_HTTP_CLIENT, deviceInfo.getUserAgent());
+    }
+
+    @Test
+    void testUnrecognisedUserAgentIsUnknown() {
+        assertEquals("UNKNOWN", deviceInfoExtractor.extractDeviceInfo("curl/8.4.0").getDeviceType());
+        assertEquals("UNKNOWN", deviceInfoExtractor.extractDeviceInfo("").getDeviceType());
+    }
+
+    @Test
+    void testDesktopUserAgentsAreStillDesktop() {
+        assertEquals("DESKTOP", deviceInfoExtractor.extractDeviceInfo(CHROME_WINDOWS).getDeviceType());
+        assertEquals("DESKTOP", deviceInfoExtractor.extractDeviceInfo(SAFARI_MACOS).getDeviceType());
+        assertEquals("DESKTOP", deviceInfoExtractor.extractDeviceInfo(FIREFOX_LINUX).getDeviceType());
+    }
+
+    /**
+     * The desktop check includes a Linux marker, which Android user agents also carry. The
+     * mobile test runs first, so an Android device must not be reclassified as a desktop.
+     */
+    @Test
+    void testMobileAndTabletUserAgentsAreUnaffected() {
+        assertEquals("MOBILE", deviceInfoExtractor.extractDeviceInfo(SAFARI_IPHONE).getDeviceType());
+        assertEquals("TABLET", deviceInfoExtractor.extractDeviceInfo(SAFARI_IPAD).getDeviceType());
+        assertEquals("MOBILE", deviceInfoExtractor.extractDeviceInfo(
+                "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36")
+                .getDeviceType());
+    }
+
+    @Test
+    void testBrowserAndOsAreParsedFromUserAgent() {
+        DeviceInfo chrome = deviceInfoExtractor.extractDeviceInfo(CHROME_WINDOWS);
+        assertEquals("Chrome", chrome.getBrowser());
+        assertEquals("120.0.0.0", chrome.getBrowserVersion());
+        assertEquals("Windows", chrome.getOperatingSystem());
+
+        DeviceInfo safari = deviceInfoExtractor.extractDeviceInfo(SAFARI_MACOS);
+        assertEquals("macOS", safari.getOperatingSystem());
+        assertEquals("10.15.7", safari.getOsVersion());
+    }
+
+    /**
+     * A missing user agent leaves the fields unset rather than filling in UNKNOWN, so the
+     * entry is excluded from the breakdowns instead of forming a bucket of its own.
+     */
+    @Test
+    void testNullUserAgentLeavesFieldsUnset() {
+        DeviceInfo deviceInfo = deviceInfoExtractor.extractDeviceInfo((String) null);
+
+        assertNotNull(deviceInfo);
+        assertNull(deviceInfo.getDeviceType());
+        assertNull(deviceInfo.getUserAgent());
+        assertNull(deviceInfo.getBrowser());
+    }
+
+    @Test
+    void testRequestOverloadReadsUserAgentHeader() {
+        when(httpRequest.getHeader("User-Agent")).thenReturn(CHROME_WINDOWS);
+
+        DeviceInfo deviceInfo = deviceInfoExtractor.extractDeviceInfo(httpRequest);
+
+        assertEquals("DESKTOP", deviceInfo.getDeviceType());
+        assertEquals(CHROME_WINDOWS, deviceInfo.getUserAgent());
+    }
+
+    @Test
+    void testNullRequestReturnsNull() {
+        assertNull(deviceInfoExtractor.extractDeviceInfo((HttpServletRequest) null));
+    }
+
+    @Test
+    void testMinimalDeviceInfoUsesUnknownDeviceType() {
+        DeviceInfo deviceInfo = deviceInfoExtractor.createMinimalDeviceInfo();
+
+        assertEquals("UNKNOWN", deviceInfo.getDeviceType());
+        assertEquals("Unknown", deviceInfo.getBrowser());
+    }
+}


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
Server half only. Populating the headers at the call sites — the person-authentication script, Casa
and `passkeys.xhtml` — is #14803, and cannot be in this PR: those modules build against the
published `jans-fido2-client` artifact, so they cannot compile against the new overloads until this
merges and republishes.
  closes #14801 

#### Implementation Details
  
The FIDO2 endpoints are never called by the browser. The Authorization Server, Casa and the
person-authentication script relay to them over `Fido2ClientFactory`, which propagates no headers, so
the only client the server can observe is the calling service. That is why `ipAddress` is the VM's
own address and `userAgent` is `Apache-HttpClient/4.5.14 (Java/17.0.20)` on every row.

**Carrying the end user's details across the hop.** `ClientContextHeaders` (new, in `model` so client
and server share one definition) names `X-Jans-Client-IP` and `X-Jans-Client-User-Agent`.
`AssertionService` and `AttestationService` gain **overloads** taking them as `@HeaderParam`. The
existing signatures are untouched deliberately: changing them would force Casa, the person
authentication script and the jans-chip demo to move in lockstep with this merge, whereas overloads
let each migrate on its own schedule. Passing null omits the header.

**Deciding whether to believe them.** A header is a claim, so `MetricService` honours these only from
a caller listed in the new `fido2TrustedClientContextSources`, which is **empty by default** — the
headers are ignored until an operator names a caller. A forwarded address is still run through
`isValidIpAddress` before use, and a malformed one falls back to the request's own address rather
than being stored. `"*"` trusts any caller, for deployments where callers have no stable address.

**Stopping the device breakdown being fabricated.** `DeviceInfoExtractor.determineDeviceType`
previously matched mobile and tablet markers and let *everything else* fall through to `DESKTOP`,
with no unknown branch — so every service-to-service call was recorded as a desktop and the chart
looked plausible rather than empty. It now tests for desktop markers explicitly and reports `UNKNOWN`
otherwise. The mobile test still runs first, so Android's shared Linux marker does not reclassify
phones as desktops. This is independent of the trust question above and worth having regardless.

There is also a new `extractDeviceInfo(String)` overload, since the user agent to parse is now often
not the one on the request.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

**Tests** — full `jans-fido2` suite green, 411 tests, 14 of them new:

- `DeviceInfoExtractorTest` (new, 9 tests) — the service-to-service user agent now reporting
  `UNKNOWN` instead of `DESKTOP`, real desktop user agents still `DESKTOP`, Android not
  reclassified, null user agent leaving fields unset.
- `MetricServiceTest` (5 added) — forwarded headers honoured from a trusted caller, ignored when
  unconfigured, ignored from an untrusted caller, wildcard trust, and a malformed forwarded address
  falling back to the request's own.

**Static analysis** — SpotBugs run locally on `model`, `client` and `server`. This change adds two
findings, `EI_EXPOSE_REP` / `EI_EXPOSE_REP2` on the new `List` getter and setter, which is the same
finding every other collection property in `AppConfiguration` already carries; left consistent with
the surrounding bean rather than making one property defensively copy. The module has 121
pre-existing findings of that class and the plugin is declared only in `pluginManagement`, so it does
not gate the build.

**Docs** — updated in a separate `docs:` commit: `passkey-telemetry.md` (a "Whose device is recorded"
section explaining the relay, the new property and the `UNKNOWN` device type),
`fido2-server-properties-config.md` and the generated `fido2-properties.md`.


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**
