### PR TITLE
fix(jans-fido2): support P-384 and P-521 curves in COSE key decoding

### DIFF
--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
@@ -66,8 +66,16 @@ public class CoseService {
 
     private static final String SECP256R1_CURVE_NAME = "secp256r1";
 
-    // COSE Elliptic Curves registry: P-256 is curve 1, Ed25519 is curve 6
+    private static final String SECP384R1_CURVE_NAME = "secp384r1";
+
+    private static final String SECP521R1_CURVE_NAME = "secp521r1";
+
+    // COSE Elliptic Curves registry: P-256 is curve 1, P-384 is 2, P-521 is 3, Ed25519 is 6
     private static final int COSE_CURVE_P256 = 1;
+
+    private static final int COSE_CURVE_P384 = 2;
+
+    private static final int COSE_CURVE_P521 = 3;
 
     private static final int COSE_CURVE_ED25519 = 6;
 
@@ -87,11 +95,16 @@ public class CoseService {
     private DataMapperService dataMapperService;
 
     private static String convertCoseCurveToSunCurveName(int curve) {
-        if (curve == COSE_CURVE_P256) {
+        switch (curve) {
+        case COSE_CURVE_P256:
             return SECP256R1_CURVE_NAME;
+        case COSE_CURVE_P384:
+            return SECP384R1_CURVE_NAME;
+        case COSE_CURVE_P521:
+            return SECP521R1_CURVE_NAME;
+        default:
+            throw new Fido2RuntimeException("Unsupported curve " + curve);
         }
-
-        throw new Fido2RuntimeException("Unsupported curve");
     }
 
     public int getCodeCurve(JsonNode uncompressedECPointNode) {

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/CoseServiceCurveTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/CoseServiceCurveTest.java
@@ -1,0 +1,147 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.jans.fido2.exception.Fido2RuntimeException;
+import io.jans.util.security.SecurityProviderUtility;
+
+/**
+ * Covers EC2 key decoding across the curves in the FIDO Server Requirements v2.3 table. P-256 is Required,
+ * P-384 Recommended and P-521 Optional, but the decoder mapped only P-256, so a credential on any other
+ * curve failed registration regardless of the algorithm it negotiated.
+ */
+@ExtendWith(MockitoExtension.class)
+class CoseServiceCurveTest {
+
+    private static final int COSE_KTY_EC2 = 2;
+    private static final int COSE_ALG_ES256 = -7;
+    private static final int COSE_CURVE_P256 = 1;
+    private static final int COSE_CURVE_P384 = 2;
+    private static final int COSE_CURVE_P521 = 3;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Mock
+    private Logger log;
+
+    @Spy
+    private Base64Service base64Service = initializedBase64Service();
+
+    @InjectMocks
+    private CoseService coseService;
+
+    @BeforeAll
+    static void beforeAll() {
+        SecurityProviderUtility.installBCProvider();
+    }
+
+    private static Base64Service initializedBase64Service() {
+        Base64Service base64Service = new Base64Service();
+        base64Service.init();
+
+        return base64Service;
+    }
+
+    private static KeyPair generateEcKeyPair(String curveName) throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC",
+                SecurityProviderUtility.getBCProvider());
+        keyPairGenerator.initialize(new ECGenParameterSpec(curveName));
+
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    /**
+     * COSE carries the affine coordinates zero-padded to the curve's field size, which is what
+     * {@code convertUncompressedPointToECKey} expects to find on either side of the point indicator.
+     */
+    private static byte[] toFixedLength(BigInteger coordinate, int keySizeBytes) {
+        byte[] unpadded = coordinate.toByteArray();
+        if (unpadded.length == keySizeBytes) {
+            return unpadded;
+        }
+        if (unpadded.length > keySizeBytes) {
+            return Arrays.copyOfRange(unpadded, unpadded.length - keySizeBytes, unpadded.length);
+        }
+
+        byte[] padded = new byte[keySizeBytes];
+        System.arraycopy(unpadded, 0, padded, keySizeBytes - unpadded.length, unpadded.length);
+
+        return padded;
+    }
+
+    private ObjectNode coseKey(int curve, ECPublicKey publicKey) {
+        int keySizeBytes = (publicKey.getParams().getOrder().bitLength() + Byte.SIZE - 1) / Byte.SIZE;
+
+        ObjectNode coseKeyNode = mapper.createObjectNode();
+        coseKeyNode.put("1", COSE_KTY_EC2);
+        coseKeyNode.put("3", COSE_ALG_ES256);
+        coseKeyNode.put("-1", curve);
+        coseKeyNode.put("-2", toFixedLength(publicKey.getW().getAffineX(), keySizeBytes));
+        coseKeyNode.put("-3", toFixedLength(publicKey.getW().getAffineY(), keySizeBytes));
+
+        return coseKeyNode;
+    }
+
+    private void assertRoundTrips(String curveName, int coseCurve) throws Exception {
+        KeyPair keyPair = generateEcKeyPair(curveName);
+        ECPublicKey publicKey = (ECPublicKey) keyPair.getPublic();
+
+        PublicKey decoded = coseService.createUncompressedPointFromCOSEPublicKey(coseKey(coseCurve, publicKey));
+
+        assertArrayEquals(publicKey.getEncoded(), decoded.getEncoded());
+    }
+
+    @Test
+    void createUncompressedPointFromCOSEPublicKey_withP256Key_rebuildsTheSameKey() throws Exception {
+        assertRoundTrips("secp256r1", COSE_CURVE_P256);
+    }
+
+    @Test
+    void createUncompressedPointFromCOSEPublicKey_withP384Key_rebuildsTheSameKey() throws Exception {
+        assertRoundTrips("secp384r1", COSE_CURVE_P384);
+    }
+
+    @Test
+    void createUncompressedPointFromCOSEPublicKey_withP521Key_rebuildsTheSameKey() throws Exception {
+        assertRoundTrips("secp521r1", COSE_CURVE_P521);
+    }
+
+    @Test
+    void createUncompressedPointFromCOSEPublicKey_withUnknownCurve_reportsTheReceivedCurve() throws Exception {
+        KeyPair keyPair = generateEcKeyPair("secp256r1");
+        ObjectNode coseKeyNode = coseKey(99, (ECPublicKey) keyPair.getPublic());
+
+        Fido2RuntimeException ex = assertThrows(Fido2RuntimeException.class,
+                () -> coseService.createUncompressedPointFromCOSEPublicKey(coseKeyNode));
+
+        assertTrue(ex.getMessage().contains("99"));
+    }
+}


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14931

Sub-issue of #14925, under #14891. Follows #14950 (#14929), which landed the OKP branch in the same method.

#### Implementation Details

`CoseService.convertCoseCurveToSunCurveName()` mapped exactly one curve:

```java
if (curve == COSE_CURVE_P256) {
    return SECP256R1_CURVE_NAME;
}
throw new Fido2RuntimeException("Unsupported curve");
```

So an authenticator on any curve other than P-256 failed registration regardless of which algorithm it
negotiated — confirmed at runtime with an EC2 key on P-384, which produced
`Fido2RuntimeException: Unsupported curve`. P-384 is **Recommended** in the FIDO Server Requirements v2.3
table and P-521 is Optional.

This maps curve `2` to `secp384r1` and curve `3` to `secp521r1`, and makes the `default` branch report the
curve identifier it actually received rather than a bare "Unsupported curve" — the old message gave an
operator nothing to act on.

No change was needed in `convertUncompressedPointToECKey`: it already derives the field size from the curve
parameters, so the coordinate handling works for all three curves once the name resolves.

Note this is the curve mapping only. The EC2 branch still accepts just `ES256`, so a P-384 credential
negotiating `ES384` remains unsupported — that is #14932, and the wrong `ES384` / `ES512` code points are
#14924.

`server-fips/` needs no mirroring: it is a pom-only module that repackages the `server` artifact and has no
`src/` tree of its own. All three curve names resolve through `AlgorithmParameters.getInstance("EC")`, which
is JDK-provided rather than provider-specific.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

New `CoseServiceCurveTest` — round-trip decode for a generated keypair on each of P-256, P-384 and P-521,
asserting the rebuilt key matches the original encoding, plus a case asserting an unknown curve identifier
appears in the error message.

```
CoseServiceCurveTest       4 tests, 0 failures
jans-fido2 server module 429 tests, 0 failures
```

No configuration property or endpoint changes — this makes credentials on already-permitted curves work, so
there is nothing user-facing to document.

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for P-384 and P-521 elliptic curves when processing COSE public keys.
  - Expanded FIDO2 compatibility for credentials using these additional security curves.

- **Bug Fixes**
  - Improved handling of unsupported elliptic curves by providing clearer error details, including the unrecognized curve value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->