### PR TITLE
fix(jans-auth-server): stop CIBA client sending Authorization twice

### DIFF
--- a/jans-auth-server/client/src/main/java/io/jans/as/client/BackchannelAuthenticationClient.java
+++ b/jans-auth-server/client/src/main/java/io/jans/as/client/BackchannelAuthenticationClient.java
@@ -7,7 +7,6 @@
 package io.jans.as.client;
 
 import io.jans.as.model.ciba.BackchannelAuthenticationRequestParam;
-import io.jans.as.model.common.AuthenticationMethod;
 import io.jans.as.model.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -112,9 +111,6 @@ public class BackchannelAuthenticationClient extends BaseClient<BackchannelAuthe
 
         // Prepare request parameters
         clientRequest.header("Content-Type", request.getContentType());
-        if (request.getAuthenticationMethod() == AuthenticationMethod.CLIENT_SECRET_BASIC && request.hasCredentials()) {
-            clientRequest.header("Authorization", "Basic " + request.getEncodedCredentials());
-        }
 
         new ClientAuthnEnabler(clientRequest, requestForm).exec(getRequest());
 

--- a/jans-auth-server/pom.xml
+++ b/jans-auth-server/pom.xml
@@ -414,6 +414,7 @@
 							<exclude>**/selenium/*</exclude>
 							<exclude>**/webdriver/*</exclude>
 							<exclude>**/xml/*</exclude>
+							<exclude>**/comp/db/*</exclude>
 						</excludes>
 
 						<suiteXmlFiles>


### PR DESCRIPTION
Two fixes found while diagnosing the CIBA failures in run [33886107411](https://github.com/JanssenProject/jans/actions/runs/33886107411).

### Duplicate `Authorization` header

`BackchannelAuthenticationClient` set the Basic header itself and then called `ClientAuthnEnabler`, which sets it under the same condition two lines later. JAX-RS `header()` appends rather than replaces, so every `CLIENT_SECRET_BASIC` `bc-authorize` request went out with two identical `Authorization` headers. nginx rejects that with 400 before proxying, so jans-auth never saw the request and the tests' expected `401 invalid_client` never happened.

From the AIO nginx log — 264 occurrences, matching the 264 failures exactly:

```
client sent duplicate header line: "Authorization: Basic ...",
previous value: "Authorization: Basic ..." while reading client request headers,
request: "POST /jans-auth/restv1/bc-authorize"
```

It is the only one of the seven `ClientAuthnEnabler` callers that also set the header directly, which is why `/token` with Basic auth was unaffected (196 requests, all 200).

Affects `BackchannelAuthenticationPing/Poll/PushMode` and the `Ciba*JwtAuthRequestTests`.

### `**/comp/db/*` excluded from surefire

`UserJansExtUidAttributeTest` and `UserServiceTest` both load `jans.properties` from a deployed Janssen install. Without one they spend ~5 min per class timing out on connections that cannot succeed — `UserJansExtUidAttributeTest` alone burned 302.8s of the auth-server unit suite's budget and truncated it. They are the only two classes in the test tree that load a deployed install's config.

They are JUnit 5 classes picked up by surefire scanning, not members of `testng.xml`, so the existing `<excludes>` block is the right place; `-Dtest` is not, because it would override `suiteXmlFiles` and change which tests run across the whole reactor.

`io.jans.as.server.comp.db.UserJansExtUidAttributeTest` stays in `KNOWN_FAILING_CLASSES` so the gate is still covered if the exclude is ever lifted.

Supersedes #14976 (same change; that branch stopped accepting pushes).
Closes #14979, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client authentication handling for backchannel authentication requests, including `CLIENT_SECRET_BASIC` configurations.

* **Tests**
  * Updated test execution configuration to exclude database component tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->