### PR TITLE
fix(ci): serve admin-ui agama-pw.gama to AIO integration image builds

### DIFF
--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -123,7 +123,8 @@ if [ -z "${AIO_IMAGE:-}" ]; then
   LOCAL_RELEASE="$REPO_ROOT/local-release"
   mkdir -p "$LOCAL_RELEASE"
   find "$HOME/.m2/repository/io/jans" -type f -path "*/0.0.0-nightly/*" \
-    \( -name '*.war' -o -name '*-distribution.jar' \) -exec cp -f {} "$LOCAL_RELEASE/" \;
+    \( -name '*.war' -o -name '*-distribution.jar' -o -name '*-agama-pw.gama' \) \
+    -exec cp -f {} "$LOCAL_RELEASE/" \;
   echo "serving local artifacts on :8088"; ls "$LOCAL_RELEASE"
   ( cd "$LOCAL_RELEASE" && exec python3 -m http.server 8088 >/dev/null 2>&1 ) &
 fi


### PR DESCRIPTION
Integration CI serves locally-built artifacts on `:8088` for the service image builds. The collector only copied `*.war` and `*-distribution.jar`, so `admin-ui-plugin-<version>-agama-pw.gama` (fetched by `docker-jans-config-api/Dockerfile:74`) 404d and the config-api image build failed with wget exit 8.

Add the `.gama` to the collected set.

Failing run: https://github.com/JanssenProject/jans/actions/runs/33504066154
Closes #14944, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Included Agama password flow artifacts in local release builds, ensuring they are available during AIO image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->