### PR TITLE
fix(jans-fido2): aggregate analytics over the correct row set

### DIFF
--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -36,8 +36,8 @@ within your organization.
 | How many users start a passkey flow but drop off? | `analytics/errors` (`dropOffRate`, `abandonmentRate`) |
 | Why are users failing — cancels, timeouts, bad credentials? | `analytics/errors` (`errorCategories`, `topErrors`) |
 | Why are authenticators being rejected at registration? | `analytics/attestation-rejections` (`reasonCodes`, `topRejectedAaguids`) |
-| Which platforms, browsers, and authenticator types are in use? | `analytics/devices` |
-| Is passkey latency healthy, or getting worse? | `analytics/performance` |
+| Which platforms, browsers, and authenticator types are in use? | `analytics/devices` (counted per completed ceremony) |
+| Is passkey latency healthy, or getting worse? | `analytics/performance` (completed ceremonies only) |
 | How does this month compare to last? | `analytics/comparison` |
 
 Since the API serves this data as plain JSON, it can be easily used by a dashboard, an alerting rule, or a periodic report. 
@@ -233,6 +233,14 @@ parameters, and response schemas, use the Swagger spec:
 `{type}` is one of `HOURLY`, `DAILY`, `WEEKLY`, `MONTHLY`; `{operationType}` is
 `REGISTRATION` or `AUTHENTICATION`.
 
+`analytics/errors` also accepts an optional `operationType` query parameter. Without it the rates
+cover registration and authentication together, which cannot tell a deployment with healthy sign-in
+and poor enrolment apart from the reverse — pass it to read one ceremony at a time:
+
+```bash
+curl -s "$BASE/analytics/errors?$RANGE&operationType=AUTHENTICATION"
+```
+
 ## Sample dashboard
 
 You can build a passkey rollout dashboard using the data provided by metrics API. 
@@ -268,7 +276,9 @@ is given below.
 - During rollout, expect a high **`adoptionRate`** (many new users); as the base matures it
   falls and **`returningUsers`** dominates — that's the healthy direction.
 - Rising **average durations** (`analytics/performance`) is an early warning of
-  infrastructure or authenticator problems.
+  infrastructure or authenticator problems. These durations cover only ceremonies that completed —
+  a ceremony the user walked away from is measured by `unfinishedRequestExpiration`, not by how
+  fast the server answered, so read abandonment from `abandonmentRate` rather than from latency.
 
 
 

--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -163,10 +163,21 @@ Beyond the outcome itself, each raw entry records where the operation came from:
 ### Aggregation schedule and retention
 
 A scheduler computes aggregations on a cadence
-(hourly aggregations shortly after each hour, then daily/weekly/monthly). Data older than
-the configured retention window is cleaned up automatically. In a cluster the aggregation
+(hourly aggregations shortly after each hour, then daily/weekly/monthly). Entries older than
+the configured retention window are cleaned up automatically. In a cluster the aggregation
 job uses a distributed lock; if the lock is unavailable it falls back to single-node mode
 and logs that it did so, so aggregation keeps working.
+
+An aggregation is computed once for its period and stored; it is not recalculated, and the
+retention sweep clears raw entries without clearing aggregations. Two consequences worth knowing:
+
+!!! note "Aggregations recorded before Jans 2.4.0"
+    Rows written before 2.4.0 averaged abandoned ceremonies into the duration figures and counted
+    device types per entry rather than per ceremony, so `aggregations/{type}/summary` and
+    `analytics/trends` report those periods as they were computed at the time. They are not
+    corrected retrospectively: once a period's raw entries pass retention there is nothing left to
+    recompute from. Treat periods predating the upgrade as legacy data and read current latency
+    from `analytics/performance`, which is computed live from entries.
 
 ## Configuration
 
@@ -180,7 +191,7 @@ as listed below:
 | `fido2MetricsEnabled` | `true` | Master switch for metrics collection. If `false`, no entries are stored. |
 | `fido2MetricsAggregationEnabled` | `true` | Enables the scheduled hourly/daily/weekly/monthly aggregation jobs. |
 | `fido2MetricsAggregationInterval` | `60` | Interval in **minutes** driving the aggregation scheduler (default `60` = hourly). |
-| `fido2MetricsRetentionDays` | `90` | Days to retain entries and aggregations before automatic cleanup. |
+| `fido2MetricsRetentionDays` | `90` | Days to retain metrics entries before automatic cleanup. Aggregations are not swept — they are the long-term record that outlives the entries they were computed from. |
 | `fido2DeviceInfoCollection` | `true` | Whether device info (browser, OS, device type) is collected and stored. Entries are still written when this is `false` — only the `deviceInfo` field is omitted. Use `fido2MetricsEnabled` to stop writing entries altogether. |
 | `fido2ErrorCategorization` | `true` | Whether failures are categorized for the error-analysis endpoint. |
 | `fido2PerformanceMetrics` | `true` | Whether operation durations are tracked. |

--- a/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
@@ -286,6 +286,17 @@ paths:
         required: true
         schema:
           type: string
+      - name: operationType
+        in: query
+        description: "Operation type to report on: REGISTRATION or AUTHENTICATION.\
+          \ Omit to report both together, in which case every rate covers registration\
+          \ and authentication combined."
+        required: false
+        schema:
+          type: string
+          enum:
+          - REGISTRATION
+          - AUTHENTICATION
       responses:
         "200":
           description: Ok

