### PR TITLE
fix(jans-config-api): errror due to removal on unused policy-store config from Admin U…

### DIFF
--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/filters/AdminUICookieFilter.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/filters/AdminUICookieFilter.java
@@ -312,9 +312,6 @@ public class AdminUICookieFilter implements ContainerRequestFilter {
         config.setAllowSmtpKeystoreEdit(appConf.getMainSettings().getUiConfig().getAllowSmtpKeystoreEdit());
         config.setAdditionalParameters(appConf.getMainSettings().getOidcConfig().getAuiWebClient().getAdditionalParameters());
         config.setCedarlingLogType(CedarlingLogType.fromString(appConf.getMainSettings().getUiConfig().getCedarlingLogType()));
-        config.setAuiCedarlingPolicyStoreUrl(appConf.getMainSettings().getUiConfig().getAuiPolicyStoreUrl());
-        config.setAuiCedarlingDefaultPolicyStorePath(appConf.getMainSettings().getUiConfig().getAuiDefaultPolicyStorePath());
-
         // Assign fully-constructed object last
         auiConfiguration = config;
     }

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/model/auth/AppConfigResponse.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/model/auth/AppConfigResponse.java
@@ -37,10 +37,6 @@ public class AppConfigResponse {
     private List<KeyValuePair> additionalParameters;
     @Schema(description = "Cedarling log type", accessMode = Schema.AccessMode.READ_WRITE)
     private CedarlingLogType cedarlingLogType;
-    @Schema(description = "Admin UI Policy Store URL", accessMode = Schema.AccessMode.READ_WRITE)
-    private String auiPolicyStoreUrl;
-    @Schema(description = "Admin UI Default Policy Store path", accessMode = Schema.AccessMode.READ_WRITE)
-    private String auiDefaultPolicyStorePath;
 
     /**
      * Retrieve the additional key-value parameters configured for the Admin UI.
@@ -167,31 +163,5 @@ public class AppConfigResponse {
 
     public void setCedarlingLogType(CedarlingLogType cedarlingLogType) {
         this.cedarlingLogType = cedarlingLogType;
-    }
-
-    public String getAuiPolicyStoreUrl() {
-        return auiPolicyStoreUrl;
-    }
-
-    /**
-     * Set the Admin UI policy store URL.
-     *
-     * @param auiPolicyStoreUrl the URL of the policy store used by the Admin UI
-     */
-    public void setAuiPolicyStoreUrl(String auiPolicyStoreUrl) {
-        this.auiPolicyStoreUrl = auiPolicyStoreUrl;
-    }
-
-    /**
-     * Gets the default policy store path used by the Admin UI.
-     *
-     * @return the configured default policy store path, or `null` if not set
-     */
-    public String getAuiDefaultPolicyStorePath() {
-        return auiDefaultPolicyStorePath;
-    }
-
-    public void setAuiDefaultPolicyStorePath(String auiDefaultPolicyStorePath) {
-        this.auiDefaultPolicyStorePath = auiDefaultPolicyStorePath;
     }
 }

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/adminui/AdminUIService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/adminui/AdminUIService.java
@@ -60,8 +60,6 @@ public class AdminUIService {
             appConfigResponse.setAllowSmtpKeystoreEdit(auiConfiguration.getAllowSmtpKeystoreEdit());
             appConfigResponse.setAdditionalParameters(auiConfiguration.getAdditionalParameters());
             appConfigResponse.setCedarlingLogType(auiConfiguration.getCedarlingLogType());
-            appConfigResponse.setAuiPolicyStoreUrl(auiConfiguration.getAuiCedarlingPolicyStoreUrl());
-            appConfigResponse.setAuiDefaultPolicyStorePath(auiConfiguration.getAuiCedarlingDefaultPolicyStorePath());
 
             return appConfigResponse;
         } catch (Exception e) {

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/adminui/AdminUIService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/adminui/AdminUIService.java
@@ -102,14 +102,7 @@ public class AdminUIService {
                 adminConf.getMainSettings().getUiConfig().setCedarlingLogType(appConfigResponse.getCedarlingLogType().getValue());
                 auiConfigurationService.getAUIConfiguration().setCedarlingLogType(appConfigResponse.getCedarlingLogType());
             }
-            if (!Strings.isNullOrEmpty(appConfigResponse.getAuiPolicyStoreUrl())) {
-                adminConf.getMainSettings().getUiConfig().setAuiPolicyStoreUrl(appConfigResponse.getAuiPolicyStoreUrl());
-                auiConfigurationService.getAUIConfiguration().setAuiCedarlingPolicyStoreUrl(appConfigResponse.getAuiPolicyStoreUrl());
-            }
-            if (!Strings.isNullOrEmpty(appConfigResponse.getAuiDefaultPolicyStorePath())) {
-                adminConf.getMainSettings().getUiConfig().setAuiDefaultPolicyStorePath(appConfigResponse.getAuiDefaultPolicyStorePath());
-                auiConfigurationService.getAUIConfiguration().setAuiCedarlingDefaultPolicyStorePath(appConfigResponse.getAuiDefaultPolicyStorePath());
-            }
+
             entryManager.merge(adminConf);
             return getAdminUIEditableConfiguration();
         } catch (Exception e) {

--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/config/AUIConfigurationService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/service/config/AUIConfigurationService.java
@@ -128,8 +128,6 @@ public class AUIConfigurationService extends BaseService {
         auiConfig.setAllowSmtpKeystoreEdit(appConf.getMainSettings().getUiConfig().getAllowSmtpKeystoreEdit());
         auiConfig.setAdditionalParameters(appConf.getMainSettings().getOidcConfig().getAuiWebClient().getAdditionalParameters());
         auiConfig.setCedarlingLogType(CedarlingLogType.fromString(appConf.getMainSettings().getUiConfig().getCedarlingLogType()));
-        auiConfig.setAuiCedarlingPolicyStoreUrl(appConf.getMainSettings().getUiConfig().getAuiPolicyStoreUrl());
-        auiConfig.setAuiCedarlingDefaultPolicyStorePath(appConf.getMainSettings().getUiConfig().getAuiDefaultPolicyStorePath());
         return auiConfig;
     }
 

--- a/jans-config-api/plugins/docs/jans-admin-ui-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/jans-admin-ui-plugin-swagger.yaml
@@ -2370,7 +2370,9 @@ components:
               administrative access to license related information (super-user level)
             https://jans.io/oauth/jans-auth-server/config/adminui/security.readonly: View
               Admin UI security related information
-            https://jans.io/oauth/jans-auth-server/config/adminui/security.write: Manage
+            https://jans.io/oauth/jans-auth-server/config/adminui/security.write: Edit
+              Admin UI security related information
+            https://jans.io/oauth/jans-auth-server/config/adminui/security.delete: Delete
               Admin UI security related information
             https://jans.io/oauth/jans-auth-server/config/adminui/properties.readonly: View
               Admin UI configuration properties related information

--- a/jans-config-api/plugins/docs/jans-admin-ui-plugin-swagger.yaml
+++ b/jans-config-api/plugins/docs/jans-admin-ui-plugin-swagger.yaml
@@ -2067,12 +2067,6 @@ components:
           enum:
           - "off"
           - std_out
-        auiPolicyStoreUrl:
-          type: string
-          description: Admin UI Policy Store URL
-        auiDefaultPolicyStorePath:
-          type: string
-          description: Admin UI Default Policy Store path
     KeyValuePair:
       type: object
       properties:

--- a/jans-config-api/pom.xml
+++ b/jans-config-api/pom.xml
@@ -219,17 +219,6 @@
 			</dependency>
 			<dependency>
 				<groupId>io.jans</groupId>
-				<artifactId>jans-core-cedarling</artifactId>
-				<version>${jans.version}</version>
-				<exclusions>
-					<exclusion>
-						<artifactId>org.jboss.resteasy</artifactId>
-						<groupId>*</groupId>
-					</exclusion>
-				</exclusions>
-			</dependency>			
-			<dependency>
-				<groupId>io.jans</groupId>
 				<artifactId>jans-orm-annotation</artifactId>
 				<version>${jans.version}</version>
 			</dependency>

--- a/jans-config-api/shared/src/main/java/io/jans/configapi/core/model/adminui/AUIConfiguration.java
+++ b/jans-config-api/shared/src/main/java/io/jans/configapi/core/model/adminui/AUIConfiguration.java
@@ -41,8 +41,6 @@ public class AUIConfiguration {
     private Boolean allowSmtpKeystoreEdit;
     private List<KeyValuePair> additionalParameters;
     private CedarlingLogType cedarlingLogType;
-    private String auiCedarlingPolicyStoreUrl;
-    private String auiCedarlingDefaultPolicyStorePath;
 
     /**
      * Retrieves the additional key-value parameters configured for the Admin UI.
@@ -603,42 +601,6 @@ public class AUIConfiguration {
     }
 
     /**
-     * Gets the Admin UI Cedarling policy store URL.
-     *
-     * @return the configured Cedarling policy store URL for the Admin UI, or {@code null} if not set.
-     */
-    public String getAuiCedarlingPolicyStoreUrl() {
-        return auiCedarlingPolicyStoreUrl;
-    }
-
-    /**
-     * Sets the Admin UI Cedarling policy store URL.
-     *
-     * @param auiCedarlingPolicyStoreUrl the URL of the Cedarling policy store used by the Admin UI
-     */
-    public void setAuiCedarlingPolicyStoreUrl(String auiCedarlingPolicyStoreUrl) {
-        this.auiCedarlingPolicyStoreUrl = auiCedarlingPolicyStoreUrl;
-    }
-
-    /**
-     * Gets the default filesystem path used for the Admin UI's Cedarling policy store.
-     *
-     * @return the default Cedarling policy store path for the Admin UI, or `null` if not set
-     */
-    public String getAuiCedarlingDefaultPolicyStorePath() {
-        return auiCedarlingDefaultPolicyStorePath;
-    }
-
-    /**
-     * Set the default filesystem path that Cedarling uses for the Admin UI policy store.
-     *
-     * @param auiCedarlingDefaultPolicyStorePath the default policy store path to use, or {@code null} to unset
-     */
-    public void setAuiCedarlingDefaultPolicyStorePath(String auiCedarlingDefaultPolicyStorePath) {
-        this.auiCedarlingDefaultPolicyStorePath = auiCedarlingDefaultPolicyStorePath;
-    }
-
-    /**
      * Produce a string representation of this AUIConfiguration containing all configuration fields and their current values.
      *
      * @return a string containing each field name and its current value for this configuration instance
@@ -675,8 +637,6 @@ public class AUIConfiguration {
                 ", allowSmtpKeystoreEdit=" + allowSmtpKeystoreEdit +
                 ", additionalParameters=" + additionalParameters +
                 ", cedarlingLogType=" + cedarlingLogType +
-                ", auiCedarlingPolicyStoreUrl='" + auiCedarlingPolicyStoreUrl + '\'' +
-                ", auiCedarlingDefaultPolicyStorePath='" + auiCedarlingDefaultPolicyStorePath +
                 '}';
     }
 }


### PR DESCRIPTION
…I plugin

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14953

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - Removed the Admin UI policy store URL and default policy store path from configuration responses and settings.
  - Admin UI configuration updates no longer modify these policy store settings.
  - Existing Cedarling, OIDC, backend API, UI, and log-type settings continue to be handled as before.

- **Documentation**
  - Updated the `security.write` OAuth scope description from “Manage” to “Edit” Admin UI security information.
  - Added a `security.delete` OAuth scope for deleting Admin UI security information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->