### PR TITLE
feat(jans-auth-server): enabled CIMD by default #14780

### DIFF
--- a/docker-jans-persistence-loader/scripts/test_data_setup.py
+++ b/docker-jans-persistence-loader/scripts/test_data_setup.py
@@ -133,7 +133,7 @@ AUTH_DYNAMIC_CONF_DELTA = {
     "tokenEndpointAuthMethodsSupported": ["client_secret_basic", "client_secret_post", "client_secret_jwt", "private_key_jwt", "tls_client_auth", "self_signed_tls_client_auth", "none"],
     "sessionIdRequestParameterEnabled": True,
     "skipRefreshTokenDuringRefreshing": False,
-    "featureFlags": ["unknown", "health_check", "userinfo", "clientinfo", "id_generation", "registration", "introspection", "revoke_token", "global_token_revocation", "end_session", "status_session", "jans_configuration", "ciba", "uma", "u2f", "device_authz", "stat", "par", "ssa", "status_list", "logout_status_jwt", "access_evaluation", "client_id_metadata_document"],
+    "featureFlags": ["unknown", "health_check", "userinfo", "clientinfo", "id_generation", "registration", "introspection", "revoke_token", "global_token_revocation", "end_session", "status_session", "jans_configuration", "ciba", "uma", "u2f", "device_authz", "stat", "par", "ssa", "status_list", "logout_status_jwt", "access_evaluation"],
     "loggingLevel": "TRACE",
 }
 

--- a/docker-jans-persistence-loader/scripts/test_data_setup.py
+++ b/docker-jans-persistence-loader/scripts/test_data_setup.py
@@ -133,7 +133,7 @@ AUTH_DYNAMIC_CONF_DELTA = {
     "tokenEndpointAuthMethodsSupported": ["client_secret_basic", "client_secret_post", "client_secret_jwt", "private_key_jwt", "tls_client_auth", "self_signed_tls_client_auth", "none"],
     "sessionIdRequestParameterEnabled": True,
     "skipRefreshTokenDuringRefreshing": False,
-    "featureFlags": ["unknown", "health_check", "userinfo", "clientinfo", "id_generation", "registration", "introspection", "revoke_token", "global_token_revocation", "end_session", "status_session", "jans_configuration", "ciba", "uma", "u2f", "device_authz", "stat", "par", "ssa", "status_list", "logout_status_jwt", "access_evaluation"],
+    "featureFlags": ["unknown", "health_check", "userinfo", "clientinfo", "id_generation", "registration", "introspection", "revoke_token", "global_token_revocation", "end_session", "status_session", "jans_configuration", "ciba", "uma", "u2f", "device_authz", "stat", "par", "ssa", "status_list", "logout_status_jwt", "access_evaluation", "client_id_metadata_document"],
     "loggingLevel": "TRACE",
 }
 

--- a/docs/janssen-server/reference/json/feature-flags/janssenauthserver-feature-flags.md
+++ b/docs/janssen-server/reference/json/feature-flags/janssenauthserver-feature-flags.md
@@ -72,7 +72,7 @@ tags:
 
 - Required: No
 
-- Default value: Disabled
+- Default value: Enabled
 
 
 ## CLIENTINFO

--- a/jans-auth-server/model/src/main/java/io/jans/as/model/common/FeatureFlagType.java
+++ b/jans-auth-server/model/src/main/java/io/jans/as/model/common/FeatureFlagType.java
@@ -89,7 +89,7 @@ public enum FeatureFlagType {
             defaultValue = "Enabled")
     SSA("ssa"),
     @DocFeatureFlag(description = "Enable/Disable OAuth Client ID Metadata Document support (URL-based client_id)",
-            defaultValue = "Disabled")
+            defaultValue = "Enabled")
     CLIENT_ID_METADATA_DOCUMENT("client_id_metadata_document"),
     @DocFeatureFlag(description = "Enable/Disable Identity Assertion Authorization Grant (Cross-App Access / ID-JAG) support",
             defaultValue = "Disabled")

--- a/jans-auth-server/server/conf/jans-config.json
+++ b/jans-auth-server/server/conf/jans-config.json
@@ -23,6 +23,7 @@
       "status_list",
       "session_status_list",
       "access_evaluation",
+      "client_id_metadata_document",
       "identity_assertion_authz_grant"
     ],
     "issuer":"${config.oxauth.issuer}",

--- a/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
+++ b/jans-linux-setup/jans_setup/setup_app/test_data_loader.py
@@ -257,7 +257,7 @@ class TestDataLoader(BaseInstaller, SetupUtils):
                                     'tokenEndpointAuthMethodsSupported': [ 'client_secret_basic', 'client_secret_post', 'client_secret_jwt', 'private_key_jwt', 'tls_client_auth', 'self_signed_tls_client_auth', 'none' ],
                                     'sessionIdRequestParameterEnabled': True,
                                     'skipRefreshTokenDuringRefreshing': False,
-                                    'featureFlags': ['unknown', 'health_check', 'userinfo', 'clientinfo', 'id_generation', 'registration', 'introspection', 'revoke_token', 'global_token_revocation', 'end_session', 'status_session', 'jans_configuration', 'ciba', 'uma', 'u2f', 'device_authz', 'stat', 'par', 'ssa', 'status_list', 'logout_status_jwt', 'access_evaluation', 'identity_assertion_authz_grant'],
+                                    'featureFlags': ['unknown', 'health_check', 'userinfo', 'clientinfo', 'id_generation', 'registration', 'introspection', 'revoke_token', 'global_token_revocation', 'end_session', 'status_session', 'jans_configuration', 'ciba', 'uma', 'u2f', 'device_authz', 'stat', 'par', 'ssa', 'status_list', 'logout_status_jwt', 'access_evaluation', 'identity_assertion_authz_grant', 'client_id_metadata_document'],
                                     'loggingLevel': 'TRACE',
                                     }
 

--- a/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
+++ b/jans-linux-setup/jans_setup/templates/jans-auth/jans-auth-config.json
@@ -24,6 +24,7 @@
       "logout_status_jwt",
       "rate_limit",
       "access_evaluation",
+      "client_id_metadata_document",
       "identity_assertion_authz_grant"
     ],
     "issuer":"https://%(hostname)s",


### PR DESCRIPTION
### Description

feat(jans-auth-server): enabled CIMD by default 

#### Target issue
  
closes #14780

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled the client ID metadata document feature by default.
  * Added the feature flag to standard Auth Server configurations and setup templates.

* **Tests**
  * Updated test configuration data to include the enabled client ID metadata document feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->