### PR TITLE
fix(jans-config-api): set the admin_ui_session_id cookie with SameSite=Strict or SameS…

### DIFF
--- a/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/rest/auth/OAuth2Resource.java
+++ b/jans-config-api/plugins/admin-ui-plugin/src/main/java/io/jans/ca/plugin/adminui/rest/auth/OAuth2Resource.java
@@ -101,7 +101,7 @@ public class OAuth2Resource {
                             "; Path=/" +
                             "; HttpOnly" +
                             "; Secure" +
-                            "; SameSite=None";
+                            "; SameSite=Strict";
             oAuth2Service.setAdminUISession(sessionId, apiTokenRequest.getUjwt());
 
             return Response.ok(CommonUtils.createGenericResponse(true, 200, "Admin UI Session created successfully."))
@@ -149,7 +149,7 @@ public class OAuth2Resource {
                             "; Max-Age=0" +
                             "; HttpOnly" +
                             "; Secure" +
-                            "; SameSite=None";
+                            "; SameSite=Strict";
 
             // Return a response with the new, invalidated cookie
             return Response.ok(CommonUtils.createGenericResponse(true, 200, "Admin UI Session revoked successfully."))


### PR DESCRIPTION
…ite=Lax so it is not sent cross site

### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #15023

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session cookie security by setting the `SameSite` attribute to `Strict` when creating and deleting sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->