### PR TITLE
feat(jans-auth-server): pass amr from agama to id_token #14781

### DIFF
--- a/docs/janssen-server/auth-server/tokens/openid-id-token.md
+++ b/docs/janssen-server/auth-server/tokens/openid-id-token.md
@@ -49,6 +49,15 @@ authentication event, not user claims. You can configure the client to "include
 claims in id_token", or you can set a Auth Server configuration property,
 `legacyIdTokenClaims` to `True` to set the behavior for all clients.
 
+The `amr` (Authentication Methods References) claim is normally derived from the
+authentication method (acr) used for the session. When authentication is performed
+through an [Agama](../../developer/agama/jans-agama-engine.md) flow, the flow itself
+can additionally report the authentication method(s) it enforced by including an
+`amr` entry in the `data` passed to `Finish`; this value is merged into the `amr`
+claim of the resulting `id_token`. See
+[Authentication and `Finish`](../../developer/agama/jans-agama-engine.md#authentication-and-finish)
+for details.
+
 ## Obtaining an ID Token
 
 The client may obtain an ID Token in the authorization response, from the

--- a/docs/janssen-server/auth-server/tokens/openid-id-token.md
+++ b/docs/janssen-server/auth-server/tokens/openid-id-token.md
@@ -49,7 +49,7 @@ authentication event, not user claims. You can configure the client to "include
 claims in id_token", or you can set a Auth Server configuration property,
 `legacyIdTokenClaims` to `True` to set the behavior for all clients.
 
-The `amr` (Authentication Methods References) claim is normally derived from the
+The `amr` (Authentication Method References) claim is normally derived from the
 authentication method (acr) used for the session. When authentication is performed
 through an [Agama](../../developer/agama/jans-agama-engine.md) flow, the flow itself
 can additionally report the authentication method(s) it enforced by including an

--- a/docs/janssen-server/developer/agama/jans-agama-engine.md
+++ b/docs/janssen-server/developer/agama/jans-agama-engine.md
@@ -58,7 +58,7 @@ obj = { success: true, data: { userId: "john_doe", amr: "otp" } }
 Finish obj
 ```
 
-`amr` may be a single string or an array of strings; blank entries are ignored. If `agamaData` is missing, or does not contain a usable `amr` value, nothing is added to the claim - this and other related situations are logged at `TRACE` level by the authentication server, which is useful for troubleshooting cases where the expected `amr` value does not appear in the issued `id_token`.
+`amr` may be a single string or an array of strings; blank entries are ignored. If `agamaData` is missing, or does not contain a usable `amr` value, nothing is added to the claim; the authentication server logs this at `TRACE` level, which is useful for troubleshooting cases where the expected `amr` value does not appear in the issued `id_token`. If `agamaData` is present but is not valid JSON, nothing is added to the claim either, but this is logged at `ERROR` level instead, since it indicates a malformed session attribute rather than simply an absent `amr` value.
 
 ## Crashes, timeouts, and failures
 

--- a/docs/janssen-server/developer/agama/jans-agama-engine.md
+++ b/docs/janssen-server/developer/agama/jans-agama-engine.md
@@ -51,6 +51,15 @@ By default `userId` maps to the `uid` attribute that generally all user entries 
 
 When the authentication succeeds, the whole contents of `data` are stored in the authentication server's session of the given user under the key `agamaData`. Contents are serialized to a JSON string previously.
 
+If `data` also includes an `amr` key, its value is propagated to the `amr` claim of the `id_token` issued for the session, in addition to whatever value(s) the authentication method normally contributes to that claim. This lets a flow report which authentication method(s) it actually enforced, for example:
+
+```
+obj = { success: true, data: { userId: "john_doe", amr: "otp" } }
+Finish obj
+```
+
+`amr` may be a single string or an array of strings; blank entries are ignored. If `agamaData` is missing, or does not contain a usable `amr` value, nothing is added to the claim - this and other related situations are logged at `TRACE` level by the authentication server, which is useful for troubleshooting cases where the expected `amr` value does not appear in the issued `id_token`.
+
 ## Crashes, timeouts, and failures
 
 [Execution rules](../../../agama/execution-rules.md) define several possible [flow states](../../../agama/execution-rules.md#flows-lifecycle). For crashed, timed out, and finished failed flows, the engine will present proper error pages to users. These are configurable by properties `crashErrorPage`, `interruptionErrorPage`, and `finishedFlowPage` respectively, of the [engine-configuration](./engine-bridge-config.md#engine-configuration).

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
@@ -140,7 +140,9 @@ public class IdTokenFactory {
             addToAmrList(amrList, amrMap);
         }
 
-        addAgamaAmr(amrList, session);
+        if (AcrService.isAgama(acrValues)) {
+            addAgamaAmr(amrList, session);
+        }
 
         jwt.getClaims().setClaim(JwtClaimName.AUTHENTICATION_METHOD_REFERENCES, amrList);
     }

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
@@ -45,6 +45,8 @@ import jakarta.inject.Named;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 
@@ -71,6 +73,9 @@ import static io.jans.as.server.token.ws.rs.TokenExchangeService.DEVICE_SECRET;
 @Stateless
 @Named
 public class IdTokenFactory {
+
+    static final String AGAMA_DATA_SESSION_ATTR_KEY = "agamaData";
+    static final String AGAMA_AMR_KEY = "amr";
 
     @Inject
     private Logger log;
@@ -108,7 +113,7 @@ public class IdTokenFactory {
     @Inject
     private ExternalAuthorizationChallengeService externalAuthorizationChallengeService;
 
-    private void setAmrClaim(JsonWebResponse jwt, String acrValues, Client client) {
+    void setAmrClaim(JsonWebResponse jwt, String acrValues, Client client, SessionId session) {
         List<String> amrList = Lists.newArrayList();
 
         CustomScriptConfiguration script = externalAuthenticationService.getCustomScriptConfigurationByName(acrValues);
@@ -135,6 +140,8 @@ public class IdTokenFactory {
             addToAmrList(amrList, amrMap);
         }
 
+        addAgamaAmr(amrList, session);
+
         jwt.getClaims().setClaim(JwtClaimName.AUTHENTICATION_METHOD_REFERENCES, amrList);
     }
 
@@ -144,6 +151,74 @@ public class IdTokenFactory {
                 amrList.add(entry.getKey() + ":" + entry.getValue());
             }
         }
+    }
+
+    /**
+     * Agama flows can report which authentication method(s) were actually used by putting an
+     * "amr" entry in the "agamaData" session attribute (a JSON object serialized as a string,
+     * see AgamaBridge.py). Propagate it into the id_token's amr claim.
+     */
+    void addAgamaAmr(List<String> amrList, SessionId session) {
+        if (session == null) {
+            log.trace("Unable to propagate amr from agama - session is not available");
+            return;
+        }
+
+        String agamaDataAsJson = session.getSessionAttributes().get(AGAMA_DATA_SESSION_ATTR_KEY);
+        if (StringUtils.isBlank(agamaDataAsJson)) {
+            log.trace("Unable to propagate amr from agama - '{}' session attribute is not set, session id: {}", AGAMA_DATA_SESSION_ATTR_KEY, session.getId());
+            return;
+        }
+
+        try {
+            List<String> agamaAmr = parseAgamaAmr(agamaDataAsJson);
+            if (agamaAmr.isEmpty()) {
+                log.trace("Unable to propagate amr from agama - no non-blank '{}' entry found in '{}' session attribute, session id: {}", AGAMA_AMR_KEY, AGAMA_DATA_SESSION_ATTR_KEY, session.getId());
+                return;
+            }
+
+            for (String amrValue : agamaAmr) {
+                if (amrList.contains(amrValue)) {
+                    log.trace("Amr value '{}' from agama is already present in id_token amr claim, session id: {}", amrValue, session.getId());
+                    continue;
+                }
+                amrList.add(amrValue);
+                log.trace("Propagated amr value '{}' from agama session attribute '{}' into id_token amr claim, session id: {}", amrValue, AGAMA_DATA_SESSION_ATTR_KEY, session.getId());
+            }
+        } catch (JSONException e) {
+            log.error("Unable to propagate amr from agama - failed to parse '{}' session attribute as JSON, session id: {}", AGAMA_DATA_SESSION_ATTR_KEY, session.getId());
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Extracts the "amr" entry (a single string or an array of strings) from the "agamaData"
+     * JSON payload. Returns an empty list when the key is absent or blank.
+     */
+    static List<String> parseAgamaAmr(String agamaDataAsJson) throws JSONException {
+        List<String> result = Lists.newArrayList();
+
+        JSONObject agamaData = new JSONObject(agamaDataAsJson);
+        if (!agamaData.has(AGAMA_AMR_KEY)) {
+            return result;
+        }
+
+        Object amr = agamaData.get(AGAMA_AMR_KEY);
+        if (amr instanceof JSONArray) {
+            JSONArray amrArray = (JSONArray) amr;
+            for (int i = 0; i < amrArray.length(); i++) {
+                String amrValue = amrArray.optString(i, null);
+                if (StringUtils.isNotBlank(amrValue)) {
+                    result.add(amrValue);
+                }
+            }
+        } else {
+            String amrValue = agamaData.optString(AGAMA_AMR_KEY, null);
+            if (StringUtils.isNotBlank(amrValue)) {
+                result.add(amrValue);
+            }
+        }
+        return result;
     }
 
     private void fillClaims(JsonWebResponse jwr,
@@ -192,7 +267,7 @@ public class IdTokenFactory {
         acrValues = AcrService.removeParametersFromAgamaAcr(acrValues);
         if (acrValues != null) {
             jwr.setClaim(JwtClaimName.AUTHENTICATION_CONTEXT_CLASS_REFERENCE, acrValues);
-            setAmrClaim(jwr, acrValues, client);
+            setAmrClaim(jwr, acrValues, client, session);
         }
         String nonce = executionContext.getNonce();
         if (StringUtils.isNotBlank(nonce)) {

--- a/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
+++ b/jans-auth-server/server/src/main/java/io/jans/as/server/model/token/IdTokenFactory.java
@@ -207,16 +207,13 @@ public class IdTokenFactory {
         if (amr instanceof JSONArray) {
             JSONArray amrArray = (JSONArray) amr;
             for (int i = 0; i < amrArray.length(); i++) {
-                String amrValue = amrArray.optString(i, null);
-                if (StringUtils.isNotBlank(amrValue)) {
-                    result.add(amrValue);
+                Object amrElement = amrArray.get(i);
+                if (amrElement instanceof String && StringUtils.isNotBlank((String) amrElement)) {
+                    result.add((String) amrElement);
                 }
             }
-        } else {
-            String amrValue = agamaData.optString(AGAMA_AMR_KEY, null);
-            if (StringUtils.isNotBlank(amrValue)) {
-                result.add(amrValue);
-            }
+        } else if (amr instanceof String && StringUtils.isNotBlank((String) amr)) {
+            result.add((String) amr);
         }
         return result;
     }

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/model/token/IdTokenFactoryTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/model/token/IdTokenFactoryTest.java
@@ -79,6 +79,27 @@ public class IdTokenFactoryTest {
         assertEquals(amr, List.of("otp", "sms"));
     }
 
+    @Test
+    public void parseAgamaAmr_whenAmrIsNonStringScalar_shouldReturnEmptyList() throws JSONException {
+        List<String> amr = IdTokenFactory.parseAgamaAmr("{\"amr\":123}");
+
+        assertTrue(amr.isEmpty());
+    }
+
+    @Test
+    public void parseAgamaAmr_whenAmrIsBoolean_shouldReturnEmptyList() throws JSONException {
+        List<String> amr = IdTokenFactory.parseAgamaAmr("{\"amr\":true}");
+
+        assertTrue(amr.isEmpty());
+    }
+
+    @Test
+    public void parseAgamaAmr_whenAmrArrayHasNonStringElements_shouldSkipThem() throws JSONException {
+        List<String> amr = IdTokenFactory.parseAgamaAmr("{\"amr\":[\"otp\", 123, true, \"sms\"]}");
+
+        assertEquals(amr, List.of("otp", "sms"));
+    }
+
     @Test(expectedExceptions = JSONException.class)
     public void parseAgamaAmr_whenJsonIsMalformed_shouldThrow() throws JSONException {
         IdTokenFactory.parseAgamaAmr("not-a-json-object");

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/model/token/IdTokenFactoryTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/model/token/IdTokenFactoryTest.java
@@ -203,6 +203,24 @@ public class IdTokenFactoryTest {
         assertEquals(jwt.getClaims().getClaim(JwtClaimName.AUTHENTICATION_METHOD_REFERENCES), List.of("some-amr"));
     }
 
+    @Test
+    public void setAmrClaim_whenAcrIsNotAgamaButSessionHasStaleAgamaData_shouldNotMergeAgamaAmr() {
+        when(externalAuthenticationService.getCustomScriptConfigurationByName("basic")).thenReturn(null);
+        when(externalAuthorizationChallengeService.getAuthenticationMethodClaims(any(ExecutionContext.class)))
+                .thenReturn(new HashMap<>());
+
+        Jwt jwt = new Jwt();
+        Client client = new Client();
+        client.setClientId("client1");
+        // session was previously authenticated via an agama flow and still carries its agamaData,
+        // but this particular id_token corresponds to a non-agama acr
+        SessionId session = sessionWithAgamaData("{\"userId\":\"admin\",\"amr\":\"some-amr\"}");
+
+        idTokenFactory.setAmrClaim(jwt, "basic", client, session);
+
+        assertEquals(jwt.getClaims().getClaim(JwtClaimName.AUTHENTICATION_METHOD_REFERENCES), List.of());
+    }
+
     private static List<String> newAmrList(String... values) {
         List<String> amrList = new ArrayList<>();
         for (String value : values) {

--- a/jans-auth-server/server/src/test/java/io/jans/as/server/model/token/IdTokenFactoryTest.java
+++ b/jans-auth-server/server/src/test/java/io/jans/as/server/model/token/IdTokenFactoryTest.java
@@ -1,0 +1,205 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2020, Janssen Project
+ */
+
+package io.jans.as.server.model.token;
+
+import io.jans.as.common.model.registration.Client;
+import io.jans.as.common.model.session.SessionId;
+import io.jans.as.model.jwt.Jwt;
+import io.jans.as.model.jwt.JwtClaimName;
+import io.jans.as.server.model.common.ExecutionContext;
+import io.jans.as.server.service.external.ExternalAuthenticationService;
+import io.jans.as.server.service.external.ExternalAuthorizationChallengeService;
+import org.json.JSONException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class IdTokenFactoryTest {
+
+    @InjectMocks
+    private IdTokenFactory idTokenFactory;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private ExternalAuthenticationService externalAuthenticationService;
+
+    @Mock
+    private ExternalAuthorizationChallengeService externalAuthorizationChallengeService;
+
+    @Test
+    public void parseAgamaAmr_whenAmrKeyMissing_shouldReturnEmptyList() throws JSONException {
+        List<String> amr = IdTokenFactory.parseAgamaAmr("{\"userId\":\"admin\"}");
+
+        assertTrue(amr.isEmpty());
+    }
+
+    @Test
+    public void parseAgamaAmr_whenAmrIsBlankString_shouldReturnEmptyList() throws JSONException {
+        List<String> amr = IdTokenFactory.parseAgamaAmr("{\"amr\":\"\"}");
+
+        assertTrue(amr.isEmpty());
+    }
+
+    @Test
+    public void parseAgamaAmr_whenAmrIsString_shouldReturnSingletonList() throws JSONException {
+        List<String> amr = IdTokenFactory.parseAgamaAmr("{\"userId\":\"admin\",\"amr\":\"some-amr\"}");
+
+        assertEquals(amr, List.of("some-amr"));
+    }
+
+    @Test
+    public void parseAgamaAmr_whenAmrIsArray_shouldReturnAllNonBlankValues() throws JSONException {
+        List<String> amr = IdTokenFactory.parseAgamaAmr("{\"amr\":[\"otp\", \"\", \"sms\"]}");
+
+        assertEquals(amr, List.of("otp", "sms"));
+    }
+
+    @Test(expectedExceptions = JSONException.class)
+    public void parseAgamaAmr_whenJsonIsMalformed_shouldThrow() throws JSONException {
+        IdTokenFactory.parseAgamaAmr("not-a-json-object");
+    }
+
+    @Test
+    public void addAgamaAmr_whenSessionIsNull_shouldNotChangeAmrListAndLogTrace() {
+        List<String> amrList = newAmrList("10");
+
+        idTokenFactory.addAgamaAmr(amrList, null);
+
+        assertEquals(amrList, List.of("10"));
+        verify(log).trace("Unable to propagate amr from agama - session is not available");
+    }
+
+    @Test
+    public void addAgamaAmr_whenAgamaDataAttributeIsAbsent_shouldNotChangeAmrListAndLogTrace() {
+        List<String> amrList = newAmrList("10");
+        SessionId session = sessionWithAttributes(new HashMap<>());
+
+        idTokenFactory.addAgamaAmr(amrList, session);
+
+        assertEquals(amrList, List.of("10"));
+        verify(log).trace(
+                eq("Unable to propagate amr from agama - '{}' session attribute is not set, session id: {}"),
+                eq(IdTokenFactory.AGAMA_DATA_SESSION_ATTR_KEY), eq(session.getId()));
+    }
+
+    @Test
+    public void addAgamaAmr_whenAgamaDataHasNoAmrKey_shouldNotChangeAmrListAndLogTrace() {
+        List<String> amrList = newAmrList("10");
+        SessionId session = sessionWithAgamaData("{\"userId\":\"admin\"}");
+
+        idTokenFactory.addAgamaAmr(amrList, session);
+
+        assertEquals(amrList, List.of("10"));
+        verify(log).trace(
+                eq("Unable to propagate amr from agama - no non-blank '{}' entry found in '{}' session attribute, session id: {}"),
+                eq(IdTokenFactory.AGAMA_AMR_KEY), eq(IdTokenFactory.AGAMA_DATA_SESSION_ATTR_KEY), eq(session.getId()));
+    }
+
+    @Test
+    public void addAgamaAmr_whenAgamaDataHasAmrString_shouldAppendItAndLogTrace() {
+        List<String> amrList = newAmrList("10");
+        SessionId session = sessionWithAgamaData("{\"userId\":\"admin\",\"amr\":\"some-amr\"}");
+
+        idTokenFactory.addAgamaAmr(amrList, session);
+
+        assertEquals(amrList, List.of("10", "some-amr"));
+        verify(log).trace(
+                eq("Propagated amr value '{}' from agama session attribute '{}' into id_token amr claim, session id: {}"),
+                eq("some-amr"), eq(IdTokenFactory.AGAMA_DATA_SESSION_ATTR_KEY), eq(session.getId()));
+    }
+
+    @Test
+    public void addAgamaAmr_whenAgamaDataHasAmrArray_shouldAppendAllValues() {
+        List<String> amrList = newAmrList("10");
+        SessionId session = sessionWithAgamaData("{\"amr\":[\"otp\",\"sms\"]}");
+
+        idTokenFactory.addAgamaAmr(amrList, session);
+
+        assertEquals(amrList, List.of("10", "otp", "sms"));
+    }
+
+    @Test
+    public void addAgamaAmr_whenAmrValueAlreadyPresent_shouldNotDuplicateAndLogTrace() {
+        List<String> amrList = newAmrList("some-amr");
+        SessionId session = sessionWithAgamaData("{\"amr\":\"some-amr\"}");
+
+        idTokenFactory.addAgamaAmr(amrList, session);
+
+        assertEquals(amrList, List.of("some-amr"));
+        verify(log).trace(
+                eq("Amr value '{}' from agama is already present in id_token amr claim, session id: {}"),
+                eq("some-amr"), eq(session.getId()));
+    }
+
+    @Test
+    public void addAgamaAmr_whenAgamaDataIsMalformedJson_shouldLogErrorAndNotThrow() {
+        List<String> amrList = newAmrList("10");
+        SessionId session = sessionWithAgamaData("not-a-json-object");
+
+        idTokenFactory.addAgamaAmr(amrList, session);
+
+        assertEquals(amrList, List.of("10"));
+    }
+
+    @Test
+    public void setAmrClaim_whenAgamaDataHasAmr_shouldMergeIntoAmrClaim() {
+        when(externalAuthenticationService.getCustomScriptConfigurationByName("agama_co.test")).thenReturn(null);
+        when(externalAuthorizationChallengeService.getAuthenticationMethodClaims(any(ExecutionContext.class)))
+                .thenReturn(new HashMap<>());
+
+        Jwt jwt = new Jwt();
+        Client client = new Client();
+        client.setClientId("client1");
+        SessionId session = sessionWithAgamaData("{\"userId\":\"admin\",\"amr\":\"some-amr\"}");
+
+        idTokenFactory.setAmrClaim(jwt, "agama_co.test", client, session);
+
+        assertEquals(jwt.getClaims().getClaim(JwtClaimName.AUTHENTICATION_METHOD_REFERENCES), List.of("some-amr"));
+    }
+
+    private static List<String> newAmrList(String... values) {
+        List<String> amrList = new ArrayList<>();
+        for (String value : values) {
+            amrList.add(value);
+        }
+        return amrList;
+    }
+
+    private static SessionId sessionWithAgamaData(String agamaDataAsJson) {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(IdTokenFactory.AGAMA_DATA_SESSION_ATTR_KEY, agamaDataAsJson);
+        return sessionWithAttributes(attributes);
+    }
+
+    private static SessionId sessionWithAttributes(Map<String, String> attributes) {
+        SessionId session = new SessionId();
+        session.setId("session-1");
+        session.setSessionAttributes(attributes);
+        return session;
+    }
+}


### PR DESCRIPTION
### Description

feat(jans-auth-server): pass amr from agama to id_token 

Agama flows can report the authentication method(s) they actually used by writing an amr entry into the agamaData session attribute — a JSON object (serialized as a string) that Agama's Finish directive stores on the session via AgamaBridge.py (e.g. "agamaData": "{\"userId\":\"admin\",\"amr\":\"some-amr\"}"). Previously this value was never surfaced anywhere: IdTokenFactory.setAmrClaim derives the amr claim purely from the acr's custom-auth-script (ExternalAuthenticationService.getCustomScriptConfigurationByName), and for Agama flows that script (AgamaBridge.py) always returns null/None for getAuthenticationMethodClaims, so the flow's own reported amr was silently dropped.

#### Target issue
  
closes #14781

### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ID tokens now include authentication methods reported by Agama flows in the `amr` claim.
  * Supports single or multiple authentication method values while ignoring blank or duplicate entries.
* **Bug Fixes**
  * Malformed or missing authentication data is handled safely without disrupting token generation.
* **Documentation**
  * Added guidance and examples for configuring Agama authentication methods in ID tokens.
* **Tests**
  * Added coverage for parsing, merging, duplicate prevention, and malformed authentication data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->