### PR TITLE
fix: correct condition

### DIFF
--- a/charts/janssen-all-in-one/templates/configmap.yaml
+++ b/charts/janssen-all-in-one/templates/configmap.yaml
@@ -295,7 +295,7 @@ data:
         namespace = {{.Values.istio.namespace | quote}}
         {{- end}}
 
-        if cert or key:
+        if cert and key:
             patch_or_create_namespaced_secret(name=name,
                                               namespace=namespace,
                                               literal="tls.crt",


### PR DESCRIPTION
closes #14981 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - TLS secrets are now created or updated only when both the certificate and private key are available, preventing incomplete TLS configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->