### PR TITLE
fix(jans-config-api): agama-pw authentication in Admin UI shows error if username is correct and password is incorrect

### DIFF
--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -71,28 +71,26 @@ public class JansPasswordService extends PasswordService {
         if (currentFailCount < DEFAULT_MAX_LOGIN_ATTEMPT) {
             int remainingCount = DEFAULT_MAX_LOGIN_ATTEMPT - currentFailCount;
             logger.info("Remaining login count: {} for user {}", remainingCount, username);
-            if (remainingCount > 0 && currentStatus.equalsIgnoreCase("active")) {
+            if (remainingCount > 0 && currentStatus.equalsIgnoreCase(GluuStatus.ACTIVE.getValue())) {
                 setCustomAttribute(currentUser, INVALID_LOGIN_COUNT_ATTRIBUTE, String.valueOf(currentFailCount));
                 logger.info("{}  more attempt(s) before account is LOCKED!", remainingCount);
             }
             return "You have " + remainingCount + " more attempt(s) before your account is locked.";
         }
-        if (currentFailCount >= DEFAULT_MAX_LOGIN_ATTEMPT && currentStatus.equalsIgnoreCase("active")) {
+        if (currentFailCount >= DEFAULT_MAX_LOGIN_ATTEMPT && currentStatus.equalsIgnoreCase(GluuStatus.ACTIVE.getValue())) {
             logger.info("Locking {} account for {} seconds.", username, DEFAULT_LOCK_EXP_TIME);
             String object_to_store = "{'locked': 'true'}";
-            currentUser.setStatus(GluuStatus.INACTIVE);
-            //userService.updateUser(currentUser);
+            currentUser.setStatus(GluuStatus.INACTIVE); // this line of code required to save user's status
             setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
             cacheService.put(DEFAULT_LOCK_EXP_TIME, CACHE_PREFIX + username, object_to_store);
             return "Your account has been locked.";
         }
-        if (currentFailCount >= DEFAULT_MAX_LOGIN_ATTEMPT && currentStatus.equalsIgnoreCase("inactive")) {
+        if (currentFailCount >= DEFAULT_MAX_LOGIN_ATTEMPT && currentStatus.equalsIgnoreCase(GluuStatus.INACTIVE.getValue())) {
             logger.info("User {} account is already locked. Checking if we can unlock", username);
             String cache_object = cacheService.get(CACHE_PREFIX + username);
             if (cache_object == null) {
                 logger.info("Unlocking user {} account", username);
-                currentUser.setStatus(GluuStatus.ACTIVE);
-                //userService.updateUser(currentUser);
+                currentUser.setStatus(GluuStatus.ACTIVE); // this line of code required to save user's status
                 setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
                 setCustomAttribute(currentUser, INVALID_LOGIN_COUNT_ATTRIBUTE, "0");
                 return "Your account  is now unlock. Try login ";

--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -69,12 +69,10 @@ public class JansPasswordService extends PasswordService {
         String currentStatus = currentUser.getStatus() != null ? currentUser.getStatus().getValue() : null;
         logger.info("Current user status is: {}", currentStatus);
         if (currentStatus == null) {
-            logger.info("User status is not set. Marking the user as inactive.");
-            String object_to_store = "{'locked': 'true'}";
+            logger.info("User status is not set. Marking the user status as inactive.");
             currentUser.setStatus(GluuStatus.INACTIVE); // this line of code required to save user's status
             setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
-            cacheService.put(DEFAULT_LOCK_EXP_TIME, CACHE_PREFIX + username, object_to_store);
-            return "User status is not set. Marking the user as inactive.";
+            return "User status is not set so marking the user as inactive. Contact administrator to make user account active.";
         }
         if (currentFailCount < DEFAULT_MAX_LOGIN_ATTEMPT) {
             int remainingCount = DEFAULT_MAX_LOGIN_ATTEMPT - currentFailCount;

--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -4,6 +4,7 @@ import io.jans.agama.engine.service.FlowService;
 import io.jans.as.common.model.common.User;
 import io.jans.as.server.service.AuthenticationService;
 import io.jans.as.server.service.UserService;
+import io.jans.model.GluuStatus;
 import io.jans.orm.model.base.CustomObjectAttribute;
 import io.jans.service.CacheService;
 import io.jans.service.cdi.util.CdiUtil;
@@ -79,7 +80,7 @@ public class JansPasswordService extends PasswordService {
         if (currentFailCount >= DEFAULT_MAX_LOGIN_ATTEMPT && currentStatus.equalsIgnoreCase("active")) {
             logger.info("Locking {} account for {} seconds.", username, DEFAULT_LOCK_EXP_TIME);
             String object_to_store = "{'locked': 'true'}";
-            setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
+            currentUser.setStatus(GluuStatus.INACTIVE);
             cacheService.put(DEFAULT_LOCK_EXP_TIME, CACHE_PREFIX + username, object_to_store);
             return "Your account has been locked.";
         }
@@ -88,7 +89,7 @@ public class JansPasswordService extends PasswordService {
             String cache_object = cacheService.get(CACHE_PREFIX + username);
             if (cache_object == null) {
                 logger.info("Unlocking user {} account", username);
-                setCustomAttribute(currentUser, JANS_STATUS, ACTIVE);
+                currentUser.setStatus(GluuStatus.ACTIVE);
                 setCustomAttribute(currentUser, INVALID_LOGIN_COUNT_ATTRIBUTE, "0");
                 return "Your account  is now unlock. Try login ";
             }

--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -81,6 +81,8 @@ public class JansPasswordService extends PasswordService {
             logger.info("Locking {} account for {} seconds.", username, DEFAULT_LOCK_EXP_TIME);
             String object_to_store = "{'locked': 'true'}";
             currentUser.setStatus(GluuStatus.INACTIVE);
+            //userService.updateUser(currentUser);
+            setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
             cacheService.put(DEFAULT_LOCK_EXP_TIME, CACHE_PREFIX + username, object_to_store);
             return "Your account has been locked.";
         }
@@ -90,6 +92,8 @@ public class JansPasswordService extends PasswordService {
             if (cache_object == null) {
                 logger.info("Unlocking user {} account", username);
                 currentUser.setStatus(GluuStatus.ACTIVE);
+                //userService.updateUser(currentUser);
+                setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
                 setCustomAttribute(currentUser, INVALID_LOGIN_COUNT_ATTRIBUTE, "0");
                 return "Your account  is now unlock. Try login ";
             }

--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -91,7 +91,7 @@ public class JansPasswordService extends PasswordService {
             if (cache_object == null) {
                 logger.info("Unlocking user {} account", username);
                 currentUser.setStatus(GluuStatus.ACTIVE); // this line of code required to save user's status
-                setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
+                setCustomAttribute(currentUser, JANS_STATUS, ACTIVE);
                 setCustomAttribute(currentUser, INVALID_LOGIN_COUNT_ATTRIBUTE, "0");
                 return "Your account  is now unlock. Try login ";
             }

--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -65,7 +65,7 @@ public class JansPasswordService extends PasswordService {
         if (invalidLoginCount != null) {
             currentFailCount = Integer.parseInt(invalidLoginCount) + 1;
         }
-        String currentStatus = currentUser.getStatus();
+        String currentStatus = currentUser.getStatus() != null ? currentUser.getStatus().getValue() : "";
         logger.info("Current user status is: {}", currentStatus);
         if (currentFailCount < DEFAULT_MAX_LOGIN_ATTEMPT) {
             int remainingCount = DEFAULT_MAX_LOGIN_ATTEMPT - currentFailCount;

--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -66,8 +66,16 @@ public class JansPasswordService extends PasswordService {
         if (invalidLoginCount != null) {
             currentFailCount = Integer.parseInt(invalidLoginCount) + 1;
         }
-        String currentStatus = currentUser.getStatus() != null ? currentUser.getStatus().getValue() : "";
+        String currentStatus = currentUser.getStatus() != null ? currentUser.getStatus().getValue() : null;
         logger.info("Current user status is: {}", currentStatus);
+        if (currentStatus == null) {
+            logger.info("User status is not set. Marking the user as inactive.");
+            String object_to_store = "{'locked': 'true'}";
+            currentUser.setStatus(GluuStatus.INACTIVE); // this line of code required to save user's status
+            setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
+            cacheService.put(DEFAULT_LOCK_EXP_TIME, CACHE_PREFIX + username, object_to_store);
+            return "User status is not set. Marking the user as inactive."
+        }
         if (currentFailCount < DEFAULT_MAX_LOGIN_ATTEMPT) {
             int remainingCount = DEFAULT_MAX_LOGIN_ATTEMPT - currentFailCount;
             logger.info("Remaining login count: {} for user {}", remainingCount, username);

--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -74,7 +74,7 @@ public class JansPasswordService extends PasswordService {
             currentUser.setStatus(GluuStatus.INACTIVE); // this line of code required to save user's status
             setCustomAttribute(currentUser, JANS_STATUS, INACTIVE);
             cacheService.put(DEFAULT_LOCK_EXP_TIME, CACHE_PREFIX + username, object_to_store);
-            return "User status is not set. Marking the user as inactive."
+            return "User status is not set. Marking the user as inactive.";
         }
         if (currentFailCount < DEFAULT_MAX_LOGIN_ATTEMPT) {
             int remainingCount = DEFAULT_MAX_LOGIN_ATTEMPT - currentFailCount;

--- a/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
+++ b/jans-config-api/plugins/admin-ui-plugin/agama/project/lib/org/gluu/agama/pw/jans/JansPasswordService.java
@@ -65,7 +65,7 @@ public class JansPasswordService extends PasswordService {
         if (invalidLoginCount != null) {
             currentFailCount = Integer.parseInt(invalidLoginCount) + 1;
         }
-        String currentStatus = getCustomAttribute(currentUser, JANS_STATUS);
+        String currentStatus = currentUser.getStatus();
         logger.info("Current user status is: {}", currentStatus);
         if (currentFailCount < DEFAULT_MAX_LOGIN_ATTEMPT) {
             int remainingCount = DEFAULT_MAX_LOGIN_ATTEMPT - currentFailCount;


### PR DESCRIPTION
…

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #14966

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Account status checks now use the user’s standard status value for more reliable active/inactive determinations.
  - Accounts without a recorded status are now correctly locked and marked inactive.
  - Locking an account now sets its status to inactive.
  - Unlocking an account now sets its status to active.
  - Account status transitions are applied consistently, improving the status displayed to administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->