### PR TITLE
ci: automate terraform provider registry release

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -485,10 +485,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout the AIO Dockerfile at the dispatched ref
+      - name: Checkout the AIO Dockerfile at the built revision
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           sparse-checkout: docker-jans-all-in-one/Dockerfile
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -499,7 +499,7 @@ jobs:
           set -euo pipefail
           VERSION="$(grep -oE 'org\.opencontainers\.image\.version="[^"]+"' \
             docker-jans-all-in-one/Dockerfile | head -1 | cut -d'"' -f2)"
-          if [[ ! "$VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+          if [[ ! "$VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
             echo "::error::could not resolve the AIO image version (got '${VERSION}')"
             exit 1
           fi

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -485,12 +485,35 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout the AIO Dockerfile at the dispatched ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          sparse-checkout: docker-jans-all-in-one/Dockerfile
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Resolve the AIO image this run built
+        id: aio
+        run: |
+          set -euo pipefail
+          VERSION="$(grep -oE 'org\.opencontainers\.image\.version="[^"]+"' \
+            docker-jans-all-in-one/Dockerfile | head -1 | cut -d'"' -f2)"
+          if [[ ! "$VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::could not resolve the AIO image version (got '${VERSION}')"
+            exit 1
+          fi
+          echo "image=ghcr.io/janssenproject/jans/all-in-one:${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch image consumers
         env:
           GH_TOKEN: ${{ github.token }}
           REF: ${{ github.event.workflow_run.head_branch }}
+          AIO_IMAGE: ${{ steps.aio.outputs.image }}
         run: |
           set -euo pipefail
-          gh workflow run test-terraform-provider.yml -R "$GITHUB_REPOSITORY" --ref "$REF"
+          gh workflow run test-terraform-provider.yml -R "$GITHUB_REPOSITORY" --ref "$REF" \
+            -f aio_image_tag="$AIO_IMAGE"
           gh workflow run scan-pentest.yml -R "$GITHUB_REPOSITORY" --ref "$REF" \
+            -f aio_image_tag="$AIO_IMAGE" \
             -f release_tag="$REF"

--- a/.github/workflows/ops-sync-tf.yml
+++ b/.github/workflows/ops-sync-tf.yml
@@ -108,9 +108,16 @@ jobs:
       if: inputs.tag != ''
       working-directory: downstream
       env:
+        GH_TOKEN: ${{ github.token }}
         TAG: ${{ inputs.tag }}
       run: |
         set -euo pipefail
+        MIRRORED="$(git -C "$GITHUB_WORKSPACE/upstream" rev-parse HEAD)"
+        SOURCE="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha')"
+        if [[ "$SOURCE" != "$MIRRORED" ]]; then
+          echo "::error::${TAG} points at ${SOURCE} upstream, but this mirror is ${MIRRORED} -- refusing to tag"
+          exit 1
+        fi
         git tag -a "${TAG}" -m "Janssen ${TAG}"
         git push origin "refs/tags/${TAG}"
 

--- a/.github/workflows/ops-sync-tf.yml
+++ b/.github/workflows/ops-sync-tf.yml
@@ -65,6 +65,17 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.MOAUTO_WORKFLOW_TOKEN }}
 
+    - name: Validate the release tag
+      if: inputs.tag != ''
+      env:
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+          echo "::error::tag must be vX.Y.Z (optionally -suffix), got '${TAG}'"
+          exit 1
+        fi
+
     - name: Refuse if the tag already exists downstream
       if: inputs.tag != ''
       working-directory: downstream

--- a/.github/workflows/ops-sync-tf.yml
+++ b/.github/workflows/ops-sync-tf.yml
@@ -1,47 +1,137 @@
 name: "Ops: Sync TF Provider"
+
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
     paths:
       - "terraform-provider-jans/**"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Monorepo ref to mirror from'
+        required: false
+        default: 'main'
+      tag:
+        description: 'Tag to create downstream (e.g. v1.2.3); empty = mirror only, no release'
+        required: false
+        default: ''
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: true
+      tag:
+        description: 'Tag to create downstream; empty = mirror only'
+        type: string
+        required: false
+        default: ''
+    outputs:
+      synced_sha:
+        description: 'Downstream commit the mirror landed on'
+        value: ${{ jobs.mirror.outputs.synced_sha }}
+
 permissions:
   contents: read
 
+concurrency:
+  group: ops-sync-tf
+  cancel-in-progress: false
+
+env:
+  DOWNSTREAM: JanssenProject/terraform-provider-jans
+
 jobs:
-  publish:
-    name: Push to terraform-provider-jans repo
+  mirror:
+    name: Mirror to terraform-provider-jans repo
     if: github.repository == 'JanssenProject/jans'
     runs-on: ubuntu-latest
+    outputs:
+      synced_sha: ${{ steps.push.outputs.sha }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
       with:
         egress-policy: audit
 
-    - name: Checkout code
+    - name: Checkout monorepo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: ${{ inputs.ref || github.sha }}
+        path: upstream
+
+    - name: Checkout downstream mirror
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: ${{ env.DOWNSTREAM }}
+        ref: main
+        path: downstream
         fetch-depth: 0
+        token: ${{ secrets.MOAUTO_WORKFLOW_TOKEN }}
 
-    - name: Split and sync to downstream repo
-      run: |
-        git config --global user.name "mo-auto"
-        git config --global user.email "54212639+mo-auto@users.noreply.github.com"
-
-        SPLIT_BRANCH="terraform-split"
-        git subtree split --prefix=terraform-provider-jans -b "$SPLIT_BRANCH"
-
-        DOWNSTREAM="https://github.com/JanssenProject/terraform-provider-jans.git"
-        git remote add downstream "$DOWNSTREAM"
-        git fetch --no-tags downstream
-
-        # Unset the extraheader injected by actions/checkout so only our credential is used
-        git config --unset-all http.https://github.com/.extraheader || true
-
-        # Use Basic auth (Git HTTPS requires Basic, not Bearer)
-        BASIC_CRED=$(echo -n "x-access-token:${TOKEN}" | base64 -w0)
-        git -c "http.https://github.com/.extraheader=AUTHORIZATION: Basic ${BASIC_CRED}" push downstream "${SPLIT_BRANCH}:main" --force-with-lease
+    - name: Refuse if the tag already exists downstream
+      if: inputs.tag != ''
+      working-directory: downstream
       env:
-        TOKEN: ${{ secrets.MOAUTO_WORKFLOW_TOKEN }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+          echo "::error::${TAG} already exists in ${DOWNSTREAM} -- nothing to release"
+          exit 1
+        fi
+
+    - name: Rsync the provider folder over the mirror
+      run: |
+        set -euo pipefail
+        rsync -a --delete \
+          --exclude '.git/' \
+          --exclude '.github/' \
+          upstream/terraform-provider-jans/ downstream/
+
+    - name: Commit and push the mirror
+      id: push
+      working-directory: downstream
+      env:
+        SRC_REF: ${{ inputs.ref || github.ref_name }}
+      run: |
+        set -euo pipefail
+        SRC_SHA="$(git -C "$GITHUB_WORKSPACE/upstream" rev-parse HEAD)"
+        git config user.name "mo-auto"
+        git config user.email "54212639+mo-auto@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "mirror already up to date"
+        else
+          git commit -m "chore: sync terraform-provider-jans from jans@${SRC_REF} (${SRC_SHA})"
+          git push origin HEAD:main
+        fi
+        echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Tag the mirror
+      if: inputs.tag != ''
+      working-directory: downstream
+      env:
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        git tag -a "${TAG}" -m "Janssen ${TAG}"
+        git push origin "refs/tags/${TAG}"
+
+    - name: Summary
+      if: always()
+      env:
+        TAG: ${{ inputs.tag }}
+        SHA: ${{ steps.push.outputs.sha }}
+      run: |
+        {
+          echo "## TF provider mirror"
+          echo ""
+          echo "- Source: \`${{ inputs.ref || github.ref_name }}\`"
+          echo "- Downstream commit: \`${SHA:-none}\`"
+          if [ -n "${TAG}" ]; then
+            echo "- Tag pushed: [\`${TAG}\`](https://github.com/${DOWNSTREAM}/releases/tag/${TAG})"
+          else
+            echo "- Mirror only, no tag."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ops-sync-tf.yml
+++ b/.github/workflows/ops-sync-tf.yml
@@ -12,10 +12,6 @@ on:
         description: 'Monorepo ref to mirror from'
         required: false
         default: 'main'
-      tag:
-        description: 'Tag to create downstream (e.g. v1.2.3); empty = mirror only, no release'
-        required: false
-        default: ''
   workflow_call:
     inputs:
       ref:
@@ -93,7 +89,7 @@ jobs:
       id: push
       working-directory: downstream
       env:
-        SRC_REF: ${{ inputs.ref || github.ref_name }}
+        SRC_REF: ${{ inputs.tag || inputs.ref || github.ref_name }}
       run: |
         set -euo pipefail
         SRC_SHA="$(git -C "$GITHUB_WORKSPACE/upstream" rev-parse HEAD)"
@@ -123,11 +119,12 @@ jobs:
       env:
         TAG: ${{ inputs.tag }}
         SHA: ${{ steps.push.outputs.sha }}
+        SRC_REF: ${{ inputs.ref || github.ref_name }}
       run: |
         {
           echo "## TF provider mirror"
           echo ""
-          echo "- Source: \`${{ inputs.ref || github.ref_name }}\`"
+          echo "- Source: \`${SRC_REF}\`"
           echo "- Downstream commit: \`${SHA:-none}\`"
           if [ -n "${TAG}" ]; then
             echo "- Tag pushed: [\`${TAG}\`](https://github.com/${DOWNSTREAM}/releases/tag/${TAG})"

--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -1,0 +1,206 @@
+name: "Release: Terraform Provider"
+
+on:
+  workflow_run:
+    workflows: ["Test: Terraform Provider"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. 1.15.0 (no leading v)'
+        required: true
+      ignore_tests:
+        description: 'Publish even though the provider tests did not pass'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-terraform-provider
+  cancel-in-progress: false
+
+env:
+  DOWNSTREAM: JanssenProject/terraform-provider-jans
+
+jobs:
+  resolve:
+    name: Resolve release version
+    if: >-
+      github.repository == 'JanssenProject/jans' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.event == 'workflow_dispatch' &&
+        startsWith(github.event.workflow_run.head_branch, 'v')))
+    runs-on: ubuntu-latest
+    outputs:
+      state: ${{ steps.resolve.outputs.state }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      reason: ${{ steps.resolve.outputs.reason }}
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+
+    - name: Resolve
+      id: resolve
+      env:
+        GH_TOKEN: ${{ github.token }}
+        EVENT: ${{ github.event_name }}
+        VERSION_INPUT: ${{ github.event.inputs.version }}
+        IGNORE_TESTS: ${{ github.event.inputs.ignore_tests }}
+        RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$EVENT" == "workflow_dispatch" ]]; then
+          VERSION="$VERSION_INPUT"
+        else
+          VERSION="${RUN_BRANCH#v}"
+        fi
+        if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            echo "::error::version must be X.Y.Z (optionally -suffix), got '${VERSION}'"
+            exit 1
+          fi
+          echo "state=skip" >> "$GITHUB_OUTPUT"
+          echo "reason=${RUN_BRANCH} is not a release tag" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        TAG="v${VERSION}"
+        echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+        if gh api "repos/${DOWNSTREAM}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+          echo "state=skip" >> "$GITHUB_OUTPUT"
+          echo "reason=${TAG} is already released downstream" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$EVENT" != "workflow_dispatch" && "$RUN_CONCLUSION" != "success" ]]; then
+          echo "state=blocked" >> "$GITHUB_OUTPUT"
+          echo "reason=provider tests concluded '${RUN_CONCLUSION}' at ${TAG}" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [[ "$EVENT" == "workflow_dispatch" && "$IGNORE_TESTS" == "true" ]]; then
+          echo "::warning::publishing ${TAG} without a green provider-test run"
+        fi
+
+        echo "state=ready" >> "$GITHUB_OUTPUT"
+        echo "reason=awaiting approval" >> "$GITHUB_OUTPUT"
+
+  notify:
+    name: Ping Zulip
+    needs: resolve
+    if: needs.resolve.outputs.state != 'skip'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+
+    - name: Build Zulip message
+      id: zulip_msg
+      env:
+        STATE: ${{ needs.resolve.outputs.state }}
+        TAG: ${{ needs.resolve.outputs.tag }}
+        REASON: ${{ needs.resolve.outputs.reason }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        {
+          echo "content<<ZEOF"
+          if [[ "$STATE" == "ready" ]]; then
+            echo "@**moabu** **terraform-provider ${TAG}** ready to publish."
+            echo ""
+            echo "Approve the \`terraform-provider-release\` environment to mirror \`terraform-provider-jans/\` to [${DOWNSTREAM}](https://github.com/${DOWNSTREAM}) and push \`${TAG}\` (goreleaser then publishes to the Terraform + OpenTofu registries)."
+            echo ""
+            echo "[approve here](${RUN_URL})"
+          else
+            echo "@**moabu** **terraform-provider ${TAG}** release blocked: ${REASON}."
+            echo ""
+            echo "Publish anyway with the \`Release: Terraform Provider\` dispatch (\`ignore_tests\`)."
+            echo ""
+            echo "[run log](${RUN_URL})"
+          fi
+          echo "ZEOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Report to Zulip
+      continue-on-error: true
+      uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: "git-gluu@gluu.org"
+        organization-url: "https://chat.gluu.org"
+        to: "bot_reporter"
+        type: "stream"
+        topic: "terraform-provider"
+        content: ${{ steps.zulip_msg.outputs.content }}
+
+  approve:
+    name: Await approval
+    needs: resolve
+    if: needs.resolve.outputs.state == 'ready'
+    runs-on: ubuntu-latest
+    environment: terraform-provider-release
+    steps:
+    - name: Approved
+      run: echo "publishing ${{ needs.resolve.outputs.tag }}"
+
+  publish:
+    name: Mirror and tag
+    needs: [resolve, approve]
+    uses: ./.github/workflows/ops-sync-tf.yml
+    secrets: inherit
+    with:
+      ref: ${{ needs.resolve.outputs.tag }}
+      tag: ${{ needs.resolve.outputs.tag }}
+
+  report:
+    name: Report result
+    needs: [resolve, publish]
+    if: always() && needs.resolve.outputs.state == 'ready'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+
+    - name: Build Zulip message
+      id: zulip_msg
+      env:
+        TAG: ${{ needs.resolve.outputs.tag }}
+        RESULT: ${{ needs.publish.result }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        {
+          echo "content<<ZEOF"
+          if [[ "$RESULT" == "success" ]]; then
+            echo "**terraform-provider ${TAG}** mirrored and tagged."
+            echo ""
+            echo "goreleaser is publishing it: [downstream runs](https://github.com/${DOWNSTREAM}/actions) · [release](https://github.com/${DOWNSTREAM}/releases/tag/${TAG})"
+          else
+            echo "@**moabu** **terraform-provider ${TAG}** mirror/tag \`${RESULT}\`."
+            echo ""
+            echo "[run log](${RUN_URL})"
+          fi
+          echo "ZEOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Report to Zulip
+      continue-on-error: true
+      uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: "git-gluu@gluu.org"
+        organization-url: "https://chat.gluu.org"
+        to: "bot_reporter"
+        type: "stream"
+        topic: "terraform-provider"
+        content: ${{ steps.zulip_msg.outputs.content }}

--- a/.github/workflows/release-terraform-provider.yml
+++ b/.github/workflows/release-terraform-provider.yml
@@ -37,6 +37,7 @@ jobs:
     outputs:
       state: ${{ steps.resolve.outputs.state }}
       tag: ${{ steps.resolve.outputs.tag }}
+      sha: ${{ steps.resolve.outputs.sha }}
       reason: ${{ steps.resolve.outputs.reason }}
     steps:
     - name: Harden Runner
@@ -53,6 +54,7 @@ jobs:
         IGNORE_TESTS: ${{ github.event.inputs.ignore_tests }}
         RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
         RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        RUN_SHA: ${{ github.event.workflow_run.head_sha }}
       run: |
         set -euo pipefail
 
@@ -84,8 +86,33 @@ jobs:
           echo "reason=provider tests concluded '${RUN_CONCLUSION}' at ${TAG}" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        if [[ "$EVENT" == "workflow_dispatch" && "$IGNORE_TESTS" == "true" ]]; then
-          echo "::warning::publishing ${TAG} without a green provider-test run"
+
+        SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha' 2>/dev/null || true)"
+        if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::${TAG} does not exist in ${GITHUB_REPOSITORY}"
+          exit 1
+        fi
+        echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+        if [[ "$EVENT" != "workflow_dispatch" && "$SHA" != "$RUN_SHA" ]]; then
+          echo "state=blocked" >> "$GITHUB_OUTPUT"
+          echo "reason=${TAG} now points at ${SHA}, not the tested ${RUN_SHA}" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$EVENT" == "workflow_dispatch" ]]; then
+          if [[ "$IGNORE_TESTS" == "true" ]]; then
+            echo "::warning::publishing ${TAG} without a green provider-test run"
+          else
+            GREEN="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/test-terraform-provider.yml/runs?head_sha=${SHA}&status=success&per_page=1" \
+              --jq '.total_count' 2>/dev/null || echo 0)"
+            if [[ "$GREEN" == "0" ]]; then
+              echo "state=blocked" >> "$GITHUB_OUTPUT"
+              echo "reason=no successful provider-test run for ${TAG} (${SHA})" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
         fi
 
         echo "state=ready" >> "$GITHUB_OUTPUT"
@@ -148,8 +175,19 @@ jobs:
     runs-on: ubuntu-latest
     environment: terraform-provider-release
     steps:
-    - name: Approved
-      run: echo "publishing ${{ needs.resolve.outputs.tag }}"
+    - name: Re-check the tag still points at the tested commit
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ needs.resolve.outputs.tag }}
+        SHA: ${{ needs.resolve.outputs.sha }}
+      run: |
+        set -euo pipefail
+        NOW="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha')"
+        if [[ "$NOW" != "$SHA" ]]; then
+          echo "::error::${TAG} moved to ${NOW} since approval (tested ${SHA}) -- refusing to publish"
+          exit 1
+        fi
+        echo "publishing ${TAG} (${SHA})"
 
   publish:
     name: Mirror and tag
@@ -157,7 +195,7 @@ jobs:
     uses: ./.github/workflows/ops-sync-tf.yml
     secrets: inherit
     with:
-      ref: ${{ needs.resolve.outputs.tag }}
+      ref: ${{ needs.resolve.outputs.sha }}
       tag: ${{ needs.resolve.outputs.tag }}
 
   report:

--- a/docs/contribute/ci-cd/architecture.md
+++ b/docs/contribute/ci-cd/architecture.md
@@ -42,15 +42,23 @@ flowchart TD
   BDI -->|workflow_run: completed| TJ[test-tf-authz-jwt.yml]
   BDI -->|workflow_dispatch at tag: nightly/v*| PT[scan-pentest.yml]
   BDI -->|workflow_dispatch at tag: nightly/v*| TP[test-terraform-provider.yml]
+  TP -->|workflow_run: completed at v*| RTP[release-terraform-provider.yml<br/>manual approval]
+  RTP -->|workflow_call| ST[ops-sync-tf.yml<br/>mirror + tag downstream]
+  ST -->|tag push| DS[terraform-provider-jans repo<br/>goreleaser to the registries]
   REL[release published] -.waits on run.-> BD[build-docs.yml]
 ```
+
+The provider release is the tail of the chain: `test-terraform-provider.yml`
+concluding at a `v*` ref means the release images exist and the provider works
+against them, so that run is the signal to publish the provider. See
+[Release Process](release-process.md#terraform-provider).
 
 ## Trigger mechanisms
 
 | Mechanism | Where | Note |
 |---|---|---|
 | tag push (PAT) | `release-trigger`, `build-nightly` | a `GITHUB_TOKEN`-pushed tag does not trigger workflows, so a PAT (`MOAUTO_WORKFLOW_TOKEN`) pushes the tag |
-| `workflow_run` | `build-docker-images`, `build-packages` listen on `Build & Publish`; tf-authz tests listen on `Build Docker Images` | loose coupling by workflow `name:`; renaming a `name:` breaks its listeners. **Does not nest**: a `workflow_run` run's own `head_branch`/`head_sha` is the default branch, so a second-level listener cannot see the release tag |
+| `workflow_run` | `build-docker-images`, `build-packages` listen on `Build & Publish`; tf-authz tests listen on `Build Docker Images`; `release-terraform-provider` listens on `Test: Terraform Provider` | loose coupling by workflow `name:`; renaming a `name:` breaks its listeners. **Does not nest**: a `workflow_run` run's own `head_branch`/`head_sha` is the default branch, so a second-level listener cannot see the release tag. `release-terraform-provider` can only see it because its source run was itself *dispatched* at the tag |
 | `workflow_call` | `release-cedarling` (reusable), `slsa-github-generator` | true reusable workflows |
 | `workflow_dispatch` | most build/release workflows; `build-docker-images` dispatches `scan-pentest` and `test-terraform-provider` at the release ref | manual entry points, and the way second-level release chaining is done (carries the tag, unlike nested `workflow_run`) |
 

--- a/docs/contribute/ci-cd/release-process.md
+++ b/docs/contribute/ci-cd/release-process.md
@@ -27,6 +27,36 @@ Releases are cut by the `release-trigger.yml` workflow (version bump, tag
 `v<version>`, GitHub Release), which starts the [build chain](architecture.md).
 Nightly prereleases are produced by `build-nightly.yml`.
 
+# Terraform provider
+
+`terraform-provider-jans/` in this repo is the source of truth. The standalone
+[terraform-provider-jans](https://github.com/JanssenProject/terraform-provider-jans)
+repo is a generated mirror of that folder; it exists only because the Terraform and
+OpenTofu registries require one repo per provider. Its `.github/` is owned downstream
+(the goreleaser + GPG release workflow lives there) and is excluded from the mirror.
+Nothing else downstream is edited by hand — a direct commit there is overwritten by the
+next sync.
+
+Two workflows, no downstream PR:
+
+- `ops-sync-tf.yml` — rsyncs the folder onto downstream `main` on every push to
+  monorepo `main` that touches it, and, when called with a `tag`, pushes that tag.
+- `release-terraform-provider.yml` — listens for `test-terraform-provider.yml`
+  concluding at a `v*` ref (the tail of the release chain: images built, provider
+  tested against them), then pings Zulip and waits for approval on the
+  `terraform-provider-release` environment. On approval it calls `ops-sync-tf.yml`
+  with the tag; the downstream tag push runs goreleaser, which signs and publishes
+  the version the registries index.
+
+The provider version therefore always equals the Janssen release version. Re-runs are
+idempotent: an existing downstream tag makes the workflow skip. If the provider tests
+are red at a release tag the workflow reports to Zulip instead of publishing; publish
+anyway with the `Release: Terraform Provider` dispatch (`ignore_tests`).
+
+One-time setup: an environment named `terraform-provider-release` with @moabu as a
+required reviewer. Without it the approval gate is a no-op and the release publishes
+unattended.
+
 # Future plans
 
 We are planning a full move to SemVer for all Janssen projects that will be scheduled bi-weekly, releasing automatically from the conventional commits submitted.

--- a/docs/contribute/ci-cd/release-process.md
+++ b/docs/contribute/ci-cd/release-process.md
@@ -40,7 +40,9 @@ next sync.
 Two workflows, no downstream PR:
 
 - `ops-sync-tf.yml` — rsyncs the folder onto downstream `main` on every push to
-  monorepo `main` that touches it, and, when called with a `tag`, pushes that tag.
+  monorepo `main` that touches it. Only `release-terraform-provider.yml` can make it
+  push a downstream tag; a manual run is always mirror-only, so every registry release
+  goes through the approval gate.
 - `release-terraform-provider.yml` — listens for `test-terraform-provider.yml`
   concluding at a `v*` ref (the tail of the release chain: images built, provider
   tested against them), then pings Zulip and waits for approval on the
@@ -48,10 +50,15 @@ Two workflows, no downstream PR:
   with the tag; the downstream tag push runs goreleaser, which signs and publishes
   the version the registries index.
 
-The provider version therefore always equals the Janssen release version. Re-runs are
-idempotent: an existing downstream tag makes the workflow skip. If the provider tests
-are red at a release tag the workflow reports to Zulip instead of publishing; publish
-anyway with the `Release: Terraform Provider` dispatch (`ignore_tests`).
+The provider version equals the Janssen release version: the version is the release tag
+either way, and a manual dispatch is rejected unless that tag exists here and a
+provider-test run succeeded for the exact commit it points at (`ignore_tests` waives
+only the test requirement, not the tag). What is mirrored is that tested commit, not the
+tag name, and the tag is re-checked after approval — if it moved, the release aborts.
+
+Re-runs are idempotent: an existing downstream tag makes the workflow skip. If the
+provider tests are red at a release tag the workflow reports to Zulip instead of
+publishing.
 
 One-time setup: an environment named `terraform-provider-release` with @moabu as a
 required reviewer. Without it the approval gate is a no-op and the release publishes

--- a/docs/contribute/ci-cd/workflows.md
+++ b/docs/contribute/ci-cd/workflows.md
@@ -21,6 +21,7 @@ One row per workflow under `.github/workflows/`. See
 | `build-docs.yml` | push/PR to docs, release, dispatch | mkdocs + Helm chart publish to GitHub Pages. |
 | `release-trigger.yml` | dispatch | version bump, tag `v<version>`, create release; call `release-cedarling`. |
 | `release-cedarling.yml` | `workflow_call`, dispatch | publish the cedarling crate to crates.io (reusable). |
+| `release-terraform-provider.yml` | `workflow_run` (Test: Terraform Provider) at a `v*` ref, dispatch | Zulip ping + `terraform-provider-release` environment approval, then call `ops-sync-tf` to mirror and tag downstream so goreleaser publishes to the Terraform/OpenTofu registries. |
 | `release-backport.yml` | `pull_request_target` | open backport PRs from a merged labelled PR. |
 
 ## Tests & checks
@@ -53,6 +54,6 @@ One row per workflow under `.github/workflows/`. See
 |---|---|---|
 | `ops-label.yml` | PR/issue events, dispatch | apply labels, add issues to the project board. |
 | `ops-pr-ref-issue.yml` | PR opened, dispatch | ensure each PR references an open issue. |
-| `ops-sync-tf.yml` | push main (tf paths), dispatch | subtree-sync the provider to its downstream repo. |
+| `ops-sync-tf.yml` | push main (tf paths), `workflow_call`, dispatch | rsync `terraform-provider-jans/` onto the downstream mirror repo (its `.github/` excluded); with a `tag` input, push that tag to cut the registry release. |
 | `ops-cache-cleanup.yml` | PR closed, dispatch | delete Actions caches for the branch. |
 | `ops-runs-cleanup.yml` | cron every 2 days, dispatch | prune old workflow runs. |

--- a/docs/contribute/ci-cd/workflows.md
+++ b/docs/contribute/ci-cd/workflows.md
@@ -32,7 +32,7 @@ One row per workflow under `.github/workflows/`. See
 | `lint-python.yml` | push/PR (py paths) | flake8 over pycloudlib/cli-tui/linux-setup. |
 | `test-cedarling.yml` | PR (cedarling paths) | Rust/wasm/python/go/C/Java/pgrx test matrix. |
 | `test-integration.yml` | cron 04:00, dispatch, PR (filtered paths) | full TestNG suite against source-built AIO on a DO droplet. PR runs only on the docker/service paths; the nightly cron and dispatch cover changes outside them. |
-| `test-terraform-provider.yml` | push/PR (main), cron, dispatch (incl. from `build-docker-images` at a release tag) | provider acceptance tests against the prebuilt AIO compose stack. No tag trigger: on a tag push the release image does not exist yet. |
+| `test-terraform-provider.yml` | push/PR (main), cron, dispatch (incl. from `build-docker-images` at a release tag, which passes the release AIO image; otherwise nightly) | provider acceptance tests against the prebuilt AIO compose stack. No tag trigger: on a tag push the release image does not exist yet. |
 | `test-tf-authz-action.yml` | push/PR, `workflow_run` (Build Docker Images) | tf-authz composite-action + Cedar policy tests via OPA. |
 | `test-tf-authz-jwt.yml` | push/PR, `workflow_run` (Build Docker Images) | self-hosted-OPA JWT allow/deny assertions (see `scripts/authz_assert.sh`). |
 | `test-pycloudlib.yml` | push/PR (pycloudlib paths) | pytest matrix. |
@@ -46,7 +46,7 @@ One row per workflow under `.github/workflows/`. See
 | `scan-sonar.yml` | push/PR, dispatch | SonarCloud quality/security scan per module. |
 | `scan-scorecard.yml` | push main, weekly | OpenSSF Scorecard. |
 | `scan-sbom.yml` | tag `v**`/`nightly` | enriched SBOM + compliance reports to release assets. |
-| `scan-pentest.yml` | dispatch from `build-docker-images` at the nightly/`v**` ref, or manual | full DAST pen-test against the live AIO for each persistence backend (MYSQL, PGSQL); one consolidated report (report-only). |
+| `scan-pentest.yml` | dispatch from `build-docker-images` at the nightly/`v**` ref (with that ref's AIO image), or manual | full DAST pen-test against the live AIO for each persistence backend (MYSQL, PGSQL); one consolidated report (report-only). |
 
 ## Ops
 


### PR DESCRIPTION
Closes #14995

After a jans release fully lands, mirror `terraform-provider-jans/` to the downstream registry repo and tag it, so goreleaser publishes to the Terraform + OpenTofu registries.

Chain: `test-terraform-provider` at a `v*` ref (release images built + provider verified) -> Zulip ping @moabu -> approval on the `terraform-provider-release` environment -> `ops-sync-tf` mirrors + tags -> downstream goreleaser.

No downstream PR: that repo is a generated mirror of this folder, review already happened here. The environment approval is the gate.

`ops-sync-tf` now rsyncs instead of `git subtree split` — the old force-push would have deleted downstream `.github/`, which holds the goreleaser release workflow.

Also fixes `build-docker-images` dispatching `test-terraform-provider` and `scan-pentest` without an image tag, so both tested the nightly image at a release tag; they now get the image the run built (resolved from the ref's OCI version label).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an automated Terraform provider release process with version validation, test-result checks, approval gating, downstream synchronization, and optional tagging.
  - Added manual and automatic release triggering from specific refs and tags.
  - Release workflows now pass the matching All-in-One image reference to downstream validation workflows.
  - Added safeguards for duplicate tags and repeatable release runs.
  - Improved downstream provider mirroring and release status reporting.

- **Documentation**
  - Documented the Terraform provider release flow, workflow triggers, approval requirements, synchronization process, and setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->