### PR TITLE
feat(cloud-native): admin-ui policy-store set-up changes

### DIFF
--- a/docker-jans-all-in-one/Dockerfile
+++ b/docker-jans-all-in-one/Dockerfile
@@ -59,7 +59,7 @@ RUN apk update \
 # Assets sync
 # ===========
 
-ARG JANS_SOURCE_VERSION=a85b887912dd857cea4f0e7f7febc06182da6035
+ARG JANS_SOURCE_VERSION=0ec865687513582fc63980c40c6cc980295182d3
 ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 
 # note that as we're pulling from a monorepo (with multiple project in it)

--- a/docker-jans-config-api/Dockerfile
+++ b/docker-jans-config-api/Dockerfile
@@ -83,7 +83,7 @@ RUN mkdir -p /etc/jans/conf \
     /app/templates/jans-config-api \
     /opt/jans/bin
 
-ARG JANS_SOURCE_VERSION=a85b887912dd857cea4f0e7f7febc06182da6035
+ARG JANS_SOURCE_VERSION=0ec865687513582fc63980c40c6cc980295182d3
 ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 ARG JANS_CONFIG_API_RESOURCES=jans-config-api/server/src/main/resources
@@ -121,13 +121,6 @@ RUN git clone --depth ${GIT_CLONE_DEPTH} --filter blob:none --no-checkout https:
     && chmod +x /opt/jans/bin/get_agama_lab_projects.py
 
 WORKDIR /
-
-# add default policy store (for admin-ui and cedarling integration) from https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore
-ARG AUI_POLICY_VERSION=v2.0.0
-ARG AUI_POLICY_FILE=admin_ui_2_0.cjar
-
-RUN mkdir -p ${JETTY_BASE}/jans-config-api/custom/config/adminUI \
-    && wget -nv https://github.com/GluuFederation/GluuFlexAdminUIPolicyStore/releases/download/${AUI_POLICY_VERSION}/${AUI_POLICY_FILE} -O ${JETTY_BASE}/jans-config-api/custom/config/adminUI/policy-store.cjar
 
 # ======
 # Python

--- a/docker-jans-config-api/scripts/plugins.py
+++ b/docker-jans-config-api/scripts/plugins.py
@@ -1,9 +1,7 @@
 import logging.config
 import os
 import shutil
-from tempfile import TemporaryDirectory
 from urllib.parse import urlparse
-from zipfile import ZipFile
 
 from jans.pycloudlib.utils import cert_to_truststore
 from jans.pycloudlib.utils import get_server_certificate
@@ -62,7 +60,6 @@ class AdminUiPlugin:
     def setup(self):
         logger.info("Configuring admin-ui plugin")
         self.import_token_server_cert()
-        self.configure_policy_store()
 
     def import_token_server_cert(self):
         cert_file = os.environ.get("CN_TOKEN_SERVER_CERT_FILE", "/etc/certs/token_server.crt")
@@ -108,31 +105,3 @@ class AdminUiPlugin:
 
         # download the cert (if possible)
         get_server_certificate(host, port, cert_file)
-
-    def configure_policy_store(self):
-        logger.info("Configuring admin-ui policy store")
-
-        hostname = self.manager.config.get("hostname")
-        policy_file = "trusted-issuers/GluuFlexAdminUI.json"
-        policy_file_found = False
-
-        with TemporaryDirectory() as tmp_dir:
-            src_archive_path = "/opt/jans/jetty/jans-config-api/custom/config/adminUI/policy-store.cjar"
-            tmp_archive_path = os.path.join(tmp_dir, "policy-store.cjar")
-
-            with ZipFile(src_archive_path, "r") as src_archive, ZipFile(tmp_archive_path, "w", compression=src_archive.compression) as tmp_archive:
-                for item in src_archive.infolist():
-                    if item.filename == policy_file:
-                        policy_file_found = True
-                        policy = src_archive.read(item.filename).decode()
-                        data = policy.replace("your-openid-provider.server", hostname).encode()
-                    else:
-                        data = src_archive.read(item.filename)
-                    # copy item and preserve the original compression
-                    tmp_archive.writestr(item, data, compress_type=item.compress_type)
-
-            if not policy_file_found:
-                raise FileNotFoundError(f"The required policy file {policy_file} is not found in {src_archive_path} archive.")
-
-            # replace the original archive
-            shutil.move(tmp_archive_path, src_archive_path)

--- a/docker-jans-persistence-loader/Dockerfile
+++ b/docker-jans-persistence-loader/Dockerfile
@@ -18,7 +18,7 @@ RUN apk update \
 RUN mkdir -p /app/static /app/schema /app/static/opendj /app/templates
 
 # janssenproject/jans SHA commit
-ARG JANS_SOURCE_VERSION=958e7b9d161cdd94c4468fc975abd58f9e3bfd14
+ARG JANS_SOURCE_VERSION=0ec865687513582fc63980c40c6cc980295182d3
 ENV JANS_SOURCE_VERSION=${JANS_SOURCE_VERSION}
 ARG JANS_SETUP_DIR=jans-linux-setup/jans_setup
 ARG JANS_SCRIPT_CATALOG_DIR=docs/script-catalog

--- a/docker-jans-persistence-loader/scripts/utils.py
+++ b/docker-jans-persistence-loader/scripts/utils.py
@@ -232,7 +232,7 @@ def get_role_scope_mappings(path="/app/templates/jans-auth/role-scope-mappings.j
         if api_role["role"] != "admin":
             continue
 
-        # add special permissions for api-admin
+        # add special permissions for admin
         for scope in scope_list:
             if scope in role_mapping["rolePermissionMapping"][i]["permissions"]:
                 continue

--- a/docker-jans-persistence-loader/scripts/utils.py
+++ b/docker-jans-persistence-loader/scripts/utils.py
@@ -229,7 +229,7 @@ def get_role_scope_mappings(path="/app/templates/jans-auth/role-scope-mappings.j
     scope_list = get_config_api_scopes()
 
     for i, api_role in enumerate(role_mapping["rolePermissionMapping"]):
-        if api_role["role"] != "api-admin":
+        if api_role["role"] != "admin":
             continue
 
         # add special permissions for api-admin


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14916

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

The policy store for admin-ui is no longer lives inside jans-config-api custom directory.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default platform revision used by container builds.
  * Corrected role permission mapping for configuration API scopes.
  * Removed legacy automatic admin UI policy-store setup during configuration.

* **Maintenance**
  * Simplified administrative setup to retain only token-server certificate configuration.
  * Aligned containerized components with the latest shared platform assets for more consistent builds and deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->