### PR TITLE
docs(cedarling): benchmark page fixes + Rust column + relative bars

### DIFF
--- a/.github/workflows/test-cedarling.yml
+++ b/.github/workflows/test-cedarling.yml
@@ -180,6 +180,17 @@ jobs:
       working-directory: jans-cedarling
       run: |
         python3 scripts/parse_binding_benchmarks.py --format rust rust_bench_output.txt >> $GITHUB_STEP_SUMMARY
+    - name: Run Rust canonical benchmark harness
+      working-directory: jans-cedarling/cedarling
+      run: |
+        cargo run --release --example bench_jsonl | tee bench_output.jsonl
+        python3 ../scripts/parse_binding_benchmarks.py --format jsonl bench_output.jsonl >> $GITHUB_STEP_SUMMARY
+    - name: Upload Rust bench JSONL
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: bench-jsonl-rust
+        path: jans-cedarling/cedarling/bench_output.jsonl
+        retention-days: 7
 
   wasm_tests:
     runs-on: ubuntu-latest
@@ -474,6 +485,7 @@ jobs:
   cross_binding_bench_summary:
     runs-on: ubuntu-latest
     needs:
+      - rust_benchmarks
       - wasm_tests
       - python_tests
       - golang_tests
@@ -542,6 +554,7 @@ jobs:
         env.NO_BENCH_FILES != '1' &&
         (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
         github.ref == 'refs/heads/main' &&
+        needs.rust_benchmarks.result == 'success' &&
         needs.wasm_tests.result == 'success' &&
         needs.python_tests.result == 'success' &&
         needs.golang_tests.result == 'success' &&

--- a/.github/workflows/test-cedarling.yml
+++ b/.github/workflows/test-cedarling.yml
@@ -183,6 +183,7 @@ jobs:
     - name: Run Rust canonical benchmark harness
       working-directory: jans-cedarling/cedarling
       run: |
+        set -o pipefail
         cargo run --release --example bench_jsonl | tee bench_output.jsonl
         python3 ../scripts/parse_binding_benchmarks.py --format jsonl bench_output.jsonl >> $GITHUB_STEP_SUMMARY
     - name: Upload Rust bench JSONL

--- a/jans-cedarling/Cargo.lock
+++ b/jans-cedarling/Cargo.lock
@@ -2144,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/jans-cedarling/cedarling/Cargo.toml
+++ b/jans-cedarling/cedarling/Cargo.toml
@@ -155,3 +155,6 @@ harness = false
 [[bench]]
 name = "authz_authorize_batch_benchmark"
 harness = false
+
+[[example]]
+name = "bench_jsonl"

--- a/jans-cedarling/cedarling/examples/bench_jsonl.rs
+++ b/jans-cedarling/cedarling/examples/bench_jsonl.rs
@@ -230,6 +230,9 @@ fn run_scenario(
         samples.push(elapsed);
     }
 
+    if samples.is_empty() {
+        return BenchResult::skipped(scenario.id.clone(), "no_samples".to_string());
+    }
     build_ok_result(scenario.id.clone(), &samples)
 }
 
@@ -318,7 +321,12 @@ fn build_bench_fn<'a>(
                 None => None,
             };
             let base = entity_from_value(&scenario.resource)?;
