### PR TITLE
fix(jans-fido2): read and enforce the crossOrigin member of client data

### DIFF
--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -52,6 +52,16 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 | <span id="servermetadatafolder">`serverMetadataFolder`</span> | String | `"/etc/jans/conf/fido2/server_metadata"` | Folder where local vendor metadata statement JSON files are placed manually. |
 | `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS65535`, `ES256`, `EdDSA` — the algorithms the server can both advertise and complete a registration with. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. |
 | `rp` | Array of Objects | `[ { "id": "https://jans.io", "origins": ["jans.io"] } ]` | Relying Party (RP) configuration mapping expected IDs to valid origins. |
+
+### Cross-origin ceremonies
+
+Registration and authentication ceremonies performed inside a cross-origin iframe are rejected. As WebAuthn
+Level 3 requires, the server reads the `crossOrigin` member of `CollectedClientData`: an absent member is
+treated as `false`, a value of `true` fails the request with `cross_origin_not_allowed`, and a non-boolean
+value fails with `invalid_request`.
+
+There is no configuration to permit a framed ceremony against a chosen set of framing origins yet, so a
+deployment that embeds the ceremony in a cross-origin iframe will stop working after this change.
 | `metadataServers` | Array of Objects | `[ { "url": "https://mds.fidoalliance.org/" } ]` | External FIDO Metadata Service endpoints to download statement catalogs. |
 | `disableMetadataService` | Boolean | `false` | If set to `true`, the FIDO2 server skips validating authenticators against the MDS3 service. |
 | `mdsDownloadStartupRetries` | Integer | `3` | Number of times the MDS TOC download is *retried* at server startup when the TOC blob is missing (a missing TOC prevents attestation validation). This is in addition to the initial attempt, so the default of `3` means up to 4 downloads. `0` disables retries. Retries stop early once the blob is present, and are skipped when the metadata server answers HTTP 429, since it has explicitly asked the server to back off. |

--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -52,16 +52,6 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 | <span id="servermetadatafolder">`serverMetadataFolder`</span> | String | `"/etc/jans/conf/fido2/server_metadata"` | Folder where local vendor metadata statement JSON files are placed manually. |
 | `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS65535`, `ES256`, `EdDSA` — the algorithms the server can both advertise and complete a registration with. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. |
 | `rp` | Array of Objects | `[ { "id": "https://jans.io", "origins": ["jans.io"] } ]` | Relying Party (RP) configuration mapping expected IDs to valid origins. |
-
-### Cross-origin ceremonies
-
-Registration and authentication ceremonies performed inside a cross-origin iframe are rejected. As WebAuthn
-Level 3 requires, the server reads the `crossOrigin` member of `CollectedClientData`: an absent member is
-treated as `false`, a value of `true` fails the request with `cross_origin_not_allowed`, and a non-boolean
-value fails with `invalid_request`.
-
-There is no configuration to permit a framed ceremony against a chosen set of framing origins yet, so a
-deployment that embeds the ceremony in a cross-origin iframe will stop working after this change.
 | `metadataServers` | Array of Objects | `[ { "url": "https://mds.fidoalliance.org/" } ]` | External FIDO Metadata Service endpoints to download statement catalogs. |
 | `disableMetadataService` | Boolean | `false` | If set to `true`, the FIDO2 server skips validating authenticators against the MDS3 service. |
 | `mdsDownloadStartupRetries` | Integer | `3` | Number of times the MDS TOC download is *retried* at server startup when the TOC blob is missing (a missing TOC prevents attestation validation). This is in addition to the initial attempt, so the default of `3` means up to 4 downloads. `0` disables retries. Retries stop early once the blob is present, and are skipped when the metadata server answers HTTP 429, since it has explicitly asked the server to back off. |
@@ -69,5 +59,15 @@ deployment that embeds the ceremony in a cross-origin iframe will stop working a
 | `hints` | Array of Strings | `["security-key", "client-device", "hybrid"]` | Preferred authenticator type hints presented to the Relying Party. |
 | `enterpriseAttestation` | Boolean | `false` | Enables support for enterprise-specific hardware attestation profiles. |
 | `attestationMode` | String | `"monitor"` | Options are: `disabled` (skip attestation checks), `monitor` (log/validate but allow credentials if attestation is absent/unknown), and `enforced` (fail credential creation if attestation check fails). |
