### PR TITLE
docs(cedarling): note relative ratios use full-precision mean_ns

### DIFF
--- a/jans-cedarling/scripts/parse_binding_benchmarks.py
+++ b/jans-cedarling/scripts/parse_binding_benchmarks.py
@@ -213,6 +213,10 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
     # compares speed across bindings without implying batch/non-batch rows are
     # comparable to each other.
     out.append("### Relative speed per scenario (x, lower = faster)\n\n")
+    out.append(
+        "_Ratios are computed from full-precision `mean_ns`, so they may not "
+        "match dividing the rounded µs values shown above._\n\n"
+    )
     out.append("| Scenario | " + " | ".join(bindings) + " |\n")
     out.append("|----------|" + "|".join(["----------:"] * len(bindings)) + "|\n")
     bar_width = 10


### PR DESCRIPTION
Review follow-up: the relative-speed ratios divide raw `mean_ns`, so they won't exactly match dividing the rounded µs values shown in the mean table. Generator now prints a note under the relative-speed heading, so regenerated reports retain the clarification.
Closes #14840, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note to benchmark reports clarifying that relative-speed ratios use full-precision measurements and may differ from ratios based on rounded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->