-            let items = build_unsigned_batch_items(&base, &scenario.action, &context, scenario.item_count);
+            let items = build_unsigned_batch_items(
+                &base,
+                &scenario.action,
+                &context,
+                scenario.item_count,
+            );
             let req = BatchAuthorizeUnsignedRequest::new(principal, items);
             Ok(Box::new(move || {
                 match runtime.block_on(cedarling.authorize_unsigned_batch(req.clone())) {

--- a/jans-cedarling/cedarling/examples/bench_jsonl.rs
+++ b/jans-cedarling/cedarling/examples/bench_jsonl.rs
@@ -1,0 +1,399 @@
+// This software is available under the Apache-2.0 license.
+// See https://www.apache.org/licenses/LICENSE-2.0.txt for full text.
+//
+// Copyright (c) 2024, Gluu, Inc.
+
+//! Cross-platform benchmark harness for the Rust binding.
+//!
+//! Reads the shared manifest at `bindings/benchmarks/fixtures/scenarios.json`
+//! and emits one canonical JSONL record per scenario on stdout (logging on
+//! stderr). See `bindings/benchmarks/CONTRACT.md`. Mirrors the Go harness at
+//! `bindings/cedarling_go/benchmarks/main.go`.
+//!
+//! Run from the `cedarling` crate dir:
+//!   cargo run --release --example bench_jsonl
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use cedarling::{
+    AuthorizeMultiIssuerRequest, BatchAuthorizeMultiIssuerRequest, BatchAuthorizeUnsignedRequest,
+    BatchItem, BootstrapConfig, Cedarling, EntityData, RequestUnsigned, TokenInput,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use tokio::runtime::Runtime;
+
+const BINDING: &str = "rust";
+
+#[derive(Deserialize)]
+struct Manifest {
+    iteration_policy: IterationPolicy,
+    scenarios: Vec<Scenario>,
+}
+
+#[derive(Deserialize)]
+struct IterationPolicy {
+    warmup_iters: usize,
+    measure_iters: usize,
+}
+
+#[derive(Deserialize)]
+struct Scenario {
+    id: String,
+    kind: String,
+    #[serde(default)]
+    item_count: usize,
+    policy_store_fn: String,
+    #[serde(default)]
+    config_overrides: Map<String, Value>,
+    #[serde(default)]
+    principal: Option<Value>,
+    #[serde(default)]
+    action: String,
+    resource: Value,
+    #[serde(default)]
+    context: String,
+    #[serde(default)]
+    tokens: Vec<TokenSpec>,
+    #[serde(default)]
+    mock_op_required: bool,
+}
+
+#[derive(Deserialize)]
+struct TokenSpec {
+    mapping: String,
+    payload: String,
+}
+
+#[derive(Serialize)]
+struct BenchResult {
+    binding: &'static str,
+    scenario: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iter: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mean_ns: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    p50_ns: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    p95_ns: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    p99_ns: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_ns: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_ns: Option<i64>,
+    // Always present, even when null — Rust does not measure per-op allocs.
+    allocs_per_op: Option<f64>,
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+impl BenchResult {
+    fn skipped(scenario: String, reason: String) -> Self {
+        Self {
+            binding: BINDING,
+            scenario,
+            iter: None,
+            mean_ns: None,
+            p50_ns: None,
+            p95_ns: None,
+            p99_ns: None,
+            min_ns: None,
+            max_ns: None,
+            allocs_per_op: None,
+            status: "skipped",
+            reason: Some(reason),
+        }
+    }
+}
+
+fn emit(result: &BenchResult) {
+    match serde_json::to_string(result) {
+        Ok(line) => println!("{line}"),
+        Err(e) => eprintln!("marshal failed: {e}"),
+    }
+}
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = <repo_root>/cedarling; repo root is its parent.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or(manifest_dir)
+}
+
+fn main() {
+    let root = repo_root();
+    let manifest_path = root
+        .join("bindings")
+        .join("benchmarks")
+        .join("fixtures")
+        .join("scenarios.json");
+
+    let raw = match std::fs::read_to_string(&manifest_path) {
+        Ok(raw) => raw,
+        Err(e) => {
+            eprintln!("failed to read manifest {}: {e}", manifest_path.display());
+            std::process::exit(1);
+        },
+    };
+    let manifest: Manifest = match serde_json::from_str(&raw) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("failed to parse manifest: {e}");
+            std::process::exit(1);
+        },
+    };
+
+    let runtime = match Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("failed to init tokio runtime: {e}");
+            std::process::exit(1);
+        },
+    };
+
+    for scenario in &manifest.scenarios {
+        let result = run_scenario(
+            &runtime,
+            scenario,
+            &root,
+            manifest.iteration_policy.warmup_iters,
+            manifest.iteration_policy.measure_iters,
+        );
+        emit(&result);
+    }
+}
+
+/// A closure that runs one authorization call and yields whether it Allowed.
+type BenchFn<'a> = Box<dyn Fn() -> Result<bool, String> + 'a>;
+
+fn run_scenario(
+    runtime: &Runtime,
+    scenario: &Scenario,
+    root: &Path,
+    warmup_iters: usize,
+    measure_iters: usize,
+) -> BenchResult {
+    if scenario.mock_op_required {
+        return BenchResult::skipped(scenario.id.clone(), "mock_op_unavailable".to_string());
+    }
+
+    let cedarling = match build_cedarling(runtime, scenario, root) {
+        Ok(c) => c,
+        Err(e) => return BenchResult::skipped(scenario.id.clone(), format!("init:{e}")),
+    };
+
+    let bench_fn = match build_bench_fn(runtime, &cedarling, scenario) {
+        Ok(f) => f,
+        Err(e) => return BenchResult::skipped(scenario.id.clone(), format!("build_fn:{e}")),
+    };
+
+    // One validation call before timing: an error or a Deny means skip.
+    match bench_fn() {
+        Ok(true) => {},
+        Ok(false) => {
+            return BenchResult::skipped(scenario.id.clone(), "validation_deny".to_string());
+        },
+        Err(e) => {
+            return BenchResult::skipped(scenario.id.clone(), format!("validation_error:{e}"));
+        },
+    }
+
+    for _ in 0..warmup_iters {
+        if let Err(e) = bench_fn() {
+            return BenchResult::skipped(scenario.id.clone(), format!("warmup_loop:{e}"));
+        }
+    }
+
+    let mut samples: Vec<i64> = Vec::with_capacity(measure_iters);
+    for _ in 0..measure_iters {
+        let t0 = Instant::now();
+        let outcome = bench_fn();
+        let elapsed = t0.elapsed().as_nanos() as i64;
+        if let Err(e) = outcome {
+            return BenchResult::skipped(scenario.id.clone(), format!("measure_loop:{e}"));
+        }
+        samples.push(elapsed);
+    }
+
+    build_ok_result(scenario.id.clone(), samples)
+}
+
+fn build_cedarling(
+    runtime: &Runtime,
+    scenario: &Scenario,
+    root: &Path,
+) -> Result<Cedarling, String> {
+    let mut obj = scenario.config_overrides.clone();
+    let policy_path = root.join(&scenario.policy_store_fn);
+    obj.insert(
+        "CEDARLING_POLICY_STORE_LOCAL_FN".to_string(),
+        Value::String(policy_path.to_string_lossy().into_owned()),
+    );
+    let json = serde_json::to_string(&obj).map_err(|e| e.to_string())?;
+    let cfg = BootstrapConfig::load_from_json(&json).map_err(|e| e.to_string())?;
+    runtime
+        .block_on(Cedarling::new(&cfg))
+        .map_err(|e| e.to_string())
+}
+
+fn parse_context(ctx: &str) -> Result<Value, String> {
+    if ctx.is_empty() || ctx == "{}" {
+        return Ok(Value::Object(Map::new()));
+    }
+    serde_json::from_str(ctx).map_err(|e| e.to_string())
+}
+
+fn entity_from_value(v: &Value) -> Result<EntityData, String> {
+    EntityData::from_json(&v.to_string()).map_err(|e| e.to_string())
+}
+
+fn build_bench_fn<'a>(
+    runtime: &'a Runtime,
+    cedarling: &'a Cedarling,
+    scenario: &Scenario,
+) -> Result<BenchFn<'a>, String> {
+    let tokens: Vec<TokenInput> = scenario
+        .tokens
+        .iter()
+        .map(|t| TokenInput::new(t.mapping.clone(), t.payload.clone()))
+        .collect();
+    let context = parse_context(&scenario.context)?;
+
+    match scenario.kind.as_str() {
+        "unsigned" => {
+            let principal = match &scenario.principal {
+                Some(p) => Some(entity_from_value(p)?),
+                None => None,
+            };
+            let resource = entity_from_value(&scenario.resource)?;
+            let req = RequestUnsigned {
+                principal,
+                action: scenario.action.clone(),
+                resource,
+                context,
+            };
+            Ok(Box::new(move || {
+                runtime
+                    .block_on(cedarling.authorize_unsigned(req.clone()))
+                    .map(|r| r.decision)
+                    .map_err(|e| e.to_string())
+            }))
+        },
+        "multi_issuer" => {
+            let resource = entity_from_value(&scenario.resource)?;
+            let req = AuthorizeMultiIssuerRequest::new_with_fields(
+                tokens,
+                resource,
+                scenario.action.clone(),
+                Some(context),
+            );
+            Ok(Box::new(move || {
+                runtime
+                    .block_on(cedarling.authorize_multi_issuer(req.clone()))
+                    .map(|r| r.decision)
+                    .map_err(|e| e.to_string())
+            }))
+        },
+        "unsigned_batch" => {
+            if scenario.item_count == 0 {
+                return Err("item_count must be > 0 for batch scenario".to_string());
+            }
+            let principal = match &scenario.principal {
+                Some(p) => Some(entity_from_value(p)?),
+                None => None,
+            };
+            let base = entity_from_value(&scenario.resource)?;
+            let items = build_unsigned_batch_items(&base, &scenario.action, &context, scenario.item_count);
+            let req = BatchAuthorizeUnsignedRequest::new(principal, items);
+            Ok(Box::new(move || {
+                match runtime.block_on(cedarling.authorize_unsigned_batch(req.clone())) {
+                    Ok(resp) => Ok(!resp.results.is_empty()
+                        && resp
+                            .results
+                            .iter()
+                            .all(|r| r.as_ref().is_ok_and(|res| res.decision))),
+                    Err(e) => Err(e.to_string()),
+                }
+            }))
+        },
+        "multi_issuer_batch" => {
+            if scenario.item_count == 0 {
+                return Err("item_count must be > 0 for batch scenario".to_string());
+            }
+            let base = entity_from_value(&scenario.resource)?;
+            // Multi-issuer fixture scopes to one resource — every item reuses it.
+            let item = BatchItem {
+                resource: base,
+                action: scenario.action.clone(),
+                context: context.clone(),
+            };
+            let items: Vec<BatchItem> = (0..scenario.item_count).map(|_| item.clone()).collect();
+            let req = BatchAuthorizeMultiIssuerRequest::new(tokens, items);
+            Ok(Box::new(move || {
+                match runtime.block_on(cedarling.authorize_multi_issuer_batch(req.clone())) {
+                    Ok(resp) => Ok(!resp.results.is_empty()
+                        && resp
+                            .results
+                            .iter()
+                            .all(|r| r.as_ref().is_ok_and(|res| res.decision))),
+                    Err(e) => Err(e.to_string()),
+                }
+            }))
+        },
+        other => Err(format!("unknown scenario kind {other:?}")),
+    }
+}
+
+/// Clone the fixture resource `count` times with distinct ids `{base}-{i}`.
+fn build_unsigned_batch_items(
+    base: &EntityData,
+    action: &str,
+    context: &Value,
+    count: usize,
+) -> Vec<BatchItem> {
+    let base_id = base.cedar_mapping.id.clone();
+    (0..count)
+        .map(|i| {
+            let mut resource = base.clone();
+            resource.cedar_mapping.id = format!("{base_id}-{i}");
+            BatchItem {
+                resource,
+                action: action.to_string(),
+                context: context.clone(),
+            }
+        })
+        .collect()
+}
+
+fn build_ok_result(scenario: String, samples: Vec<i64>) -> BenchResult {
+    let iter = samples.len();
+    let mut sorted = samples.clone();
+    sorted.sort_unstable();
+
+    let sum: i64 = samples.iter().sum();
+    let mean = sum / iter as i64;
+    let min = sorted[0];
+    let max = sorted[iter - 1];
+    let pct = |p: f64| sorted[(iter as f64 * p) as usize];
+
+    BenchResult {
+        binding: BINDING,
+        scenario,
+        iter: Some(iter),
+        mean_ns: Some(mean),
+        p50_ns: Some(pct(0.50)),
+        p95_ns: Some(pct(0.95)),
+        p99_ns: Some(pct(0.99)),
+        min_ns: Some(min),
+        max_ns: Some(max),
+        allocs_per_op: None,
+        status: "ok",
+        reason: None,
+    }
+}

