### PR TITLE
fix(jans-fido2): report uncomputable metrics rates as null instead of 0.0

### DIFF
--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -119,6 +119,19 @@ observed to have lapsed. In multi-node deployments the sweep is not coordinated 
 `abandonmentRate` is approximate — an exact count is available by querying `jansStatus = 'abandoned'`
 directly within the retention window.
 
+!!! note "An unknown rate is `null`, not zero"
+    A rate here is a ratio against the `ATTEMPT` count. A range can hold terminal entries whose
+    `ATTEMPT` falls outside it, or predate attempt tracking entirely, and then a rate has no
+    denominator to be computed from. Those rates are reported as `null` and never as `0.0` or `1.0`,
+    which on a dashboard would be indistinguishable from a range that really was measured at a
+    flawless completion rate with no abandonment.
+
+    Whenever any rate in the response is `null`, capped at `1.0`, or measured against a different
+    denominator, a `rateNote` field is present saying which and why; it is absent when everything was
+    computed as normal. `successRate` and `failureRate` are reported as observed and are never
+    rescaled, so in a range whose completions outnumber its recorded starts they can sum above 1.0 —
+    the `rateNote` says so. Render an unknown rate as unknown; it must not look like a zero.
+
 !!! warning "A failed fingerprint is never a `FAILURE`"
     With platform authenticators such as Touch ID, Face ID or Windows Hello, user verification
     happens **inside the authenticator**. A wrong fingerprint causes the operating system to retry

--- a/jans-fido2/docs/jansFido2Swagger.yaml
+++ b/jans-fido2/docs/jansFido2Swagger.yaml
@@ -1419,22 +1419,30 @@ components:
           description: Count of errors by message.
         successRate:
           type: number
-          description: Ratio of started operations that succeeded (0.0–1.0). Based on ATTEMPT count as denominator.
+          nullable: true
+          description: Ratio of started operations that succeeded. Based on ATTEMPT count as denominator, and reported as observed, so it can exceed 1.0 when completions in the range belong to starts outside it. Null when nothing was recorded. Where no ATTEMPT entries exist at all it is the share of completed ceremonies that succeeded instead — see rateNote.
         failureRate:
           type: number
-          description: Ratio of started operations that failed (0.0–1.0). Based on ATTEMPT count as denominator.
+          nullable: true
+          description: Ratio of started operations that failed. Same denominator and same caveats as successRate.
         completionRate:
           type: number
-          description: Ratio of started operations that completed (success or failure). Equals successRate + failureRate (0.0–1.0).
+          nullable: true
+          description: Ratio of started operations that completed (success or failure), 0.0–1.0. Capped at 1.0 when completions outnumber recorded starts, and null when no starts were recorded at all, since it then has no denominator — see rateNote.
         dropOffRate:
           type: number
-          description: Ratio of started operations that did not complete (user dropped off). Equals 1 - completionRate (0.0–1.0). Inferred as a residual, so it also absorbs ceremonies still in flight at the edge of the query window.
+          nullable: true
+          description: Ratio of started operations that did not complete (user dropped off). Equals 1 - completionRate (0.0–1.0). Inferred as a residual, so it also absorbs ceremonies still in flight at the edge of the query window, and is null when there is no residual to infer it from — see rateNote.
         abandonedOperations:
           type: integer
           description: Count of authentication ceremonies observed to have lapsed without ever being completed. Unlike dropOffRate this is counted from ceremonies actually relabelled as abandoned, not inferred. Approximate in multi-node deployments, where a ceremony may be counted more than once.
         abandonmentRate:
           type: number