--- a/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2MetricsResource.java
+++ b/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/rest/Fido2MetricsResource.java
@@ -582,10 +582,12 @@ public class Fido2MetricsResource extends BaseResource {
      *                   after this date
      * @param endDate    optional end date (dd-MM-yyyy) to include entries on or
      *                   before this date
-     * 
+     * @param operationType optional REGISTRATION or AUTHENTICATION to report that
+     *                   ceremony alone; omitted, both are reported together
+     *
      *
      * @return a Response containing a JsonNode with the matching entries
-     * 
+     *
      */
     @Operation(summary = "Get Fido2 error analysis metrics by time range.", description = "Get Fido2 error analysis metrics by time range.", operationId = "get-fido2-metrics-analytics-errors", tags = {
             "Fido2 - Metrics" }, security = {
@@ -606,10 +608,11 @@ public class Fido2MetricsResource extends BaseResource {
                     ApiAccessConstants.SUPER_ADMIN_READ_ACCESS, ApiAccessConstants.SUPER_ADMIN_WRITE_ACCESS })
     public Response getErrorAnalysis(
             @Parameter(description = "Start date/time for the log entries report. Accepted format dd-MM-yyyy or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example, 31-12-2025 and 2025-12-31T23:59:59Z.", schema = @Schema(type = "string")) @QueryParam(value = "start_date") @NotNull(message="The attribute 'Start Date Time' is required for this operation")  String startDate,
-            @Parameter(description = "End date/time for the log entries. Accepted format dd-MM-yyyy or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example, 31-12-2025 and 2025-12-31T23:59:59Z.", schema = @Schema(type = "string")) @QueryParam(value = "end_date") @NotNull(message="The attribute 'End Date Time' is required for this operation") String endDate) {
+            @Parameter(description = "End date/time for the log entries. Accepted format dd-MM-yyyy or ISO-8601 date-time like yyyy-MM-ddTHH:mm:ssZ, for example, 31-12-2025 and 2025-12-31T23:59:59Z.", schema = @Schema(type = "string")) @QueryParam(value = "end_date") @NotNull(message="The attribute 'End Date Time' is required for this operation") String endDate,
+            @Parameter(description = "Operation type to report on: REGISTRATION or AUTHENTICATION. Omit to report both together, in which case every rate covers registration and authentication combined.", schema = @Schema(type = "string", allowableValues = { "REGISTRATION", "AUTHENTICATION" })) @QueryParam(value = "operationType") String operationType) {
 
         return rangedAnalytics(startDate, endDate, "Fido2ErrorAnalysis",
-                (start, end) -> fido2MetricsService.getErrorAnalysis(null, start, end));
+                (start, end) -> fido2MetricsService.getErrorAnalysis(null, start, end, operationType));
     }
 
     /**

--- a/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/service/Fido2MetricsService.java
+++ b/jans-config-api/plugins/fido2-plugin/src/main/java/io/jans/configapi/plugin/fido2/service/Fido2MetricsService.java
@@ -30,6 +30,7 @@ public class Fido2MetricsService {
 
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String AUTHORIZATION = "Authorization";
+    private static final String OPERATION_TYPE = "operationType";
     private static final String METRICS_ENTRY_BASE_DN = "ou=fido2-metrics,o=jans";
     private static final String FIDO2_METRICS_BASE_URL = "/jans-fido2/restv1/metrics";
     private static final String FIDO2_METRICS_ENTRIES_URL = "/entries";
@@ -269,7 +270,30 @@ public class Fido2MetricsService {
      */
     public JsonNode getErrorAnalysis(String token, LocalDateTime startTime, LocalDateTime endTime)
             throws JsonProcessingException {
-        return getAnalyticsMetrics(token, this.getErrorAnalysisUrl(), startTime, endTime);
+        return getErrorAnalysis(token, startTime, endTime, null);
+    }
+
+    /**
+     * Get error analysis (error categories, frequencies), optionally for one operation type
+     *
+     * @param startTime     Start time in ISO format
+     * @param endTime       End time in ISO format
+     * @param operationType REGISTRATION or AUTHENTICATION to report that ceremony
+     *                      alone, or null to report both together
+     * @return Error analysis data
+     */
+    public JsonNode getErrorAnalysis(String token, LocalDateTime startTime, LocalDateTime endTime,
+            String operationType) throws JsonProcessingException {
+        // Request headers
+        Map<String, String> headers = buildHeaders(token);
+
+        // Request data
+        Map<String, String> data = buildTimeRange(startTime, endTime);
+        if (StringUtils.isNotBlank(operationType)) {
+            data.put(OPERATION_TYPE, operationType);
+        }
+
+        return getMetricsData(this.getErrorAnalysisUrl(), headers, data);
     }
 
     /**

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -790,7 +790,13 @@ paths:
       tags:
         - FIDO2 Metrics
       summary: Get performance analytics
-      description: Returns performance statistics (average, min, max durations in milliseconds for registration and authentication).
+      description: >-
+        Returns performance statistics (average, min, max durations in milliseconds for registration
+        and authentication). Durations cover only ceremonies that completed - SUCCESS or FAILURE.
+        An abandoned ceremony's recorded duration is how long it stayed open before the sweep
+        claimed it, which measures unfinishedRequestExpiration rather than user-perceived latency,
+        so including it would make these figures track the configured window instead of the server.
+        The keys for an operation type are absent when nothing completed in the range.
       operationId: get-metrics-analytics-performance
       parameters:
         - name: startTime
@@ -823,7 +829,13 @@ paths:
       tags:
         - FIDO2 Metrics
       summary: Get device analytics
-      description: Returns device analytics (device types, OS, browsers, authenticator types).
+      description: >-
+        Returns device analytics (device types, OS, browsers, authenticator types). Counts are per
+        completed ceremony, not per recorded entry: a ceremony writes an ATTEMPT when it starts and
+        a terminal entry when it resolves, so counting entries reported one sign-in more than once.
+        Abandoned ceremonies do not appear - abandonment is recorded off a request thread, which has
+        no device details to read. Still approximate in multi-node deployments, where a ceremony can
+        be recorded more than once.
       operationId: get-metrics-analytics-devices
       parameters:
         - name: startTime
@@ -856,7 +868,11 @@ paths:
       tags:
         - FIDO2 Metrics
       summary: Get error analytics
-      description: Returns error analysis (categories, top errors, success/failure rates).
+      description: >-
+        Returns error analysis (categories, top errors, success/failure rates). Without
+        operationType the tally covers registration and authentication together, which cannot
+        distinguish a deployment with healthy sign-in and poor enrolment from the reverse - pass
+        operationType to report one ceremony at a time.
       operationId: get-metrics-analytics-errors
       parameters:
         - name: startTime
@@ -871,6 +887,15 @@ paths:
           schema:
             type: string
           description: End time (ISO 8601, UTC).
+        - name: operationType
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [REGISTRATION, AUTHENTICATION]
+          description: >-
+            Report this ceremony alone. Omit to report both together, which is the long-standing
+            behaviour of this endpoint.
       responses:
         200:
           description: Error analytics.

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -714,7 +714,12 @@ paths:
       tags:
         - FIDO2 Metrics
       summary: Get aggregation summary
-      description: Returns a single summary over all aggregations in the time range (totals and average success rates).
+      description: >-
+        Returns a single summary over all aggregations in the time range (totals and average success
+        rates). Reads stored aggregations, which are computed once for their period and never
+        recalculated, so periods aggregated before 2.4.0 still carry the duration and device figures
+        computed at the time. Read current latency from analytics/performance, which is computed
+        live from entries.
       operationId: get-metrics-aggregation-summary
       parameters:
         - name: aggregationType
@@ -951,7 +956,11 @@ paths:
       tags:
         - FIDO2 Metrics
       summary: Get trend analysis
-      description: Returns trend data over time for the chosen aggregation granularity, with insights (e.g. direction, growth rate).
+      description: >-
+        Returns trend data over time for the chosen aggregation granularity, with insights (e.g.
+        direction, growth rate). Built from stored aggregations rather than recomputed, so periods
+        aggregated before 2.4.0 still carry the duration and device figures computed at the time and
+        should be read as legacy data.
       operationId: get-metrics-analytics-trends
       parameters:
         - name: aggregationType

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricsConstants.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricsConstants.java
@@ -121,6 +121,7 @@ public final class Fido2MetricsConstants {
     // Query parameter names
     public static final String PARAM_START_TIME = "startTime";
     public static final String PARAM_END_TIME = "endTime";
+    public static final String PARAM_OPERATION_TYPE = "operationType";
     
     // Fallback method constants
     public static final String FALLBACK_METHOD_PASSWORD = "PASSWORD";

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -56,6 +56,12 @@ public class Fido2MetricsService {
     private static final String REJECTION_RATE = "rejectionRate";
     private static final String REJECTION_RATE_NOTE = "rejectionRateNote";
 
+    /** Response keys for the performance analysis, alongside the average in Fido2MetricsConstants. */
+    private static final String REGISTRATION_MIN_DURATION = "registrationMinDuration";
+    private static final String REGISTRATION_MAX_DURATION = "registrationMaxDuration";
+    private static final String AUTHENTICATION_MIN_DURATION = "authenticationMinDuration";
+    private static final String AUTHENTICATION_MAX_DURATION = "authenticationMaxDuration";
+
     private static final String METRICS_ENTRY_BASE_DN = "ou=fido2-metrics,o=jans";
     private static final String METRICS_AGGREGATION_BASE_DN = "ou=fido2-aggregations,o=jans";
 
@@ -391,50 +397,86 @@ public class Fido2MetricsService {
     }
 
     /**
+     * Whether this entry records a ceremony a user was actually present for.
+     * <p>
+     * A ceremony writes more than one entry: an ATTEMPT when it starts, and a terminal entry when it
+     * resolves. The ATTEMPT carries no duration, and an ABANDONED entry's duration is the expiration
+     * window the sweep observed rather than anything the user waited on. Only SUCCESS and FAILURE are
+     * outcomes reached with the user there, and only those occur exactly once per ceremony, so only
+     * those may enter a latency figure or a per-ceremony count.
+     */
+    private static boolean isCompletedCeremony(Fido2MetricsEntry entry) {
+        return Fido2MetricsConstants.SUCCESS.equals(entry.getStatus())
+                || Fido2MetricsConstants.FAILURE.equals(entry.getStatus());
+    }
+
+    /**
      * Get performance metrics
      */
     public Map<String, Object> getPerformanceMetrics(LocalDateTime startTime, LocalDateTime endTime) {
         List<Fido2MetricsEntry> entries = getMetricsEntries(startTime, endTime);
-        
-        Map<String, Object> metrics = new HashMap<>();
-        
-        // Registration performance
-        List<Long> registrationDurations = entries.stream()
-            .filter(e -> "REGISTRATION".equals(e.getOperationType()) && e.getDurationMs() != null)
-            .map(Fido2MetricsEntry::getDurationMs)
-            .collect(Collectors.toList());
-        
-        if (!registrationDurations.isEmpty()) {
-            metrics.put("registrationAvgDuration", registrationDurations.stream().mapToLong(Long::longValue).average().orElse(0.0));
-            metrics.put("registrationMinDuration", registrationDurations.stream().mapToLong(Long::longValue).min().orElse(0L));
-            metrics.put("registrationMaxDuration", registrationDurations.stream().mapToLong(Long::longValue).max().orElse(0L));
-        }
 
-        // Authentication performance
-        List<Long> authenticationDurations = entries.stream()
-            .filter(e -> "AUTHENTICATION".equals(e.getOperationType()) && e.getDurationMs() != null)
-            .map(Fido2MetricsEntry::getDurationMs)
-            .collect(Collectors.toList());
-        
-        if (!authenticationDurations.isEmpty()) {
-            metrics.put("authenticationAvgDuration", authenticationDurations.stream().mapToLong(Long::longValue).average().orElse(0.0));
-            metrics.put("authenticationMinDuration", authenticationDurations.stream().mapToLong(Long::longValue).min().orElse(0L));
-            metrics.put("authenticationMaxDuration", authenticationDurations.stream().mapToLong(Long::longValue).max().orElse(0L));
-        }
+        Map<String, Object> metrics = new HashMap<>();
+
+        putDurationStats(metrics, entries, Fido2MetricsConstants.REGISTRATION,
+                Fido2MetricsConstants.REGISTRATION_AVG_DURATION, REGISTRATION_MIN_DURATION,
+                REGISTRATION_MAX_DURATION);
+        putDurationStats(metrics, entries, Fido2MetricsConstants.AUTHENTICATION,
+                Fido2MetricsConstants.AUTHENTICATION_AVG_DURATION, AUTHENTICATION_MIN_DURATION,
+                AUTHENTICATION_MAX_DURATION);
 
         return metrics;
+    }
+
+    /**
+     * Summarize how long one operation type took, over the ceremonies that completed.
+     * <p>
+     * Abandoned ceremonies are excluded: their recorded duration is how long the ceremony stayed open
+     * before the sweep claimed it, which measures {@code unfinishedRequestExpiration} rather than
+     * user-perceived latency. Including them made the average track the configured window instead of
+     * the server — three sign-ins of about 30ms alongside four abandonments reported roughly 111
+     * seconds.
+     * <p>
+     * The keys are left absent rather than zeroed when nothing completed, which is the behaviour
+     * callers have always seen for an empty range.
+     */
+    private void putDurationStats(Map<String, Object> metrics, List<Fido2MetricsEntry> entries,
+            String operationType, String avgKey, String minKey, String maxKey) {
+        LongSummaryStatistics durations = entries.stream()
+            .filter(e -> operationType.equals(e.getOperationType()))
+            .filter(Fido2MetricsService::isCompletedCeremony)
+            .filter(e -> e.getDurationMs() != null)
+            .mapToLong(Fido2MetricsEntry::getDurationMs)
+            .summaryStatistics();
+
+        if (durations.getCount() == 0) {
+            return;
+        }
+
+        metrics.put(avgKey, durations.getAverage());
+        metrics.put(minKey, durations.getMin());
+        metrics.put(maxKey, durations.getMax());
     }
 
     /**
      * Get device/platform analytics
      */
     public Map<String, Object> getDeviceAnalytics(LocalDateTime startTime, LocalDateTime endTime) {
-        List<Fido2MetricsEntry> entries = getMetricsEntries(startTime, endTime);
-        
+        // Counted per ceremony rather than per entry. A ceremony writes an ATTEMPT at /options and a
+        // terminal entry at /result, and a conditional-UI ceremony writes a further ATTEMPT that the
+        // login page issues on every page load, so grouping every entry counted one sign-in two or
+        // three times. Proportions survived that; absolute counts did not. Abandoned ceremonies
+        // cannot appear here either way — the sweep runs off a request thread and so has no device
+        // details to record. Still approximate in multi-node deployments, where a ceremony can be
+        // recorded more than once.
+        List<Fido2MetricsEntry> ceremonies = getMetricsEntries(startTime, endTime).stream()
+            .filter(Fido2MetricsService::isCompletedCeremony)
+            .collect(Collectors.toList());
+
         Map<String, Object> analytics = new HashMap<>();
-        
+
         // Device types
-        Map<String, Long> deviceTypes = entries.stream()
+        Map<String, Long> deviceTypes = ceremonies.stream()
             .filter(e -> e.getDeviceInfo() != null && e.getDeviceInfo().getDeviceType() != null)
             .collect(Collectors.groupingBy(
                 e -> e.getDeviceInfo().getDeviceType(),
@@ -443,7 +485,7 @@ public class Fido2MetricsService {
         analytics.put("deviceTypes", deviceTypes);
 
         // Authenticator types
-        Map<String, Long> authenticatorTypes = entries.stream()
+        Map<String, Long> authenticatorTypes = ceremonies.stream()
             .filter(e -> e.getAuthenticatorType() != null)
             .collect(Collectors.groupingBy(
                 Fido2MetricsEntry::getAuthenticatorType,
@@ -452,7 +494,7 @@ public class Fido2MetricsService {
         analytics.put("authenticatorTypes", authenticatorTypes);
 
         // Browsers
-        Map<String, Long> browsers = entries.stream()
+        Map<String, Long> browsers = ceremonies.stream()
             .filter(e -> e.getDeviceInfo() != null && e.getDeviceInfo().getBrowser() != null)
             .collect(Collectors.groupingBy(
                 e -> e.getDeviceInfo().getBrowser(),
@@ -461,7 +503,7 @@ public class Fido2MetricsService {
         analytics.put("browsers", browsers);
 
         // Operating systems
-        Map<String, Long> operatingSystems = entries.stream()
+        Map<String, Long> operatingSystems = ceremonies.stream()
             .filter(e -> e.getDeviceInfo() != null && e.getDeviceInfo().getOs() != null)
             .collect(Collectors.groupingBy(
                 e -> e.getDeviceInfo().getOs(),
@@ -473,11 +515,30 @@ public class Fido2MetricsService {
     }
 
     /**
-     * Get error analysis
+     * Get error analysis over both operation types.
      */
     public Map<String, Object> getErrorAnalysis(LocalDateTime startTime, LocalDateTime endTime) {
-        List<Fido2MetricsEntry> entries = getMetricsEntries(startTime, endTime);
-        
+        return getErrorAnalysis(startTime, endTime, null);
+    }
+
+    /**
+     * Get error analysis, optionally for one operation type.
+     * <p>
+     * Pooling registration and authentication makes a deployment with healthy sign-in and poor
+     * enrolment indistinguishable from the reverse: both report the same middling success rate, and
+     * the two have different causes and different fixes. Pooling stays the default so existing
+     * callers see what they always have.
+     *
+     * @param operationType {@link Fido2MetricsConstants#REGISTRATION} or
+     *        {@link Fido2MetricsConstants#AUTHENTICATION} to report that ceremony alone, or null to
+     *        report both together
+     */
+    public Map<String, Object> getErrorAnalysis(LocalDateTime startTime, LocalDateTime endTime,
+            String operationType) {
+        List<Fido2MetricsEntry> entries = getMetricsEntries(startTime, endTime).stream()
+            .filter(e -> operationType == null || operationType.equals(e.getOperationType()))
+            .collect(Collectors.toList());
+
         Map<String, Object> analysis = new HashMap<>();
         
         // Error categories

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -27,7 +27,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import java.util.OptionalDouble;
 
 /**
  * Service for managing FIDO2 metrics data operations
@@ -442,12 +441,7 @@ public class Fido2MetricsService {
      */
     private void putDurationStats(Map<String, Object> metrics, List<Fido2MetricsEntry> entries,
             String operationType, String avgKey, String minKey, String maxKey) {
-        LongSummaryStatistics durations = entries.stream()
-            .filter(e -> operationType.equals(e.getOperationType()))
-            .filter(Fido2MetricsService::isCompletedCeremony)
-            .filter(e -> e.getDurationMs() != null)
-            .mapToLong(Fido2MetricsEntry::getDurationMs)
-            .summaryStatistics();
+        LongSummaryStatistics durations = completedDurations(entries, operationType);
 
         if (durations.getCount() == 0) {
             return;
@@ -456,6 +450,23 @@ public class Fido2MetricsService {
         metrics.put(avgKey, durations.getAverage());
         metrics.put(minKey, durations.getMin());
         metrics.put(maxKey, durations.getMax());
+    }
+
+    /**
+     * How long one operation type took, over the ceremonies that completed.
+     * <p>
+     * Shared by the live analytics and by aggregation generation so both apply one rule. An
+     * aggregation is persisted and never recomputed, so a duration admitted here is one no later fix
+     * can take back out.
+     */
+    private static LongSummaryStatistics completedDurations(List<Fido2MetricsEntry> entries,
+            String operationType) {
+        return entries.stream()
+            .filter(e -> operationType.equals(e.getOperationType()))
+            .filter(Fido2MetricsService::isCompletedCeremony)
+            .filter(e -> e.getDurationMs() != null)
+            .mapToLong(Fido2MetricsEntry::getDurationMs)
+            .summaryStatistics();
     }
 
     /**
@@ -815,8 +826,11 @@ public class Fido2MetricsService {
                 .collect(Collectors.toSet());
             aggregation.setUniqueUsers((long) uniqueUsers.size());
 
-            // Calculate device types
+            // Calculate device types, one per completed ceremony. An ATTEMPT or ABANDONED entry has
+            // no authenticator type to record, so this held by construction; selecting on the
+            // ceremony makes it hold by intent, as it does on the devices endpoint.
             Map<String, Long> deviceTypes = entries.stream()
+                .filter(Fido2MetricsService::isCompletedCeremony)
                 .filter(e -> e.getAuthenticatorType() != null)
                 .collect(Collectors.groupingBy(
                     Fido2MetricsEntry::getAuthenticatorType,
@@ -833,25 +847,20 @@ public class Fido2MetricsService {
                 ));
             metricsData.put(Fido2MetricsConstants.ERROR_COUNTS, errorCounts);
 
-            // Calculate average durations
-            OptionalDouble avgRegistrationDuration = entries.stream()
-                .filter(e -> Fido2MetricsConstants.REGISTRATION.equals(e.getOperationType()) && 
-                           e.getDurationMs() != null)
-                .mapToLong(Fido2MetricsEntry::getDurationMs)
-                .average();
-            
-            if (avgRegistrationDuration.isPresent()) {
-                metricsData.put(Fido2MetricsConstants.REGISTRATION_AVG_DURATION, avgRegistrationDuration.getAsDouble());
+            // Calculate average durations, over the ceremonies that completed. Abandonment records
+            // the expiration window the ceremony sat open rather than user-perceived latency, and an
+            // aggregation row is written once and never recalculated, so admitting one here would
+            // outlive any later correction.
+            LongSummaryStatistics registrationDurations = completedDurations(entries,
+                    Fido2MetricsConstants.REGISTRATION);
+            if (registrationDurations.getCount() > 0) {
+                metricsData.put(Fido2MetricsConstants.REGISTRATION_AVG_DURATION, registrationDurations.getAverage());
             }
 
-            OptionalDouble avgAuthenticationDuration = entries.stream()
-                .filter(e -> Fido2MetricsConstants.AUTHENTICATION.equals(e.getOperationType()) && 
-                           e.getDurationMs() != null)
-                .mapToLong(Fido2MetricsEntry::getDurationMs)
-                .average();
-            
-            if (avgAuthenticationDuration.isPresent()) {
-                metricsData.put(Fido2MetricsConstants.AUTHENTICATION_AVG_DURATION, avgAuthenticationDuration.getAsDouble());
+            LongSummaryStatistics authenticationDurations = completedDurations(entries,
+                    Fido2MetricsConstants.AUTHENTICATION);
+            if (authenticationDurations.getCount() > 0) {
+                metricsData.put(Fido2MetricsConstants.AUTHENTICATION_AVG_DURATION, authenticationDurations.getAverage());
             }
 
             aggregation.setMetricsData(metricsData);

--- a/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/Fido2MetricsController.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/ws/rs/controller/Fido2MetricsController.java
@@ -292,9 +292,11 @@ public class Fido2MetricsController {
 
     /**
      * Get error analysis (error categories, frequencies)
-     * 
+     *
      * @param startTime Start time in ISO format
      * @param endTime End time in ISO format
+     * @param operationType REGISTRATION or AUTHENTICATION to report that ceremony alone; omit to
+     *        report both together, which is what this endpoint has always done
      * @return Error analysis data
      */
     @GET
@@ -302,15 +304,17 @@ public class Fido2MetricsController {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getErrorAnalysis(
             @QueryParam("startTime") String startTime,
-            @QueryParam("endTime") String endTime) {
+            @QueryParam("endTime") String endTime,
+            @QueryParam("operationType") String operationType) {
         return processRequest(() -> {
             checkMetricsEnabled();
-            
+
             LocalDateTime start = parseDateTime(startTime, Fido2MetricsConstants.PARAM_START_TIME);
             LocalDateTime end = parseDateTime(endTime, Fido2MetricsConstants.PARAM_END_TIME);
             validateTimeRange(start, end);
-            
-            Map<String, Object> errors = metricsService.getErrorAnalysis(start, end);
+            String operation = normalizeOptionalOperationType(operationType);
+
+            Map<String, Object> errors = metricsService.getErrorAnalysis(start, end, operation);
             return Response.ok(dataMapperService.writeValueAsString(errors)).build();
         });
     }
@@ -580,6 +584,24 @@ public class Fido2MetricsController {
             );
         }
         return upperType;
+    }
+
+    /**
+     * Normalize and validate an operation type that the caller may omit.
+     * <p>
+     * An absent parameter means "both operation types" and is not an error. A supplied one is held to
+     * the same vocabulary as everywhere else, so a typo is rejected rather than silently reporting an
+     * empty result the caller would read as "no errors".
+     *
+     * @param operationType Operation type to normalize and validate, or null/blank for both
+     * @return Normalized (uppercase) operation type, or null when none was supplied
+     * @throws WebApplicationException if a value was supplied and is invalid
+     */
+    private String normalizeOptionalOperationType(String operationType) {
+        if (operationType == null || operationType.trim().isEmpty()) {
+            return null;
+        }
+        return normalizeOperationType(operationType);
     }
 
     /**

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
@@ -217,6 +217,157 @@ class Fido2MetricsServiceTest {
         assertEquals(0.5, (Double) metrics.get(Fido2MetricsConstants.AUTHENTICATION_SUCCESS_RATE), 0.0001);
     }
 
+    /**
+     * The numbers are the ones measured on a live deployment: three sign-ins of a few tens of
+     * milliseconds alongside four ceremonies the user walked away from. An abandonment's duration is
+     * how long the ceremony stayed open before the sweep claimed it — it measures
+     * unfinishedRequestExpiration, not anything the user waited on — so counting it reported roughly
+     * 111 seconds for sign-ins that actually took about 30 milliseconds.
+     */
+    @Test
+    void getPerformanceMetrics_ifCeremonyWasAbandoned_isExcludedFromTheAverage() {
+        stubMetricsEntries(
+                durationEntry(Fido2MetricsConstants.SUCCESS, 27L),
+                durationEntry(Fido2MetricsConstants.SUCCESS, 35L),
+                durationEntry(Fido2MetricsConstants.SUCCESS, 28L),
+                durationEntry(Fido2MetricsConstants.ABANDONED, 189363L),
+                durationEntry(Fido2MetricsConstants.ABANDONED, 199059L),
+                durationEntry(Fido2MetricsConstants.ABANDONED, 205321L),
+                durationEntry(Fido2MetricsConstants.ABANDONED, 182586L));
+
+        Map<String, Object> metrics = performance();
+
+        assertEquals(30.0, (Double) metrics.get(Fido2MetricsConstants.AUTHENTICATION_AVG_DURATION), 0.0001);
+        assertEquals(27L, metrics.get("authenticationMinDuration"));
+        assertEquals(35L, metrics.get("authenticationMaxDuration"),
+                "the longest completed sign-in, not the longest a ceremony sat open");
+    }
+
+    /**
+     * A rejected ceremony is still one the user waited on, so its duration is real latency and stays
+     * in. Only abandonment — where nothing was ever posted back — is excluded.
+     */
+    @Test
+    void getPerformanceMetrics_countsFailureAsACompletedCeremony() {
+        stubMetricsEntries(
+                durationEntry(Fido2MetricsConstants.SUCCESS, 40L),
+                durationEntry(Fido2MetricsConstants.FAILURE, 60L));
+
+        assertEquals(50.0, (Double) performance().get(Fido2MetricsConstants.AUTHENTICATION_AVG_DURATION), 0.0001);
+    }
+
+    /**
+     * With nothing completed there is no latency to report. The keys stay absent rather than
+     * reporting a zero that reads as an instant sign-in.
+     */
+    @Test
+    void getPerformanceMetrics_ifNothingCompleted_emitsNoDurationKeys() {
+        stubMetricsEntries(
+                durationEntry(Fido2MetricsConstants.ABANDONED, 189363L),
+                statusEntry(Fido2MetricsConstants.ATTEMPT));
+
+        Map<String, Object> metrics = performance();
+
+        assertNull(metrics.get(Fido2MetricsConstants.AUTHENTICATION_AVG_DURATION));
+        assertNull(metrics.get("authenticationMaxDuration"));
+    }
+
+    /**
+     * A completed ceremony writes two entries — the ATTEMPT at /options and the terminal one at
+     * /result — and both carry the device details of the same request. Grouping entries therefore
+     * reported one sign-in as two devices.
+     */
+    @Test
+    void getDeviceAnalytics_ifCeremonyWritesAttemptAndTerminalEntry_countsTheDeviceOnce() {
+        stubMetricsEntries(
+                browserEntry(Fido2MetricsConstants.ATTEMPT, "Chrome"),
+                browserEntry(Fido2MetricsConstants.SUCCESS, "Chrome"));
+
+        assertEquals(Map.of("Chrome", 1L), browsers());
+    }
+
+    /**
+     * The login page issues a usernameless ceremony on every page load, each of which records an
+     * ATTEMPT that no terminal entry ever follows. Counting attempts would therefore have inflated
+     * the breakdown by page views rather than by sign-ins.
+     */
+    @Test
+    void getDeviceAnalytics_ifConditionalUiAttemptIsPresent_isNotCounted() {
+        stubMetricsEntries(
+                browserEntry(Fido2MetricsConstants.ATTEMPT, "Safari"),
+                browserEntry(Fido2MetricsConstants.ATTEMPT, "Chrome"),
+                browserEntry(Fido2MetricsConstants.SUCCESS, "Chrome"));
+
+        assertEquals(Map.of("Chrome", 1L), browsers(),
+                "an attempt that never resolved is not a ceremony this breakdown can count");
+    }
+
+    /**
+     * Pooling the two ceremonies made a deployment with healthy sign-in and poor enrolment
+     * indistinguishable from the reverse: both report the same middling rate.
+     */
+    @Test
+    void getErrorAnalysis_ifOperationTypeGiven_excludesTheOtherOperation() {
+        stubMetricsEntries(
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.FAILURE));
+
+        Map<String, Object> authentication = fido2MetricsService.getErrorAnalysis(
+                LocalDateTime.now().minusDays(1), LocalDateTime.now(), Fido2MetricsConstants.AUTHENTICATION);
+        Map<String, Object> registration = fido2MetricsService.getErrorAnalysis(
+                LocalDateTime.now().minusDays(1), LocalDateTime.now(), Fido2MetricsConstants.REGISTRATION);
+
+        assertEquals(1.0, (Double) authentication.get(Fido2MetricsConstants.SUCCESS_RATE), 0.0001);
+        assertEquals(0.0, (Double) registration.get(Fido2MetricsConstants.SUCCESS_RATE), 0.0001);
+        assertEquals(1.0, (Double) registration.get(Fido2MetricsConstants.FAILURE_RATE), 0.0001);
+    }
+
+    /**
+     * Omitting the parameter must keep the long-standing pooled behaviour, so existing callers see
+     * no change.
+     */
+    @Test
+    void getErrorAnalysis_ifOperationTypeAbsent_poolsBothAsBefore() {
+        stubMetricsEntries(
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.FAILURE));
+
+        Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now());
+
+        assertEquals(0.5, (Double) analysis.get(Fido2MetricsConstants.SUCCESS_RATE), 0.0001);
+        assertEquals(0.5, (Double) analysis.get(Fido2MetricsConstants.FAILURE_RATE), 0.0001);
+    }
+
+    private Map<String, Object> performance() {
+        return fido2MetricsService.getPerformanceMetrics(LocalDateTime.now().minusDays(1), LocalDateTime.now());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Long> browsers() {
+        return (Map<String, Long>) fido2MetricsService
+                .getDeviceAnalytics(LocalDateTime.now().minusDays(1), LocalDateTime.now())
+                .get("browsers");
+    }
+
+    private Fido2MetricsEntry durationEntry(String status, long durationMs) {
+        Fido2MetricsEntry entry = statusEntry(status);
+        entry.setDurationMs(durationMs);
+        return entry;
+    }
+
+    private Fido2MetricsEntry browserEntry(String status, String browser) {
+        Fido2MetricsEntry entry = statusEntry(status);
+        Fido2MetricsEntry.DeviceInfo deviceInfo = new Fido2MetricsEntry.DeviceInfo();
+        deviceInfo.setBrowser(browser);
+        entry.setDeviceInfo(deviceInfo);
+        return entry;
+    }
+
     private Map<String, Object> aggregate(Fido2MetricsEntry... entries) {
         stubMetricsEntries(entries);
 

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
@@ -343,6 +343,36 @@ class Fido2MetricsServiceTest {
         assertEquals(0.5, (Double) analysis.get(Fido2MetricsConstants.FAILURE_RATE), 0.0001);
     }
 
+    /**
+     * The same exclusion has to hold when an aggregation is generated, and matters more there: an
+     * aggregation row is persisted and never recalculated, and the retention sweep clears raw entries
+     * without clearing aggregations, so a duration admitted here cannot be recomputed away afterwards.
+     */
+    @Test
+    void aggregation_ifCeremonyWasAbandoned_isExcludedFromTheAverageDuration() {
+        Map<String, Object> metrics = aggregate(
+                durationEntry(Fido2MetricsConstants.SUCCESS, 27L),
+                durationEntry(Fido2MetricsConstants.SUCCESS, 35L),
+                durationEntry(Fido2MetricsConstants.SUCCESS, 28L),
+                durationEntry(Fido2MetricsConstants.ABANDONED, 189363L),
+                durationEntry(Fido2MetricsConstants.ABANDONED, 199059L));
+
+        assertEquals(30.0, (Double) metrics.get(Fido2MetricsConstants.AUTHENTICATION_AVG_DURATION), 0.0001);
+    }
+
+    /**
+     * An ATTEMPT never carries an authenticator type, so it was already absent from this breakdown;
+     * the selection now says so rather than relying on that.
+     */
+    @Test
+    void aggregation_countsDeviceTypesPerCompletedCeremony() {
+        Map<String, Object> metrics = aggregate(
+                authenticatorEntry(Fido2MetricsConstants.ATTEMPT, "PLATFORM"),
+                authenticatorEntry(Fido2MetricsConstants.SUCCESS, "PLATFORM"));
+
+        assertEquals(Map.of("PLATFORM", 1L), metrics.get(Fido2MetricsConstants.DEVICE_TYPES));
+    }
+
     private Map<String, Object> performance() {
         return fido2MetricsService.getPerformanceMetrics(LocalDateTime.now().minusDays(1), LocalDateTime.now());
     }
@@ -357,6 +387,12 @@ class Fido2MetricsServiceTest {
     private Fido2MetricsEntry durationEntry(String status, long durationMs) {
         Fido2MetricsEntry entry = statusEntry(status);
         entry.setDurationMs(durationMs);
+        return entry;
+    }
+
+    private Fido2MetricsEntry authenticatorEntry(String status, String authenticatorType) {
+        Fido2MetricsEntry entry = statusEntry(status);
+        entry.setAuthenticatorType(authenticatorType);
         return entry;
     }
 


### PR DESCRIPTION
### Description

Three analytics endpoints aggregated over row sets that did not match what they reported.
analytics/performance averaged abandoned ceremonies into latency, reporting ~111s where sign-ins actually took ~30ms; analytics/devices counted one ceremony two or three times; analytics/errors pooled registration with authentication.
All three are corrected at the read path, so existing rows report correctly with no schema change and no migration.
analytics/errors now accepts an optional operationType; omitted, it pools exactly as before, and the config-api fido2 plugin passes it through.


#### Target issue

An abandoned ceremony records the expiration window it sat open, not user-perceived latency, so folding it into the average made analytics/performance track configuration instead of the server.
A completed ceremony writes an ATTEMPT and a terminal entry, so grouping entries double-counted devices, browsers and operating systems.
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14829

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional filtering for FIDO2 error analytics by registration or authentication operation.
  * Combined error results remain available when no operation filter is provided.

* **Bug Fixes**
  * Performance analytics now exclude abandoned ceremonies and include only completed ceremonies with recorded durations.
  * Device and platform analytics now count completed ceremonies more accurately.

* **Documentation**
  * Updated analytics documentation to clarify counting, exclusions, duration metrics, and operation-specific filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->