+
+### Cross-origin ceremonies
+
+Registration and authentication ceremonies performed inside a cross-origin iframe are rejected. As WebAuthn
+Level 3 requires, the server reads the `crossOrigin` member of `CollectedClientData`: an absent member is
+treated as `false`, a value of `true` fails the request with `cross_origin_not_allowed`, and both a
+non-boolean value and an explicit `null` fail with `invalid_request`.
+
+There is no configuration to permit a framed ceremony against a chosen set of framing origins yet, so a
+deployment that embeds the ceremony in a cross-origin iframe will stop working after this change.
 
 

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/error/CommonErrorResponseType.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/error/CommonErrorResponseType.java
@@ -17,6 +17,11 @@ public enum CommonErrorResponseType implements IErrorType {
     INVALID_DOMAIN("invalid_domain"),
 
     /**
+     * The ceremony was performed in a cross-origin iframe, which is not allowed.
+     */
+    CROSS_ORIGIN_NOT_ALLOWED("cross_origin_not_allowed"),
+
+    /**
      * Unknown or not found error.
      */
     UNKNOWN_ERROR("unknown_error"),

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/CommonVerifiers.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/CommonVerifiers.java
@@ -33,6 +33,7 @@ import io.jans.fido2.model.attestation.AttestationResult;
 import io.jans.fido2.model.auth.AuthData;
 import io.jans.fido2.model.auth.CredAndCounterData;
 import io.jans.fido2.model.conf.RequestedParty;
+import io.jans.fido2.model.error.CommonErrorResponseType;
 import io.jans.fido2.model.error.ErrorResponseFactory;
 import io.jans.fido2.service.Base64Service;
 import io.jans.fido2.service.DataMapperService;
@@ -72,6 +73,7 @@ public class CommonVerifiers {
     private ErrorResponseFactory errorResponseFactory;
 
     private static final String CHALLENGE = "challenge";
+    private static final String CROSS_ORIGIN = "crossOrigin";
     private static final String INVALID_FIELD = "Invalid field ";
 
     public void verifyRpIdHash(AuthData authData, String domain) {
@@ -357,8 +359,33 @@ public class CommonVerifiers {
         	log.error("Client data origin parameter should be string");
             throw errorResponseFactory.invalidRequest("Client data origin parameter should be string");
         }
-        
+
+        verifyCrossOrigin(clientJsonNode);
+
         return clientJsonNode;
+    }
+
+    /**
+     * WebAuthn Level 3 requires the RP to inspect the crossOrigin member of CollectedClientData. An absent
+     * member means false. A framed ceremony is rejected here; accepting one against a configured topOrigin
+     * policy is tracked separately.
+     */
+    private void verifyCrossOrigin(JsonNode clientJsonNode) {
+        if (!clientJsonNode.hasNonNull(CROSS_ORIGIN)) {
+            return;
+        }
+
+        JsonNode crossOriginNode = clientJsonNode.get(CROSS_ORIGIN);
+        if (!crossOriginNode.isBoolean()) {
+            log.error("Client data crossOrigin parameter should be boolean");
+            throw errorResponseFactory.invalidRequest("Client data crossOrigin parameter should be boolean");
+        }
+
+        if (crossOriginNode.booleanValue()) {
+            log.error("Cross-origin ceremony rejected: crossOrigin is true");
+            throw errorResponseFactory.badRequestException(CommonErrorResponseType.CROSS_ORIGIN_NOT_ALLOWED,
+                    "Cross-origin ceremony is not allowed");
+        }
     }
 
     public JsonNode verifyClientRaw(JsonNode responseNode) {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/CommonVerifiers.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/CommonVerifiers.java
@@ -366,12 +366,12 @@ public class CommonVerifiers {
     }
 
     /**
-     * WebAuthn Level 3 requires the RP to inspect the crossOrigin member of CollectedClientData. An absent
-     * member means false. A framed ceremony is rejected here; accepting one against a configured topOrigin
-     * policy is tracked separately.
+     * WebAuthn Level 3 requires the RP to inspect the crossOrigin member of CollectedClientData. Only an
+     * absent member means false — a member present as null is malformed, not absent. A framed ceremony is
+     * rejected here; accepting one against a configured topOrigin policy is tracked separately.
      */
     private void verifyCrossOrigin(JsonNode clientJsonNode) {
-        if (!clientJsonNode.hasNonNull(CROSS_ORIGIN)) {
+        if (!clientJsonNode.has(CROSS_ORIGIN)) {
             return;
         }
 

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/CommonVerifiersTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/CommonVerifiersTest.java
@@ -15,6 +15,7 @@ import io.jans.fido2.model.attestation.AttestationOptions;
 import io.jans.fido2.model.auth.AuthData;
 import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.conf.RequestedParty;
+import io.jans.fido2.model.error.CommonErrorResponseType;
 import io.jans.fido2.model.error.ErrorResponseFactory;
 import io.jans.fido2.service.Base64Service;
 import io.jans.fido2.service.DataMapperService;
@@ -42,6 +43,7 @@ import java.util.*;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -856,5 +858,62 @@ class CommonVerifiersTest {
         when(dataMapperService.readTree(new TextNode("TEST-metadataStatement").toPrettyString())).thenReturn(metaDataStatementNode);
 
         commonVerifiers.verifyThatMetadataIsValid(metadata);
+    }
+
+    private String stubClientDataJson(ObjectNode clientJsonNode) throws IOException {
+        byte[] jsonBytes = clientJsonNode.toString().getBytes(StandardCharsets.UTF_8);
+        String encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(jsonBytes);
+        when(base64Service.urlDecode(encoded)).thenReturn(jsonBytes);
+        when(dataMapperService.readTree(new String(jsonBytes, StandardCharsets.UTF_8))).thenReturn(clientJsonNode);
+
+        return encoded;
+    }
+
+    private ObjectNode validClientDataNode() {
+        ObjectNode clientJsonNode = mapper.createObjectNode();
+        clientJsonNode.put("challenge", "TEST-challenge");
+        clientJsonNode.put("origin", "TEST-origin");
+        clientJsonNode.put("type", "TEST-type");
+
+        return clientJsonNode;
+    }
+
+    @Test
+    void verifyClientJSON_whenCrossOriginAbsent_valid() throws IOException {
+        // WebAuthn L3: an absent crossOrigin member means false.
+        String encoded = stubClientDataJson(validClientDataNode());
+
+        assertNotNull(commonVerifiers.verifyClientJSON(encoded));
+    }
+
+    @Test
+    void verifyClientJSON_whenCrossOriginFalse_valid() throws IOException {
+        String encoded = stubClientDataJson(validClientDataNode().put("crossOrigin", false));
+
+        assertNotNull(commonVerifiers.verifyClientJSON(encoded));
+    }
+
+    @Test
+    void verifyClientJSON_whenCrossOriginTrue_rejected() throws IOException {
+        String encoded = stubClientDataJson(validClientDataNode().put("crossOrigin", true));
+        when(errorResponseFactory.badRequestException(eq(CommonErrorResponseType.CROSS_ORIGIN_NOT_ALLOWED), any()))
+                .thenReturn(new WebApplicationException(Response.status(400).entity("cross origin").build()));
+
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> commonVerifiers.verifyClientJSON(encoded));
+
+        assertEquals(400, ex.getResponse().getStatus());
+    }
+
+    @Test
+    void verifyClientJSON_whenCrossOriginNotBoolean_rejected() throws IOException {
+        String encoded = stubClientDataJson(validClientDataNode().put("crossOrigin", "yes"));
+        when(errorResponseFactory.invalidRequest(any()))
+                .thenReturn(new WebApplicationException(Response.status(400).entity("not boolean").build()));
+
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> commonVerifiers.verifyClientJSON(encoded));
+
+        assertEquals(400, ex.getResponse().getStatus());
     }
 }

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/CommonVerifiersTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/CommonVerifiersTest.java
@@ -916,4 +916,19 @@ class CommonVerifiersTest {
 
         assertEquals(400, ex.getResponse().getStatus());
     }
+
+    @Test
+    void verifyClientJSON_whenCrossOriginNull_rejected() throws IOException {
+        // A member present as null is malformed, not absent — it must not default to false.
+        ObjectNode clientJsonNode = validClientDataNode();
+        clientJsonNode.putNull("crossOrigin");
+        String encoded = stubClientDataJson(clientJsonNode);
+        when(errorResponseFactory.invalidRequest(any()))
+                .thenReturn(new WebApplicationException(Response.status(400).entity("not boolean").build()));
+
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> commonVerifiers.verifyClientJSON(encoded));
+
+        assertEquals(400, ex.getResponse().getStatus());
+    }
 }


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14939