-          description: Ratio of started operations observed to have been abandoned (0.0–1.0). Based on ATTEMPT count as denominator. Reported alongside dropOffRate, not instead of it.
+          nullable: true
+          description: Ratio of started operations observed to have been abandoned (0.0–1.0). Based on ATTEMPT count as denominator. Reported alongside dropOffRate, not instead of it. Null when no starts were recorded — see rateNote.
+        rateNote:
+          type: string
+          description: Present only when a rate in this response is null, capped, or measured against a different denominator, and explains which and why. An unknown rate must not be rendered as a zero.
     MetricsTrends:
       type: object
       description: Trend analysis over time with data points, growth rate, direction, and insights.

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricsConstants.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/metric/Fido2MetricsConstants.java
@@ -28,6 +28,12 @@ public final class Fido2MetricsConstants {
     public static final String FAILURE_RATE = "failureRate";
     public static final String COMPLETION_RATE = "completionRate";
     public static final String DROP_OFF_RATE = "dropOffRate";
+    /**
+     * Explains any rate in the same response that is null, or that had to be capped or read against a
+     * different denominator than usual. Absent when every rate was computed as it should be. An
+     * unknown rate must not be rendered as a zero.
+     */
+    public static final String RATE_NOTE = "rateNote";
 
     // Aggregation Types
     public static final String HOURLY = "HOURLY";

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsService.java
@@ -655,51 +655,89 @@ public class Fido2MetricsService {
         // Approximate in multi-node deployments, where a ceremony can be counted more than once.
         analysis.put(Fido2MetricsConstants.ABANDONED_OPERATIONS, abandonedOperations);
 
-        if (totalStarted > 0) {
-            // Normal case: rates as proportion of started operations (ATTEMPT count)
-            double successRate = (double) successfulOperations / totalStarted;
-            double failureRate = (double) failedOperations / totalStarted;
-            // When mixed legacy/new data (SUCCESS+FAILURE > ATTEMPT), scale so completionRate = successRate + failureRate and all stay in [0.0, 1.0]
-            double rawCompletion = successRate + failureRate;
-            if (rawCompletion > 1.0) {
-                double scale = 1.0 / rawCompletion;
-                successRate *= scale;
-                failureRate *= scale;
-            }
-            double completionRate = successRate + failureRate;
-            double dropOffRate = Math.max(0.0, 1.0 - completionRate);
-
-            analysis.put(Fido2MetricsConstants.SUCCESS_RATE, successRate);
-            analysis.put(Fido2MetricsConstants.FAILURE_RATE, failureRate);
-            analysis.put(Fido2MetricsConstants.COMPLETION_RATE, completionRate);
-            analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, dropOffRate);
-            // Clamped for data recorded before conditional-UI ceremonies were counted as attempts:
-            // those produce an abandonment with no matching ATTEMPT, which can push the ratio past 1.
-            analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE,
-                    Math.min(1.0, (double) abandonedOperations / totalStarted));
-        } else {
-            // Fallback when no ATTEMPT entries (e.g. legacy data): use completed-only denominator
-            long totalCompleted = successfulOperations + failedOperations;
-            if (totalCompleted > 0) {
-                double successRate = (double) successfulOperations / totalCompleted;
-                double failureRate = (double) failedOperations / totalCompleted;
-                analysis.put(Fido2MetricsConstants.SUCCESS_RATE, successRate);
-                analysis.put(Fido2MetricsConstants.FAILURE_RATE, failureRate);
-                analysis.put(Fido2MetricsConstants.COMPLETION_RATE, 1.0);
-                analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, 0.0);
-                // No ATTEMPT entries to divide by, so the rate is not computable from this data.
-                analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE, 0.0);
-            } else {
-                // Empty dataset: emit rate keys with defaults so response shape is stable for clients
-                analysis.put(Fido2MetricsConstants.SUCCESS_RATE, 0.0);
-                analysis.put(Fido2MetricsConstants.FAILURE_RATE, 0.0);
-                analysis.put(Fido2MetricsConstants.COMPLETION_RATE, 0.0);
-                analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, 0.0);
-                analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE, 0.0);
-            }
-        }
+        putCeremonyRates(analysis, totalStarted, successfulOperations, failedOperations, abandonedOperations);
 
         return analysis;
