### PR TITLE
fix(jans-linux-setup): correct passkey interception script key in scr…

### DIFF
--- a/jans-linux-setup/jans_setup/templates/scripts.ldif
+++ b/jans-linux-setup/jans_setup/templates/scripts.ldif
@@ -288,7 +288,7 @@ jansLevel: 70
 jansModuleProperty: {"value1":"usage_type","value2":"interactive","description":""}
 jansModuleProperty: {"value1":"location_type","value2":"db","description":""}
 jansRevision: 1
-jansScr::%(person_authentication_fido2_external_authenticator_passkeyinterceptionscript)s
+jansScr::%(person_authentication_passkey_passkeyinterceptionscript)s
 jansScrTyp: person_authentication
 objectClass: top
 objectClass: jansCustomScr


### PR DESCRIPTION
### Description

Fresh installs crashed with KeyError: 'person_authentication_fido2_external_authenticator_passkeyinterceptionscript' while rendering scripts.ldif, because PR #14852 renamed both the catalog folder and the script file but the template only tracked the filename half.
This points the template at the key setup actually generates: person_authentication_passkey_passkeyinterceptionscript.
Checked all 49 jansScr::%(...)s refs against the script catalog — this was the only stale one.


#### Target issue

setup fails with KeyError: 'person_authentication_fido2_external_authenticator_passkeyinterceptionscript' while rendering scripts.ldif

PR #14852 renamed both the passkey script's catalog folder (fido2-external-authenticator -> passkey) and its file (Fido2ExternalAuthenticator.py -> PasskeyInterceptionScript.py), but scripts.ldif was updated for the filename half of the generated key only.
The stale key is never produced, so every fresh install — VM setup and cloud-native persistence-loader alike — aborts at jans_auth.py:152 with KeyError before any LDIF is imported.
Expected: the key reads %(person_authentication_passkey_passkeyinterceptionscript)s and setup completes.

  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14879 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FIDO2 authentication configuration to correctly reference the passkey interception script, improving passkey authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->