Sub-issue of #14938. Unrelated to the #14891 algorithm-table tree — this is client-data verification, and
none of #14891's acceptance criteria touch it.

#### Implementation Details

WebAuthn Level 3 requires the Relying Party to inspect the `crossOrigin` member of `CollectedClientData`
during both registration and authentication verification. We never read it:

```
grep -rn "crossOrigin\|topOrigin" --include=*.java   # across the entire monorepo
-> zero hits
```

`CommonVerifiers.verifyClientJSON()` required `challenge`, `origin` and `type` to be present, validated the
challenge as base64url, optionally validated `tokenBinding`, and checked `origin` was a non-empty string.
That was the whole of it, so a ceremony performed inside a cross-origin iframe was accepted exactly as if it
had been performed at the top level. The `origin` check we do run compares against the RP's configured
origins, so this was not an open door — but it is precisely the check L3 adds for the framed case.

This adds `verifyCrossOrigin(...)` to `verifyClientJSON()`:

- an absent `crossOrigin` member is treated as `false`, per spec
- `crossOrigin = true` is rejected with a logged error and a distinct error type
- a non-boolean `crossOrigin` is rejected as `invalid_request`, so a string is never silently read as false

One guard covers both ceremonies: `verifyClientJSON` is called from `AttestationService:263` (registration)
and `AssertionService:366` (assertion), which is exactly the pair L3 names.