+    }
+
+    /**
+     * Publish the ceremony rates for this range, saying so where one cannot be computed.
+     * <p>
+     * These rates are ratios against the ATTEMPT count, which is what a ceremony writes when it
+     * starts. A range can hold terminal entries whose ATTEMPT falls outside it, or predate attempt
+     * tracking altogether, and then some of them have no denominator. Publishing 0.0 or 1.0 in that
+     * case made an unmeasured rate indistinguishable from a measured one: a window holding only
+     * legacy data reported a flawless completion rate with no abandonment, none of which had been
+     * observed. A rate that cannot be computed is reported as null with a
+     * {@link Fido2MetricsConstants#RATE_NOTE} saying why, as {@code rejectionRateNote} already does
+     * for the attestation breakdown.
+     * <p>
+     * successRate and failureRate are reported as observed. They were previously scaled down
+     * whenever the completions outnumbered the attempts so that the two summed inside [0,1], which
+     * published a figure nobody had measured and marked it in no way; the inconsistency goes in the
+     * note instead.
+     */
+    private static void putCeremonyRates(Map<String, Object> analysis, long totalStarted, long successfulOperations,
+            long failedOperations, long abandonedOperations) {
+        long totalCompleted = successfulOperations + failedOperations;
+
+        if (totalStarted <= 0) {
+            // No denominator for anything measured against starts. The share of the completions that
+            // succeeded is still worth reporting where there are any, but it answers a different
+            // question from the usual successRate, so the note says which one.
+            Double successRate = totalCompleted > 0 ? (double) successfulOperations / totalCompleted : null;
+            Double failureRate = totalCompleted > 0 ? (double) failedOperations / totalCompleted : null;
+            analysis.put(Fido2MetricsConstants.SUCCESS_RATE, successRate);
+            analysis.put(Fido2MetricsConstants.FAILURE_RATE, failureRate);
+            analysis.put(Fido2MetricsConstants.COMPLETION_RATE, null);
+            analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, null);
+            analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE, null);
+            analysis.put(Fido2MetricsConstants.RATE_NOTE, totalCompleted > 0
+                    ? "No ceremony starts were recorded in this range, so completionRate, dropOffRate and "
+                            + "abandonmentRate have no denominator and cannot be computed. successRate and "
+                            + "failureRate are shares of the ceremonies that completed, not of the ceremonies "
+                            + "that started. Widen the range, or check whether this data predates attempt "
+                            + "tracking."
+                    : "No ceremonies were recorded in this range, so no rate can be computed.");
+            return;
+        }
+
+        analysis.put(Fido2MetricsConstants.SUCCESS_RATE, (double) successfulOperations / totalStarted);
+        analysis.put(Fido2MetricsConstants.FAILURE_RATE, (double) failedOperations / totalStarted);
+
+        List<String> notes = new ArrayList<>();
+
+        if (totalCompleted > totalStarted) {
+            // More ceremonies completed than were seen to start, so some of them started before this
+            // range or before attempts were recorded at all. Completion is capped at the whole
+            // population rather than published above 1.0, and the residual that dropOffRate is inferred
+            // from then carries no information about anyone dropping off.
+            analysis.put(Fido2MetricsConstants.COMPLETION_RATE, 1.0);
+            analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, null);
+            notes.add("More ceremonies completed than were recorded as started, so some completions belong to "
+                    + "starts outside this range: completionRate is capped at 1.0, and dropOffRate, inferred "
+                    + "from what is left over, cannot be computed. successRate and failureRate are reported as "
+                    + "observed and may sum above 1.0. Widen the range for an exact figure.");
+        } else {
+            double completionRate = (double) totalCompleted / totalStarted;
+            analysis.put(Fido2MetricsConstants.COMPLETION_RATE, completionRate);
+            analysis.put(Fido2MetricsConstants.DROP_OFF_RATE, 1.0 - completionRate);
+        }
+
+        if (abandonedOperations > totalStarted) {
+            // Same shape of gap, seen from the other side: data recorded before conditional-UI
+            // ceremonies were counted as attempts produces abandonments with no matching ATTEMPT.
+            analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE, 1.0);
+            notes.add("More ceremonies were abandoned than were recorded as started, so some abandonments "
+                    + "belong to starts outside this range: abandonmentRate is capped at 1.0. Widen the range "
+                    + "for an exact figure.");
+        } else {
+            analysis.put(Fido2MetricsConstants.ABANDONMENT_RATE, (double) abandonedOperations / totalStarted);
+        }
+
+        if (!notes.isEmpty()) {
+            analysis.put(Fido2MetricsConstants.RATE_NOTE, String.join(" ", notes));
+        }
     }
 
     /**

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
@@ -144,12 +144,11 @@ class Fido2MetricsServiceTest {
                 LocalDateTime.now());
 
         assertEquals(0L, analysis.get(Fido2MetricsConstants.ABANDONED_OPERATIONS));
-        assertTrue(analysis.containsKey(Fido2MetricsConstants.ABANDONMENT_RATE));
-        assertNull(analysis.get(Fido2MetricsConstants.SUCCESS_RATE));
-        assertNull(analysis.get(Fido2MetricsConstants.FAILURE_RATE));
-        assertNull(analysis.get(Fido2MetricsConstants.COMPLETION_RATE));
-        assertNull(analysis.get(Fido2MetricsConstants.DROP_OFF_RATE));
-        assertNull(analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE));
+        assertRateUnknown(analysis, Fido2MetricsConstants.SUCCESS_RATE);
+        assertRateUnknown(analysis, Fido2MetricsConstants.FAILURE_RATE);
+        assertRateUnknown(analysis, Fido2MetricsConstants.COMPLETION_RATE);
+        assertRateUnknown(analysis, Fido2MetricsConstants.DROP_OFF_RATE);
+        assertRateUnknown(analysis, Fido2MetricsConstants.ABANDONMENT_RATE);
         assertNotNull(analysis.get(Fido2MetricsConstants.RATE_NOTE));
     }
 
@@ -169,9 +168,9 @@ class Fido2MetricsServiceTest {
         Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
                 LocalDateTime.now());
 
-        assertNull(analysis.get(Fido2MetricsConstants.COMPLETION_RATE));
-        assertNull(analysis.get(Fido2MetricsConstants.DROP_OFF_RATE));
-        assertNull(analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE));
+        assertRateUnknown(analysis, Fido2MetricsConstants.COMPLETION_RATE);
+        assertRateUnknown(analysis, Fido2MetricsConstants.DROP_OFF_RATE);
+        assertRateUnknown(analysis, Fido2MetricsConstants.ABANDONMENT_RATE);
         // Reported against the completions instead, which is a different question and is what the
         // note has to explain.
         assertEquals(2.0 / 3.0, (Double) analysis.get(Fido2MetricsConstants.SUCCESS_RATE), 0.0001);
@@ -199,7 +198,7 @@ class Fido2MetricsServiceTest {
         assertEquals(1.0, (Double) analysis.get(Fido2MetricsConstants.FAILURE_RATE), 0.0001);
         assertEquals(1.0, (Double) analysis.get(Fido2MetricsConstants.COMPLETION_RATE), 0.0001);
         // Nothing is left over to infer a drop-off from, and 0.0 would read as "nobody dropped off".
-        assertNull(analysis.get(Fido2MetricsConstants.DROP_OFF_RATE));
+        assertRateUnknown(analysis, Fido2MetricsConstants.DROP_OFF_RATE);
         assertNotNull(analysis.get(Fido2MetricsConstants.RATE_NOTE));
     }
 
@@ -554,6 +553,16 @@ class Fido2MetricsServiceTest {
         stubAdoptionQueries(List.of(), List.of());
 
         assertNull(adoption().get(Fido2MetricsConstants.ADOPTION_RATE));
+    }
+
+    /**
+     * A rate that could not be computed must be present and null, never absent: {@code Map.get}
+     * cannot tell a missing key from a null one, so a client relying on the response shape would not
+     * see the difference between "we did not measure this" and "this field no longer exists".
+     */
+    private static void assertRateUnknown(Map<String, Object> analysis, String rate) {
+        assertTrue(analysis.containsKey(rate), rate + " must stay present so the response shape is stable");
+        assertNull(analysis.get(rate), rate + " was not observed and must not be published as a number");
     }
 
     private Map<String, Object> adoption() {

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/metric/Fido2MetricsServiceTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -131,18 +132,114 @@ class Fido2MetricsServiceTest {
     }
 
     /**
-     * The response shape stays stable when there is nothing to report, so clients do not have to
-     * distinguish "absent key" from "zero".
+     * The response shape stays stable when there is nothing to report — every rate key is still
+     * present — but an unobserved rate is null rather than 0.0, so a client cannot render an empty
+     * range as a measured one. The note says which it is.
      */
     @Test
-    void getErrorAnalysis_ifNoEntries_stillEmitsAbandonmentKeys() {
+    void getErrorAnalysis_ifNoEntries_emitsRateKeysAsNullWithANote() {
         stubMetricsEntries();
 
         Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
                 LocalDateTime.now());
 
         assertEquals(0L, analysis.get(Fido2MetricsConstants.ABANDONED_OPERATIONS));
-        assertEquals(0.0, (Double) analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE), 0.0001);
+        assertTrue(analysis.containsKey(Fido2MetricsConstants.ABANDONMENT_RATE));
+        assertNull(analysis.get(Fido2MetricsConstants.SUCCESS_RATE));
+        assertNull(analysis.get(Fido2MetricsConstants.FAILURE_RATE));
+        assertNull(analysis.get(Fido2MetricsConstants.COMPLETION_RATE));
+        assertNull(analysis.get(Fido2MetricsConstants.DROP_OFF_RATE));
+        assertNull(analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE));
+        assertNotNull(analysis.get(Fido2MetricsConstants.RATE_NOTE));
+    }
+
+    /**
+     * A range holding only completed ceremonies — data predating attempt tracking, or a window whose
+     * starts fall before it — has no denominator for completion, drop-off or abandonment. Those were
+     * published as completionRate 1.0 with no drop-off and no abandonment, which on a dashboard is
+     * indistinguishable from a flawless window that was actually measured.
+     */
+    @Test
+    void getErrorAnalysis_ifNoAttemptsRecorded_leavesRatesWithoutADenominatorNull() {
+        stubMetricsEntries(
+                statusEntry(Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.FAILURE));
+
+        Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now());
+
+        assertNull(analysis.get(Fido2MetricsConstants.COMPLETION_RATE));
+        assertNull(analysis.get(Fido2MetricsConstants.DROP_OFF_RATE));
+        assertNull(analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE));
+        // Reported against the completions instead, which is a different question and is what the
+        // note has to explain.
+        assertEquals(2.0 / 3.0, (Double) analysis.get(Fido2MetricsConstants.SUCCESS_RATE), 0.0001);
+        assertNotNull(analysis.get(Fido2MetricsConstants.RATE_NOTE));
+    }
+
+    /**
+     * When more ceremonies completed than were recorded as started, successRate used to be scaled
+     * down so that success and failure summed inside [0,1] — publishing a rate nobody had measured,
+     * with nothing marking it as adjusted. The observed rate stands, and the note carries the
+     * inconsistency.
+     */
+    @Test
+    void getErrorAnalysis_ifCompletionsOutnumberAttempts_reportsObservedRatesAndSaysSo() {
+        stubMetricsEntries(
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.SUCCESS),
+                statusEntry(Fido2MetricsConstants.FAILURE));
+
+        Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now());
+
+        assertEquals(2.0, (Double) analysis.get(Fido2MetricsConstants.SUCCESS_RATE), 0.0001);
+        assertEquals(1.0, (Double) analysis.get(Fido2MetricsConstants.FAILURE_RATE), 0.0001);
+        assertEquals(1.0, (Double) analysis.get(Fido2MetricsConstants.COMPLETION_RATE), 0.0001);
+        // Nothing is left over to infer a drop-off from, and 0.0 would read as "nobody dropped off".
+        assertNull(analysis.get(Fido2MetricsConstants.DROP_OFF_RATE));
+        assertNotNull(analysis.get(Fido2MetricsConstants.RATE_NOTE));
+    }
+
+    /**
+     * A window where every rate is computable carries no note, so a client can treat the note's
+     * presence as the signal that something needs explaining.
+     */
+    @Test
+    void getErrorAnalysis_ifEveryRateIsComputable_emitsNoNote() {
+        stubMetricsEntries(
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.SUCCESS));
+
+        Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now());
+
+        assertEquals(0.5, (Double) analysis.get(Fido2MetricsConstants.COMPLETION_RATE), 0.0001);
+        assertEquals(0.5, (Double) analysis.get(Fido2MetricsConstants.DROP_OFF_RATE), 0.0001);
+        assertFalse(analysis.containsKey(Fido2MetricsConstants.RATE_NOTE));
+    }
+
+    /**
+     * Abandonments can outnumber the recorded starts — data written before conditional-UI ceremonies
+     * were counted as attempts produces an abandonment with no matching ATTEMPT. The ratio is capped
+     * rather than published above 1.0, and the cap is stated instead of being applied silently.
+     */
+    @Test
+    void getErrorAnalysis_ifAbandonmentsOutnumberAttempts_capsTheRateAndSaysSo() {
+        stubMetricsEntries(
+                statusEntry(Fido2MetricsConstants.ATTEMPT),
+                statusEntry(Fido2MetricsConstants.ABANDONED),
+                statusEntry(Fido2MetricsConstants.ABANDONED));
+
+        Map<String, Object> analysis = fido2MetricsService.getErrorAnalysis(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now());
+
+        assertEquals(2L, analysis.get(Fido2MetricsConstants.ABANDONED_OPERATIONS));
+        assertEquals(1.0, (Double) analysis.get(Fido2MetricsConstants.ABANDONMENT_RATE), 0.0001);
+        assertNotNull(analysis.get(Fido2MetricsConstants.RATE_NOTE));
     }
 
     /**


### PR DESCRIPTION
Prepare

- [x] Read PR guidelines (https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read license information (https://github.com/JanssenProject/jans/blob/main/LICENSE)

---

Description

Target issue

closes #14831

Implementation Details

/fido2/metrics/analytics/errors published two kinds of number that were never observed, with nothing distinguishing them from measured ones.

1. The no-ATTEMPT fallback published certainty. A window holding no ATTEMPT rows emitted completionRate: 1.0, dropOffRate: 0.0 and abandonmentRate: 0.0 — the comment on the last one said the rate "is not computable from this data" and then published 0.0. On a dashboard that is indistinguishable from a genuine flawless window. The empty-dataset branch did the same with zeros.

2. Rate scaling silently rewrote successRate. Whenever SUCCESS + FAILURE > ATTEMPT, both successRate and failureRate were scaled down so the two summed inside [0,1]. The published figure was not the observed one and nothing marked it as adjusted.

The rate block is now one helper, putCeremonyRates, that reports what was measured and says so where it could not measure:

- No ATTEMPT rows in range — completionRate, dropOffRate and abandonmentRate are null; they have no denominator. successRate/failureRate are still reported against the completions, and the note states that this is a different denominator from the usual one.
- Empty range — all five rates are null.
- Completions outnumber recorded starts — successRate and failureRate stand as observed and are never rescaled. completionRate is capped at 1.0; dropOffRate, which is inferred from the residual, is null, because there is no residual left to infer anyone dropping off from.
- Abandonments outnumber recorded starts — abandonmentRate is still capped at 1.0, but the cap is now stated rather than applied silently.

A new rateNote field carries the explanation, following the rejectionRateNote pattern the file already uses for the attestation breakdown. It is absent when every rate computed normally, so a client can treat its presence as the signal that something needs explaining.

Impact on existing behaviour

- Response shape: every rate key is still present. The controller serializes through a default ObjectMapper (inclusion ALWAYS), so an uncomputable rate arrives as "completionRate": null, not a missing key. The type widens from number to number-or-null; the swagger schema is updated with nullable: true.
- A healthy window is unchanged. completionRate is now totalCompleted / totalStarted rather than successRate + failureRate — the same value. Only the anomalous branches behave differently.
- successRate can now exceed 1.0 in a window whose completions belong to starts recorded outside it. That is the observed figure; the rateNote says so. This is the change most likely to surprise a UI that renders the value as a percentage bar.
- Consumers: the config-api plugin passes the payload through as JsonNode, so nothing there binds to a primitive. The in-repo Java reader (Fido2AnalyticsService) already casts to Double and null-guards before comparing, so it degrades to "no insight" rather than throwing. There are no Python, TypeScript or Go consumers of these fields in this repo.
- Aggregations are untouched — calculateAggregation and rateDenominator are unchanged, and persisted aggregation rows keep their shape.

@arnab-dutta @faisalsiddique — the Passkey Security Monitor has to render an unknown rate as unknown. "Unknown" and "zero" must not look alike there either, which is the whole point of the change; the rateNote gives the UI the text to show alongside it.

---
Test and Document the changes

- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)


Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FIDO2 ceremony analytics now provide more accurate success, failure, completion, drop-off, and abandonment rates.
  * Rates without a valid denominator are reported as unknown instead of zero.
  * Analytics responses include an explanatory note when rates are unknown, capped, or use an alternate denominator.

* **Documentation**
  * Updated Passkey Telemetry guidance and API documentation to explain rate calculations and how unknown values should be displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->