### PR TITLE
fix(ci): stop double-counting integration test results

### DIFF
--- a/.github/workflows/scripts/summarize_testng.py
+++ b/.github/workflows/scripts/summarize_testng.py
@@ -122,7 +122,8 @@ def collect(reports_dir):
     for module, root in junit:
         for tc in root.iter("testcase"):
             cname, mname = tc.get("classname", ""), tc.get("name", "")
-            if (cname, mname) in testng_methods:  # already counted from testng-results
+            # JUnit names a data-provider test "method[p1, p2](1)", testng-results just "method".
+            if (cname, mname) in testng_methods or (cname, mname.split("[", 1)[0]) in testng_methods:
                 continue
             if tc.find("failure") is not None or tc.find("error") is not None:
                 st = "FAIL"

--- a/automation/ci/run_aio_integration.sh
+++ b/automation/ci/run_aio_integration.sh
@@ -202,6 +202,14 @@ else
     }
   done
   [ "$img_rc" -eq 0 ] || exit 1
+  # The images pin jans-linux-setup at JANS_SOURCE_VERSION, so this checkout's schema must be
+  # overlaid or the loader creates the tables from the pinned one.
+  for svc in persistence-loader config-api auth-server scim fido2; do
+    docker build -q -t "local/$svc:ci" -f - jans-linux-setup/jans_setup/schema >/dev/null <<EOF
+FROM local/$svc:ci
+COPY jans_schema.json custom_schema.json /app/schema/
+EOF
+  done
   docker build -t local/aio:ci \
     --build-arg JANS_PERSISTENCE_LOADER_IMAGE=local/persistence-loader:ci \
     --build-arg JANS_CONFIG_API_IMAGE=local/config-api:ci \
@@ -514,6 +522,11 @@ find jans-orm jans-core jans-auth-server jans-scim jans-config-api jans-fido2 \
      agama jans-cedarling/bindings/cedarling-java jans-lock/lock-server \
   -path '*/target/surefire-reports/*.xml' 2>/dev/null | while read -r f; do
   mod=$(printf '%s' "$f" | sed -E 's#/target/surefire-reports/.*##; s#[/ ]+#_#g')
+  # TEST-TestSuite.xml repeats the per-class reports; the JUnit reporter counts both.
+  if [ "$(basename "$f")" = "TEST-TestSuite.xml" ] && [ -n "$(find "$(dirname "$f")" \
+       -maxdepth 1 -name 'TEST-*.xml' ! -name 'TEST-TestSuite.xml' -print -quit)" ]; then
+    continue
+  fi
   cp "$f" "test-reports/${mod}-$(basename "$f")" 2>/dev/null || true
 done
 echo "collected $(find test-reports -name '*.xml' 2>/dev/null | wc -l) report files"


### PR DESCRIPTION
[Run 34217731523](https://github.com/JanssenProject/jans/actions/runs/34217731523) reported `4181 passed, 4 failed and 30 skipped` — double the real figures, each failure listed twice.

surefire+TestNG writes an aggregate `TEST-TestSuite.xml` next to the per-class `TEST-<class>.xml` reports, holding the same testcases again; `dorny/test-reporter` counts both. The step summary hit the same duplication via parameterised names (`method[p1, p2](1)` in JUnit vs `method` in testng-results), so parameterised tests were folded in twice — 3849 "distinct" tests instead of 2129, plus a phantom `AccessProtectedResourceFlowHttpTest` failure that had passed on retry.

Fix: drop the aggregate at collection time (verified suite ⊂ per-class on that run — 0 suite-only tests), and match JUnit testcases on the bare method name. Re-run against that artifact: **2129 distinct, 0 failed** (was 3849 / 1); JUnit check **2093 / 2 / 21** (was 4181 / 4 / 30).

Also: the service images pin jans-linux-setup at `JANS_SOURCE_VERSION`, so the `jansId`/`jti` schema additions from #15018 never reached the AIO tables. CI now overlays this checkout's `jans_schema.json` / `custom_schema.json` onto the loader and service images. Released images still need the pin bumped.
Closes #15022, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected test reporting to prevent parameterized data-provider tests from being counted twice.
  * Prevented duplicate per-class test reports from being included in aggregate results.

* **Tests**
  * Integration testing now uses the checkout’s current schema files when building service images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->