### PR TITLE
fix(jans-fido2): measure user-adoption metrics against the right population

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -14,6 +14,7 @@ import io.jans.fido2.model.metric.Fido2MetricsEntry;
 import io.jans.fido2.model.trust.AttestationTrustDiagnostic;
 import io.jans.as.common.service.common.ApplicationFactory;
 import io.jans.orm.PersistenceEntryManager;
+import io.jans.orm.model.SearchScope;
 import io.jans.orm.search.filter.Filter;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -63,6 +64,9 @@ public class Fido2MetricsService {
 
     private static final String METRICS_ENTRY_BASE_DN = "ou=fido2-metrics,o=jans";
     private static final String METRICS_AGGREGATION_BASE_DN = "ou=fido2-aggregations,o=jans";
+
+    /** Page size for the paged prior-adopters lookup in {@link #getUsersRegisteredBefore}. */
+    private static final int PRIOR_ADOPTERS_CHUNK_SIZE = 1000;
 
     // ========== METRICS ENTRY OPERATIONS ==========
 
@@ -435,7 +439,12 @@ public class Fido2MetricsService {
                 Filter.createLessOrEqualFilter(Fido2MetricsConstants.JANS_TIMESTAMP, exclusiveUpperBound)
             );
 
-            return persistenceEntryManager.findEntries(METRICS_ENTRY_BASE_DN, Fido2MetricsEntry.class, filter)
+            // Paged retrieval: the unpaged findEntries(filter) overload issues a single search that a
+            // persistence backend enforcing a result-size limit can reject outright, which would
+            // misclassify every in-window registration as new. Paging in PRIOR_ADOPTERS_CHUNK_SIZE
+            // batches keeps this working past that limit.
+            return persistenceEntryManager.findEntries(METRICS_ENTRY_BASE_DN, Fido2MetricsEntry.class, filter,
+                    SearchScope.SUB, null, 0, 0, PRIOR_ADOPTERS_CHUNK_SIZE)
                 .stream()
                 .map(Fido2MetricsEntry::getUserId)
                 .filter(Objects::nonNull)

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -360,39 +360,90 @@ public class Fido2MetricsService {
     // ========== ANALYTICS AND REPORTING ==========
 
     /**
-     * Get user adoption metrics
+     * Get user adoption metrics.
+     * <p>
+     * "New" and "returning" are decided against every successful registration on record, not just the
+     * rows inside {@code [startTime, endTime]}: a user only counts as new the first time their
+     * registration succeeds, and as returning if they had already registered before the window began.
+     * {@code adoptionRate} is newUsers against the cumulative population of everyone who has ever
+     * registered as of {@code endTime} — a self-contained figure bounded by how long metrics entries
+     * are retained, not a rate against the full identity directory.
      */
     public Map<String, Object> getUserAdoptionMetrics(LocalDateTime startTime, LocalDateTime endTime) {
         List<Fido2MetricsEntry> entries = getMetricsEntries(startTime, endTime);
-        
+
         Map<String, Object> metrics = new HashMap<>();
-        
-        // Total unique users
+
+        // Every user with any activity in this window, regardless of operation or outcome
         Set<String> uniqueUsers = entries.stream()
             .map(Fido2MetricsEntry::getUserId)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
         metrics.put(Fido2MetricsConstants.TOTAL_UNIQUE_USERS, uniqueUsers.size());
 
-        // New users (first registration)
-        Set<String> newUsers = entries.stream()
-            .filter(e -> Fido2MetricsConstants.REGISTRATION.equals(e.getOperationType()) && Fido2MetricsConstants.SUCCESS.equals(e.getStatus()))
+        // Users already known to have registered successfully before this window began
+        Set<String> priorAdopters = getUsersRegisteredBefore(startTime);
+
+        // Registration successes recorded inside this window
+        Set<String> registeredInWindow = entries.stream()
+            .filter(e -> Fido2MetricsConstants.REGISTRATION.equals(e.getOperationType())
+                    && Fido2MetricsConstants.SUCCESS.equals(e.getStatus()))
             .map(Fido2MetricsEntry::getUserId)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
+
+        // New users: this is the first time their registration ever succeeded
+        Set<String> newUsers = new HashSet<>(registeredInWindow);
+        newUsers.removeAll(priorAdopters);
         metrics.put(Fido2MetricsConstants.NEW_USERS, newUsers.size());
 
-        // Returning users
+        // Returning users: active this window, and already an adopter before it began.
+        // Computed directly against priorAdopters rather than as uniqueUsers minus newUsers, so a user
+        // who registers a second passkey and signs in within the same window is still counted here.
         Set<String> returningUsers = new HashSet<>(uniqueUsers);
-        returningUsers.removeAll(newUsers);
+        returningUsers.retainAll(priorAdopters);
         metrics.put(Fido2MetricsConstants.RETURNING_USERS, returningUsers.size());
 
-        // Adoption rate
-        if (!uniqueUsers.isEmpty()) {
-            metrics.put(Fido2MetricsConstants.ADOPTION_RATE, (double) newUsers.size() / uniqueUsers.size());
+        // Adoption rate: new users against the cumulative population of everyone who has ever
+        // registered as of endTime (priorAdopters and newUsers are disjoint by construction).
+        long cumulativeAdopters = priorAdopters.size() + newUsers.size();
+        if (cumulativeAdopters > 0) {
+            metrics.put(Fido2MetricsConstants.ADOPTION_RATE, (double) newUsers.size() / cumulativeAdopters);
+        } else {
+            metrics.put(Fido2MetricsConstants.ADOPTION_RATE, null);
         }
 
         return metrics;
+    }
+
+    /**
+     * Distinct users whose registration succeeded at any point before {@code beforeTime}, searched
+     * directly against the metrics store rather than derived from the {@code [startTime, endTime]}
+     * window. Bounded by the metrics retention policy: a user whose only prior registration entry has
+     * already been cleaned up by {@link #cleanupOldData} will not appear here, and will be reported as
+     * new again.
+     */
+    private Set<String> getUsersRegisteredBefore(LocalDateTime beforeTime) {
+        try {
+            // Strictly before beforeTime, so a registration timestamped exactly at the window's start
+            // is not counted both as a prior adopter and as part of this window.
+            Date exclusiveUpperBound = new Date(convertToDate(beforeTime).getTime() - 1);
+
+            Filter filter = Filter.createANDFilter(
+                Filter.createEqualityFilter("jansFido2MetricsOperationType", Fido2MetricsConstants.REGISTRATION),
+                Filter.createEqualityFilter("jansFido2MetricsStatus", Fido2MetricsConstants.SUCCESS),
+                Filter.createLessOrEqualFilter(Fido2MetricsConstants.JANS_TIMESTAMP, exclusiveUpperBound)
+            );
+
+            return persistenceEntryManager.findEntries(METRICS_ENTRY_BASE_DN, Fido2MetricsEntry.class, filter)
+                .stream()
+                .map(Fido2MetricsEntry::getUserId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.error("Failed to retrieve prior registrations before {}: {}", beforeTime, e.getMessage(), e);
+            return Collections.emptySet();
+        }
     }
 
     /**

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -406,7 +406,7 @@ public class Fido2MetricsService {
 
         // Adoption rate: new users against the cumulative population of everyone who has ever
         // registered as of endTime (priorAdopters and newUsers are disjoint by construction).
-        long cumulativeAdopters = priorAdopters.size() + newUsers.size();
+        long cumulativeAdopters = (long) priorAdopters.size() + newUsers.size();
         if (cumulativeAdopters > 0) {
             metrics.put(Fido2MetricsConstants.ADOPTION_RATE, (double) newUsers.size() / cumulativeAdopters);
         } else {

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -371,6 +372,114 @@ class Fido2MetricsServiceTest {
                 authenticatorEntry(Fido2MetricsConstants.SUCCESS, "PLATFORM"));
 
         assertEquals(Map.of("PLATFORM", 1L), metrics.get(Fido2MetricsConstants.DEVICE_TYPES));
+    }
+
+    /**
+     * A user who already registered before the window and only signs in during it must be reported as
+     * returning, never as new — the prior definition only ever looked at rows inside the window, so an
+     * established user with no registration activity here fell out of both buckets.
+     */
+    @Test
+    void getUserAdoptionMetrics_ifUserRegisteredBeforeWindowAndSignsInDuringIt_isReturningNotNew() {
+        Fido2MetricsEntry signIn = statusEntry(Fido2MetricsConstants.AUTHENTICATION, Fido2MetricsConstants.SUCCESS);
+        signIn.setUserId("user-1");
+        stubAdoptionQueries(List.of(signIn), List.of("user-1"));
+
+        Map<String, Object> metrics = adoption();
+
+        assertEquals(1, metrics.get(Fido2MetricsConstants.TOTAL_UNIQUE_USERS));
+        assertEquals(0, metrics.get(Fido2MetricsConstants.NEW_USERS));
+        assertEquals(1, metrics.get(Fido2MetricsConstants.RETURNING_USERS));
+    }
+
+    /**
+     * The previous formula measured adoption against uniqueUsers active in the window, which shrinks
+     * as new registrations taper off — so it reported near-zero adoption exactly when adoption
+     * finished. A user with no prior registration record is new the first time they register,
+     * regardless of what else happens in the window.
+     */
+    @Test
+    void getUserAdoptionMetrics_ifUserHasNoPriorRegistration_firstSuccessIsNew() {
+        Fido2MetricsEntry registration = statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.SUCCESS);
+        registration.setUserId("user-2");
+        stubAdoptionQueries(List.of(registration), List.of());
+
+        Map<String, Object> metrics = adoption();
+
+        assertEquals(1, metrics.get(Fido2MetricsConstants.NEW_USERS));
+        assertEquals(0, metrics.get(Fido2MetricsConstants.RETURNING_USERS));
+        assertEquals(1.0, (Double) metrics.get(Fido2MetricsConstants.ADOPTION_RATE), 0.0001);
+    }
+
+    /**
+     * Enrolling a second passkey must not make an already-adopted user look new again — the old
+     * "newUsers" filter only checked REGISTRATION + SUCCESS inside the window, with no check for a
+     * prior registration, so this changed meaning with the date picker.
+     */
+    @Test
+    void getUserAdoptionMetrics_ifUserEnrolsSecondPasskey_isNotCountedAsNewAgain() {
+        Fido2MetricsEntry secondRegistration = statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.SUCCESS);
+        secondRegistration.setUserId("user-3");
+        stubAdoptionQueries(List.of(secondRegistration), List.of("user-3"));
+
+        Map<String, Object> metrics = adoption();
+
+        assertEquals(0, metrics.get(Fido2MetricsConstants.NEW_USERS));
+        assertEquals(1, metrics.get(Fido2MetricsConstants.RETURNING_USERS));
+    }
+
+    /**
+     * adoptionRate is newUsers against everyone who has ever registered as of the end of the window
+     * (prior adopters plus this window's new ones) rather than against uniqueUsers active in the
+     * window, so it keeps meaning "share of all adopters that are new" instead of falling toward zero
+     * as adoption succeeds.
+     */
+    @Test
+    void getUserAdoptionMetrics_adoptionRateIsAgainstCumulativeAdoptersNotWindowActivity() {
+        Fido2MetricsEntry newUser = statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.SUCCESS);
+        newUser.setUserId("user-new");
+        stubAdoptionQueries(List.of(newUser), List.of("user-old-1", "user-old-2", "user-old-3"));
+
+        Map<String, Object> metrics = adoption();
+
+        // 1 new user out of 4 cumulative adopters (3 prior + this 1 new)
+        assertEquals(0.25, (Double) metrics.get(Fido2MetricsConstants.ADOPTION_RATE), 0.0001);
+    }
+
+    /**
+     * With nobody ever having registered, there is no population to measure adoption against — the
+     * rate must be left unknown rather than published as a misleading 0.0.
+     */
+    @Test
+    void getUserAdoptionMetrics_ifNoOneHasEverRegistered_adoptionRateIsNull() {
+        stubAdoptionQueries(List.of(), List.of());
+
+        assertNull(adoption().get(Fido2MetricsConstants.ADOPTION_RATE));
+    }
+
+    private Map<String, Object> adoption() {
+        return fido2MetricsService.getUserAdoptionMetrics(LocalDateTime.now().minusDays(1), LocalDateTime.now());
+    }
+
+    /**
+     * getUserAdoptionMetrics issues two distinct queries against the same store: one for activity
+     * inside the window, and one for registrations that succeeded before it began. The window query
+     * carries no status filter, so that is what distinguishes the two for stubbing purposes.
+     */
+    private void stubAdoptionQueries(List<Fido2MetricsEntry> windowEntries, List<String> priorAdopterUserIds) {
+        when(persistenceEntryManager.findEntries(any(String.class), eq(Fido2MetricsEntry.class),
+                argThat(filter -> filter == null || !filter.toString().contains("jansFido2MetricsStatus"))))
+                .thenReturn(windowEntries);
+
+        List<Fido2MetricsEntry> priorEntries = priorAdopterUserIds.stream().map(userId -> {
+            Fido2MetricsEntry entry = statusEntry(Fido2MetricsConstants.REGISTRATION, Fido2MetricsConstants.SUCCESS);
+            entry.setUserId(userId);
+            return entry;
+        }).collect(java.util.stream.Collectors.toList());
+
+        when(persistenceEntryManager.findEntries(any(String.class), eq(Fido2MetricsEntry.class),
+                argThat(filter -> filter != null && filter.toString().contains("jansFido2MetricsStatus"))))
+                .thenReturn(priorEntries);
     }
 
     private Map<String, Object> performance() {

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
@@ -12,6 +12,7 @@ import io.jans.fido2.model.metric.Fido2MetricsConstants;
 import io.jans.fido2.model.metric.Fido2MetricsData;
 import io.jans.fido2.model.metric.Fido2MetricsEntry;
 import io.jans.orm.PersistenceEntryManager;
+import io.jans.orm.model.SearchScope;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -478,7 +480,8 @@ class Fido2MetricsServiceTest {
         }).collect(java.util.stream.Collectors.toList());
 
         when(persistenceEntryManager.findEntries(any(String.class), eq(Fido2MetricsEntry.class),
-                argThat(filter -> filter != null && filter.toString().contains("jansFido2MetricsStatus"))))
+                argThat(filter -> filter != null && filter.toString().contains("jansFido2MetricsStatus")),
+                any(SearchScope.class), any(), anyInt(), anyInt(), anyInt()))
                 .thenReturn(priorEntries);
     }
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14830

