### PR TITLE
fix(ci): run image consumers after the image build; honour TRACE

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -448,6 +448,7 @@ jobs:
         if: matrix.docker-images == 'all-in-one' && steps.build_docker_image.outputs.build
         env:
           GH_TOKEN: ${{ secrets.MOAUTO_WORKFLOW_TOKEN }}
+          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           cosign sign-blob --yes \
             --bundle trivy-report.json.bundle \
@@ -455,8 +456,41 @@ jobs:
           cosign sign-blob --yes \
             --bundle trivy-report.txt.bundle \
             trivy-report.txt
-            if [[ -z "${{ github.event.release.tag_name }}" ]]; then
-                gh release upload "nightly" trivy-report.json trivy-report.json.bundle trivy-report.txt trivy-report.txt.bundle --clobber || echo "Failed to upload Trivy reports to nightly release"
-            else
-                gh release upload "${{ github.event.release.tag_name }}" trivy-report.json trivy-report.json.bundle trivy-report.txt trivy-report.txt.bundle --clobber
-            fi
+          if [[ -z "$RELEASE_TAG" || "$RELEASE_TAG" == "nightly" ]]; then
+              gh release upload "nightly" trivy-report.json trivy-report.json.bundle trivy-report.txt trivy-report.txt.bundle --clobber || echo "Failed to upload Trivy reports to nightly release"
+          else
+              gh release upload "$RELEASE_TAG" trivy-report.json trivy-report.json.bundle trivy-report.txt trivy-report.txt.bundle --clobber
+          fi
+
+  trigger-downstream:
+    # A nested workflow_run reports head_branch/head_sha as the default branch, so the
+    # image consumers cannot chain off this run and see the release tag. Dispatch them
+    # at the tag instead; the bumped tagged tree already points at the released image.
+    name: Trigger post-image-build workflows
+    needs: docker
+    if: >-
+      github.repository == 'JanssenProject/jans' &&
+      github.event_name == 'workflow_run' &&
+      needs.docker.result == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      (github.event.workflow_run.head_branch == 'nightly' ||
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Dispatch image consumers
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          gh workflow run test-terraform-provider.yml -R "$GITHUB_REPOSITORY" --ref "$REF"
+          gh workflow run scan-pentest.yml -R "$GITHUB_REPOSITORY" --ref "$REF" \
+            -f release_tag="$REF"

--- a/.github/workflows/scan-pentest.yml
+++ b/.github/workflows/scan-pentest.yml
@@ -1,5 +1,5 @@
 # Nightly and tagged-release DAST pen-test against a live all-in-one instance.
-# Chained after "Build Docker Images" so it scans the freshly published image.
+# Dispatched by "Build Docker Images" so it scans the freshly published image.
 #
 # The `scan` job runs the DAST tooling (ZAP baseline + ZAP API scans of every
 # in-repo OpenAPI spec + full nuclei template set) against a fresh AIO for each
@@ -14,40 +14,31 @@
 name: "Scan: Pen Test (DAST)"
 
 on:
-  # Chained after the images are published for a nightly or vX.Y.Z release, so the
-  # freshly built all-in-one image is what gets scanned (not the prior one).
-  workflow_run:
-    workflows: ["Build Docker Images"]
-    types: [completed]
+  # Dispatched by build-docker-images.yml at the release ref once the images are
+  # published, so the freshly built all-in-one image is what gets scanned.
   workflow_dispatch:
     inputs:
       aio_image_tag:
         description: "AIO image to scan"
         required: false
         default: "ghcr.io/janssenproject/jans/all-in-one:0.0.0-nightly"
+      release_tag:
+        description: "Release holding the SBOM/Trivy assets to ingest (vX.Y.Z or nightly); empty = artifact-only, best-effort"
+        required: false
+        default: ""
 
 permissions:
   contents: read
 
 concurrency:
   # Per-release group; never cancel an in-progress scan (completion matters).
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.release_tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
   scan:
     name: DAST scan (${{ matrix.persistence }})
-    # Manual dispatch, or a successful RELEASE-chain images build (workflow_run
-    # originating from this repo) for a nightly / vX.Y.Z ref. The event + repo
-    # checks stop a fork PR's image build from launching a scan.
-    if: >-
-      github.repository == 'JanssenProject/jans' &&
-      (github.event_name == 'workflow_dispatch' ||
-       (github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'workflow_run' &&
-        github.event.workflow_run.head_repository.full_name == github.repository &&
-        (github.event.workflow_run.head_branch == 'nightly' ||
-         startsWith(github.event.workflow_run.head_branch, 'v'))))
+    if: github.repository == 'JanssenProject/jans'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,13 +66,8 @@ jobs:
 
       - name: Resolve AIO image
         env:
-          EVENT: ${{ github.event_name }}
-          WF_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           INPUT_TAG: ${{ github.event.inputs.aio_image_tag }}
         run: |
-          # dispatch input wins; a vX.Y.Z release maps to the version-tagged image
-          # (build-docker-images tags all-in-one:<version>, no leading v); nightly
-          # and everything else use the moving nightly image.
           repo=ghcr.io/janssenproject/jans/all-in-one
           if [ -n "$INPUT_TAG" ]; then
             # Untrusted dispatch input: reject anything but a plain image reference
@@ -91,8 +77,6 @@ jobs:
                 echo "::error::invalid aio_image_tag (unexpected characters)"; exit 1 ;;
             esac
             TAG="$INPUT_TAG"
-          elif [ "$EVENT" = "workflow_run" ] && [ "${WF_HEAD_BRANCH#v}" != "$WF_HEAD_BRANCH" ]; then
-            TAG="${repo}:${WF_HEAD_BRANCH#v}"
           else
             TAG="${repo}:0.0.0-nightly"
           fi
@@ -233,10 +217,10 @@ jobs:
         # (build-docker-images) publish to the release from other workflows that may
         # still be running. A release report must be complete, so wait for both and
         # HARD-FAIL if they do not appear (manual dispatch skips this and is best-effort).
-        if: github.event_name == 'workflow_run'
+        if: inputs.release_tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE: ${{ github.event.workflow_run.head_branch }}
+          RELEASE: ${{ inputs.release_tag }}
         run: |
           for i in $(seq 1 60); do
             assets=$(gh release view "$RELEASE" -R "$GITHUB_REPOSITORY" \
@@ -256,31 +240,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PENTEST_CONTEXT: context.json
-          # Empty on manual dispatch -> SBOM ingest is skipped (no release to pull).
-          PENTEST_RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
+          # Empty on manual dispatch -> SBOM/Trivy ingest is skipped (no release to pull).
+          PENTEST_RELEASE_TAG: ${{ inputs.release_tag }}
         run: python3 .github/workflows/scripts/pentest_ingest_scans.py || true
 
       - name: Compute run metadata
         id: meta
         env:
           EVENT: ${{ github.event_name }}
-          WF_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          WF_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
           INPUT_TAG: ${{ github.event.inputs.aio_image_tag }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # Report describes/uploads to: workflow_run (nightly / vX.Y.Z) -> that
-          # release; dispatch -> none (artifact only). The scanned commit is the
-          # triggering build's head_sha (GITHUB_SHA here is the default branch).
-          if [ "$EVENT" = "workflow_run" ]; then RELEASE="$WF_HEAD_BRANCH"; else RELEASE=""; fi
+          # Dispatched AT the release ref, so GITHUB_SHA is the scanned commit.
+          RELEASE="$RELEASE_TAG"
           echo "release=${RELEASE}" >> "$GITHUB_OUTPUT"
 
           repo=ghcr.io/janssenproject/jans/all-in-one
           if [ -n "$INPUT_TAG" ]; then IMAGE="$INPUT_TAG"
-          elif [ "$EVENT" = "workflow_run" ] && [ "${WF_HEAD_BRANCH#v}" != "$WF_HEAD_BRANCH" ]; then IMAGE="${repo}:${WF_HEAD_BRANCH#v}"
           else IMAGE="${repo}:0.0.0-nightly"; fi
 
-          COMMIT="${WF_HEAD_SHA:-$GITHUB_SHA}"
+          COMMIT="$GITHUB_SHA"
           # Every run does baseline + API (all in-repo specs) + full nuclei.
           SCAN="baseline+api+nuclei"
 

--- a/.github/workflows/test-terraform-provider.yml
+++ b/.github/workflows/test-terraform-provider.yml
@@ -12,10 +12,10 @@ name: "Test: Terraform Provider"
 
 on:
   push:
+    # No tag trigger: the release image does not exist yet at tag-push time.
+    # build-docker-images.yml dispatches this workflow at the tag once it does.
     branches:
       - main
-    tags:
-      - "v*"
     paths:
       - "terraform-provider-jans/**"
       - ".github/workflows/test-terraform-provider.yml"

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -244,7 +244,7 @@ export MYSQL_MEM_LIMIT="${MYSQL_MEM_LIMIT:-3G}"
 # Run the demo in the background and relax its mode-600 TLS certs as they appear, so the
 # in-container configurator (uid 1000) reads ca.key/web_https.key on its FIRST run. A restart
 # instead would re-run key-gen against a half-initialised keystore and corrupt jansConfWebKeys.
-bash automation/start_janssen_aio_demo.sh "$JANS_FQDN" "$JANS_PERSISTENCE" "" 127.0.0.1 &
+bash automation/start_janssen_aio_demo.sh "$JANS_FQDN" "$JANS_PERSISTENCE" "" 127.0.0.1 "${JANS_CI_CD_RUN:-}" &
 demo_pid=$!
 for _ in $(seq 1 120); do
   [ -d automation/jans-aio-demo/templates ] && chmod -R a+rX automation/jans-aio-demo/templates 2>/dev/null || true

--- a/automation/start_janssen_aio_demo.sh
+++ b/automation/start_janssen_aio_demo.sh
@@ -530,7 +530,7 @@ JANS_FQDN=$1
 JANS_PERSISTENCE=$2
 JANS_VERSION=$3
 EXT_IP=$4
-JANS_CI_CD_RUN=$5
+JANS_CI_CD_RUN=${5:-${JANS_CI_CD_RUN:-}}
 
 if [[ ! "$JANS_FQDN" ]]; then
     read -rp "Enter Hostname [demoexample.jans.io]: " JANS_FQDN

--- a/docs/contribute/ci-cd/architecture.md
+++ b/docs/contribute/ci-cd/architecture.md
@@ -40,7 +40,8 @@ flowchart TD
   BP -->|workflow_run: completed| BPK[build-packages.yml]
   BDI -->|workflow_run: completed| TA[test-tf-authz-action.yml]
   BDI -->|workflow_run: completed| TJ[test-tf-authz-jwt.yml]
-  BDI -->|workflow_run: nightly/v*| PT[scan-pentest.yml]
+  BDI -->|workflow_dispatch at tag: nightly/v*| PT[scan-pentest.yml]
+  BDI -->|workflow_dispatch at tag: nightly/v*| TP[test-terraform-provider.yml]
   REL[release published] -.waits on run.-> BD[build-docs.yml]
 ```
 
@@ -49,9 +50,9 @@ flowchart TD
 | Mechanism | Where | Note |
 |---|---|---|
 | tag push (PAT) | `release-trigger`, `build-nightly` | a `GITHUB_TOKEN`-pushed tag does not trigger workflows, so a PAT (`MOAUTO_WORKFLOW_TOKEN`) pushes the tag |
-| `workflow_run` | `build-docker-images`, `build-packages` listen on `Build & Publish`; tf-authz tests and `scan-pentest` (nightly/`v*`) listen on `Build Docker Images` | loose coupling by workflow `name:`; renaming a `name:` breaks its listeners |
+| `workflow_run` | `build-docker-images`, `build-packages` listen on `Build & Publish`; tf-authz tests listen on `Build Docker Images` | loose coupling by workflow `name:`; renaming a `name:` breaks its listeners. **Does not nest**: a `workflow_run` run's own `head_branch`/`head_sha` is the default branch, so a second-level listener cannot see the release tag |
 | `workflow_call` | `release-cedarling` (reusable), `slsa-github-generator` | true reusable workflows |
-| `workflow_dispatch` | most build/release workflows | manual entry points |
+| `workflow_dispatch` | most build/release workflows; `build-docker-images` dispatches `scan-pentest` and `test-terraform-provider` at the release ref | manual entry points, and the way second-level release chaining is done (carries the tag, unlike nested `workflow_run`) |
 
 !!! note "Renaming caution"
     `workflow_run` and branch-protection required-status checks both key off the

--- a/docs/contribute/ci-cd/security-scanning.md
+++ b/docs/contribute/ci-cd/security-scanning.md
@@ -53,10 +53,10 @@ Flow:
    pulling every available data source into `context.json`: open code-scanning
    alerts (CodeQL SAST + Scorecard), Dependabot advisories, the Trivy container-image
    CVE report, and the enriched CycloneDX SBOM (component inventory + per-component
-   vulnerabilities). On a release run it first waits for the SBOM and Trivy assets
-   to be published by their own workflows and hard-fails if they never appear, so a
-   release report is always complete; manual dispatch skips the wait and is
-   best-effort. These become findings in the
+   vulnerabilities). Whenever `release_tag` is set it first waits for that release's
+   SBOM and Trivy assets to be published by their own workflows and hard-fails if they
+   never appear, so a release report is always complete; only an empty `release_tag`
+   skips the wait and is best-effort. These become findings in the
    report alongside DAST, so one document covers DAST + SAST + SCA + container image
    + supply-chain.
 5. **Analysis (optional)** — if `PENTEST_AI_ENDPOINT` / `PENTEST_AI_TOKEN` secrets

--- a/docs/contribute/ci-cd/security-scanning.md
+++ b/docs/contribute/ci-cd/security-scanning.md
@@ -22,9 +22,11 @@ output, and where results land, then describes the pen-test that correlates them
 
 ## Pen-test (DAST)
 
-`scan-pentest.yml` runs after "Build Docker Images" completes for a nightly or
-tagged (`v**`) release — so it scans the freshly published all-in-one image — and
-on manual dispatch. It runs the full DAST template set within a bounded time
+`scan-pentest.yml` is dispatched by "Build Docker Images" at the release ref once
+the images are published for a nightly or tagged (`v**`) release — so it scans the
+freshly published all-in-one image — and can also be dispatched manually (pass
+`release_tag` to ingest that release's SBOM/Trivy assets; leave it empty for an
+artifact-only, best-effort run). It runs the full DAST template set within a bounded time
 window (a per-scan shell timeout under a step `timeout-minutes` backstop); if the
 limit is reached the scan stops and the report is built from partial results. It
 It does **not fail on findings** (severity never breaks the build), but a release

--- a/docs/contribute/ci-cd/security-scanning.md
+++ b/docs/contribute/ci-cd/security-scanning.md
@@ -29,9 +29,9 @@ freshly published all-in-one image — and can also be dispatched manually (pass
 artifact-only, best-effort run). It runs the full DAST template set within a bounded time
 window (a per-scan shell timeout under a step `timeout-minutes` backstop); if the
 limit is reached the scan stops and the report is built from partial results. It
-It does **not fail on findings** (severity never breaks the build), but a release
-run **hard-fails** if the required upstream release assets (SBOM/Trivy) never
-publish, so a release report is never silently incomplete.
+does **not fail on findings** (severity never breaks the build), but a run with a
+non-empty `release_tag` **hard-fails** if that release's SBOM/Trivy assets never
+publish. An empty `release_tag` skips that wait and is best-effort.
 
 Two-stage: a `scan` matrix runs the DAST tooling against a fresh AIO for each
 persistence backend (`MYSQL`, `PGSQL`) in parallel; a `report` job then produces
@@ -55,8 +55,10 @@ Flow:
    CVE report, and the enriched CycloneDX SBOM (component inventory + per-component
    vulnerabilities). Whenever `release_tag` is set it first waits for that release's
    SBOM and Trivy assets to be published by their own workflows and hard-fails if they
-   never appear, so a release report is always complete; only an empty `release_tag`
-   skips the wait and is best-effort. These become findings in the
+   never appear; only an empty `release_tag` skips the wait. The ingest step itself is
+   best-effort — a source that errors is logged and dropped, never fatal — so the wait
+   guarantees the assets exist, not that every source landed in the report. These
+   become findings in the
    report alongside DAST, so one document covers DAST + SAST + SCA + container image
    + supply-chain.
 5. **Analysis (optional)** — if `PENTEST_AI_ENDPOINT` / `PENTEST_AI_TOKEN` secrets

--- a/docs/contribute/ci-cd/workflows.md
+++ b/docs/contribute/ci-cd/workflows.md
@@ -31,7 +31,7 @@ One row per workflow under `.github/workflows/`. See
 | `lint-python.yml` | push/PR (py paths) | flake8 over pycloudlib/cli-tui/linux-setup. |
 | `test-cedarling.yml` | PR (cedarling paths) | Rust/wasm/python/go/C/Java/pgrx test matrix. |
 | `test-integration.yml` | cron 04:00, dispatch, PR (filtered paths) | full TestNG suite against source-built AIO on a DO droplet. PR runs only on the docker/service paths; the nightly cron and dispatch cover changes outside them. |
-| `test-terraform-provider.yml` | push/PR/tag, cron, dispatch | provider acceptance tests against the prebuilt AIO compose stack. |
+| `test-terraform-provider.yml` | push/PR (main), cron, dispatch (incl. from `build-docker-images` at a release tag) | provider acceptance tests against the prebuilt AIO compose stack. No tag trigger: on a tag push the release image does not exist yet. |
 | `test-tf-authz-action.yml` | push/PR, `workflow_run` (Build Docker Images) | tf-authz composite-action + Cedar policy tests via OPA. |
 | `test-tf-authz-jwt.yml` | push/PR, `workflow_run` (Build Docker Images) | self-hosted-OPA JWT allow/deny assertions (see `scripts/authz_assert.sh`). |
 | `test-pycloudlib.yml` | push/PR (pycloudlib paths) | pytest matrix. |
@@ -45,7 +45,7 @@ One row per workflow under `.github/workflows/`. See
 | `scan-sonar.yml` | push/PR, dispatch | SonarCloud quality/security scan per module. |
 | `scan-scorecard.yml` | push main, weekly | OpenSSF Scorecard. |
 | `scan-sbom.yml` | tag `v**`/`nightly` | enriched SBOM + compliance reports to release assets. |
-| `scan-pentest.yml` | `workflow_run` (Build Docker Images) for nightly/`v**`, dispatch | full DAST pen-test against the live AIO for each persistence backend (MYSQL, PGSQL); one consolidated report (report-only). |
+| `scan-pentest.yml` | dispatch from `build-docker-images` at the nightly/`v**` ref, or manual | full DAST pen-test against the live AIO for each persistence backend (MYSQL, PGSQL); one consolidated report (report-only). |
 
 ## Ops
 


### PR DESCRIPTION
Three CI fixes.

**Terraform tests ran before the image existed.** `test-terraform-provider.yml` fired on the `v*` tag push, but the tagged tree pins `AIO_IMAGE_TAG` to the release image, published ~2h later: `Error response from daemon: manifest unknown`. Tag trigger dropped.

**DAST pen test never ran.** `scan-pentest.yml` chained off Build Docker Images via `workflow_run`, but that build is itself `workflow_run`-triggered and a nested `workflow_run` reports `head_branch`/`head_sha` as the default branch. Its release guard never matched — every release and nightly run was skipped. Now dispatched, with `release_tag`, so the report ingests the release's Dependabot/CodeQL/Trivy/SBOM sources.

Build Docker Images dispatches both at the release ref once the images are published.

**Trivy report went to the wrong release.** Upload keyed off `github.event.release.tag_name`, always empty in this workflow, so every release's report landed on `nightly`.

**TRACE log level ignored.** `start_janssen_aio_demo.sh` reads `JANS_CI_CD_RUN` from `$5`, which `run_aio_integration.sh` never passed, clobbering the export — a TRACE run still logged INFO/STDOUT.
Closes #14994, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI/CD Improvements**
  - Release automation now dispatches security scans and Terraform provider tests after container images are published.
  - Security scans can target a specified release, including nightly builds, with clearer handling for manual runs.
  - Signed Trivy reports are uploaded to the appropriate nightly or versioned release.
  - Terraform provider tests no longer run directly on version-tag pushes.

- **Developer Experience**
  - AIO demos can receive CI/CD settings through environment variables, enabling enhanced logging.

- **Documentation**
  - Updated CI/CD architecture, workflow triggers, and security-scanning guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->