### PR TITLE
fix(jans-cedarling): fix cargo lint check  

### DIFF
--- a/jans-cedarling/cedarling/src/lib.rs
+++ b/jans-cedarling/cedarling/src/lib.rs
@@ -263,13 +263,13 @@ impl Cedarling {
     }
 
     // The following public methods retain async signatures for API compatibility
-    // to avoid breaking changes. They use #[allow(clippy::unused_async)] since
+    // to avoid breaking changes. They use #[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)] since
     // they no longer await internally. Future maintainers can safely remove
     // or refactor these methods when compatibility constraints allow.
 
     /// Authorize request with unsigned data.
     /// makes authorization decision based on the [`RequestUnverified`]
-    #[allow(clippy::unused_async)]
+    #[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn authorize_unsigned(
         &self,
         request: RequestUnsigned,
@@ -287,7 +287,7 @@ impl Cedarling {
     /// Batch-level failures (validation, principal parse) return `Err(AuthorizeError)`;
     /// per-item failures are returned as `Err(BatchItemError)` for that item,
     /// while genuine Cedar denials remain `Ok(AuthorizeResult)` with `decision=false`.
-    #[allow(clippy::unused_async)]
+    #[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn authorize_unsigned_batch(
         &self,
         request: BatchAuthorizeUnsignedRequest,
@@ -298,7 +298,7 @@ impl Cedarling {
 
     /// Authorize multi-issuer request.
     /// makes authorization decision based on multiple JWT tokens from different issuers
-    #[allow(clippy::unused_async)]
+    #[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn authorize_multi_issuer(
         &self,
         request: AuthorizeMultiIssuerRequest,
@@ -315,7 +315,7 @@ impl Cedarling {
     /// status-list refresh) return `Err(AuthorizeError)`; per-item failures are
     /// returned as `Err(BatchItemError)`, while genuine Cedar denials remain
     /// `Ok(MultiIssuerAuthorizeResult)` with `decision=false`.
-    #[allow(clippy::unused_async)]
+    #[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn authorize_multi_issuer_batch(
         &self,
         request: BatchAuthorizeMultiIssuerRequest,


### PR DESCRIPTION
Clippy 1.98 added `unused_async_trait_impl`, which fires on the four public `async fn` on `Cedarling` that no longer `.await` internally. Dropping `async` would break the public API, so widen the existing `unused_async` allow instead.

`unknown_lints` is included so the attribute stays quiet on the pinned 1.95.0 toolchain in rust-toolchain.toml, which does not know the new lint; CI runs clippy on floating `+stable`. Verified clean on both.

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #issue-number-here

#### Implementation Details

Clippy 1.98 introduced `unused_async_trait_impl`, which fires on four public
`async fn` methods on `Cedarling` that no longer contain a `.await`:

- `authorize_unsigned`
- `authorize_unsigned_batch`
- `authorize_multi_issuer`
- `authorize_multi_issuer_batch`

These already carried `#[allow(clippy::unused_async)]` (added in #14615) for the
same reason. This PR widens that attribute rather than acting on the lint's
suggestion:

```rust
#[allow(unknown_lints, clippy::unused_async, clippy::unused_async_trait_impl)]
```

**Why not drop `async`?** These are public API. Removing `async` breaks every
downstream caller, which is out of scope here.

**Why not the suggested `-> impl Future` + `std::future::ready(..)`?** It is
call-site compatible but changes execution semantics from lazy to eager: the
Cedar evaluation and the audit log entry would run when the method is *called*,
not when the future is *awaited*. That makes the work unskippable for a dropped
future and moves it outside any `select!`/timeout wrapper. Not worth it to
silence a lint.

**Why `unknown_lints`?** `rust-toolchain.toml` pins 1.95.0, which does not know
`unused_async_trait_impl` and would fail on the unknown lint name under
`-D warnings`, while CI runs clippy on floating `+stable` (currently 1.98).

Verified clean on both toolchains:

```
cargo +stable  clippy --workspace --exclude cedarling_pg --all-targets -- -D warnings   # exit 0
cargo +1.95.0  clippy -p cedarling --lib -- -D warnings                                  # exit 0
```

No public interface change; no behavior change.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #14851, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with lint checking by allowing additional recognized lint names during authorization processing.
  * Preserved existing authorization behavior and method interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->