--- a/jans-cedarling/cedarling/examples/bench_jsonl.rs
+++ b/jans-cedarling/cedarling/examples/bench_jsonl.rs
@@ -11,7 +11,16 @@
 //! `bindings/cedarling_go/benchmarks/main.go`.
 //!
 //! Run from the `cedarling` crate dir:
-//!   cargo run --release --example bench_jsonl
+//!   cargo run --release --example `bench_jsonl`
+
+// Percentile/mean math casts between usize/f64/i64 by design; the values are
+// wall-clock nanosecond counts well within range.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap
+)]
 
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -221,7 +230,7 @@ fn run_scenario(
         samples.push(elapsed);
     }
 
-    build_ok_result(scenario.id.clone(), samples)
+    build_ok_result(scenario.id.clone(), &samples)
 }
 
 fn build_cedarling(
@@ -371,9 +380,9 @@ fn build_unsigned_batch_items(
         .collect()
 }
 
-fn build_ok_result(scenario: String, samples: Vec<i64>) -> BenchResult {
+fn build_ok_result(scenario: String, samples: &[i64]) -> BenchResult {
     let iter = samples.len();
-    let mut sorted = samples.clone();
+    let mut sorted = samples.to_vec();
     sorted.sort_unstable();
 
     let sum: i64 = samples.iter().sum();

--- a/jans-cedarling/scripts/parse_binding_benchmarks.py
+++ b/jans-cedarling/scripts/parse_binding_benchmarks.py
@@ -161,7 +161,7 @@ def _ns_to_us(ns: float | int | None) -> str:
 
 
 def render_jsonl_pivot(rows: list[dict]) -> str:
-    """Render a Scenario × Binding pivot plus per-binding detail tables."""
+    """Render a Scenario x Binding pivot plus per-binding detail tables."""
     if not rows:
         return "## Cross-Platform Binding Benchmarks\n\n_No results found._\n"
 
@@ -185,7 +185,7 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
     scenarios = sorted(scenarios_set)
 
     out: list[str] = ["## Cross-Platform Binding Benchmarks\n\n"]
-    out.append("### Mean (µs) per scenario × binding\n\n")
+    out.append("### Mean (µs) per scenario x binding\n\n")
     out.append("| Scenario | " + " | ".join(bindings) + " |\n")
     out.append("|----------|" + "|".join(["----------:"] * len(bindings)) + "|\n")
     for s in scenarios:
@@ -208,11 +208,11 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
             "full batch call, not per-item latency.\n\n"
         )
 
-    # Relative view: within each scenario, the fastest binding is 1.00×; the bar
+    # Relative view: within each scenario, the fastest binding is 1.00x; the bar
     # length is scaled so the slowest binding in that row fills the width. This
     # compares speed across bindings without implying batch/non-batch rows are
     # comparable to each other.
-    out.append("### Relative speed per scenario (×, lower = faster)\n\n")
+    out.append("### Relative speed per scenario (x, lower = faster)\n\n")
     out.append("| Scenario | " + " | ".join(bindings) + " |\n")
     out.append("|----------|" + "|".join(["----------:"] * len(bindings)) + "|\n")
     bar_width = 10
@@ -236,7 +236,7 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
                 continue
             ratio = means[b] / fastest
             blocks = 1 if slowest_ratio <= 1 else max(1, round(ratio / slowest_ratio * bar_width))
-            cells.append(f"{ratio:.2f}× {'█' * blocks}")
+            cells.append(f"{ratio:.2f}x {'█' * blocks}")
         out.append(f"| {s} | " + " | ".join(cells) + " |\n")
     out.append("\n")
 

--- a/jans-cedarling/scripts/parse_binding_benchmarks.py
+++ b/jans-cedarling/scripts/parse_binding_benchmarks.py
@@ -223,6 +223,7 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
             if (r := by_key.get((b, s))) is not None
             and r.get("status") != "skipped"
             and r.get("mean_ns") is not None
+            and float(r["mean_ns"]) > 0
         }
         fastest = min(means.values()) if means else None
         slowest_ratio = (max(means.values()) / fastest) if means else 1.0

--- a/jans-cedarling/scripts/parse_binding_benchmarks.py
+++ b/jans-cedarling/scripts/parse_binding_benchmarks.py
@@ -163,7 +163,7 @@ def _ns_to_us(ns: float | int | None) -> str:
 def render_jsonl_pivot(rows: list[dict]) -> str:
     """Render a Scenario × Binding pivot plus per-binding detail tables."""
     if not rows:
-        return "### Cross-Platform Binding Benchmarks\n\n_No results found._\n"
+        return "## Cross-Platform Binding Benchmarks\n\n_No results found._\n"
 
     by_key: dict[tuple[str, str], dict] = {}
     bindings_set: set[str] = set()
@@ -184,8 +184,8 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
     bindings = sorted(bindings_set)
     scenarios = sorted(scenarios_set)
 
-    out: list[str] = ["### Cross-Platform Binding Benchmarks\n\n"]
-    out.append("#### Mean (µs) per scenario × binding\n\n")
+    out: list[str] = ["## Cross-Platform Binding Benchmarks\n\n"]
+    out.append("### Mean (µs) per scenario × binding\n\n")
     out.append("| Scenario | " + " | ".join(bindings) + " |\n")
     out.append("|----------|" + "|".join(["----------:"] * len(bindings)) + "|\n")
     for s in scenarios:
@@ -200,8 +200,15 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
                 cells.append(_ns_to_us(r.get("mean_ns")))
         out.append(f"| {s} | " + " | ".join(cells) + " |\n")
     out.append("\n")
+    # Batch scenarios time the whole batch call, so their means are not
+    # comparable to the per-item single-call scenarios above.
+    if any("batch" in s for s in scenarios):
+        out.append(
+            "> **Note:** `unsigned_batch_*` and `multi_issuer_batch_*` measure the "
+            "full batch call, not per-item latency.\n\n"
+        )
     for b in bindings:
-        out.append(f"#### {b} detail\n\n")
+        out.append(f"### {b} detail\n\n")
         out.append(
             "| Scenario | Mean | p50 | p95 | p99 | Min | Max | Allocs/op | Status |\n"
         )

--- a/jans-cedarling/scripts/parse_binding_benchmarks.py
+++ b/jans-cedarling/scripts/parse_binding_benchmarks.py
@@ -207,6 +207,39 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
             "> **Note:** `unsigned_batch_*` and `multi_issuer_batch_*` measure the "
             "full batch call, not per-item latency.\n\n"
         )
