### PR TITLE
ci(cedarling): sign auto-generated benchmark commits + provenance/units

### DIFF
--- a/.github/workflows/test-cedarling.yml
+++ b/.github/workflows/test-cedarling.yml
@@ -533,6 +533,10 @@ jobs:
       if: env.NO_BENCH_FILES != '1'
       run: |
         doc=docs/cedarling/reference/benchmarks.md
+        manifest=jans-cedarling/bindings/benchmarks/fixtures/scenarios.json
+        warmup=$(python3 -c "import json;print(json.load(open('$manifest'))['iteration_policy']['warmup_iters'])")
+        measure=$(python3 -c "import json;print(json.load(open('$manifest'))['iteration_policy']['measure_iters'])")
+        run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}"
         {
           echo "# Cedarling Benchmarks"
           echo
@@ -546,8 +550,36 @@ jobs:
           echo
           echo "_Last updated: $(date -u '+%Y-%m-%d %H:%M UTC') (commit ${GITHUB_SHA:0:7})._"
           echo
+          echo "## Provenance"
+          echo
+          echo "- Each binding is measured on its own GitHub-hosted \`ubuntu-latest\` runner."
+          echo "- Warm-up iterations per scenario: **$warmup**; measured (sample count) per scenario: **$measure**."
+          echo "- Exact host, OS, and compiler/runtime versions for this run are recorded"
+          echo "  in the immutable workflow logs: [$run_url]($run_url)."
+          echo "- Scenario definitions and fixtures: \`jans-cedarling/bindings/benchmarks/fixtures/scenarios.json\`."
+          echo
           python3 jans-cedarling/scripts/parse_binding_benchmarks.py --format jsonl $BENCH_FILES
         } > "$doc"
+    - name: Import GPG key for signed commits
+      # Branch protection requires verified (GPG-signed) commits, so the bot
+      # commit must be signed with the mo-auto key. Same gate as the publish step.
+      if: >-
+        env.NO_BENCH_FILES != '1' &&
+        (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+        github.ref == 'refs/heads/main' &&
+        needs.rust_benchmarks.result == 'success' &&
+        needs.wasm_tests.result == 'success' &&
+        needs.python_tests.result == 'success' &&
+        needs.golang_tests.result == 'success' &&
+        needs.c_tests.result == 'success' &&
+        needs.uniffi_benchmarks.result == 'success'
+      id: import_gpg
+      uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+      with:
+        gpg_private_key: ${{ secrets.MOAUTO_GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.MOAUTO_GPG_PRIVATE_KEY_PASSPHRASE }}
+        git_user_signingkey: true
+        git_commit_gpgsign: true
     - name: Open PR with updated benchmarks doc page
       # Only publish when every binding job succeeded, so a failed/partial run
       # can't overwrite the doc with incomplete results.
@@ -572,11 +604,13 @@ jobs:
         branch=cn-jans-update-cedarling-benchmarks
         git config user.name "mo-auto"
         git config user.email "54212639+mo-auto@users.noreply.github.com"
+        # signingkey + commit.gpgsign are set globally by the import GPG step.
         git remote set-url origin \
           "https://mo-auto:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         git checkout -b "$branch"
         git add "$doc"
-        git commit -s -m "docs(cedarling): update benchmark summary"
+        # -s adds the DCO Signed-off-by trailer; commit.gpgsign adds the GPG signature.
+        git commit -s -S -m "docs(cedarling): update benchmark summary"
         # Branch is regenerated from main each run; overwrite any stale tip.
         git push --force --set-upstream origin "$branch"
         open_prs=$(gh pr list --head "$branch" --state open --json number --jq 'length')

--- a/jans-cedarling/scripts/parse_binding_benchmarks.py
+++ b/jans-cedarling/scripts/parse_binding_benchmarks.py
@@ -241,10 +241,14 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
         out.append(f"| {s} | " + " | ".join(cells) + " |\n")
     out.append("\n")
 
+    out.append(
+        "_Latency columns (Mean, p50, p95, p99, Min, Max) in the detail "
+        "tables below are microseconds (µs)._\n\n"
+    )
     for b in bindings:
         out.append(f"### {b} detail\n\n")
         out.append(
-            "| Scenario | Mean | p50 | p95 | p99 | Min | Max | Allocs/op | Status |\n"
+            "| Scenario | Mean (µs) | p50 (µs) | p95 (µs) | p99 (µs) | Min (µs) | Max (µs) | Allocs/op | Status |\n"
         )
         out.append(
             "|----------|----:|----:|----:|----:|----:|----:|----------:|--------|\n"


### PR DESCRIPTION
Re-targets the benchmark workflow/generator improvements at `main` (the earlier PR #14816 was merged into the bot branch #14814 by mistake, so main never received these).

- **Signed commits:** `cross_binding_bench_summary` imports the mo-auto GPG key and commits `-S` so the auto-generated benchmark PR passes require-signed-commits (mirrors `build-docs.yml`).
- **Provenance:** generated page gets a Provenance section (per-binding `ubuntu-latest` runners, warm-up + sample counts, link to the immutable run attempt for host/OS/toolchain versions).
- **Units:** detail tables label latency columns as microseconds (µs).
- **Robustness:** relative-speed ratios exclude non-positive means.

Once merged, the next run regenerates the benchmark docs PR with a CI-signed, DCO-correct commit — superseding the tangled #14814.
Closes #14819, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Benchmark reports now include warmup and measurement counts, runner scope, workflow details, and fixture provenance.
  * Cross-binding latency tables now clearly label all timing values in microseconds (µs).

* **Chores**
  * Published benchmark updates now include verified GPG signatures for improved commit authenticity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->