### PR TITLE
ci: read AIO Dockerfile via API, not checkout

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -489,8 +489,6 @@ jobs:
         id: aio
         env:
           GH_TOKEN: ${{ github.token }}
-          # Read the one file we need over the API instead of checking the built
-          # revision out, so no tree from the upstream run lands on this runner.
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -485,20 +485,22 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout the AIO Dockerfile at the built revision
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          sparse-checkout: docker-jans-all-in-one/Dockerfile
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
-
       - name: Resolve the AIO image this run built
         id: aio
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Read the one file we need over the API instead of checking the built
+          # revision out, so no tree from the upstream run lands on this runner.
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          VERSION="$(grep -oE 'org\.opencontainers\.image\.version="[^"]+"' \
-            docker-jans-all-in-one/Dockerfile | head -1 | cut -d'"' -f2)"
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::unexpected head_sha '${HEAD_SHA}'"
+            exit 1
+          fi
+          VERSION="$(gh api "repos/${GITHUB_REPOSITORY}/contents/docker-jans-all-in-one/Dockerfile?ref=${HEAD_SHA}" \
+            -H 'Accept: application/vnd.github.raw' \
+            | grep -oE 'org\.opencontainers\.image\.version="[^"]+"' | head -1 | cut -d'"' -f2)"
           if [[ ! "$VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
             echo "::error::could not resolve the AIO image version (got '${VERSION}')"
             exit 1


### PR DESCRIPTION
Scorecard flagged `untrusted code checkout '${{ github.event.workflow_run.head_sha }}'` in `build-docker-images.yml`.

The `trigger-downstream` job checked out the built revision only to grep one version label out of `docker-jans-all-in-one/Dockerfile`. Now fetches that file over the contents API at the same SHA — no upstream tree on the runner, one less step, no permission change (`contents: read` already present). `head_sha` is validated as 40-hex before use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved downstream Docker image version resolution by retrieving the relevant Dockerfile from the exact workflow revision.
  * Added validation to prevent processing when the referenced revision identifier is invalid.
  * Preserved image version extraction while improving reliability and consistency in Docker image build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->