#### Implementation Details

`Fido2MetricsService.getUserAdoptionMetrics` reported three figures that did not mean what their
names said:

- **`adoptionRate` fell as adoption succeeded.** It was `newUsers / uniqueUsers`, where `uniqueUsers`
  counted only users active in the query window. Once everyone had enrolled and was only signing in,
  `newUsers` tended to zero and the rate reported near-zero adoption exactly when adoption was
  complete.
- **`newUsers` did not mean first registration.** The filter was `REGISTRATION` + `SUCCESS` inside the
  window, with no check for prior registrations — an existing user enrolling a second passkey counted
  as new, and the number changed meaning with the date picker.
- **`returningUsers` was derived by subtraction** (`uniqueUsers - newUsers`), so a user who both
  registered and authenticated in the same window was counted only as new, never as returning.

**The fix.** `getUserAdoptionMetrics` now issues a second, targeted query against the metrics store —
`getUsersRegisteredBefore(startTime)` — for users whose registration already succeeded before the
window began ("prior adopters"). Everything downstream is derived from that set directly rather than
from window-only activity:

- `newUsers` = registrations succeeding in the window, minus prior adopters — first-ever success only.
- `returningUsers` = users active this window who are already prior adopters — computed directly, not
  by subtracting `newUsers` from `uniqueUsers`.
