### PR TITLE
perf(ci): cut AIO integration build time

### DIFF
--- a/.github/workflows/build-ci-snapshot.yml
+++ b/.github/workflows/build-ci-snapshot.yml
@@ -1,0 +1,130 @@
+name: "Build: CI droplet snapshot"
+
+# Bakes the toolchain the integration run installs on every VM (JDK, maven, docker, the pinned rust
+# toolchain, protoc) into a DigitalOcean snapshot. test-integration.yml boots from the newest
+# jans-ci-base-* snapshot and falls back to stock Ubuntu when none exists, so this is optional.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 0"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build and snapshot
+        env:
+          DO_TOKEN: ${{ secrets.DO_TOKEN }}
+        run: |
+          set -euo pipefail
+          [ -n "${DO_TOKEN:-}" ] || { echo "::error::DO_TOKEN secret is not set"; exit 1; }
+          api() { curl -sS --connect-timeout 10 --max-time 60 -H "Authorization: Bearer ${DO_TOKEN}" \
+                    -H "Content-Type: application/json" "$@"; }
+
+          rust=$(sed -n 's/^ *channel *= *"\(.*\)"/\1/p' jans-cedarling/rust-toolchain.toml)
+          [ -n "$rust" ] || { echo "::error::could not read the pinned rust channel"; exit 1; }
+          echo "[info] rust toolchain: $rust"
+          stamp=$(date -u +%Y%m%d%H%M)
+
+          # Marker file: the poll below waits for it rather than trusting cloud-init's own status,
+          # which reports done even when a package step failed.
+          user_data=$(cat <<EOF
+          #!/bin/bash
+          set -euxo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get -o DPkg::Lock::Timeout=600 update -qq
+          apt-get -o DPkg::Lock::Timeout=600 install -y -qq \
+            openjdk-17-jdk maven rsync build-essential pkg-config libssl-dev protobuf-compiler zip unzip
+          curl -fsSL https://get.docker.com | sh
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${rust}
+          git config --global --add safe.directory '*'
+          touch /root/.jans-ci-base-ready
+          EOF
+          )
+
+          ssh-keygen -t rsa -b 4096 -N '' -f id_snap -q
+          key_id=$(api -X POST "https://api.digitalocean.com/v2/account/keys" \
+            -d "$(jq -n --arg name "jans-ci-snap-${{ github.run_id }}" --arg key "$(cat id_snap.pub)" \
+                  '{name:$name, public_key:$key}')" | jq -er '.ssh_key.id')
+          cleanup() {
+            [ -n "${droplet_id:-}" ] && api -X DELETE "https://api.digitalocean.com/v2/droplets/$droplet_id" >/dev/null || true
+            api -X DELETE "https://api.digitalocean.com/v2/account/keys/$key_id" >/dev/null || true
+          }
+          trap cleanup EXIT
+
+          droplet_id=$(api -X POST "https://api.digitalocean.com/v2/droplets" \
+            -d "$(jq -n --arg name "jans-ci-snap-${{ github.run_id }}" --argjson key "$key_id" \
+                        --arg ud "$user_data" \
+                  '{name:$name, region:"nyc1", size:"s-4vcpu-8gb", image:"ubuntu-22-04-x64",
+                    ssh_keys:[$key], tags:["jans-ci-snap"], user_data:$ud}')" \
+            | jq -er '.droplet.id')
+          echo "[info] droplet $droplet_id"
+
+          ip=""
+          for _ in $(seq 1 60); do
+            ip=$(api "https://api.digitalocean.com/v2/droplets/$droplet_id" \
+                 | jq -r '.droplet.networks.v4[]? | select(.type=="public") | .ip_address' | head -n1)
+            [ -n "$ip" ] && [ "$ip" != "null" ] && break
+            sleep 10
+          done
+          [ -n "$ip" ] && [ "$ip" != "null" ] || { echo "::error::no public IP"; exit 1; }
+          SSH=(ssh -i id_snap -o StrictHostKeyChecking=no -o ConnectTimeout=10 "root@$ip")
+          for _ in $(seq 1 60); do "${SSH[@]}" true 2>/dev/null && break; sleep 10; done
+
+          ready=""
+          for _ in $(seq 1 90); do
+            "${SSH[@]}" 'test -f /root/.jans-ci-base-ready' 2>/dev/null && { ready=1; break; }
+            sleep 20
+          done
+          [ -n "$ready" ] || {
+            echo "::error::provisioning never completed"
+            "${SSH[@]}" 'tail -n 60 /var/log/cloud-init-output.log' 2>&1 || true
+            exit 1; }
+          "${SSH[@]}" 'java -version; mvn -v | head -1; docker --version; . /root/.cargo/env && rustc -V' 2>&1
+
+          api -X POST "https://api.digitalocean.com/v2/droplets/$droplet_id/actions" \
+            -d '{"type":"shutdown"}' >/dev/null
+          for _ in $(seq 1 30); do
+            [ "$(api "https://api.digitalocean.com/v2/droplets/$droplet_id" | jq -r '.droplet.status')" = "off" ] && break
+            sleep 10
+          done
+
+          action_id=$(api -X POST "https://api.digitalocean.com/v2/droplets/$droplet_id/actions" \
+            -d "$(jq -n --arg n "jans-ci-base-$stamp" '{type:"snapshot", name:$n}')" | jq -er '.action.id')
+          for _ in $(seq 1 90); do
+            st=$(api "https://api.digitalocean.com/v2/actions/$action_id" | jq -r '.action.status')
+            [ "$st" = "completed" ] && break
+            [ "$st" = "errored" ] && { echo "::error::snapshot action errored"; exit 1; }
+            sleep 20
+          done
+          [ "$st" = "completed" ] || { echo "::error::snapshot did not complete in time"; exit 1; }
+          echo "[info] created snapshot jans-ci-base-$stamp"
+
+          # Keep the two newest; a rollback target plus the current one.
+          api "https://api.digitalocean.com/v2/snapshots?resource_type=droplet&per_page=200" \
+          | jq -r '[.snapshots[]? | select(.name|startswith("jans-ci-base-"))]
+                   | sort_by(.created_at) | reverse | .[2:] | .[].id' \
+          | while read -r old; do
+              [ -n "$old" ] || continue
+              echo "[info] deleting old snapshot $old"
+              api -X DELETE "https://api.digitalocean.com/v2/snapshots/$old" >/dev/null || true
+            done

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -220,9 +220,29 @@ jobs:
           # Only the two 422s handled below are recoverable; any other non-2xx aborts (a re-POST
           # after e.g. a 5xx could duplicate an already-accepted droplet). Dedicated-CPU classes
           # first (the build is CPU-bound and Basic droplets get throttled), degrading to Basic.
+          # Newest jans-ci-base-* snapshot has the toolchain prebaked; stock Ubuntu is the fallback,
+          # and is tried again when the snapshot's own regions have no capacity for any size.
+          snap=$(curl -fsS --connect-timeout 10 --max-time 30 -H "Authorization: Bearer ${DO_TOKEN}" \
+            'https://api.digitalocean.com/v2/snapshots?resource_type=droplet&per_page=200' \
+            | jq -c '[.snapshots[]? | select(.name|startswith("jans-ci-base-"))]
+                     | sort_by(.created_at) | last // empty') || snap=""
+          snap_id=""; snap_regions=""
+          if [ -n "$snap" ]; then
+            snap_id=$(jq -r '.id' <<<"$snap")
+            snap_regions=$(jq -r '.regions | join(" ")' <<<"$snap")
+            echo "[info] CI snapshot $(jq -r '.name' <<<"$snap") ($snap_id) in: $snap_regions"
+          else
+            echo "[info] no jans-ci-base-* snapshot; booting stock Ubuntu"
+          fi
           droplet_id=""
-          for SIZE in g-8vcpu-32gb c-8 s-8vcpu-16gb; do
-            for region in nyc1 nyc3 sfo3 ams3 fra1 tor1; do
+          for image in ${snap_id:+$snap_id} ubuntu-22-04-x64; do
+           if [ "$image" = "ubuntu-22-04-x64" ]; then
+             img_json='"ubuntu-22-04-x64"'; regions="nyc1 nyc3 sfo3 ams3 fra1 tor1"
+           else
+             img_json="$image"; regions="$snap_regions"
+           fi
+           for SIZE in g-8vcpu-32gb c-8 s-8vcpu-16gb; do
+            for region in $regions; do
               for attempt in 1 2 3 4 5; do
                 out=$(curl -sS --connect-timeout 10 --max-time 30 -w '\n%{http_code}' -X POST \
                   "https://api.digitalocean.com/v2/droplets" \
@@ -231,13 +251,13 @@ jobs:
                         --arg name "jans-ci-${{ github.run_id }}-${{ matrix.persistence }}" \
                         --argjson key "$key_id" \
                         --arg run "run-${{ github.run_id }}" \
-                        --arg region "$region" --arg size "$SIZE" \
-                        '{name:$name, region:$region, size:$size, image:"ubuntu-22-04-x64",
+                        --arg region "$region" --arg size "$SIZE" --argjson image "$img_json" \
+                        '{name:$name, region:$region, size:$size, image:$image,
                           ssh_keys:[$key], tags:["jans-ci", $run]}')")
                 status=${out##*$'\n'}; body=${out%$'\n'*}
                 if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
                   droplet_id=$(jq -er '.droplet.id' <<<"$body")
-                  echo "[info] created droplet $droplet_id ($SIZE) in $region"
+                  echo "[info] created droplet $droplet_id ($SIZE, image $image) in $region"
                   break
                 fi
                 msg=$(jq -rc '.message // .' <<<"$body" 2>/dev/null || echo "$body")
@@ -260,6 +280,9 @@ jobs:
             done
             if [ -n "$droplet_id" ]; then break; fi
             echo "[warn] $SIZE unavailable in every candidate region, trying the next size"
+           done
+           if [ -n "$droplet_id" ]; then break; fi
+           echo "[warn] no capacity for image $image, trying the next image"
           done
           [ -n "$droplet_id" ] && [ "$droplet_id" != "null" ] || {
             echo "::error::could not create a droplet of any candidate size in any candidate region"; exit 1; }
@@ -342,8 +365,10 @@ jobs:
           "${SSH[@]}" "set -e
             export DEBIAN_FRONTEND=noninteractive
             cloud-init status --wait 2>/dev/null || true
-            apt-get -o DPkg::Lock::Timeout=600 update -qq
-            apt-get -o DPkg::Lock::Timeout=600 install -y -qq openjdk-17-jdk maven rsync
+            if ! command -v mvn >/dev/null 2>&1 || ! command -v javac >/dev/null 2>&1 || ! command -v rsync >/dev/null 2>&1; then
+              apt-get -o DPkg::Lock::Timeout=600 update -qq
+              apt-get -o DPkg::Lock::Timeout=600 install -y -qq openjdk-17-jdk maven rsync
+            fi
             command -v docker >/dev/null 2>&1 || curl -fsSL https://get.docker.com | sh
             git config --global --add safe.directory '*'
             grep -q '$JANS_FQDN\$' /etc/hosts || echo '127.0.0.1 $JANS_FQDN' >> /etc/hosts"

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -210,26 +210,19 @@ jobs:
             | jq -er '.ssh_key.id')
           # Persist now so teardown can delete the key even if droplet creation below fails.
           echo "key_id=$key_id" >> "$GITHUB_OUTPUT"
-          # DO accepts the key POST before the key is usable for droplet creation, which surfaces as
-          # a 422 "... are invalid key identifiers" on the create below. Poll until the API reports
-          # the key so the common case never reaches that retry.
+          # DO accepts the key POST before the key is usable for droplet creation.
           for _ in $(seq 1 10); do
             curl -fsS --connect-timeout 10 --max-time 30 -o /dev/null \
               -H "Authorization: Bearer ${DO_TOKEN}" \
               "https://api.digitalocean.com/v2/account/keys/$key_id" && break
             sleep 3
           done
-          # Exactly two 422s are recoverable: "not available in this region" moves to the next
-          # region, "invalid key identifiers" retries the same one. Any other non-2xx aborts (a
-          # re-POST after e.g. a 5xx could duplicate an already-accepted droplet).
-          # Dedicated-CPU classes first: the maven/cargo build is CPU-bound and a shared-CPU Basic
-          # droplet gets throttled mid-build. The list degrades to the historical Basic size, so an
-          # unavailable dedicated class can never fail the run.
+          # Only the two 422s handled below are recoverable; any other non-2xx aborts (a re-POST
+          # after e.g. a 5xx could duplicate an already-accepted droplet). Dedicated-CPU classes
+          # first (the build is CPU-bound and Basic droplets get throttled), degrading to Basic.
           droplet_id=""
           for SIZE in g-8vcpu-32gb c-8 s-8vcpu-16gb; do
             for region in nyc1 nyc3 sfo3 ams3 fra1 tor1; do
-              # The retry covers only the key-propagation 422; every other outcome breaks out on the
-              # first attempt, so a real API error is still never re-POSTed.
               for attempt in 1 2 3 4 5; do
                 out=$(curl -sS --connect-timeout 10 --max-time 30 -w '\n%{http_code}' -X POST \
                   "https://api.digitalocean.com/v2/droplets" \
@@ -248,8 +241,7 @@ jobs:
                   break
                 fi
                 msg=$(jq -rc '.message // .' <<<"$body" 2>/dev/null || echo "$body")
-                # No region or size can fix an unusable key, so give up on the whole step rather
-                # than walking the candidate list five sleeps at a time.
+                # No region or size can fix an unusable key, so stop rather than walk the list.
                 if [ "$status" -eq 422 ] && printf '%s' "$msg" | grep -qi "invalid key identifier"; then
                   if [ "$attempt" -eq 5 ]; then
                     echo "::error::DO still rejects SSH key $key_id after 5 attempts: $msg"; exit 1
@@ -328,13 +320,10 @@ jobs:
         id: bcache
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          # ci-cache/ sits in the workspace so the bootstrap rsync ships it to the VM unchanged;
-          # run_aio_integration.sh seeds ~/.m2 + ~/.cargo from it and repacks it after the build.
+          # In the workspace so the bootstrap rsync ships it to the VM, which seeds ~/.m2 + ~/.cargo.
           path: ci-cache
-          # Weekly bucket, not a pom/lockfile hash: the entry is ~3 GB and cache entries are
-          # immutable, so a content key would write a fresh one on every dependency change and churn
-          # the 10 GB budget this repo shares with the other workflows. A dependency added mid-week
-          # just downloads, exactly as it did before this cache existed.
+          # Weekly bucket, not a content hash: entries are immutable, so a pom change would write
+          # another ~3 GB entry and churn the 10 GB budget shared with the other workflows.
           key: aio-build-${{ steps.date.outputs.week }}
           restore-keys: aio-build-
 
@@ -384,11 +373,8 @@ jobs:
           scp -i id_ci -o StrictHostKeyChecking=no -r "root@$IP:/root/jans/test-reports" ./ || true
           scp -i id_ci -o StrictHostKeyChecking=no -r "root@$IP:/root/jans/aio-logs" ./ || true
 
-      # Saves are restricted twice over, because the repo's 10 GB cache budget is shared with every
-      # other workflow. Only the first matrix leg saves (both legs build the same artifacts), and
-      # only non-PR runs save at all: a PR's cache is scoped to that PR's ref, so a pom-touching PR
-      # would write a multi-GB entry nothing else can read, evicting caches that are in use. PRs
-      # still restore, via the base-branch fallback to main's entry.
+      # First matrix leg only (both build the same artifacts), and non-PR only: a PR's cache is
+      # scoped to its own ref, so it would evict in-use entries while being readable by nothing.
       - name: Collect build caches from the VM
         id: ccache
         if: always() && github.event_name != 'pull_request' && matrix.persistence == fromJson(needs.setup.outputs.matrix)[0]

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -210,36 +210,61 @@ jobs:
             | jq -er '.ssh_key.id')
           # Persist now so teardown can delete the key even if droplet creation below fails.
           echo "key_id=$key_id" >> "$GITHUB_OUTPUT"
-          # Only a "size not available in this region" 422 tries the next region; any other non-2xx
-          # aborts (a re-POST after e.g. a 5xx could duplicate an already-accepted droplet).
+          # DO accepts the key POST before the key is usable for droplet creation, which surfaces as
+          # a 422 "... are invalid key identifiers" on the create below. Poll until the API reports
+          # the key so the common case never reaches that retry.
+          for _ in $(seq 1 10); do
+            curl -fsS --connect-timeout 10 --max-time 30 -o /dev/null \
+              -H "Authorization: Bearer ${DO_TOKEN}" \
+              "https://api.digitalocean.com/v2/account/keys/$key_id" && break
+            sleep 3
+          done
+          # Exactly two 422s are recoverable: "not available in this region" moves to the next
+          # region, "invalid key identifiers" retries the same one. Any other non-2xx aborts (a
+          # re-POST after e.g. a 5xx could duplicate an already-accepted droplet).
           # Dedicated-CPU classes first: the maven/cargo build is CPU-bound and a shared-CPU Basic
           # droplet gets throttled mid-build. The list degrades to the historical Basic size, so an
           # unavailable dedicated class can never fail the run.
           droplet_id=""
           for SIZE in g-8vcpu-32gb c-8 s-8vcpu-16gb; do
             for region in nyc1 nyc3 sfo3 ams3 fra1 tor1; do
-              out=$(curl -sS --connect-timeout 10 --max-time 30 -w '\n%{http_code}' -X POST \
-                "https://api.digitalocean.com/v2/droplets" \
-                -H "Authorization: Bearer ${DO_TOKEN}" -H "Content-Type: application/json" \
-                -d "$(jq -n \
-                      --arg name "jans-ci-${{ github.run_id }}-${{ matrix.persistence }}" \
-                      --argjson key "$key_id" \
-                      --arg run "run-${{ github.run_id }}" \
-                      --arg region "$region" --arg size "$SIZE" \
-                      '{name:$name, region:$region, size:$size, image:"ubuntu-22-04-x64",
-                        ssh_keys:[$key], tags:["jans-ci", $run]}')")
-              status=${out##*$'\n'}; body=${out%$'\n'*}
-              if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-                droplet_id=$(jq -er '.droplet.id' <<<"$body")
-                echo "[info] created droplet $droplet_id ($SIZE) in $region"
-                break
-              fi
-              msg=$(jq -rc '.message // .' <<<"$body" 2>/dev/null || echo "$body")
-              if [ "$status" -eq 422 ] && printf '%s' "$msg" | grep -qi "not available in this region"; then
-                echo "[warn] $region: $SIZE unavailable here, trying next region"
-                continue
-              fi
-              echo "::error::DO droplet create -> HTTP $status: $msg"; exit 1
+              # The retry covers only the key-propagation 422; every other outcome breaks out on the
+              # first attempt, so a real API error is still never re-POSTed.
+              for attempt in 1 2 3 4 5; do
+                out=$(curl -sS --connect-timeout 10 --max-time 30 -w '\n%{http_code}' -X POST \
+                  "https://api.digitalocean.com/v2/droplets" \
+                  -H "Authorization: Bearer ${DO_TOKEN}" -H "Content-Type: application/json" \
+                  -d "$(jq -n \
+                        --arg name "jans-ci-${{ github.run_id }}-${{ matrix.persistence }}" \
+                        --argjson key "$key_id" \
+                        --arg run "run-${{ github.run_id }}" \
+                        --arg region "$region" --arg size "$SIZE" \
+                        '{name:$name, region:$region, size:$size, image:"ubuntu-22-04-x64",
+                          ssh_keys:[$key], tags:["jans-ci", $run]}')")
+                status=${out##*$'\n'}; body=${out%$'\n'*}
+                if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+                  droplet_id=$(jq -er '.droplet.id' <<<"$body")
+                  echo "[info] created droplet $droplet_id ($SIZE) in $region"
+                  break
+                fi
+                msg=$(jq -rc '.message // .' <<<"$body" 2>/dev/null || echo "$body")
+                # No region or size can fix an unusable key, so give up on the whole step rather
+                # than walking the candidate list five sleeps at a time.
+                if [ "$status" -eq 422 ] && printf '%s' "$msg" | grep -qi "invalid key identifier"; then
+                  if [ "$attempt" -eq 5 ]; then
+                    echo "::error::DO still rejects SSH key $key_id after 5 attempts: $msg"; exit 1
+                  fi
+                  echo "[warn] SSH key $key_id not usable yet (attempt $attempt/5); retrying in 10s"
+                  sleep 10
+                  continue
+                fi
+                if [ "$status" -eq 422 ] && printf '%s' "$msg" | grep -qi "not available in this region"; then
+                  echo "[warn] $region: $SIZE unavailable here, trying next region"
+                  continue 2
+                fi
+                echo "::error::DO droplet create -> HTTP $status: $msg"; exit 1
+              done
+              if [ -n "$droplet_id" ]; then break; fi
             done
             if [ -n "$droplet_id" ]; then break; fi
             echo "[warn] $SIZE unavailable in every candidate region, trying the next size"

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -295,6 +295,10 @@ jobs:
           echo "modules=${sel:-all}" >> "$GITHUB_OUTPUT"
           echo "[info] selected test modules: ${sel:-all}"
 
+      - name: Cache week
+        id: date
+        run: echo "week=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
+
       - name: Restore build caches
         id: bcache
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -302,10 +306,12 @@ jobs:
           # ci-cache/ sits in the workspace so the bootstrap rsync ships it to the VM unchanged;
           # run_aio_integration.sh seeds ~/.m2 + ~/.cargo from it and repacks it after the build.
           path: ci-cache
-          key: aio-build-${{ hashFiles('jans-cedarling/rust-toolchain.toml', 'jans-cedarling/Cargo.lock') }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            aio-build-${{ hashFiles('jans-cedarling/rust-toolchain.toml', 'jans-cedarling/Cargo.lock') }}-
-            aio-build-
+          # Weekly bucket, not a pom/lockfile hash: the entry is ~3 GB and cache entries are
+          # immutable, so a content key would write a fresh one on every dependency change and churn
+          # the 10 GB budget this repo shares with the other workflows. A dependency added mid-week
+          # just downloads, exactly as it did before this cache existed.
+          key: aio-build-${{ steps.date.outputs.week }}
+          restore-keys: aio-build-
 
       - name: Bootstrap + run on the VM
         env:
@@ -335,7 +341,7 @@ jobs:
             AIO_IMAGE='${{ inputs.aio_image }}' \
             LOG_LEVEL='${{ inputs.log_level }}' \
             TEST_MODULES='${{ steps.mods.outputs.modules }}' \
-            SAVE_CACHE='${{ matrix.persistence == fromJson(needs.setup.outputs.matrix)[0] && 1 || 0 }}' \
+            SAVE_CACHE='${{ github.event_name != 'pull_request' && matrix.persistence == fromJson(needs.setup.outputs.matrix)[0] && 1 || 0 }}' \
             DB_NAME='$DB_NAME' DB_USER='$DB_USER' DB_PASSWORD='$DB_PASSWORD' \
             CN_CONFIG_API_TEST_CLIENT_ID='$CN_CONFIG_API_TEST_CLIENT_ID' \
             CN_CONFIG_API_TEST_CLIENT_SECRET='$CN_CONFIG_API_TEST_CLIENT_SECRET' \
@@ -353,11 +359,14 @@ jobs:
           scp -i id_ci -o StrictHostKeyChecking=no -r "root@$IP:/root/jans/test-reports" ./ || true
           scp -i id_ci -o StrictHostKeyChecking=no -r "root@$IP:/root/jans/aio-logs" ./ || true
 
-      # Only the first matrix leg saves: both legs build the same artifacts, and a per-backend key
-      # would double a cache that already has to fit the repo's 10 GB budget.
+      # Saves are restricted twice over, because the repo's 10 GB cache budget is shared with every
+      # other workflow. Only the first matrix leg saves (both legs build the same artifacts), and
+      # only non-PR runs save at all: a PR's cache is scoped to that PR's ref, so a pom-touching PR
+      # would write a multi-GB entry nothing else can read, evicting caches that are in use. PRs
+      # still restore, via the base-branch fallback to main's entry.
       - name: Collect build caches from the VM
         id: ccache
-        if: always() && matrix.persistence == fromJson(needs.setup.outputs.matrix)[0]
+        if: always() && github.event_name != 'pull_request' && matrix.persistence == fromJson(needs.setup.outputs.matrix)[0]
         env:
           IP: ${{ steps.ip.outputs.ip }}
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -212,34 +212,40 @@ jobs:
           echo "key_id=$key_id" >> "$GITHUB_OUTPUT"
           # Only a "size not available in this region" 422 tries the next region; any other non-2xx
           # aborts (a re-POST after e.g. a 5xx could duplicate an already-accepted droplet).
-          SIZE="s-8vcpu-16gb"
+          # Dedicated-CPU classes first: the maven/cargo build is CPU-bound and a shared-CPU Basic
+          # droplet gets throttled mid-build. The list degrades to the historical Basic size, so an
+          # unavailable dedicated class can never fail the run.
           droplet_id=""
-          for region in nyc1 nyc3 sfo3 ams3 fra1 tor1; do
-            out=$(curl -sS --connect-timeout 10 --max-time 30 -w '\n%{http_code}' -X POST \
-              "https://api.digitalocean.com/v2/droplets" \
-              -H "Authorization: Bearer ${DO_TOKEN}" -H "Content-Type: application/json" \
-              -d "$(jq -n \
-                    --arg name "jans-ci-${{ github.run_id }}-${{ matrix.persistence }}" \
-                    --argjson key "$key_id" \
-                    --arg run "run-${{ github.run_id }}" \
-                    --arg region "$region" --arg size "$SIZE" \
-                    '{name:$name, region:$region, size:$size, image:"ubuntu-22-04-x64",
-                      ssh_keys:[$key], tags:["jans-ci", $run]}')")
-            status=${out##*$'\n'}; body=${out%$'\n'*}
-            if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-              droplet_id=$(jq -er '.droplet.id' <<<"$body")
-              echo "[info] created droplet $droplet_id ($SIZE) in $region"
-              break
-            fi
-            msg=$(jq -rc '.message // .' <<<"$body" 2>/dev/null || echo "$body")
-            if [ "$status" -eq 422 ] && printf '%s' "$msg" | grep -qi "not available in this region"; then
-              echo "[warn] $region: $SIZE unavailable here, trying next region"
-              continue
-            fi
-            echo "::error::DO droplet create -> HTTP $status: $msg"; exit 1
+          for SIZE in g-8vcpu-32gb c-8 s-8vcpu-16gb; do
+            for region in nyc1 nyc3 sfo3 ams3 fra1 tor1; do
+              out=$(curl -sS --connect-timeout 10 --max-time 30 -w '\n%{http_code}' -X POST \
+                "https://api.digitalocean.com/v2/droplets" \
+                -H "Authorization: Bearer ${DO_TOKEN}" -H "Content-Type: application/json" \
+                -d "$(jq -n \
+                      --arg name "jans-ci-${{ github.run_id }}-${{ matrix.persistence }}" \
+                      --argjson key "$key_id" \
+                      --arg run "run-${{ github.run_id }}" \
+                      --arg region "$region" --arg size "$SIZE" \
+                      '{name:$name, region:$region, size:$size, image:"ubuntu-22-04-x64",
+                        ssh_keys:[$key], tags:["jans-ci", $run]}')")
+              status=${out##*$'\n'}; body=${out%$'\n'*}
+              if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+                droplet_id=$(jq -er '.droplet.id' <<<"$body")
+                echo "[info] created droplet $droplet_id ($SIZE) in $region"
+                break
+              fi
+              msg=$(jq -rc '.message // .' <<<"$body" 2>/dev/null || echo "$body")
+              if [ "$status" -eq 422 ] && printf '%s' "$msg" | grep -qi "not available in this region"; then
+                echo "[warn] $region: $SIZE unavailable here, trying next region"
+                continue
+              fi
+              echo "::error::DO droplet create -> HTTP $status: $msg"; exit 1
+            done
+            if [ -n "$droplet_id" ]; then break; fi
+            echo "[warn] $SIZE unavailable in every candidate region, trying the next size"
           done
           [ -n "$droplet_id" ] && [ "$droplet_id" != "null" ] || {
-            echo "::error::could not create a $SIZE droplet in any candidate region"; exit 1; }
+            echo "::error::could not create a droplet of any candidate size in any candidate region"; exit 1; }
           echo "droplet_id=$droplet_id" >> "$GITHUB_OUTPUT"
           echo "[info] created droplet $droplet_id (key $key_id)"
 
@@ -289,6 +295,18 @@ jobs:
           echo "modules=${sel:-all}" >> "$GITHUB_OUTPUT"
           echo "[info] selected test modules: ${sel:-all}"
 
+      - name: Restore build caches
+        id: bcache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          # ci-cache/ sits in the workspace so the bootstrap rsync ships it to the VM unchanged;
+          # run_aio_integration.sh seeds ~/.m2 + ~/.cargo from it and repacks it after the build.
+          path: ci-cache
+          key: aio-build-${{ hashFiles('jans-cedarling/rust-toolchain.toml', 'jans-cedarling/Cargo.lock') }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            aio-build-${{ hashFiles('jans-cedarling/rust-toolchain.toml', 'jans-cedarling/Cargo.lock') }}-
+            aio-build-
+
       - name: Bootstrap + run on the VM
         env:
           IP: ${{ steps.ip.outputs.ip }}
@@ -317,6 +335,7 @@ jobs:
             AIO_IMAGE='${{ inputs.aio_image }}' \
             LOG_LEVEL='${{ inputs.log_level }}' \
             TEST_MODULES='${{ steps.mods.outputs.modules }}' \
+            SAVE_CACHE='${{ matrix.persistence == fromJson(needs.setup.outputs.matrix)[0] && 1 || 0 }}' \
             DB_NAME='$DB_NAME' DB_USER='$DB_USER' DB_PASSWORD='$DB_PASSWORD' \
             CN_CONFIG_API_TEST_CLIENT_ID='$CN_CONFIG_API_TEST_CLIENT_ID' \
             CN_CONFIG_API_TEST_CLIENT_SECRET='$CN_CONFIG_API_TEST_CLIENT_SECRET' \
@@ -333,6 +352,32 @@ jobs:
           [ -n "${IP:-}" ] || { echo "[warn] no VM IP; skipping result collection"; exit 0; }
           scp -i id_ci -o StrictHostKeyChecking=no -r "root@$IP:/root/jans/test-reports" ./ || true
           scp -i id_ci -o StrictHostKeyChecking=no -r "root@$IP:/root/jans/aio-logs" ./ || true
+
+      # Only the first matrix leg saves: both legs build the same artifacts, and a per-backend key
+      # would double a cache that already has to fit the repo's 10 GB budget.
+      - name: Collect build caches from the VM
+        id: ccache
+        if: always() && matrix.persistence == fromJson(needs.setup.outputs.matrix)[0]
+        env:
+          IP: ${{ steps.ip.outputs.ip }}
+        run: |
+          set -uo pipefail
+          [ -n "${IP:-}" ] || exit 0
+          rm -rf ci-cache
+          rsync -az -e "ssh -i id_ci -o StrictHostKeyChecking=no" \
+            "root@$IP:/root/jans/ci-cache/" ci-cache/ || echo "[warn] cache fetch failed; nothing to save"
+          # Gate the save on this rather than hashFiles(), which would walk every file of a multi-GB tree.
+          [ -d ci-cache/m2 ] && echo "ok=1" >> "$GITHUB_OUTPUT"
+          du -sh ci-cache 2>/dev/null || true
+
+      - name: Save build caches
+        # A re-save under an unchanged key only warns; never let it fail the run.
+        continue-on-error: true
+        if: always() && steps.ccache.outputs.ok == '1'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ci-cache
+          key: ${{ steps.bcache.outputs.cache-primary-key }}
 
       - name: Summarise results
         if: always()

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -409,11 +409,18 @@ jobs:
           set -uo pipefail
           [ -n "${IP:-}" ] || exit 0
           rm -rf ci-cache
-          rsync -az -e "ssh -i id_ci -o StrictHostKeyChecking=no" \
-            "root@$IP:/root/jans/ci-cache/" ci-cache/ || echo "[warn] cache fetch failed; nothing to save"
-          # Gate the save on this rather than hashFiles(), which would walk every file of a multi-GB tree.
-          [ -d ci-cache/m2 ] && echo "ok=1" >> "$GITHUB_OUTPUT"
-          du -sh ci-cache 2>/dev/null || true
+          # Timeouts throughout: this step is if:always(), so a wedged VM would otherwise hang it
+          # until the job cap.
+          if rsync -az --timeout=300 \
+               -e "ssh -i id_ci -o StrictHostKeyChecking=no -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=4" \
+               "root@$IP:/root/jans/ci-cache/" ci-cache/; then
+            # The VM writes .save-ok only when the repack was complete and inside the size budget.
+            [ -f ci-cache/.save-ok ] && echo "ok=1" >> "$GITHUB_OUTPUT"
+            du -sh ci-cache 2>/dev/null || true
+          else
+            echo "[warn] cache fetch failed; discarding the partial copy"
+            rm -rf ci-cache
+          fi
 
       - name: Save build caches
         # A re-save under an unchanged key only warns; never let it fail the run.

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ grype.json
 /jans-cedarling/cedarling_pg/scripts/install-binary.sh
 
 CLAUDE.md
+
+# integration-test build cache staged on the runner (see .github/workflows/test-integration.yml)
+/ci-cache/

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -58,17 +58,18 @@ trap collect_diag EXIT
 # ---------------------------------------------------------------------------
 # Seed the build caches shipped with the checkout
 # ---------------------------------------------------------------------------
-# ci-cache/ arrives inside the rsync'd checkout (actions/cache on the runner) and holds third-party
-# maven artifacts, the cargo registry and the cedarling release target dir. io/jans is deliberately
-# never cached: a stale 0.0.0-nightly artifact from another commit would be resolved silently.
+# ci-cache/ arrives inside the rsync'd checkout (actions/cache on the runner) and holds downloaded
+# dependencies only -- third-party maven artifacts and the cargo registry. Two things are
+# deliberately absent: io/jans, because a stale 0.0.0-nightly from another commit would be resolved
+# silently, and jans-cedarling/target, because the compiled rust output would take the entry to
+# ~8 GB and evict every other workflow's cache from the repo's 10 GB budget.
 CACHE_DIR="$REPO_ROOT/ci-cache"
 if [ -d "$CACHE_DIR" ]; then
   echo "::group::seed build caches"
   du -sh "$CACHE_DIR"/* 2>/dev/null || true
-  mkdir -p "$HOME/.m2/repository" "$HOME/.cargo" jans-cedarling/target
+  mkdir -p "$HOME/.m2/repository" "$HOME/.cargo"
   [ -d "$CACHE_DIR/m2" ] && cp -a "$CACHE_DIR/m2/." "$HOME/.m2/repository/"
   [ -d "$CACHE_DIR/cargo" ] && cp -a "$CACHE_DIR/cargo/." "$HOME/.cargo/"
-  [ -d "$CACHE_DIR/cedarling-target" ] && cp -a "$CACHE_DIR/cedarling-target/." jans-cedarling/target/
   echo "::endgroup::"
 fi
 
@@ -120,13 +121,16 @@ set -e
 # -T 1C: the reactor was serial, leaving 7 of the VM's 8 cores idle for the whole build.
 # -pl '!server-fips': a packaging-only variant of the same WAR. Nothing downstream consumes it --
 # the service images fetch the plain jans-<svc>-<ver>.war -- and it cost ~8 min per reactor.
+# gitcommitid.skip: git-commit-id-plugin:revision took 8 min per module against the shallow
+# actions/checkout clone; it only writes cosmetic git.properties build metadata.
 MVN_PAR="-T 1C"
+MVN_SKIPS="-Dmaven.gitcommitid.skip=true"
 NO_FIPS="-pl !server-fips"
 for mod in jans-bom jans-orm jans-core jans-auth-server jans-scim jans-config-api jans-fido2; do
   pl=""
   case "$mod" in jans-auth-server | jans-scim | jans-config-api | jans-fido2) pl="$NO_FIPS" ;; esac
   echo "::group::build $mod"
-  mvn $MVN_PAR -B -ntp -s "$MVN_SETTINGS" -Dcfg=default -Dmaven.test.skip=true -fae \
+  mvn $MVN_PAR -B -ntp -s "$MVN_SETTINGS" -Dcfg=default -Dmaven.test.skip=true $MVN_SKIPS -fae \
     $pl -f "$mod/pom.xml" clean install
   echo "::endgroup::"
 done
@@ -140,7 +144,7 @@ for mod in agama jans-cedarling/bindings/cedarling-java jans-lock/lock-server; d
   pl=""
   case "$mod" in *lock-server) pl="$NO_FIPS" ;; esac
   echo "::group::build $mod"
-  mvn $MVN_PAR -B -ntp -s "$MVN_SETTINGS" -Dcfg=default -Dmaven.test.skip=true -fae $CED_OPTS \
+  mvn $MVN_PAR -B -ntp -s "$MVN_SETTINGS" -Dcfg=default -Dmaven.test.skip=true $MVN_SKIPS -fae $CED_OPTS \
     $pl -f "$mod/pom.xml" clean install || echo "[warn] build $mod failed; its tests will be skipped"
   echo "::endgroup::"
 done
@@ -166,14 +170,32 @@ if [ -n "${AIO_IMAGE:-}" ]; then
   docker pull "$AIO_IMAGE"
   base_image="$AIO_IMAGE"
 else
-  docker build -t local/persistence-loader:ci ./docker-jans-persistence-loader
+  # The five service images are independent of each other, so build them concurrently -- serially
+  # they cost ~17 min. Each gets its own log (parallel output would interleave unreadably); the logs
+  # land in aio-logs/ and so reach the run's artifact.
+  pids=""
+  docker build -t local/persistence-loader:ci ./docker-jans-persistence-loader \
+    > aio-logs/image-persistence-loader.log 2>&1 &
+  pids="$pids $!:persistence-loader"
   # Build every service image from the PR artifacts served on :8088 (CN_RELEASE_DOWNLOAD_URL), so the
   # running AIO exercises this checkout's auth/scim/fido2/config-api code -- not the nightly release.
   # Otherwise a fix under test would only reach the client-side suites, never the live server.
   for svc in config-api auth-server scim fido2; do
     docker build --network=host --build-arg CN_RELEASE_DOWNLOAD_URL=http://127.0.0.1:8088 \
-      -t "local/$svc:ci" "./docker-jans-$svc"
+      -t "local/$svc:ci" "./docker-jans-$svc" > "aio-logs/image-$svc.log" 2>&1 &
+    pids="$pids $!:$svc"
   done
+  # set -e does not fire for a background job, so collect every exit status explicitly and echo the
+  # tail of whichever image failed -- otherwise the failure is invisible in the run log.
+  img_rc=0
+  for p in $pids; do
+    wait "${p%%:*}" || {
+      echo "::error::image build failed: ${p#*:}"
+      tail -n 40 "aio-logs/image-${p#*:}.log" || true
+      img_rc=1
+    }
+  done
+  [ "$img_rc" -eq 0 ] || exit 1
   docker build -t local/aio:ci \
     --build-arg JANS_PERSISTENCE_LOADER_IMAGE=local/persistence-loader:ci \
     --build-arg JANS_CONFIG_API_IMAGE=local/config-api:ci \
@@ -398,7 +420,7 @@ for entry in jans-scim:jans-scim/client jans-config-api:jans-config-api \
   echo "::group::test $dir"
   suitelog="aio-logs/test-$(printf '%s' "$dir" | tr / _).log"
   timeout -k 30 2400 bash -c \
-    "cd '$dir' && mvn -B -ntp -s '$MVN_SETTINGS' -Dcfg='$JANS_FQDN' -DfailIfNoTests=false test" \
+    "cd '$dir' && mvn -B -ntp -s '$MVN_SETTINGS' -Dcfg='$JANS_FQDN' -DfailIfNoTests=false $MVN_SKIPS test" \
     > "$suitelog" 2>&1 || echo "[warn] $dir reported failures or timed out"
   echo "----- tail $suitelog -----"; tail -n 25 "$suitelog" 2>/dev/null || true
   echo "::endgroup::"
@@ -410,7 +432,9 @@ echo "::endgroup::"
 # ---------------------------------------------------------------------------
 echo "::group::run unit suites"
 # In-process unit suites (no live server); each hard-bounded with `timeout` as a safety net.
-OPTS="-B -ntp -s $MVN_SETTINGS -Dcfg=default -Dmaven.test.failure.ignore=true -DfailIfNoTests=false"
+# $MVN_SKIPS matters here too: the auth-server unit suite covers -pl server, the one remaining
+# module that still declares git-commit-id-plugin.
+OPTS="-B -ntp -s $MVN_SETTINGS -Dcfg=default -Dmaven.test.failure.ignore=true -DfailIfNoTests=false $MVN_SKIPS"
 want_module jans-orm && timeout -k 30 420 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || echo "[warn/skip] jans-orm units"
 want_module jans-core && timeout -k 30 420 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || echo "[warn/skip] jans-core units"
 want_module jans-auth-server && timeout -k 30 420 mvn $OPTS -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || echo "[warn/skip] jans-auth-server units"
@@ -434,14 +458,11 @@ if [ "${SAVE_CACHE:-1}" = 1 ]; then
   # Registry + git sources only: ~/.cargo/bin is rustup's own install, re-fetched each run.
   rsync -a --include 'registry/***' --include 'git/***' --exclude '*' \
     "$HOME/.cargo/" "$CACHE_DIR/cargo/" 2>/dev/null || true
-  rsync -a --delete jans-cedarling/target/release/ "$CACHE_DIR/cedarling-target/release/" 2>/dev/null || true
-  # GitHub's per-repo cache budget is 10 GB across all workflows (compressed). Cap the uncompressed
-  # tree well under that and drop the compiled rust output first: the maven half helps every module,
-  # the rust half only the one cargo step. Tune the cap from the per-component du printed below.
+  # GitHub's per-repo budget is 10 GB across all workflows. Downloaded deps alone should land near
+  # 3 GB; anything much larger means something unintended got in, so say so rather than upload it.
   sz=$(du -sm "$CACHE_DIR" 2>/dev/null | cut -f1)
-  if [ -n "$sz" ] && [ "$sz" -gt 8000 ]; then
-    echo "[warn] cache is ${sz}MB; dropping the cedarling target dir to stay under the repo cache budget"
-    rm -rf "$CACHE_DIR/cedarling-target"
+  if [ -n "$sz" ] && [ "$sz" -gt 5000 ]; then
+    echo "::warning::build cache is ${sz}MB, above the 5000MB guard -- check the per-component sizes below"
   fi
   du -sh "$CACHE_DIR"/* 2>/dev/null || true
   echo "::endgroup::"

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -449,15 +449,26 @@ echo "::group::run unit suites"
 # burns another 303s here, but it can't be excluded with -Dtest: that makes surefire ignore the
 # suiteXmlFiles jans-auth-server/pom.xml sets, changing which tests run across the whole reactor.
 OPTS="-B -ntp -s $MVN_SETTINGS -Dcfg=default -Dmaven.test.failure.ignore=true -DfailIfNoTests=false $MVN_SKIPS"
-want_module jans-orm && timeout -k 30 600 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || echo "[warn/skip] jans-orm units"
-want_module jans-core && timeout -k 30 600 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || echo "[warn/skip] jans-core units"
-want_module jans-auth-server && timeout -k 30 600 mvn $OPTS -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || echo "[warn/skip] jans-auth-server units"
-want_module agama && timeout -k 30 600 mvn $OPTS -f agama/pom.xml test > aio-logs/unit-agama.log 2>&1 || echo "[warn/skip] agama units"
-[ "$CED_READY" = 1 ] && want_module jans-cedarling && timeout -k 30 600 mvn $OPTS $CED_OPTS -f jans-cedarling/bindings/cedarling-java/pom.xml test > aio-logs/unit-cedarling-java.log 2>&1 || echo "[warn/skip] cedarling-java units"
-[ "$CED_READY" = 1 ] && want_module jans-lock && timeout -k 30 600 mvn $OPTS $CED_OPTS $NO_FIPS -f jans-lock/lock-server/pom.xml test > aio-logs/unit-jans-lock.log 2>&1 || echo "[warn/skip] jans-lock units"
+# A timed-out suite (124) produces no reports for the tests it never reached, so the gate would see
+# a smaller run rather than a failure. Record it and fail at the end, once reports are collected.
+unit_timeouts=""
+note_unit() {
+  if [ "$1" = 124 ]; then
+    echo "::error::$2 units timed out after 600s; its results are incomplete"
+    unit_timeouts="$unit_timeouts $2"
+  else
+    echo "[warn/skip] $2 units"
+  fi
+}
+want_module jans-orm && { timeout -k 30 600 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || note_unit $? jans-orm; }
+want_module jans-core && { timeout -k 30 600 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || note_unit $? jans-core; }
+want_module jans-auth-server && { timeout -k 30 600 mvn $OPTS -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || note_unit $? jans-auth-server; }
+want_module agama && { timeout -k 30 600 mvn $OPTS -f agama/pom.xml test > aio-logs/unit-agama.log 2>&1 || note_unit $? agama; }
+[ "$CED_READY" = 1 ] && want_module jans-cedarling && { timeout -k 30 600 mvn $OPTS $CED_OPTS -f jans-cedarling/bindings/cedarling-java/pom.xml test > aio-logs/unit-cedarling-java.log 2>&1 || note_unit $? cedarling-java; }
+[ "$CED_READY" = 1 ] && want_module jans-lock && { timeout -k 30 600 mvn $OPTS $CED_OPTS $NO_FIPS -f jans-lock/lock-server/pom.xml test > aio-logs/unit-jans-lock.log 2>&1 || note_unit $? jans-lock; }
 # fido2-server units: exclude the two *DeviceRegistration* TestNG tests (need an embedded Weld+DB
 # harness that does not exist here) and the MDS test (hits mds3.fido.tools over the network).
-want_module jans-fido2 && timeout -k 30 600 mvn $OPTS -Dtest='!Fido2DeviceRegistration*,!FetchMdsProviderServiceTest' -f jans-fido2/server/pom.xml test > aio-logs/unit-fido2-server.log 2>&1 || echo "[warn/skip] fido2-server units"
+want_module jans-fido2 && { timeout -k 30 600 mvn $OPTS -Dtest='!Fido2DeviceRegistration*,!FetchMdsProviderServiceTest' -f jans-fido2/server/pom.xml test > aio-logs/unit-fido2-server.log 2>&1 || note_unit $? fido2-server; }
 echo "::endgroup::"
 
 # ---------------------------------------------------------------------------
@@ -467,16 +478,27 @@ echo "::endgroup::"
 if [ "${SAVE_CACHE:-1}" = 1 ]; then
   echo "::group::repack build caches"
   mkdir -p "$CACHE_DIR"
-  rsync -a --delete --exclude 'io/jans' "$HOME/.m2/repository/" "$CACHE_DIR/m2/" 2>/dev/null || true
+  # The workflow saves only when .save-ok is present, so a partial or oversized repack is discarded
+  # rather than published over the entry other workflows are still using.
+  rm -f "$CACHE_DIR/.save-ok"
+  repack_rc=0
+  # --delete-excluded too: --exclude alone protects a receiver-side io/jans from --delete.
+  rsync -a --delete --delete-excluded --exclude 'io/jans' \
+    "$HOME/.m2/repository/" "$CACHE_DIR/m2/" || repack_rc=1
   # Registry + git sources only: ~/.cargo/bin is rustup's own install, re-fetched each run.
   rsync -a --include 'registry/***' --include 'git/***' --exclude '*' \
-    "$HOME/.cargo/" "$CACHE_DIR/cargo/" 2>/dev/null || true
+    "$HOME/.cargo/" "$CACHE_DIR/cargo/" || repack_rc=1
   # Deps alone should land near 3 GB; much larger means something unintended got in.
   sz=$(du -sm "$CACHE_DIR" 2>/dev/null | cut -f1)
-  if [ -n "$sz" ] && [ "$sz" -gt 5000 ]; then
-    echo "::warning::build cache is ${sz}MB, above the 5000MB guard -- check the per-component sizes below"
-  fi
   du -sh "$CACHE_DIR"/* 2>/dev/null || true
+  if [ "$repack_rc" -ne 0 ]; then
+    echo "::warning::cache repack failed; leaving it unsaved"
+    rm -rf "$CACHE_DIR/m2"
+  elif [ -z "$sz" ] || [ "$sz" -gt 5000 ]; then
+    echo "::warning::build cache is ${sz:-unknown}MB, over the 5000MB budget guard; leaving it unsaved"
+  else
+    : > "$CACHE_DIR/.save-ok"
+  fi
   echo "::endgroup::"
 else
   echo "[info] SAVE_CACHE=0; the sibling matrix leg repacks the build cache"
@@ -513,4 +535,8 @@ for s in jans-auth jans-config-api jans-scim jans-fido2 jans-casa; do
 done
 echo "::endgroup::"
 
+if [ -n "$unit_timeouts" ]; then
+  echo "::error::incomplete unit results, suites timed out:$unit_timeouts"
+  exit 1
+fi
 echo "[info] run_aio_integration.sh complete"

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -72,13 +72,15 @@ if [ -d "$CACHE_DIR" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Build the cedarling native lib (cedarling-java + jans-lock tests need it)
+# Start the cedarling native lib build (cedarling-java + jans-lock tests need it)
 # ---------------------------------------------------------------------------
 # cedarling-java's pom fetches libcedarling_uniffi-<ver>.so + the kotlin bindings from
 # cedarling.base.url. Build them from source and serve them locally so those modules build without
 # the release (mirrors build-test.yml). Best-effort: a failure only skips the cedarling-java /
 # jans-lock tests, not the rest of the run.
-echo "::group::build cedarling native lib"
+# Backgrounded: the core maven reactor below needs none of this, and the two together were ~30 min
+# serial. Cores are split while they overlap; the consumers wait on $ced_pid.
+echo "::group::start cedarling native lib build"
 set +e
 export DEBIAN_FRONTEND=noninteractive
 command -v cc     >/dev/null 2>&1 || apt-get -o DPkg::Lock::Timeout=600 install -y -qq build-essential pkg-config libssl-dev
@@ -90,23 +92,16 @@ CEDARLING_NV=0.0.0
 CED_OPTS=""   # set only on the ready path below; consumers are gated on CED_READY, not on this
 CED_READY=0
 ced_serve="$REPO_ROOT/cedarling-native"; mkdir -p "$ced_serve"
-# Build BOTH artifacts, &&-chained so any failing step aborts the whole prep (set -e is suppressed
-# inside an if-condition subshell), then serve + confirm reachable before enabling the consumers.
-if ( cd jans-cedarling/bindings/cedarling_uniffi &&
-     cargo build -r --locked -p cedarling_uniffi &&
-     cp ../../target/release/libcedarling_uniffi.so "$ced_serve/libcedarling_uniffi-${CEDARLING_NV}.so" &&
-     cargo run --locked --bin uniffi-bindgen generate \
-       --library "$REPO_ROOT/jans-cedarling/target/release/libcedarling_uniffi.so" --language kotlin --out-dir ./ &&
-     zip -qr "$ced_serve/cedarling_uniffi-kotlin-${CEDARLING_NV}.zip" uniffi ); then
-  ( cd "$ced_serve" && exec python3 -m http.server 8099 >/dev/null 2>&1 ) &
-  for _ in $(seq 1 10); do
-    curl -sf "http://127.0.0.1:8099/libcedarling_uniffi-${CEDARLING_NV}.so" -o /dev/null \
-      && curl -sf "http://127.0.0.1:8099/cedarling_uniffi-kotlin-${CEDARLING_NV}.zip" -o /dev/null \
-      && { CED_READY=1; CED_OPTS="-Dcedarling.base.url=http://127.0.0.1:8099 -Dcedarling.native.version=${CEDARLING_NV}"; break; }
-    sleep 1
-  done
-fi
-[ "$CED_READY" = 1 ] || echo "[warn] cedarling native prep failed; cedarling-java + jans-lock will be skipped"
+ced_log="aio-logs/cedarling-native.log"
+export CARGO_BUILD_JOBS=4
+# &&-chained so any failing step aborts the whole prep.
+( cd jans-cedarling/bindings/cedarling_uniffi &&
+  cargo build -r --locked -p cedarling_uniffi &&
+  cp ../../target/release/libcedarling_uniffi.so "$ced_serve/libcedarling_uniffi-${CEDARLING_NV}.so" &&
+  cargo run --locked --bin uniffi-bindgen generate \
+    --library "$REPO_ROOT/jans-cedarling/target/release/libcedarling_uniffi.so" --language kotlin --out-dir ./ &&
+  zip -qr "$ced_serve/cedarling_uniffi-kotlin-${CEDARLING_NV}.zip" uniffi ) > "$ced_log" 2>&1 &
+ced_pid=$!
 echo "::endgroup::"
 
 # ---------------------------------------------------------------------------
@@ -119,7 +114,7 @@ set -e
 # server-fips is a packaging-only WAR variant nothing downstream consumes (the service images fetch
 # the plain jans-<svc>-<ver>.war); git-commit-id-plugin cost 8 min per module against the shallow
 # checkout for cosmetic git.properties. The reactor was also serial on an 8-core VM.
-MVN_PAR="-T 1C"
+MVN_PAR="-T 4"   # the backgrounded cargo build holds the other four until it finishes
 MVN_SKIPS="-Dmaven.gitcommitid.skip=true"
 NO_FIPS="-pl !server-fips"
 for mod in jans-bom jans-orm jans-core jans-auth-server jans-scim jans-config-api jans-fido2; do
@@ -131,6 +126,23 @@ for mod in jans-bom jans-orm jans-core jans-auth-server jans-scim jans-config-ap
   echo "::endgroup::"
 done
 set +e
+
+echo "::group::cedarling native lib"
+wait "$ced_pid" && ced_ok=1 || ced_ok=0
+tail -n 30 "$ced_log" 2>/dev/null || true
+MVN_PAR="-T 1C"
+if [ "$ced_ok" = 1 ]; then
+  ( cd "$ced_serve" && exec python3 -m http.server 8099 >/dev/null 2>&1 ) &
+  for _ in $(seq 1 10); do
+    curl -sf "http://127.0.0.1:8099/libcedarling_uniffi-${CEDARLING_NV}.so" -o /dev/null \
+      && curl -sf "http://127.0.0.1:8099/cedarling_uniffi-kotlin-${CEDARLING_NV}.zip" -o /dev/null \
+      && { CED_READY=1; CED_OPTS="-Dcedarling.base.url=http://127.0.0.1:8099 -Dcedarling.native.version=${CEDARLING_NV}"; break; }
+    sleep 1
+  done
+fi
+[ "$CED_READY" = 1 ] || echo "[warn] cedarling native prep failed; cedarling-java + jans-lock will be skipped"
+echo "::endgroup::"
+
 # Extra-coverage modules (best-effort; tested in the unit phase). Built after the core reactor so a
 # failure can't block the AIO build or the core suites. $CED_OPTS is harmless to agama.
 for mod in agama jans-cedarling/bindings/cedarling-java jans-lock/lock-server; do

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -58,11 +58,9 @@ trap collect_diag EXIT
 # ---------------------------------------------------------------------------
 # Seed the build caches shipped with the checkout
 # ---------------------------------------------------------------------------
-# ci-cache/ arrives inside the rsync'd checkout (actions/cache on the runner) and holds downloaded
-# dependencies only -- third-party maven artifacts and the cargo registry. Two things are
-# deliberately absent: io/jans, because a stale 0.0.0-nightly from another commit would be resolved
-# silently, and jans-cedarling/target, because the compiled rust output would take the entry to
-# ~8 GB and evict every other workflow's cache from the repo's 10 GB budget.
+# ci-cache/ arrives inside the rsync'd checkout and holds downloaded dependencies only. io/jans is
+# excluded so a stale 0.0.0-nightly from another commit can't be resolved silently; the cedarling
+# target dir is excluded to keep the entry inside the repo's shared 10 GB cache budget.
 CACHE_DIR="$REPO_ROOT/ci-cache"
 if [ -d "$CACHE_DIR" ]; then
   echo "::group::seed build caches"
@@ -118,11 +116,9 @@ echo "::endgroup::"
 # (coordinate-named in ~/.m2) to its docker build, so Phase D doesn't depend on the nightly release.
 echo "::group::build jans modules"
 set -e
-# -T 1C: the reactor was serial, leaving 7 of the VM's 8 cores idle for the whole build.
-# -pl '!server-fips': a packaging-only variant of the same WAR. Nothing downstream consumes it --
-# the service images fetch the plain jans-<svc>-<ver>.war -- and it cost ~8 min per reactor.
-# gitcommitid.skip: git-commit-id-plugin:revision took 8 min per module against the shallow
-# actions/checkout clone; it only writes cosmetic git.properties build metadata.
+# server-fips is a packaging-only WAR variant nothing downstream consumes (the service images fetch
+# the plain jans-<svc>-<ver>.war); git-commit-id-plugin cost 8 min per module against the shallow
+# checkout for cosmetic git.properties. The reactor was also serial on an 8-core VM.
 MVN_PAR="-T 1C"
 MVN_SKIPS="-Dmaven.gitcommitid.skip=true"
 NO_FIPS="-pl !server-fips"
@@ -170,9 +166,8 @@ if [ -n "${AIO_IMAGE:-}" ]; then
   docker pull "$AIO_IMAGE"
   base_image="$AIO_IMAGE"
 else
-  # The five service images are independent of each other, so build them concurrently -- serially
-  # they cost ~17 min. Each gets its own log (parallel output would interleave unreadably); the logs
-  # land in aio-logs/ and so reach the run's artifact.
+  # Independent of each other, so build concurrently; serially they cost ~17 min. Per-image logs
+  # because parallel output interleaves unreadably.
   pids=""
   docker build -t local/persistence-loader:ci ./docker-jans-persistence-loader \
     > aio-logs/image-persistence-loader.log 2>&1 &
@@ -185,8 +180,7 @@ else
       -t "local/$svc:ci" "./docker-jans-$svc" > "aio-logs/image-$svc.log" 2>&1 &
     pids="$pids $!:$svc"
   done
-  # set -e does not fire for a background job, so collect every exit status explicitly and echo the
-  # tail of whichever image failed -- otherwise the failure is invisible in the run log.
+  # set -e does not fire for a background job, so collect every exit status explicitly.
   img_rc=0
   for p in $pids; do
     wait "${p%%:*}" || {
@@ -209,6 +203,13 @@ fi
 # compose expects, so start_janssen_aio_demo.sh uses it unchanged.
 cat > Dockerfile.ci-aio <<EOF
 FROM ${base_image}
+# info surfaces the reason for a 400 nginx raises itself; the buffers stop jans-auth's session
+# headers overflowing them ("upstream sent too big header" -> 502). Defaults ship unchanged.
+ENV CN_AIO_NGINX_LOG_LEVEL=info
+ENV CN_AIO_NGINX_PROXY_BUFFER_SIZE=16k
+ENV CN_AIO_NGINX_PROXY_BUFFERS="8 16k"
+ENV CN_AIO_NGINX_PROXY_BUSY_BUFFERS_SIZE=32k
+ENV CN_AIO_NGINX_LARGE_CLIENT_HEADER_BUFFERS="4 16k"
 ENV CN_PERSISTENCE_LOAD_TEST_DATA=true
 ENV CN_SCIM_ENABLED=true
 ENV CN_CONFIG_API_TEST_CLIENT_ID=${CN_CONFIG_API_TEST_CLIENT_ID}
@@ -432,8 +433,6 @@ echo "::endgroup::"
 # ---------------------------------------------------------------------------
 echo "::group::run unit suites"
 # In-process unit suites (no live server); each hard-bounded with `timeout` as a safety net.
-# $MVN_SKIPS matters here too: the auth-server unit suite covers -pl server, the one remaining
-# module that still declares git-commit-id-plugin.
 OPTS="-B -ntp -s $MVN_SETTINGS -Dcfg=default -Dmaven.test.failure.ignore=true -DfailIfNoTests=false $MVN_SKIPS"
 want_module jans-orm && timeout -k 30 420 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || echo "[warn/skip] jans-orm units"
 want_module jans-core && timeout -k 30 420 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || echo "[warn/skip] jans-core units"
@@ -453,13 +452,11 @@ echo "::endgroup::"
 if [ "${SAVE_CACHE:-1}" = 1 ]; then
   echo "::group::repack build caches"
   mkdir -p "$CACHE_DIR"
-  # io/jans is excluded on purpose (see the seed block at the top of this script).
   rsync -a --exclude 'io/jans' "$HOME/.m2/repository/" "$CACHE_DIR/m2/" 2>/dev/null || true
   # Registry + git sources only: ~/.cargo/bin is rustup's own install, re-fetched each run.
   rsync -a --include 'registry/***' --include 'git/***' --exclude '*' \
     "$HOME/.cargo/" "$CACHE_DIR/cargo/" 2>/dev/null || true
-  # GitHub's per-repo budget is 10 GB across all workflows. Downloaded deps alone should land near
-  # 3 GB; anything much larger means something unintended got in, so say so rather than upload it.
+  # Deps alone should land near 3 GB; much larger means something unintended got in.
   sz=$(du -sm "$CACHE_DIR" 2>/dev/null | cut -f1)
   if [ -n "$sz" ] && [ "$sz" -gt 5000 ]; then
     echo "::warning::build cache is ${sz}MB, above the 5000MB guard -- check the per-component sizes below"

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -433,16 +433,18 @@ echo "::endgroup::"
 # ---------------------------------------------------------------------------
 echo "::group::run unit suites"
 # In-process unit suites (no live server); each hard-bounded with `timeout` as a safety net.
+# UserJansExtUidAttributeTest is already baselined as known-failing and spends 303s timing out
+# against an LDAP pool the AIO does not have; server-fips has no tests but adds ~6 min of compile.
 OPTS="-B -ntp -s $MVN_SETTINGS -Dcfg=default -Dmaven.test.failure.ignore=true -DfailIfNoTests=false $MVN_SKIPS"
-want_module jans-orm && timeout -k 30 420 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || echo "[warn/skip] jans-orm units"
-want_module jans-core && timeout -k 30 420 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || echo "[warn/skip] jans-core units"
-want_module jans-auth-server && timeout -k 30 420 mvn $OPTS -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || echo "[warn/skip] jans-auth-server units"
-want_module agama && timeout -k 30 420 mvn $OPTS -f agama/pom.xml test > aio-logs/unit-agama.log 2>&1 || echo "[warn/skip] agama units"
-[ "$CED_READY" = 1 ] && want_module jans-cedarling && timeout -k 30 420 mvn $OPTS $CED_OPTS -f jans-cedarling/bindings/cedarling-java/pom.xml test > aio-logs/unit-cedarling-java.log 2>&1 || echo "[warn/skip] cedarling-java units"
-[ "$CED_READY" = 1 ] && want_module jans-lock && timeout -k 30 420 mvn $OPTS $CED_OPTS -f jans-lock/lock-server/pom.xml test > aio-logs/unit-jans-lock.log 2>&1 || echo "[warn/skip] jans-lock units"
+want_module jans-orm && timeout -k 30 600 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || echo "[warn/skip] jans-orm units"
+want_module jans-core && timeout -k 30 600 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || echo "[warn/skip] jans-core units"
+want_module jans-auth-server && timeout -k 30 600 mvn $OPTS -Dtest='!UserJansExtUidAttributeTest' -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || echo "[warn/skip] jans-auth-server units"
+want_module agama && timeout -k 30 600 mvn $OPTS -f agama/pom.xml test > aio-logs/unit-agama.log 2>&1 || echo "[warn/skip] agama units"
+[ "$CED_READY" = 1 ] && want_module jans-cedarling && timeout -k 30 600 mvn $OPTS $CED_OPTS -f jans-cedarling/bindings/cedarling-java/pom.xml test > aio-logs/unit-cedarling-java.log 2>&1 || echo "[warn/skip] cedarling-java units"
+[ "$CED_READY" = 1 ] && want_module jans-lock && timeout -k 30 600 mvn $OPTS $CED_OPTS $NO_FIPS -f jans-lock/lock-server/pom.xml test > aio-logs/unit-jans-lock.log 2>&1 || echo "[warn/skip] jans-lock units"
 # fido2-server units: exclude the two *DeviceRegistration* TestNG tests (need an embedded Weld+DB
 # harness that does not exist here) and the MDS test (hits mds3.fido.tools over the network).
-want_module jans-fido2 && timeout -k 30 420 mvn $OPTS -Dtest='!Fido2DeviceRegistration*,!FetchMdsProviderServiceTest' -f jans-fido2/server/pom.xml test > aio-logs/unit-fido2-server.log 2>&1 || echo "[warn/skip] fido2-server units"
+want_module jans-fido2 && timeout -k 30 600 mvn $OPTS -Dtest='!Fido2DeviceRegistration*,!FetchMdsProviderServiceTest' -f jans-fido2/server/pom.xml test > aio-logs/unit-fido2-server.log 2>&1 || echo "[warn/skip] fido2-server units"
 echo "::endgroup::"
 
 # ---------------------------------------------------------------------------
@@ -452,7 +454,7 @@ echo "::endgroup::"
 if [ "${SAVE_CACHE:-1}" = 1 ]; then
   echo "::group::repack build caches"
   mkdir -p "$CACHE_DIR"
-  rsync -a --exclude 'io/jans' "$HOME/.m2/repository/" "$CACHE_DIR/m2/" 2>/dev/null || true
+  rsync -a --delete --exclude 'io/jans' "$HOME/.m2/repository/" "$CACHE_DIR/m2/" 2>/dev/null || true
   # Registry + git sources only: ~/.cargo/bin is rustup's own install, re-fetched each run.
   rsync -a --include 'registry/***' --include 'git/***' --exclude '*' \
     "$HOME/.cargo/" "$CACHE_DIR/cargo/" 2>/dev/null || true

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Whole jans-side integration-test flow, run ON the ephemeral CI VM (8 vCPU) rather than the
-# 2-core GitHub runner. Run from the repo root (checkout rsync'd to /root/jans).
+# Whole jans-side integration-test flow, run ON the ephemeral CI VM (8 dedicated vCPU) rather than
+# the 2-core GitHub runner. Run from the repo root (checkout rsync'd to /root/jans).
 #
 # Required env (set by the workflow over SSH):
 #   JANS_FQDN, JANS_PERSISTENCE (MYSQL|PGSQL), LOG_LEVEL (INFO|TRACE),
@@ -56,6 +56,23 @@ collect_diag() {
 trap collect_diag EXIT
 
 # ---------------------------------------------------------------------------
+# Seed the build caches shipped with the checkout
+# ---------------------------------------------------------------------------
+# ci-cache/ arrives inside the rsync'd checkout (actions/cache on the runner) and holds third-party
+# maven artifacts, the cargo registry and the cedarling release target dir. io/jans is deliberately
+# never cached: a stale 0.0.0-nightly artifact from another commit would be resolved silently.
+CACHE_DIR="$REPO_ROOT/ci-cache"
+if [ -d "$CACHE_DIR" ]; then
+  echo "::group::seed build caches"
+  du -sh "$CACHE_DIR"/* 2>/dev/null || true
+  mkdir -p "$HOME/.m2/repository" "$HOME/.cargo" jans-cedarling/target
+  [ -d "$CACHE_DIR/m2" ] && cp -a "$CACHE_DIR/m2/." "$HOME/.m2/repository/"
+  [ -d "$CACHE_DIR/cargo" ] && cp -a "$CACHE_DIR/cargo/." "$HOME/.cargo/"
+  [ -d "$CACHE_DIR/cedarling-target" ] && cp -a "$CACHE_DIR/cedarling-target/." jans-cedarling/target/
+  echo "::endgroup::"
+fi
+
+# ---------------------------------------------------------------------------
 # Build the cedarling native lib (cedarling-java + jans-lock tests need it)
 # ---------------------------------------------------------------------------
 # cedarling-java's pom fetches libcedarling_uniffi-<ver>.so + the kotlin bindings from
@@ -100,10 +117,17 @@ echo "::endgroup::"
 # (coordinate-named in ~/.m2) to its docker build, so Phase D doesn't depend on the nightly release.
 echo "::group::build jans modules"
 set -e
+# -T 1C: the reactor was serial, leaving 7 of the VM's 8 cores idle for the whole build.
+# -pl '!server-fips': a packaging-only variant of the same WAR. Nothing downstream consumes it --
+# the service images fetch the plain jans-<svc>-<ver>.war -- and it cost ~8 min per reactor.
+MVN_PAR="-T 1C"
+NO_FIPS="-pl !server-fips"
 for mod in jans-bom jans-orm jans-core jans-auth-server jans-scim jans-config-api jans-fido2; do
+  pl=""
+  case "$mod" in jans-auth-server | jans-scim | jans-config-api | jans-fido2) pl="$NO_FIPS" ;; esac
   echo "::group::build $mod"
-  mvn -B -ntp -s "$MVN_SETTINGS" -Dcfg=default -Dmaven.test.skip=true -fae \
-    -f "$mod/pom.xml" clean install
+  mvn $MVN_PAR -B -ntp -s "$MVN_SETTINGS" -Dcfg=default -Dmaven.test.skip=true -fae \
+    $pl -f "$mod/pom.xml" clean install
   echo "::endgroup::"
 done
 set +e
@@ -113,9 +137,11 @@ for mod in agama jans-cedarling/bindings/cedarling-java jans-lock/lock-server; d
   case "$mod" in
     *cedarling*|*lock*) [ "$CED_READY" = 1 ] || { echo "[info] skip build $mod (cedarling native lib not ready)"; continue; } ;;
   esac
+  pl=""
+  case "$mod" in *lock-server) pl="$NO_FIPS" ;; esac
   echo "::group::build $mod"
-  mvn -B -ntp -s "$MVN_SETTINGS" -Dcfg=default -Dmaven.test.skip=true -fae $CED_OPTS \
-    -f "$mod/pom.xml" clean install || echo "[warn] build $mod failed; its tests will be skipped"
+  mvn $MVN_PAR -B -ntp -s "$MVN_SETTINGS" -Dcfg=default -Dmaven.test.skip=true -fae $CED_OPTS \
+    $pl -f "$mod/pom.xml" clean install || echo "[warn] build $mod failed; its tests will be skipped"
   echo "::endgroup::"
 done
 set -e
@@ -178,7 +204,7 @@ echo "::group::start AIO demo stack"
 # TRACE (detailed FILE logs) is opt-in via LOG_LEVEL: the demo enables TRACE + FILE logging
 # when JANS_CI_CD_RUN is set; default stays INFO/STDOUT (lower memory).
 [ "${LOG_LEVEL:-INFO}" = "TRACE" ] && export JANS_CI_CD_RUN=true && echo "[info] AIO log level: TRACE/FILE" || true
-# The demo default (768M) OOM-kills mysql under the test-data load; the CI VM has 16GB.
+# The demo default (768M) OOM-kills mysql under the test-data load; the CI VM has 16-32GB.
 export MYSQL_MEM_LIMIT="${MYSQL_MEM_LIMIT:-3G}"
 # Run the demo in the background and relax its mode-600 TLS certs as they appear, so the
 # in-container configurator (uid 1000) reads ca.key/web_https.key on its FIRST run. A restart
@@ -385,16 +411,43 @@ echo "::endgroup::"
 echo "::group::run unit suites"
 # In-process unit suites (no live server); each hard-bounded with `timeout` as a safety net.
 OPTS="-B -ntp -s $MVN_SETTINGS -Dcfg=default -Dmaven.test.failure.ignore=true -DfailIfNoTests=false"
-want_module jans-orm && timeout -k 30 900 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || echo "[warn/skip] jans-orm units"
-want_module jans-core && timeout -k 30 900 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || echo "[warn/skip] jans-core units"
-want_module jans-auth-server && timeout -k 30 900 mvn $OPTS -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || echo "[warn/skip] jans-auth-server units"
-want_module agama && timeout -k 30 900 mvn $OPTS -f agama/pom.xml test > aio-logs/unit-agama.log 2>&1 || echo "[warn/skip] agama units"
-[ "$CED_READY" = 1 ] && want_module jans-cedarling && timeout -k 30 900 mvn $OPTS $CED_OPTS -f jans-cedarling/bindings/cedarling-java/pom.xml test > aio-logs/unit-cedarling-java.log 2>&1 || echo "[warn/skip] cedarling-java units"
-[ "$CED_READY" = 1 ] && want_module jans-lock && timeout -k 30 900 mvn $OPTS $CED_OPTS -f jans-lock/lock-server/pom.xml test > aio-logs/unit-jans-lock.log 2>&1 || echo "[warn/skip] jans-lock units"
+want_module jans-orm && timeout -k 30 420 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || echo "[warn/skip] jans-orm units"
+want_module jans-core && timeout -k 30 420 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || echo "[warn/skip] jans-core units"
+want_module jans-auth-server && timeout -k 30 420 mvn $OPTS -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || echo "[warn/skip] jans-auth-server units"
+want_module agama && timeout -k 30 420 mvn $OPTS -f agama/pom.xml test > aio-logs/unit-agama.log 2>&1 || echo "[warn/skip] agama units"
+[ "$CED_READY" = 1 ] && want_module jans-cedarling && timeout -k 30 420 mvn $OPTS $CED_OPTS -f jans-cedarling/bindings/cedarling-java/pom.xml test > aio-logs/unit-cedarling-java.log 2>&1 || echo "[warn/skip] cedarling-java units"
+[ "$CED_READY" = 1 ] && want_module jans-lock && timeout -k 30 420 mvn $OPTS $CED_OPTS -f jans-lock/lock-server/pom.xml test > aio-logs/unit-jans-lock.log 2>&1 || echo "[warn/skip] jans-lock units"
 # fido2-server units: exclude the two *DeviceRegistration* TestNG tests (need an embedded Weld+DB
 # harness that does not exist here) and the MDS test (hits mds3.fido.tools over the network).
-want_module jans-fido2 && timeout -k 30 900 mvn $OPTS -Dtest='!Fido2DeviceRegistration*,!FetchMdsProviderServiceTest' -f jans-fido2/server/pom.xml test > aio-logs/unit-fido2-server.log 2>&1 || echo "[warn/skip] fido2-server units"
+want_module jans-fido2 && timeout -k 30 420 mvn $OPTS -Dtest='!Fido2DeviceRegistration*,!FetchMdsProviderServiceTest' -f jans-fido2/server/pom.xml test > aio-logs/unit-fido2-server.log 2>&1 || echo "[warn/skip] fido2-server units"
 echo "::endgroup::"
+
+# ---------------------------------------------------------------------------
+# Repack the build caches for the runner to save
+# ---------------------------------------------------------------------------
+# Only the leg the workflow elected to save bothers repacking; the sibling's copy is discarded.
+if [ "${SAVE_CACHE:-1}" = 1 ]; then
+  echo "::group::repack build caches"
+  mkdir -p "$CACHE_DIR"
+  # io/jans is excluded on purpose (see the seed block at the top of this script).
+  rsync -a --exclude 'io/jans' "$HOME/.m2/repository/" "$CACHE_DIR/m2/" 2>/dev/null || true
+  # Registry + git sources only: ~/.cargo/bin is rustup's own install, re-fetched each run.
+  rsync -a --include 'registry/***' --include 'git/***' --exclude '*' \
+    "$HOME/.cargo/" "$CACHE_DIR/cargo/" 2>/dev/null || true
+  rsync -a --delete jans-cedarling/target/release/ "$CACHE_DIR/cedarling-target/release/" 2>/dev/null || true
+  # GitHub's per-repo cache budget is 10 GB across all workflows (compressed). Cap the uncompressed
+  # tree well under that and drop the compiled rust output first: the maven half helps every module,
+  # the rust half only the one cargo step. Tune the cap from the per-component du printed below.
+  sz=$(du -sm "$CACHE_DIR" 2>/dev/null | cut -f1)
+  if [ -n "$sz" ] && [ "$sz" -gt 8000 ]; then
+    echo "[warn] cache is ${sz}MB; dropping the cedarling target dir to stay under the repo cache budget"
+    rm -rf "$CACHE_DIR/cedarling-target"
+  fi
+  du -sh "$CACHE_DIR"/* 2>/dev/null || true
+  echo "::endgroup::"
+else
+  echo "[info] SAVE_CACHE=0; the sibling matrix leg repacks the build cache"
+fi
 
 # ---------------------------------------------------------------------------
 # Collect surefire reports

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -433,12 +433,13 @@ echo "::endgroup::"
 # ---------------------------------------------------------------------------
 echo "::group::run unit suites"
 # In-process unit suites (no live server); each hard-bounded with `timeout` as a safety net.
-# UserJansExtUidAttributeTest is already baselined as known-failing and spends 303s timing out
-# against an LDAP pool the AIO does not have; server-fips has no tests but adds ~6 min of compile.
+# server-fips has no tests but adds ~6 min of compile to the jans-lock reactor. UserJansExtUidAttributeTest
+# burns another 303s here, but it can't be excluded with -Dtest: that makes surefire ignore the
+# suiteXmlFiles jans-auth-server/pom.xml sets, changing which tests run across the whole reactor.
 OPTS="-B -ntp -s $MVN_SETTINGS -Dcfg=default -Dmaven.test.failure.ignore=true -DfailIfNoTests=false $MVN_SKIPS"
 want_module jans-orm && timeout -k 30 600 mvn $OPTS -f jans-orm/pom.xml test > aio-logs/unit-jans-orm.log 2>&1 || echo "[warn/skip] jans-orm units"
 want_module jans-core && timeout -k 30 600 mvn $OPTS -f jans-core/pom.xml test > aio-logs/unit-jans-core.log 2>&1 || echo "[warn/skip] jans-core units"
-want_module jans-auth-server && timeout -k 30 600 mvn $OPTS -Dtest='!UserJansExtUidAttributeTest' -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || echo "[warn/skip] jans-auth-server units"
+want_module jans-auth-server && timeout -k 30 600 mvn $OPTS -f jans-auth-server/pom.xml -pl model,common,server test > aio-logs/unit-jans-auth-server.log 2>&1 || echo "[warn/skip] jans-auth-server units"
 want_module agama && timeout -k 30 600 mvn $OPTS -f agama/pom.xml test > aio-logs/unit-agama.log 2>&1 || echo "[warn/skip] agama units"
 [ "$CED_READY" = 1 ] && want_module jans-cedarling && timeout -k 30 600 mvn $OPTS $CED_OPTS -f jans-cedarling/bindings/cedarling-java/pom.xml test > aio-logs/unit-cedarling-java.log 2>&1 || echo "[warn/skip] cedarling-java units"
 [ "$CED_READY" = 1 ] && want_module jans-lock && timeout -k 30 600 mvn $OPTS $CED_OPTS $NO_FIPS -f jans-lock/lock-server/pom.xml test > aio-logs/unit-jans-lock.log 2>&1 || echo "[warn/skip] jans-lock units"

--- a/docker-jans-all-in-one/app/jans_aio/bootstrap.py
+++ b/docker-jans-all-in-one/app/jans_aio/bootstrap.py
@@ -167,15 +167,17 @@ def _max_memory_from_sysconf() -> int:
 
 NGINX_LOG_LEVELS = ("debug", "info", "notice", "warn", "error", "crit", "alert", "emerg")
 
-NGINX_BUFFER_TUNABLES = (
-    ("CN_AIO_NGINX_PROXY_BUFFER_SIZE", "proxy_buffer_size"),
-    ("CN_AIO_NGINX_PROXY_BUFFERS", "proxy_buffers"),
-    ("CN_AIO_NGINX_PROXY_BUSY_BUFFERS_SIZE", "proxy_busy_buffers_size"),
-    ("CN_AIO_NGINX_LARGE_CLIENT_HEADER_BUFFERS", "large_client_header_buffers"),
-)
+# Validated before rendering: a stray ';' in an env var would inject arbitrary nginx directives,
+# and the wrong arity (a count where nginx wants a bare size) makes nginx refuse to start.
+NGINX_SIZE_RE = re.compile(r"^\d+[kKmM]?$")
+NGINX_COUNT_SIZE_RE = re.compile(r"^\d+ \d+[kKmM]?$")
 
-# Validated before rendering: a stray ';' in an env var would inject arbitrary nginx directives.
-NGINX_SIZE_RE = re.compile(r"^\d+[kKmM]?( \d+[kKmM]?)?$")
+NGINX_BUFFER_TUNABLES = (
+    ("CN_AIO_NGINX_PROXY_BUFFER_SIZE", "proxy_buffer_size", NGINX_SIZE_RE),
+    ("CN_AIO_NGINX_PROXY_BUFFERS", "proxy_buffers", NGINX_COUNT_SIZE_RE),
+    ("CN_AIO_NGINX_PROXY_BUSY_BUFFERS_SIZE", "proxy_busy_buffers_size", NGINX_SIZE_RE),
+    ("CN_AIO_NGINX_LARGE_CLIENT_HEADER_BUFFERS", "large_client_header_buffers", NGINX_COUNT_SIZE_RE),
+)
 
 
 def render_nginx_default_conf(enabled_programs, nginx_includes):
@@ -209,12 +211,13 @@ def render_nginx_default_conf(enabled_programs, nginx_includes):
             print(f"[warn] ignoring CN_AIO_NGINX_LOG_LEVEL={log_level!r}: not an nginx log level")
 
     buffer_tunables = []
-    for env_name, directive in NGINX_BUFFER_TUNABLES:
+    for env_name, directive, pattern in NGINX_BUFFER_TUNABLES:
         value = (os.environ.get(env_name) or "").strip()
         if not value:
             continue
-        if not NGINX_SIZE_RE.match(value):
-            print(f"[warn] ignoring {env_name}={value!r}: not an nginx size or count-and-size pair")
+        if not pattern.match(value):
+            want = "a size" if pattern is NGINX_SIZE_RE else "a count and a size"
+            print(f"[warn] ignoring {env_name}={value!r}: {directive} takes {want}")
             continue
         buffer_tunables.append(f"{directive} {value};")
     tunables.extend(buffer_tunables)

--- a/docker-jans-all-in-one/app/jans_aio/bootstrap.py
+++ b/docker-jans-all-in-one/app/jans_aio/bootstrap.py
@@ -1,4 +1,5 @@
 import os
+import re
 import typing as _t
 from pathlib import Path
 from contextlib import suppress
@@ -164,6 +165,19 @@ def _max_memory_from_sysconf() -> int:
     return os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
 
 
+NGINX_LOG_LEVELS = ("debug", "info", "notice", "warn", "error", "crit", "alert", "emerg")
+
+NGINX_BUFFER_TUNABLES = (
+    ("CN_AIO_NGINX_PROXY_BUFFER_SIZE", "proxy_buffer_size"),
+    ("CN_AIO_NGINX_PROXY_BUFFERS", "proxy_buffers"),
+    ("CN_AIO_NGINX_PROXY_BUSY_BUFFERS_SIZE", "proxy_busy_buffers_size"),
+    ("CN_AIO_NGINX_LARGE_CLIENT_HEADER_BUFFERS", "large_client_header_buffers"),
+)
+
+# Validated before rendering: a stray ';' in an env var would inject arbitrary nginx directives.
+NGINX_SIZE_RE = re.compile(r"^\d+[kKmM]?( \d+[kKmM]?)?$")
+
+
 def render_nginx_default_conf(enabled_programs, nginx_includes):
     upstream_includes = []
     location_includes = []
@@ -183,10 +197,33 @@ def render_nginx_default_conf(enabled_programs, nginx_includes):
             else:
                 location_includes.append(val)
 
+    # Emitted only when set: nginx's own defaults here are page-size dependent (buffers) or come
+    # from the base nginx.conf (error_log), so a literal default would silently override them.
+    tunables = []
+
+    log_level = (os.environ.get("CN_AIO_NGINX_LOG_LEVEL") or "").strip()
+    if log_level:
+        if log_level in NGINX_LOG_LEVELS:
+            tunables.append(f"error_log /var/log/nginx/error.log {log_level};")
+        else:
+            print(f"[warn] ignoring CN_AIO_NGINX_LOG_LEVEL={log_level!r}: not an nginx log level")
+
+    buffer_tunables = []
+    for env_name, directive in NGINX_BUFFER_TUNABLES:
+        value = (os.environ.get(env_name) or "").strip()
+        if not value:
+            continue
+        if not NGINX_SIZE_RE.match(value):
+            print(f"[warn] ignoring {env_name}={value!r}: not an nginx size or count-and-size pair")
+            continue
+        buffer_tunables.append(f"{directive} {value};")
+    tunables.extend(buffer_tunables)
+
     # context for rendered templates
     ctx = {
         "upstream_includes": "\n".join(upstream_includes),
         "location_includes": "\n\t".join(location_includes),
+        "tunables": "\n" + "\n".join(tunables) + "\n" if tunables else "",
     }
     tmpl = Path("/app/templates/nginx/nginx-default.conf").read_text().strip()
     Path("/etc/nginx/http.d/default.conf").write_text(tmpl % ctx)

--- a/docker-jans-all-in-one/app/templates/nginx/nginx-default.conf
+++ b/docker-jans-all-in-one/app/templates/nginx/nginx-default.conf
@@ -7,7 +7,7 @@ geo $literal_dollar {
 
 client_header_timeout 300;
 client_body_timeout 300;
-
+%(tunables)s
 server {
     listen 8080 default_server;
     server_name _;


### PR DESCRIPTION
Run [33770049400](https://github.com/JanssenProject/jans/actions/runs/33770049400) burned 98 of its 150 min on the build before the first test ran; both matrix legs were killed by `timeout-minutes: 150` mid-suite.

### Build time

| change | saves |
|---|---|
| `-Dmaven.gitcommitid.skip=true` — the plugin sat 8 min per module against the shallow checkout, writing only cosmetic `git.properties` | ~8m |
| skip `*-fips` reactors (`-pl '!server-fips'`) — packaging-only WARs; the service images fetch the plain `jans-<svc>-<ver>.war` | ~33m |
| build the five service images concurrently instead of in a serial loop | ~10m |
| `-T 1C` — the reactor was serial on an 8-core VM | build-bound |
| dedicated-CPU droplet (`g-8vcpu-32gb`/`c-8`), falling back to `s-8vcpu-16gb` | removes CPU steal |
| `actions/cache` for `~/.m2` (minus `io/jans`) + cargo registry, staged in the rsync'd checkout | cold-start downloads |
| unit-suite `timeout` 900s → 420s | six suites at 900s alone exceeded the budget |

Cache is deliberately bounded, since the 10 GB budget is shared with the other workflows:
- downloaded dependencies only — `jans-cedarling/target` would take the entry to ~8 GB
- `io/jans` never cached; a stale `0.0.0-nightly` from another commit would resolve silently
- saved only on non-PR runs and only from the first matrix leg — a PR's cache is scoped to its own ref, so it would evict entries still in use while being readable by nothing. PRs still restore via the base-branch fallback
- weekly key: entries are immutable, so a content hash would write a fresh ~3 GB entry per dependency change

### Droplet provisioning

Both legs of [33869974704](https://github.com/JanssenProject/jans/actions/runs/33869974704) failed ~7s after creating their SSH key with `422 ... are invalid key identifiers`. The key is now polled before first use, and that specific 422 retries the same region 5 times before aborting. Every other non-2xx still aborts on the first attempt, so a 5xx is never re-POSTed into a duplicate droplet.

### AIO nginx diagnostics

The CIBA `bc-authorize` negative tests fail with an HTML 400 that the AIO's own nginx generates — indistinguishable from an upstream 400, because nginx logs its rejection reasons at `info` and the image sets no `error_log`. Adds `CN_AIO_NGINX_LOG_LEVEL` plus four buffer vars, **emitted only when set**, so an unset var leaves nginx on its own defaults (which for the buffers are page-size dependent). Values are validated before rendering — a stray `;` would otherwise inject arbitrary directives. CI opts into `info` and wider buffers, the latter for the `upstream sent too big header` 502s in the same run.

Parallel builds interleave output, so both the reactor (`-T 1C`) and the image builds read less linearly; each image gets its own log under `aio-logs/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved integration build times through reusable build caches and parallelized build and service-image preparation.
  * Reduced unit-test timeout limits for faster feedback.

* **Reliability**
  * Added fallback provisioning across dedicated-CPU and Basic compute sizes and multiple regions.
  * Improved SSH setup retry handling and integration-test result collection.
  * Preserved build caches after integration runs where enabled.
  * Improved consistency across supported build and integration-test environments.

* **Configuration**
  * Added configurable Nginx logging and proxy buffer settings, with validation for supported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->