**New public error value, worth a reviewer's eye.** #14939 asks for "a distinct, logged error rather than a
generic invalid-request" but leaves the mechanism open. I added
`CommonErrorResponseType.CROSS_ORIGIN_NOT_ALLOWED` (`cross_origin_not_allowed`) rather than reusing
`invalid_request`, so a client can tell a framed-ceremony rejection from a malformed challenge. It went in
`CommonErrorResponseType` because `verifyClientJSON` serves both ceremonies — a ceremony-specific enum would
have forced the verifier to branch on which ceremony called it. This value is visible to clients in the
`{status, errorMessage}` envelope, so it is effectively API surface.

**Behaviour change.** Framed ceremonies that are accepted today start failing. Nothing in the repo depends on
this — the grep above returns nothing — but a deployment that embeds the ceremony in a cross-origin iframe
will break, and there is no configuration to permit it yet. That configuration is #14940, which adds the
`topOrigin` allow-list; between this merging and that landing, framed ceremonies are hard-blocked. Rejecting
by default is the conservative posture #14939 specifies, but if reviewers would rather wait and land
#14939 + #14940 together, that is a reasonable call.

`server-fips/` needs no mirroring: the module is `pom.xml` and `target/` only, with no `src/` tree — its
antrun step copies `${server.webapp.dir}` from the `server` module.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

Four cases added to `CommonVerifiersTest`, covering the member absent, `false`, `true`, and a non-boolean
value.

```
CommonVerifiersTest         67 tests, 0 failures
jans-fido2 model + server  493 tests, 0 failures
```

Docs: `docs/janssen-server/fido/fido2-server-properties-config.md` gains a "Cross-origin ceremonies" section
recording the rejection, the treatment of an absent member, both error codes, and the fact that permitting a
framed ceremony is not yet configurable — carried in a separate `docs:` commit.

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FIDO2 registration and authentication ceremonies now reject requests initiated from cross-origin iframes.
  * Invalid cross-origin indicators, including non-boolean and null values, are rejected with a request error.
  * Requests without a cross-origin indicator, or with it set to false, continue to be accepted.

* **Documentation**
  * Documented cross-origin iframe handling, error responses, and the absence of configurable exceptions for selected framing origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->