- `adoptionRate` = `newUsers / (priorAdopters + newUsers)` — new users against the cumulative
  population of everyone who has ever registered as of `endTime`, so it tracks growth instead of
  falling toward zero as sign-in-only activity comes to dominate. When nobody has ever registered, the
  rate is `null` rather than a misleading `0.0`.

This is intentionally the self-contained option: no new dependency on a directory-wide user count, and
no response-shape drop of `adoptionRate` — see the issue's "needs a product decision" note for the two
alternatives considered. It is bounded by the metrics retention policy: a user whose only prior
registration entry has already been cleaned up by `cleanupOldData` is reported as new again. That
tradeoff is documented on `getUsersRegisteredBefore`'s Javadoc.

**Unrelated bug found while implementing this, filed separately as #14859**: `Fido2AnalyticsService.
generateExecutiveSummary` recomputes its own adoption rate from `totalUniqueUsers`/`newUsers` instead
of using this method's `adoptionRate`, and casts those `Integer` values to `Long`, throwing
`ClassCastException`. Not touched here — it's a different file with its own review, and the class is
currently unwired from any controller.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

**Tests** — `Fido2MetricsServiceTest`, 5 added (34 total in the file, all green):

- a user who registered before the window and only signs in during it is returning, not new
- a user with no prior registration is new the first time they register
- enrolling a second passkey does not make an already-adopted user look new again
- `adoptionRate` is against cumulative adopters, not window activity
- `adoptionRate` is `null`, not `0.0`, when nobody has ever registered


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FIDO2 adoption metrics by accurately distinguishing new users from returning users.
  * Adoption rates now account for users who registered before the selected reporting period.
  * Adoption rates correctly return no value when there are no registered users.
  * Metrics now correctly handle additional passkey registrations and cumulative adopter totals.

* **Tests**
  * Added coverage for first-time registrations, returning users, additional passkeys, cumulative adoption rates, and empty registration history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->