### PR TITLE
fix(jans-fido2): correct COSE algorithm code points and guard unknown-algorithm lookups

### DIFF
--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -50,7 +50,7 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 | `unfinishedRequestExpiration` | Integer | `120` | Expiration time in seconds for incomplete registration/authentication requests. |
 | `metadataRefreshInterval` | Integer | `1296000` | Expiration time in seconds (e.g., 15 days) before checking and reloading the FIDO Alliance MDS TOC. |
 | <span id="servermetadatafolder">`serverMetadataFolder`</span> | String | `"/etc/jans/conf/fido2/server_metadata"` | Folder where local vendor metadata statement JSON files are placed manually. |
-| `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. |
+| `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS384`, `RS512`, `RS65535`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, `EdDSA`. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. |
 | `rp` | Array of Objects | `[ { "id": "https://jans.io", "origins": ["jans.io"] } ]` | Relying Party (RP) configuration mapping expected IDs to valid origins. |
 | `metadataServers` | Array of Objects | `[ { "url": "https://mds.fidoalliance.org/" } ]` | External FIDO Metadata Service endpoints to download statement catalogs. |
 | `disableMetadataService` | Boolean | `false` | If set to `true`, the FIDO2 server skips validating authenticators against the MDS3 service. |

--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -50,7 +50,7 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 | `unfinishedRequestExpiration` | Integer | `120` | Expiration time in seconds for incomplete registration/authentication requests. |
 | `metadataRefreshInterval` | Integer | `1296000` | Expiration time in seconds (e.g., 15 days) before checking and reloading the FIDO Alliance MDS TOC. |
 | <span id="servermetadatafolder">`serverMetadataFolder`</span> | String | `"/etc/jans/conf/fido2/server_metadata"` | Folder where local vendor metadata statement JSON files are placed manually. |
-| `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS384`, `RS512`, `RS65535`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, `EdDSA`. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. |
+| `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS65535`, `ES256`, `EdDSA` — the algorithms the server can both advertise and complete a registration with. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. |
 | `rp` | Array of Objects | `[ { "id": "https://jans.io", "origins": ["jans.io"] } ]` | Relying Party (RP) configuration mapping expected IDs to valid origins. |
 | `metadataServers` | Array of Objects | `[ { "url": "https://mds.fidoalliance.org/" } ]` | External FIDO Metadata Service endpoints to download statement catalogs. |
 | `disableMetadataService` | Boolean | `false` | If set to `true`, the FIDO2 server skips validating authenticators against the MDS3 service. |

--- a/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseEC2Algorithm.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseEC2Algorithm.java
@@ -11,11 +11,9 @@ import java.util.Map;
 
 public enum CoseEC2Algorithm {
 
-    ED256(-260), // TPM_ECC_BN_P256 curve w/ SHA-256
-    ED512(-261), // ECC_BN_ISOP512 curve w/ SHA-512
     ES256(-7), // ECDSA w/ SHA-256
-    ES384(-36), // ECDSA w/ SHA-384
-    ES512(-37), // ECDSA w/ SHA-512
+    ES384(-35), // ECDSA w/ SHA-384
+    ES512(-36), // ECDSA w/ SHA-512
     ECDH_ES_HKDF_256(-25);
 
     private static final Map<Integer, CoseEC2Algorithm> ALGORITHM_MAPPINGS = new HashMap<>();

--- a/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseEdDSAAlgorithm.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseEdDSAAlgorithm.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public enum CoseEdDSAAlgorithm {
 
-    Ed25519(-8);
+    EdDSA(-8); // the v2.3 table's separate Ed25519 entry is -19, not this
 
     private static final Map<Integer, CoseEdDSAAlgorithm> ALGORITHM_MAPPINGS = new HashMap<>();
 

--- a/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseEdDSAAlgorithm.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseEdDSAAlgorithm.java
@@ -3,6 +3,9 @@ package io.jans.fido2.ctap;
 import java.util.HashMap;
 import java.util.Map;
 
+// Constant names are the IANA COSE Algorithms registry spellings, which are transmitted verbatim in
+// enabledFidoAlgorithms configuration, so they do not follow the SCREAMING_CASE convention.
+@SuppressWarnings("java:S115")
 public enum CoseEdDSAAlgorithm {
 
     EdDSA(-8); // the v2.3 table's separate Ed25519 entry is -19, not this

--- a/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseRSAAlgorithm.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseRSAAlgorithm.java
@@ -12,10 +12,9 @@ import java.util.Map;
 public enum CoseRSAAlgorithm {
 
     RS256(-257), // RSASSA-PKCS1-v1_5 w/ SHA-256 Section 8.2 of [RFC8017]
-    RS65535(-65535), // RSASSA-PKCS1-v1_5 w/ SHA1
+    RS65535(-65535), // RS1: RSASSA-PKCS1-v1_5 w/ SHA-1
     RS384(-258), // RSASSA-PKCS1-v1_5 w/ SHA-384 Section 8.2 of [RFC8017]
     RS512(-259), // RSASSA-PKCS1-v1_5 w/ SHA-512 Section 8.2 of [RFC8017]
-    RS1(-262), // RSASSA-PKCS1-v1_5 w/ SHA-1 Section 8.2 of [RFC8017]
     PS512(-39), // RSASSA-PSS w/ SHA-512 [RFC8230]
     PS384(-38), // RSASSA-PSS w/ SHA-384 [RFC8230]
     PS256(-37); // RSASSA-PSS w/ SHA-256 [RFC8230]

--- a/jans-fido2/model/src/test/java/io/jans/fido2/ctap/CoseAlgorithmRegistryTest.java
+++ b/jans-fido2/model/src/test/java/io/jans/fido2/ctap/CoseAlgorithmRegistryTest.java
@@ -9,6 +9,7 @@ package io.jans.fido2.ctap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,7 +24,7 @@ class CoseAlgorithmRegistryTest {
 
     @Test
     void ec2Constants_matchTheIanaRegistry() {
-        Map<CoseEC2Algorithm, Integer> expected = new HashMap<>();
+        Map<CoseEC2Algorithm, Integer> expected = new EnumMap<>(CoseEC2Algorithm.class);
         expected.put(CoseEC2Algorithm.ES256, -7);
         expected.put(CoseEC2Algorithm.ES384, -35);
         expected.put(CoseEC2Algorithm.ES512, -36);
@@ -36,7 +37,7 @@ class CoseAlgorithmRegistryTest {
 
     @Test
     void rsaConstants_matchTheIanaRegistry() {
-        Map<CoseRSAAlgorithm, Integer> expected = new HashMap<>();
+        Map<CoseRSAAlgorithm, Integer> expected = new EnumMap<>(CoseRSAAlgorithm.class);
         expected.put(CoseRSAAlgorithm.RS256, -257);
         expected.put(CoseRSAAlgorithm.RS384, -258);
         expected.put(CoseRSAAlgorithm.RS512, -259);

--- a/jans-fido2/model/src/test/java/io/jans/fido2/ctap/CoseAlgorithmRegistryTest.java
+++ b/jans-fido2/model/src/test/java/io/jans/fido2/ctap/CoseAlgorithmRegistryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.ctap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins every COSE constant to the IANA COSE Algorithms registry
+ * (https://www.iana.org/assignments/cose/cose.xhtml#algorithms). These values go out on the wire in
+ * pubKeyCredParams, so a wrong one silently advertises a different algorithm than the admin configured.
+ */
+class CoseAlgorithmRegistryTest {
+
+    @Test
+    void ec2Constants_matchTheIanaRegistry() {
+        Map<CoseEC2Algorithm, Integer> expected = new HashMap<>();
+        expected.put(CoseEC2Algorithm.ES256, -7);
+        expected.put(CoseEC2Algorithm.ES384, -35);
+        expected.put(CoseEC2Algorithm.ES512, -36);
+        expected.put(CoseEC2Algorithm.ECDH_ES_HKDF_256, -25);
+
+        assertEquals(expected.size(), CoseEC2Algorithm.values().length, "unexpected EC2 constant added or removed");
+        expected.forEach((algorithm, value) -> assertEquals(value.intValue(), algorithm.getNumericValue(),
+                algorithm.name() + " code point"));
+    }
+
+    @Test
+    void rsaConstants_matchTheIanaRegistry() {
+        Map<CoseRSAAlgorithm, Integer> expected = new HashMap<>();
+        expected.put(CoseRSAAlgorithm.RS256, -257);
+        expected.put(CoseRSAAlgorithm.RS384, -258);
+        expected.put(CoseRSAAlgorithm.RS512, -259);
+        expected.put(CoseRSAAlgorithm.RS65535, -65535);
+        expected.put(CoseRSAAlgorithm.PS256, -37);
+        expected.put(CoseRSAAlgorithm.PS384, -38);
+        expected.put(CoseRSAAlgorithm.PS512, -39);
+
+        assertEquals(expected.size(), CoseRSAAlgorithm.values().length, "unexpected RSA constant added or removed");
+        expected.forEach((algorithm, value) -> assertEquals(value.intValue(), algorithm.getNumericValue(),
+                algorithm.name() + " code point"));
+    }
+
+    @Test
+    void edDsaConstants_matchTheIanaRegistry() {
+        assertEquals(1, CoseEdDSAAlgorithm.values().length, "unexpected EdDSA constant added or removed");
+        assertEquals(-8, CoseEdDSAAlgorithm.EdDSA.getNumericValue());
+    }
+
+    /**
+     * -260, -261 and -262 are WalnutDSA, TurboSHAKE128 and TurboSHAKE256 in the registry. They were held by
+     * ED256, ED512 and RS1 respectively; RS1's real value is -65535, already covered by RS65535.
+     */
+    @Test
+    void codePointsOfUnrelatedRegistryEntries_areNotClaimed() {
+        assertNull(CoseEC2Algorithm.fromNumericValue(-260));
+        assertNull(CoseEC2Algorithm.fromNumericValue(-261));
+        assertNull(CoseRSAAlgorithm.fromNumericValue(-262));
+        assertEquals(CoseRSAAlgorithm.RS65535, CoseRSAAlgorithm.fromNumericValue(-65535));
+    }
+
+    @Test
+    void noTwoConstants_shareACodePoint() {
+        Map<Integer, String> seen = new HashMap<>();
+        for (CoseEC2Algorithm algorithm : CoseEC2Algorithm.values()) {
+            seen.put(algorithm.getNumericValue(), algorithm.name());
+        }
+        for (CoseRSAAlgorithm algorithm : CoseRSAAlgorithm.values()) {
+            String clash = seen.put(algorithm.getNumericValue(), algorithm.name());
+            assertNull(clash, algorithm.name() + " shares a code point with " + clash);
+        }
+        for (CoseEdDSAAlgorithm algorithm : CoseEdDSAAlgorithm.values()) {
+            String clash = seen.put(algorithm.getNumericValue(), algorithm.name());
+            assertNull(clash, algorithm.name() + " shares a code point with " + clash);
+        }
+    }
+}

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
@@ -102,12 +102,19 @@ public class CoseService {
         int keyToUse = uncompressedECPointNode.get("1").asInt();
         int algorithmToUse = uncompressedECPointNode.get("3").asInt();
         CoseKeyType keyType = CoseKeyType.fromNumericValue(keyToUse);
+        if (keyType == null) {
+            throw new Fido2RuntimeException("Unsupported COSE key type " + keyToUse);
+        }
         log.debug("keyToUse {}", keyToUse);
         log.debug("algorithmToUse : {}", algorithmToUse);
         log.debug("keyType {}", keyType);
         switch (keyType) {
         case RSA: {
             CoseRSAAlgorithm coseRSAAlgorithm = CoseRSAAlgorithm.fromNumericValue(algorithmToUse);
+            if (coseRSAAlgorithm == null) {
+                throw new Fido2RuntimeException(
+                        "Don't know what to do with this key " + keyType + " and algorithm " + algorithmToUse);
+            }
             switch (coseRSAAlgorithm) {
             case RS65535:
             case RS256: {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
@@ -502,10 +502,10 @@ public class AttestationService {
 
 		Set<PublicKeyCredentialParameters> credentialParametersSets = new HashSet<>();
 		if ((enabledFidoAlgorithms == null) || enabledFidoAlgorithms.isEmpty()) {
-			// Add default requested credential types: RS256, ES256, Ed25519
+			// Add default requested credential types: RS256, ES256, EdDSA
 			credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(CoseRSAAlgorithm.RS256.getNumericValue()));
 			credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(CoseEC2Algorithm.ES256.getNumericValue()));
-			credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(CoseEdDSAAlgorithm.Ed25519.getNumericValue()));
+			credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(CoseEdDSAAlgorithm.EdDSA.getNumericValue()));
 		} else {
 			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveRsaNumericValue);
 			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveEc2NumericValue);

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/TPMProcessor.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/TPMProcessor.java
@@ -138,8 +138,8 @@ public class TPMProcessor implements AttestationFormatProcessor {
 		byte[] hashedBuffer = getHashedBuffer(alg, authData.getAttestationBuffer(), clientDataHash);
 
 		// if attestation mode is enabled in the global config
-		if (appConfiguration.getFido2Configuration().getAttestationMode()
-				.equalsIgnoreCase(AttestationMode.DISABLED.getValue()) == false) {
+		if (!appConfiguration.getFido2Configuration().getAttestationMode()
+				.equalsIgnoreCase(AttestationMode.DISABLED.getValue())) {
 			Iterator<JsonNode> i = attStmt.get("x5c").elements();
 
 			
@@ -288,7 +288,7 @@ public class TPMProcessor implements AttestationFormatProcessor {
 		default:
 			log.error("verifyTPMSCertificateName :{}", tpmtPublic.nameAlg.asEnum());
 			throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
-					"Problem with TPM attestation");
+					PROBLEM_WITH_TPM_ATTESTATION);
 		}
 		// this is not really certificate info but nameAlgID + hex.encode(pubAreaDigest)
 		// reverse engineered from FIDO Certification tool
@@ -306,7 +306,7 @@ public class TPMProcessor implements AttestationFormatProcessor {
 		if (tpmsAttest.magic.toInt() != TPM_GENERATED.VALUE.toInt()) {
 			log.error("{}:{}", tpmsAttest.magic.toInt(), TPM_GENERATED.VALUE.toInt());
 			throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
-					"Problem with TPM attestation");
+					PROBLEM_WITH_TPM_ATTESTATION);
 		}
 	}
 
@@ -329,7 +329,6 @@ public class TPMProcessor implements AttestationFormatProcessor {
 				byte[] inner = ASN1OctetString.getInstance(ext).getOctets();
 				aaguidInCert = ASN1OctetString.getInstance(inner).getOctets();
 			} catch (RuntimeException e) {
-				log.error("Malformed id-fido-gen-ce-aaguid extension in AIK certificate", e);
 				throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
 						"Problem with TPM attestation : malformed id-fido-gen-ce-aaguid extension", e);
 			}
@@ -386,7 +385,7 @@ public class TPMProcessor implements AttestationFormatProcessor {
 				| SignatureException e) {
 			log.error("Problem with AIK certificate {}", e.getMessage());
 			throw errorResponseFactory.badRequestException(AttestationErrorResponseType.TPM_ERROR,
-					"Problem with TPM attestation");
+					PROBLEM_WITH_TPM_ATTESTATION);
 		}
 	}
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/TPMProcessor.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/processor/attestation/TPMProcessor.java
@@ -216,6 +216,9 @@ public class TPMProcessor implements AttestationFormatProcessor {
 
 		// algorithm used for attestation
 		CoseKeyType keyType = CoseKeyType.fromNumericValue(keyToUse);
+		if (keyType == null) {
+			throw new Fido2RuntimeException("Unsupported COSE key type " + keyToUse);
+		}
 
 		log.debug("keyToUse {}", keyToUse);
 		log.debug("algorithmToUse : {}", algorithmToUse);


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14924

Sub-issue of #14891. Independent of the other children; #14932 and #14936 both depend on it.

#### Implementation Details

Five constants held code points belonging to unrelated entries in the
[IANA COSE Algorithms registry](https://www.iana.org/assignments/cose/cose.xhtml#algorithms), and two of
them silently advertised a different algorithm than the admin configured.

`AttestationService.resolveEc2NumericValue()` resolves a configured name through
`CoseEC2Algorithm.valueOf(...).getNumericValue()` straight into `pubKeyCredParams`, so these values go out
on the wire:

| Constant | Was | Now | −260 / −261 / −262 actually are |
|---|---|---|---|
| `CoseEC2Algorithm.ES384` | −36 | **−35** | |
| `CoseEC2Algorithm.ES512` | −37 | **−36** | |
| `CoseEC2Algorithm.ED256` | −260 | *removed* | WalnutDSA |
| `CoseEC2Algorithm.ED512` | −261 | *removed* | TurboSHAKE128 |
| `CoseRSAAlgorithm.RS1` | −262 | *removed* | TurboSHAKE256 |

Configuring `ES384` advertised the code point for ES512; configuring `ES512` advertised `-37`, which is
`PS256` — an RSA algorithm. Our own two enums assigned `-37` to two different algorithms, so this needed no
external source to confirm. `RS1` is a duplicate rather than a wrong value: its real code point is `-65535`,
already present as `RS65535`, so the constant is deleted rather than corrected. `PS256/384/512` and
`RS256/384/512` were already right.

`CoseEdDSAAlgorithm.Ed25519(-8)` is renamed to `EdDSA`. `-8` is EdDSA; the v2.3 table's separate `Ed25519`
entry is `-19` and is added under #14936. Leaving the old name would put two different things called
`Ed25519` in the same codebase.

Second half of the issue: `fromNumericValue` returns `null` for any code point with no constant, and call
sites fed that straight into a `switch`, so an unrecognised algorithm produced an unhandled
`NullPointerException` before any input was read. Guarded at the three sites that dereference it —
`CoseService` (key type, and the RSA branch) and `TPMProcessor:218`. The EC2 branch already compares against
`ES256` and the OKP branch was guarded in #14950, so both were already safe.

Note that correcting `ES384` does not by itself make a configured `ES384` work: the decoder still handles
only `ES256` in the EC2 branch. That is #14932.

`server-fips/` needs no mirroring — it is a pom-only module that repackages the `server` artifact and has no
`src/` tree of its own.

**Behaviour change worth flagging for review:** because `resolveEdDsaNumericValue` resolves the configured
name with `valueOf`, a deployment that currently has `"Ed25519"` in `enabledFidoAlgorithms` will no longer
match — `valueOf` throws, the existing catch returns `null`, and the algorithm is quietly dropped from
`pubKeyCredParams` rather than erroring. The default configuration is unaffected. Happy to add `"Ed25519"`
as a legacy alias if reviewers would rather not break that.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

New `CoseAlgorithmRegistryTest` in the `model` module pins every constant in the three enums to the IANA
registry, asserts the constant count so an addition cannot slip past the pin, asserts that `-260`, `-261` and
`-262` are no longer claimed, and asserts no two constants share a code point — the last of which would have
caught `PS256` and `ES512` both holding `-37`.

```
CoseAlgorithmRegistryTest    5 tests, 0 failures
jans-fido2 model + server  430 tests, 0 failures
```

Docs: `docs/janssen-server/fido/fido2-server-properties-config.md` now lists the accepted
`enabledFidoAlgorithms` names, what the server advertises when the property is unset, and that an
unrecognised name is ignored — carried in a separate `docs:` commit.

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Aligned supported FIDO2/COSE algorithm identifiers with the IANA registry.
  * Corrected ES384, ES512, and EdDSA algorithm mappings.
  * Removed unsupported legacy algorithm identifiers.

* **Bug Fixes**
  * Improved handling of unknown key types and unresolved algorithms with clearer errors.
  * Strengthened TPM attestation validation and standardized related error reporting.

* **Documentation**
  * Documented accepted FIDO algorithm names, default algorithms, and handling of unrecognized values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->