### PR TITLE
docs(cedarling): Rust-baseline relative speed + list Rust binding

### DIFF
--- a/jans-cedarling/bindings/benchmarks/CONTRACT.md
+++ b/jans-cedarling/bindings/benchmarks/CONTRACT.md
@@ -1,6 +1,6 @@
 # Cedarling Cross-Platform Benchmark Contract
 
-Single source of truth for how every binding bench (Java/UniFFI, Go, Python, WASM, C) must behave so the results are directly comparable.
+Single source of truth for how every binding bench (Rust, Java/UniFFI, Go, Python, WASM, C) must behave so the results are directly comparable.
 
 ## Fixtures (`fixtures/scenarios.json`)
 
@@ -64,7 +64,7 @@ One JSON object per scenario × binding, one per line on stdout. Example:
 
 | field | type | notes |
 |---|---|---|
-| `binding` | string | `"java"`, `"go"`, `"python"`, `"wasm"`, `"c"` |
+| `binding` | string | `"rust"`, `"java"`, `"go"`, `"python"`, `"wasm"`, `"c"` |
 | `scenario` | string | matches `id` from the manifest |
 | `iter` | number | `measure_iters` executed |
 | `mean_ns` / `p50_ns` / `p95_ns` / `p99_ns` / `min_ns` / `max_ns` | number | wall-clock per call, nanoseconds |

--- a/jans-cedarling/bindings/benchmarks/README.md
+++ b/jans-cedarling/bindings/benchmarks/README.md
@@ -13,6 +13,7 @@ Every binding loads the same manifest, runs the same iteration policy (100 warmu
 
 | Binding | Cd to | Invocation |
 |---|---|---|
+| **Rust** | `cedarling` | `cargo run --release --example bench_jsonl` |
 | **Java / UniFFI** | `bindings/cedarling_uniffi/javaApp` | `mvn -q compile exec:java -Dexec.mainClass=org.example.Benchmark` |
 | **Go** | `bindings/cedarling_go` | `LD_LIBRARY_PATH="$(pwd)" go run ./benchmarks/` |
 | **Python** | `bindings/cedarling_python` | `tox -e benchmark` *(or)* `python3 benchmarks/benchmark_cedarling.py` |

--- a/jans-cedarling/scripts/parse_binding_benchmarks.py
+++ b/jans-cedarling/scripts/parse_binding_benchmarks.py
@@ -208,14 +208,16 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
             "full batch call, not per-item latency.\n\n"
         )
 
-    # Relative view: within each scenario, the fastest binding is 1.00x; the bar
-    # length is scaled so the slowest binding in that row fills the width. This
-    # compares speed across bindings without implying batch/non-batch rows are
-    # comparable to each other.
-    out.append("### Relative speed per scenario (x, lower = faster)\n\n")
+    # Relative view: within each scenario the Rust core is the baseline (1.00x)
+    # and every binding is shown as its mean over Rust's, so the table reads as
+    # "overhead versus the native Rust engine". Rows where Rust is unavailable
+    # fall back to the fastest binding as baseline. The bar length is scaled so
+    # the slowest binding in that row fills the width.
+    out.append("### Relative speed per scenario (x vs Rust, lower = faster)\n\n")
     out.append(
-        "_Ratios are computed from full-precision `mean_ns`, so they may not "
-        "match dividing the rounded µs values shown above._\n\n"
+        "_Ratios use each binding's full-precision `mean_ns` over Rust's, so "
+        "they may not match dividing the rounded µs values shown above. Rows "
+        "where Rust is unavailable use the fastest binding as the baseline._\n\n"
     )
     out.append("| Scenario | " + " | ".join(bindings) + " |\n")
     out.append("|----------|" + "|".join(["----------:"] * len(bindings)) + "|\n")
@@ -229,8 +231,9 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
             and r.get("mean_ns") is not None
             and float(r["mean_ns"]) > 0
         }
-        fastest = min(means.values()) if means else None
-        slowest_ratio = (max(means.values()) / fastest) if means else 1.0
+        # Prefer Rust as the baseline; fall back to the fastest if Rust is absent.
+        baseline = means.get("rust") or (min(means.values()) if means else None)
+        max_ratio = (max(means.values()) / baseline) if means else 1.0
         cells: list[str] = []
         for b in bindings:
             if b not in means:
@@ -239,8 +242,8 @@ def render_jsonl_pivot(rows: list[dict]) -> str:
                     "_skipped_" if r is not None and r.get("status") == "skipped" else "—"
                 )
                 continue
-            ratio = means[b] / fastest
-            blocks = 1 if slowest_ratio <= 1 else max(1, round(ratio / slowest_ratio * bar_width))
+            ratio = means[b] / baseline
+            blocks = 1 if max_ratio <= 0 else max(1, round(ratio / max_ratio * bar_width))
             cells.append(f"{ratio:.2f}x {'█' * blocks}")
         out.append(f"| {s} | " + " | ".join(cells) + " |\n")
     out.append("\n")


### PR DESCRIPTION
Addresses the review comments on the auto-generated benchmark page #14983. Fixes are in the generator + contract docs (the page itself is regenerated each run).

- **Relative-speed baseline (was: fastest-in-row):** now the Rust core is the per-row baseline — Rust = 1.00x and every binding is its `mean_ns` over Rust's, reading as overhead vs the native engine (values <1 mean faster than Rust). Falls back to the fastest binding on rows where Rust is unavailable.
- **Six bindings listed consistently:** added Rust to the `binding` value list and header in `CONTRACT.md` and to the invocation table in the benchmarks `README.md`. The pivot table already renders all six (Rust, Java/UniFFI, Go, Python, WASM, C).

Once merged, the next benchmark run regenerates #14983's page with the Rust-baseline table.
Closes #15013, 