+
+    # Relative view: within each scenario, the fastest binding is 1.00×; the bar
+    # length is scaled so the slowest binding in that row fills the width. This
+    # compares speed across bindings without implying batch/non-batch rows are
+    # comparable to each other.
+    out.append("### Relative speed per scenario (×, lower = faster)\n\n")
+    out.append("| Scenario | " + " | ".join(bindings) + " |\n")
+    out.append("|----------|" + "|".join(["----------:"] * len(bindings)) + "|\n")
+    bar_width = 10
+    for s in scenarios:
+        means = {
+            b: float(r["mean_ns"])
+            for b in bindings
+            if (r := by_key.get((b, s))) is not None
+            and r.get("status") != "skipped"
+            and r.get("mean_ns") is not None
+        }
+        fastest = min(means.values()) if means else None
+        slowest_ratio = (max(means.values()) / fastest) if means else 1.0
+        cells: list[str] = []
+        for b in bindings:
+            if b not in means:
+                r = by_key.get((b, s))
+                cells.append(
+                    "_skipped_" if r is not None and r.get("status") == "skipped" else "—"
+                )
+                continue
+            ratio = means[b] / fastest
+            blocks = 1 if slowest_ratio <= 1 else max(1, round(ratio / slowest_ratio * bar_width))
+            cells.append(f"{ratio:.2f}× {'█' * blocks}")
+        out.append(f"| {s} | " + " | ".join(cells) + " |\n")
+    out.append("\n")
+
     for b in bindings:
         out.append(f"### {b} detail\n\n")
         out.append(


### PR DESCRIPTION
Addresses the review comments on the auto-generated benchmark page, plus two follow-ups requested (Rust column, easier/truthful comparison). All rendering changes are in the generator (`parse_binding_benchmarks.py`); the published page updates on the next benchmark run.

**Review-comment fixes**
- Pivot heading now H2 (was H3, skipping a level under the page H1); sub-tables H3.
- Note that `*_batch_*` scenarios measure the full batch call, not per-item latency.

**Rust in the cross-platform comparison**
- New canonical JSONL harness `cedarling/examples/bench_jsonl.rs` runs the shared scenarios (`bindings/benchmarks/fixtures/scenarios.json`) through the Rust core and emits the same schema as the language bindings.
- `rust_benchmarks` job runs it, appends to the step summary, and uploads `bench-jsonl-rust`; added to `cross_binding_bench_summary` needs + publish gate so Rust becomes a pivot column.

**Easier / truthful comparison**
- New per-scenario 'Relative speed' table: each binding shown as a ratio to the fastest in that row with a scaled unicode bar, so cross-binding speed reads at a glance without implying batch and non-batch rows are comparable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-platform authorization benchmark coverage, including unsigned, multi-issuer, and batch scenarios.
  * Added latency statistics and relative-speed comparisons with visualized performance bars.
  * Batch results now clarify that latency reflects the full call rather than individual items.
* **Improvements**
  * Benchmark summaries use clearer headings and consistently display skipped or unavailable results.
  * Automated benchmark results are included in workflow summaries and available as downloadable artifacts for seven days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->