### PR TITLE
fix(jans-fido2): use the fixed adoption rate in the executive summary

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2AnalyticsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2AnalyticsService.java
@@ -132,11 +132,11 @@ public class Fido2AnalyticsService {
         // Top insights
         List<String> insights = new ArrayList<>();
         
-        // User adoption insights
-        Long totalUsers = (Long) userAdoption.get(Fido2MetricsConstants.TOTAL_UNIQUE_USERS);
-        Long newUsers = (Long) userAdoption.get(Fido2MetricsConstants.NEW_USERS);
-        if (totalUsers != null && newUsers != null && totalUsers > 0) {
-            double adoptionRate = (double) newUsers / totalUsers;
+        // User adoption insights - reuse getUserAdoptionMetrics's adoptionRate rather than
+        // recomputing one from totalUniqueUsers/newUsers, which measures window activity rather
+        // than a user population and falls toward zero exactly as adoption succeeds.
+        Double adoptionRate = (Double) userAdoption.get(Fido2MetricsConstants.ADOPTION_RATE);
+        if (adoptionRate != null) {
             if (adoptionRate > STRONG_ADOPTION_RATE_THRESHOLD) {
                 insights.add("Strong user adoption with " + String.format("%.1f%%", adoptionRate * 100) + " new users");
             } else if (adoptionRate < LOW_ADOPTION_RATE_THRESHOLD) {

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2AnalyticsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2AnalyticsServiceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Janssen Project software is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.service.metric;
+
+import io.jans.fido2.model.metric.Fido2MetricsConstants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link Fido2AnalyticsService#generateExecutiveSummary}.
+ *
+ * <p>{@code getUserAdoptionMetrics} stores {@code totalUniqueUsers} and {@code newUsers} as
+ * {@code Set.size()} — an {@code int}, autoboxed to {@code Integer} — so casting either to
+ * {@code Long} here threw {@code ClassCastException} on every window with at least one active user.
+ * The recomputed rate also measured window activity rather than a user population, which is exactly
+ * the defect fixed in {@code Fido2MetricsService.getUserAdoptionMetrics} itself; reusing its
+ * {@code adoptionRate} fixes both at once.
+ *
+ * @author Janssen Project
+ * @version 1.0
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class Fido2AnalyticsServiceTest {
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private Fido2MetricsService metricsService;
+
+    @InjectMocks
+    private Fido2AnalyticsService fido2AnalyticsService;
+
+    @Test
+    void generateExecutiveSummary_ifWindowHasActiveUsers_doesNotThrow() {
+        stubAdoption(Map.of(
+                Fido2MetricsConstants.TOTAL_UNIQUE_USERS, 5,
+                Fido2MetricsConstants.NEW_USERS, 2,
+                Fido2MetricsConstants.ADOPTION_RATE, 0.6));
+
+        Map<String, Object> summary = summary();
+
+        assertEquals(0.6, (Double) summary.get(Fido2MetricsConstants.ADOPTION_RATE), 0.0001);
+        assertTrue(insights(summary).stream().anyMatch(i -> i.contains("Strong user adoption")));
+    }
+
+    /**
+     * A recompute from totalUniqueUsers/newUsers would have reported this as low adoption
+     * (1 new / 5 active = 0.2), even though the population-correct adoptionRate is high. Reusing the
+     * already-fixed figure keeps the two call sites in agreement instead of disagreeing about what
+     * "adoption" means.
+     */
+    @Test
+    void generateExecutiveSummary_usesAdoptionRateFromMetricsService_notWindowActivityRatio() {
+        stubAdoption(Map.of(
+                Fido2MetricsConstants.TOTAL_UNIQUE_USERS, 5,
+                Fido2MetricsConstants.NEW_USERS, 1,
+                Fido2MetricsConstants.ADOPTION_RATE, 0.75));
+
+        List<String> insights = insights(summary());
+
+        assertTrue(insights.stream().anyMatch(i -> i.contains("Strong user adoption")),
+                "must reflect the fixed adoptionRate (0.75), not the window ratio newUsers/totalUniqueUsers (0.2)");
+    }
+
+    /**
+     * With no population to measure adoption against, getUserAdoptionMetrics reports adoptionRate as
+     * null rather than a misleading 0.0; the summary must not add an insight from an unknown rate, and
+     * must not throw unboxing it.
+     */
+    @Test
+    void generateExecutiveSummary_ifAdoptionRateIsUnknown_addsNoAdoptionInsight() {
+        Map<String, Object> adoption = new HashMap<>();
+        adoption.put(Fido2MetricsConstants.TOTAL_UNIQUE_USERS, 0);
+        adoption.put(Fido2MetricsConstants.NEW_USERS, 0);
+        adoption.put(Fido2MetricsConstants.ADOPTION_RATE, null);
+        stubAdoption(adoption);
+
+        List<String> insights = insights(summary());
+
+        assertFalse(insights.stream().anyMatch(i -> i.contains("adoption")));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> insights(Map<String, Object> summary) {
+        return (List<String>) summary.get("keyInsights");
+    }
+
+    private void stubAdoption(Map<String, Object> adoption) {
+        when(metricsService.getUserAdoptionMetrics(any(), any())).thenReturn(adoption);
+        when(metricsService.getPerformanceMetrics(any(), any())).thenReturn(Map.of());
+        when(metricsService.getErrorAnalysis(any(), any())).thenReturn(Map.of());
+    }
+
+    private Map<String, Object> summary() {
+        return fido2AnalyticsService.generateExecutiveSummary(LocalDateTime.now().minusDays(1), LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
# PR body

### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14859

#### Implementation Details

`Fido2AnalyticsService.generateExecutiveSummary` did not use `Fido2MetricsService.
getUserAdoptionMetrics`'s `adoptionRate` — it pulled `totalUniqueUsers` and `newUsers` back out of
that map and recomputed its own rate. Two defects from that:

1. **Same population bug as #14830, independently.** `totalUsers` is `totalUniqueUsers` — everyone
   active in the query window, not a user population — so the recompute fell into the same
   "`adoptionRate` falls as adoption succeeds" trap that #14830 fixes in `getUserAdoptionMetrics`
   itself. Fixing the source method did not fix this call site, because this call site threw the
   fixed value away.
2. **`(Long)` cast threw on every non-empty window.** `getUserAdoptionMetrics` stores
   `totalUniqueUsers`/`newUsers` as `Set.size()` — an `int`, autoboxed to `Integer` — not a `Long`.
   Casting an `Integer` to `Long` throws `ClassCastException` at runtime. `generateExecutiveSummary`
   is only ever called from `generateComprehensiveReport`, which wraps it in a try/catch, so the
   entire comprehensive report silently failed and returned only an `error` key — discarding
   performance, device, error and trends data along with it — whenever the window had at least one
   active user.

**The fix.** Read `adoptionRate` straight from `userAdoption.get(Fido2MetricsConstants.ADOPTION_RATE)`
as a `Double` and use it directly for the insight thresholds, instead of recomputing from
`totalUniqueUsers`/`newUsers`. Fixes both defects at once: no more cast mismatch, and the insight now
agrees with the corrected, population-scoped rate.

**Currently unreachable from the REST API.** `Fido2AnalyticsService` has no caller in
`Fido2MetricsController` or anywhere else in `jans-fido2` — `generateComprehensiveReport` and
`generateExecutiveSummary` are dead code today. Fixing it now so it's correct before the service is
ever wired up, rather than rediscovered as a production incident afterward.

**Relationship to #14830.** This PR does not depend on #14830 landing first — `adoptionRate` already
exists as a key on `getUserAdoptionMetrics`'s response regardless of which PR merges first, this PR
just stops bypassing it. Once #14830 also lands, the value this reads becomes the corrected one.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

**Tests** — new `Fido2AnalyticsServiceTest` (3 tests, all green):

- a window with active users no longer throws `ClassCastException`
- the "strong adoption" insight reflects `adoptionRate` from the metrics service, not a window-activity
  ratio recomputed from `totalUniqueUsers`/`newUsers`
- an unknown (`null`) adoption rate adds no adoption insight and does not throw

**Docs** — no docs page describes `Fido2AnalyticsService`'s executive summary (it isn't wired to a
controller yet), so none needed updating.


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Executive adoption summaries now use the configured adoption rate, improving the accuracy of “strong” and “low” adoption insights.
  * Summaries remain stable when adoption data is unavailable or active-user windows contain incomplete data.

* **Tests**
  * Added coverage for configured adoption rates, missing adoption data, and active-user reporting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->