### PR TITLE
fix(jans-fido2): remove unused metrics aggregation interval property

### DIFF
--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -28,8 +28,7 @@ The following properties represent the dynamic configuration for the Janssen FID
 | `metricReporterKeepDataDays` | `15` | The retention period in days for legacy metric reporter records stored in persistence. |
 | `metricReporterEnabled` | `true` | Boolean value specifying whether to enable the legacy jans-core metric reporter. |
 | `fido2MetricsEnabled` | `true` | Master switch for passkey telemetry collection. If `false`, no metric entries are stored. See [Passkey Telemetry & Metrics](passkey-telemetry.md). |
-| `fido2MetricsAggregationEnabled` | `true` | Enables the scheduled hourly/daily/weekly/monthly aggregation jobs for passkey telemetry. |
-| `fido2MetricsAggregationInterval` | `60` | Interval in minutes driving the passkey metrics aggregation scheduler (default `60` = hourly). |
+| `fido2MetricsAggregationEnabled` | `true` | Enables the scheduled hourly/daily/weekly/monthly aggregation jobs for passkey telemetry. The times those jobs run are fixed by cron expressions packaged with the server, not by dynamic configuration — see [Aggregation schedule](passkey-telemetry.md#aggregation-schedule). |
 | `fido2MetricsRetentionDays` | `90` | Retention period in days for passkey metric entries and aggregations before automatic cleanup. |
 | `fido2DeviceInfoCollection` | `true` | Whether device info (browser, OS, device type) is collected and stored with passkey metrics. |
 | `fido2ErrorCategorization` | `true` | Whether passkey operation failures are categorized for the error-analysis endpoint. |

--- a/docs/janssen-server/fido/passkey-telemetry.md
+++ b/docs/janssen-server/fido/passkey-telemetry.md
@@ -203,11 +203,28 @@ as listed below:
 |---|---|---|
 | `fido2MetricsEnabled` | `true` | Master switch for metrics collection. If `false`, no entries are stored. |
 | `fido2MetricsAggregationEnabled` | `true` | Enables the scheduled hourly/daily/weekly/monthly aggregation jobs. |
-| `fido2MetricsAggregationInterval` | `60` | Interval in **minutes** driving the aggregation scheduler (default `60` = hourly). |
 | `fido2MetricsRetentionDays` | `90` | Days to retain metrics entries before automatic cleanup. Aggregations are not swept — they are the long-term record that outlives the entries they were computed from. |
 | `fido2DeviceInfoCollection` | `true` | Whether device info (browser, OS, device type) is collected and stored. Entries are still written when this is `false` — only the `deviceInfo` field is omitted. Use `fido2MetricsEnabled` to stop writing entries altogether. |
 | `fido2ErrorCategorization` | `true` | Whether failures are categorized for the error-analysis endpoint. |
 | `fido2PerformanceMetrics` | `true` | Whether operation durations are tracked. |
+
+### Aggregation schedule
+
+`fido2MetricsAggregationEnabled` turns the aggregation jobs on and off, but *when* they run is not
+part of the dynamic configuration. Each job is registered against a fixed Quartz cron expression
+read from `fido2-metrics.properties`, which is packaged inside `fido2-server.war`:
+
+| Key | Default cron | Runs |
+|---|---|---|
+| `fido2.metrics.aggregation.hourly.cron` | `0 5 * * * ?` | 5 minutes past every hour |
+| `fido2.metrics.aggregation.daily.cron` | `0 10 1 * * ?` | 01:10 every day |
+| `fido2.metrics.aggregation.weekly.cron` | `0 15 1 ? * MON` | 01:15 every Monday |
+| `fido2.metrics.aggregation.monthly.cron` | `0 20 1 1 * ?` | 01:20 on the 1st of each month |
+
+Each cron key has a matching `...enabled` key that registers or skips that individual job. The
+properties file is read once when the scheduler class loads, so changes require a server restart.
+Because it ships inside the WAR, these values are not reachable through the Config API and there is
+currently no supported way to retune the schedule from dynamic configuration.
 
 !!! warning "Don't confuse these with `metricReporter*`"
     The `metricReporterEnabled` / `metricReporterInterval` / `metricReporterKeepDataDays`

--- a/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/fido2-plugin-swagger.yaml
@@ -1658,9 +1658,6 @@ components:
           type: boolean
         fido2MetricsAggregationEnabled:
           type: boolean
-        fido2MetricsAggregationInterval:
-          type: integer
-          format: int32
         personCustomObjectClassList:
           type: array
           items:

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/AppConfiguration.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/AppConfiguration.java
@@ -89,9 +89,6 @@ public class AppConfiguration implements Configuration, Serializable {
 	@DocProperty(description = "Boolean value specifying whether FIDO2 metrics aggregation is enabled", defaultValue = "true")
     private boolean fido2MetricsAggregationEnabled = true;
 	
-	@DocProperty(description = "Interval in minutes for FIDO2 metrics aggregation", defaultValue = "60")
-    private int fido2MetricsAggregationInterval = 60;
-	
 	@DocProperty(description = "Custom object class list for dynamic person enrolment")
     private List<String> personCustomObjectClassList;
 	
@@ -252,14 +249,6 @@ public class AppConfiguration implements Configuration, Serializable {
 
 	public void setFido2MetricsAggregationEnabled(boolean fido2MetricsAggregationEnabled) {
 		this.fido2MetricsAggregationEnabled = fido2MetricsAggregationEnabled;
-	}
-
-	public int getFido2MetricsAggregationInterval() {
-		return fido2MetricsAggregationInterval;
-	}
-
-	public void setFido2MetricsAggregationInterval(int fido2MetricsAggregationInterval) {
-		this.fido2MetricsAggregationInterval = fido2MetricsAggregationInterval;
 	}
 
 	public List<String> getPersonCustomObjectClassList() {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsAggregationScheduler.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/metric/Fido2MetricsAggregationScheduler.java
@@ -273,13 +273,6 @@ public class Fido2MetricsAggregationScheduler {
 
 
     /**
-     * Get aggregation interval in minutes
-     */
-    public int getAggregationInterval() {
-        return appConfiguration.getFido2MetricsAggregationInterval();
-    }
-
-    /**
      * Get data retention days
      */
     public int getDataRetentionDays() {


### PR DESCRIPTION
Description

`fido2MetricsAggregationInterval` was read only by `getAggregationInterval()` in
`Fido2MetricsAggregationScheduler`, which had no callers — it appears in a single commit in the
repository's history (39d742bbe4c, the one that introduced it), so it was never wired. The schedule
is driven by the four Quartz cron expressions resolved in `initTimer()`. Wiring the property up was
rejected because one minutes value has no coherent mapping onto four independent job types and would
create a second source of truth, so the property, its dead getter, its Config API schema entry, and
the two hand-written doc rows describing it are removed instead. `passkey-telemetry.md` gains an
"Aggregation schedule" section documenting the actual cron keys; `fido2-properties.md` is left alone
as it is autogenerated from `@DocProperty`. There is no runtime behaviour change and no upgrade
impact — `AppConfiguration` is `@JsonIgnoreProperties(ignoreUnknown = true)` and the resource exposes
only GET and PUT, so a stored config or older client still carrying the key is ignored, not rejected.
Verified: `model` and `server` both compile, no references remain, no tests referenced it, and
`server-fips/` has no Java sources to mirror.

Target issue

The property is documented in three places as controlling the passkey metrics aggregation schedule,
but nothing reads it — an operator who tunes it sees no change and no error, while aggregation keeps
running on its fixed cron schedule. This is the last open sub-issue of #14828.
  
closes #14832

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FIDO2 metrics guidance to use fixed, packaged schedules for hourly, daily, weekly, and monthly aggregation jobs.
  * Documented per-job enablement controls and noted that schedule changes require a server restart.
  * Clarified that schedules cannot currently be changed through the configuration API.

* **Configuration**
  * Removed the configurable metrics aggregation interval from supported FIDO2 settings and API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->