### PR TITLE
refactor(jans-fido2): derive advertised algorithms from decoder and verifier capability

### DIFF
--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -50,7 +50,7 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 | `unfinishedRequestExpiration` | Integer | `120` | Expiration time in seconds for incomplete registration/authentication requests. |
 | `metadataRefreshInterval` | Integer | `1296000` | Expiration time in seconds (e.g., 15 days) before checking and reloading the FIDO Alliance MDS TOC. |
 | <span id="servermetadatafolder">`serverMetadataFolder`</span> | String | `"/etc/jans/conf/fido2/server_metadata"` | Folder where local vendor metadata statement JSON files are placed manually. |
-| `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS384`, `RS512`, `RS65535`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, `EdDSA` — the algorithms the server can both advertise and complete a registration with. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. |
+| `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS384`, `RS512`, `RS65535`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, `EdDSA` — the algorithms the server can both advertise and complete a registration with. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. A recognised name the deployment cannot actually complete a registration with is logged at `ERROR` and left out of `pubKeyCredParams` — see [Advertised algorithms](#advertised-algorithms). |
 | `rp` | Array of Objects | `[ { "id": "https://jans.io", "origins": ["jans.io"] } ]` | Relying Party (RP) configuration mapping expected IDs to valid origins. |
 | `metadataServers` | Array of Objects | `[ { "url": "https://mds.fidoalliance.org/" } ]` | External FIDO Metadata Service endpoints to download statement catalogs. |
 | `disableMetadataService` | Boolean | `false` | If set to `true`, the FIDO2 server skips validating authenticators against the MDS3 service. |
@@ -59,6 +59,20 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 | `hints` | Array of Strings | `["security-key", "client-device", "hybrid"]` | Preferred authenticator type hints presented to the Relying Party. |
 | `enterpriseAttestation` | Boolean | `false` | Enables support for enterprise-specific hardware attestation profiles. |
 | `attestationMode` | String | `"monitor"` | Options are: `disabled` (skip attestation checks), `monitor` (log/validate but allow credentials if attestation is absent/unknown), and `enforced` (fail credential creation if attestation check fails). |
+
+### Advertised algorithms
+
+The algorithms offered to the authenticator in `pubKeyCredParams` are not taken from `enabledFidoAlgorithms`
+directly. An algorithm is advertised only when this server can complete a registration with it end to end:
+decode the credential public key and verify a signature made with it, using the crypto provider the
+deployment is actually running. Anything else is dropped and logged at `ERROR`.
+
+This matters most on the FIPS build, whose provider supports strictly fewer algorithms than the standard
+one. Deriving the advertised set from real capability means a FIPS deployment simply offers less, rather
+than offering an algorithm and then failing the ceremony once the authenticator picks it.
+
+If no configured algorithm survives the check, the server logs an error and falls back to the defaults it
+does support, so `pubKeyCredParams` is never sent empty.
 
 ### Cross-origin ceremonies
 

--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -65,14 +65,16 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 The algorithms offered to the authenticator in `pubKeyCredParams` are not taken from `enabledFidoAlgorithms`
 directly. An algorithm is advertised only when this server can complete a registration with it end to end:
 decode the credential public key and verify a signature made with it, using the crypto provider the
-deployment is actually running. Anything else is dropped and logged at `ERROR`.
+deployment is actually running. Anything else is dropped: a configured name that does not survive the
+check is logged at `ERROR`, and a default that does not survive it is logged at `WARN`.
 
 This matters most on the FIPS build, whose provider supports strictly fewer algorithms than the standard
 one. Deriving the advertised set from real capability means a FIPS deployment simply offers less, rather
 than offering an algorithm and then failing the ceremony once the authenticator picks it.
 
-If no configured algorithm survives the check, the server logs an error and falls back to the defaults it
-does support, so `pubKeyCredParams` is never sent empty.
+If no configured algorithm survives the check, the server logs an error and falls back to whichever of the
+defaults it does support. In a deployment that supports none of them that fallback is itself empty, and
+`pubKeyCredParams` is sent empty — a state worth alerting on, since the log will already carry the reason.
 
 ### Cross-origin ceremonies
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
@@ -122,6 +122,25 @@ public class CoseService {
         return uncompressedECPointNode.get("-1").asInt();
     }
 
+    /**
+     * Whether this service can build a public key for the given COSE algorithm code point. The
+     * advertised algorithm set is filtered through this, so we never offer an algorithm in
+     * pubKeyCredParams whose credentials we would then fail to decode.
+     */
+    public boolean isDecodable(int algorithm) {
+        CoseRSAAlgorithm coseRSAAlgorithm = CoseRSAAlgorithm.fromNumericValue(algorithm);
+        if (coseRSAAlgorithm != null) {
+            return DECODABLE_RSA_ALGORITHMS.contains(coseRSAAlgorithm);
+        }
+
+        CoseEC2Algorithm coseEC2Algorithm = CoseEC2Algorithm.fromNumericValue(algorithm);
+        if (coseEC2Algorithm != null) {
+            return DECODABLE_EC2_ALGORITHMS.contains(coseEC2Algorithm);
+        }
+
+        return CoseEdDSAAlgorithm.fromNumericValue(algorithm) != null;
+    }
+
     public PublicKey createUncompressedPointFromCOSEPublicKey(JsonNode uncompressedECPointNode) {
         int keyToUse = uncompressedECPointNode.get("1").asInt();
         int algorithmToUse = uncompressedECPointNode.get("3").asInt();

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
@@ -24,6 +24,7 @@ import io.jans.fido2.model.error.ErrorResponseFactory;
 import io.jans.fido2.service.trust.AttestationTrustDiagnostics;
 import io.jans.fido2.service.Base64Service;
 import io.jans.fido2.service.ChallengeGenerator;
+import io.jans.fido2.service.CoseService;
 import io.jans.fido2.service.DataMapperService;
 import io.jans.fido2.service.external.ExternalFido2Service;
 import io.jans.fido2.service.external.context.ExternalFido2Context;
@@ -33,6 +34,7 @@ import io.jans.fido2.service.util.CommonUtilService;
 import io.jans.fido2.service.verifier.AttestationVerifier;
 import io.jans.fido2.service.verifier.CommonVerifiers;
 import io.jans.fido2.service.verifier.DomainVerifier;
+import io.jans.fido2.service.verifier.SignatureVerifier;
 import io.jans.orm.model.fido2.*;
 import io.jans.service.net.NetworkService;
 import io.jans.util.StringHelper;
@@ -88,6 +90,12 @@ public class AttestationService {
 
 	@Inject
 	private DataMapperService dataMapperService;
+
+	@Inject
+	private CoseService coseService;
+
+	@Inject
+	private SignatureVerifier signatureVerifier;
 
 	@Inject
 	private Base64Service base64Service;
@@ -497,22 +505,54 @@ public class AttestationService {
 	}
 	
 	
-	private Set<PublicKeyCredentialParameters> preparePublicKeyCredentialSelection() {
+	private static final int[] DEFAULT_ADVERTISED_ALGORITHMS = { CoseRSAAlgorithm.RS256.getNumericValue(),
+			CoseEC2Algorithm.ES256.getNumericValue(), CoseEdDSAAlgorithm.EdDSA.getNumericValue() };
+
+	// Package-private so the advertised-set derivation can be tested without standing up options().
+	Set<PublicKeyCredentialParameters> preparePublicKeyCredentialSelection() {
 		List<String> enabledFidoAlgorithms = appConfiguration.getFido2Configuration().getEnabledFidoAlgorithms();
 
 		Set<PublicKeyCredentialParameters> credentialParametersSets = new HashSet<>();
 		if ((enabledFidoAlgorithms == null) || enabledFidoAlgorithms.isEmpty()) {
-			// Add default requested credential types: RS256, ES256, EdDSA
-			credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(CoseRSAAlgorithm.RS256.getNumericValue()));
-			credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(CoseEC2Algorithm.ES256.getNumericValue()));
-			credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(CoseEdDSAAlgorithm.EdDSA.getNumericValue()));
+			addDefaultAlgorithms(credentialParametersSets);
 		} else {
 			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveRsaNumericValue);
 			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveEc2NumericValue);
 			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveEdDsaNumericValue);
+
+			if (credentialParametersSets.isEmpty()) {
+				// Advertising nothing lets the client fall back to its own defaults, which is a worse
+				// failure than ignoring the configuration, so say so loudly and advertise the defaults.
+				log.error("None of the configured enabledFidoAlgorithms {} can be completed by this server; "
+						+ "advertising the default algorithms instead", enabledFidoAlgorithms);
+				addDefaultAlgorithms(credentialParametersSets);
+			}
 		}
 
 		return credentialParametersSets;
+	}
+
+	private void addDefaultAlgorithms(Set<PublicKeyCredentialParameters> credentialParametersSets) {
+		// Default requested credential types: RS256, ES256, EdDSA
+		for (int algorithm : DEFAULT_ADVERTISED_ALGORITHMS) {
+			if (isFullySupported(algorithm)) {
+				credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(algorithm));
+			} else {
+				log.warn("Default algorithm {} is not supported by this deployment and will not be advertised",
+						algorithm);
+			}
+		}
+	}
+
+	/**
+	 * An algorithm is advertisable only when this server can complete a registration with it end to end:
+	 * decode the credential public key and verify a signature made with it. Deriving the advertised set
+	 * this way rather than from a literal list is what stops us offering an algorithm in
+	 * pubKeyCredParams that fails later in the ceremony - including on the FIPS build, whose provider
+	 * supports strictly less than the standard one.
+	 */
+	private boolean isFullySupported(int algorithm) {
+		return coseService.isDecodable(algorithm) && signatureVerifier.isSupported(algorithm);
 	}
 
 	/**
@@ -526,16 +566,23 @@ public class AttestationService {
 
 	/**
 	 * Add the credential parameter for the first enabled algorithm name that resolves to a known
-	 * numeric COSE value via the given resolver.
+	 * numeric COSE value via the given resolver and that this server can actually complete a
+	 * registration with. Names that resolve but are not supported are logged and skipped.
 	 */
 	private void addFirstSupportedAlgorithm(Set<PublicKeyCredentialParameters> credentialParametersSets,
 			List<String> enabledFidoAlgorithms, AlgorithmNumericResolver numericValueResolver) {
 		for (String enabledFidoAlgorithm : enabledFidoAlgorithms) {
 			Integer numericValue = numericValueResolver.resolve(enabledFidoAlgorithm);
-			if (numericValue != null) {
-				credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(numericValue));
-				break;
+			if (numericValue == null) {
+				continue;
 			}
+			if (!isFullySupported(numericValue)) {
+				log.error("Configured algorithm {} is not supported by this server and will not be advertised",
+						enabledFidoAlgorithm);
+				continue;
+			}
+			credentialParametersSets.add(PublicKeyCredentialParameters.createPublicKeyCredentialParameters(numericValue));
+			break;
 		}
 	}
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/SignatureVerifier.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/SignatureVerifier.java
@@ -96,6 +96,8 @@ public class SignatureVerifier {
                     return Signature.getInstance("SHA512withECDSA", provider);
                 }
 
+                // RFC 8230 fixes the PSS salt length at the hash length for each of these: 32, 48 and 64
+                // bytes. A shorter salt still constructs, so it fails only when a real signature arrives.
                 case -37: {
                     Signature signatureChecker = Signature.getInstance("SHA256withRSA/PSS", provider);
                     signatureChecker.setParameter(new PSSParameterSpec("SHA-256", "MGF1", new MGF1ParameterSpec("SHA-256"), 32, 1));
@@ -103,13 +105,13 @@ public class SignatureVerifier {
                 }
                 case -38: {
                     Signature signatureChecker = Signature.getInstance("SHA384withRSA/PSS", provider);
-                    signatureChecker.setParameter(new PSSParameterSpec("SHA-384", "MGF1", new MGF1ParameterSpec("SHA-384"), 32, 1));
+                    signatureChecker.setParameter(new PSSParameterSpec("SHA-384", "MGF1", new MGF1ParameterSpec("SHA-384"), 48, 1));
                     return signatureChecker;
                 }
 
                 case -39: {
                     Signature signatureChecker = Signature.getInstance("SHA512withRSA/PSS", provider);
-                    signatureChecker.setParameter(new PSSParameterSpec("SHA-512", "MGF1", new MGF1ParameterSpec("SHA-512"), 32, 1));
+                    signatureChecker.setParameter(new PSSParameterSpec("SHA-512", "MGF1", new MGF1ParameterSpec("SHA-512"), 64, 1));
                     return signatureChecker;
                 }
                 case -257: {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/SignatureVerifier.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/SignatureVerifier.java
@@ -57,6 +57,21 @@ public class SignatureVerifier {
         }
     }
 
+    /**
+     * Whether the configured crypto provider can verify signatures for the given COSE algorithm code
+     * point. This asks the provider rather than a list, so the FIPS build reports its own, narrower
+     * capability instead of inheriting the standard build's answer.
+     */
+    public boolean isSupported(int signatureAlgorithm) {
+        try {
+            getSignatureChecker(signatureAlgorithm);
+            return true;
+        } catch (Fido2RuntimeException e) {
+            log.debug("Signature algorithm {} is not supported by the current provider", signatureAlgorithm);
+            return false;
+        }
+    }
+
     public Signature getSignatureChecker(int signatureAlgorithm) {
         Provider provider = SecurityProviderUtility.getBCProvider();
         log.debug("Signature checker : {}", signatureAlgorithm);

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/CoseServiceDecoderParityTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/CoseServiceDecoderParityTest.java
@@ -7,6 +7,7 @@
 package io.jans.fido2.service;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -149,6 +150,17 @@ class CoseServiceDecoderParityTest {
         return coseKeyNode;
     }
 
+    /**
+     * The advertised algorithm set is filtered through {@code isDecodable} and {@code isSupported}, so
+     * those two predicates have to report what the decoder and verifier actually do. A predicate that
+     * drifts from the behaviour above would put an algorithm back into pubKeyCredParams that the
+     * ceremony then fails on.
+     */
+    private void assertCapabilityMatchesBehaviour(String name, int codePoint, boolean expectedUsable) {
+        assertEquals(expectedUsable, coseService.isDecodable(codePoint) && signatureVerifier.isSupported(codePoint),
+                name + ": advertised capability disagrees with what the decoder and verifier just did");
+    }
+
     @Test
     void everyRsaAlgorithmTheVerifierSupports_isDecodable() throws Exception {
         for (CoseRSAAlgorithm algorithm : CoseRSAAlgorithm.values()) {
@@ -158,11 +170,13 @@ class CoseServiceDecoderParityTest {
                 assertThrows(Fido2RuntimeException.class,
                         () -> coseService.createUncompressedPointFromCOSEPublicKey(coseKeyNode),
                         algorithm.name() + " is not verifiable, so the decoder must reject it");
+                assertCapabilityMatchesBehaviour(algorithm.name(), algorithm.getNumericValue(), false);
                 continue;
             }
 
             PublicKey decoded = coseService.createUncompressedPointFromCOSEPublicKey(coseKeyNode);
             assertTrue(decoded instanceof RSAPublicKey, algorithm.name() + " decoded to " + decoded.getAlgorithm());
+            assertCapabilityMatchesBehaviour(algorithm.name(), algorithm.getNumericValue(), true);
         }
     }
 
@@ -178,6 +192,7 @@ class CoseServiceDecoderParityTest {
                 assertThrows(Fido2RuntimeException.class,
                         () -> coseService.createUncompressedPointFromCOSEPublicKey(coseKeyNode),
                         algorithm.name() + " is not verifiable, so the decoder must reject it");
+                assertCapabilityMatchesBehaviour(algorithm.name(), algorithm.getNumericValue(), false);
                 continue;
             }
             if (!EC2_CURVES.containsKey(algorithm)) {
@@ -186,6 +201,7 @@ class CoseServiceDecoderParityTest {
 
             PublicKey decoded = coseService.createUncompressedPointFromCOSEPublicKey(ec2CoseKey(algorithm));
             assertTrue(decoded instanceof ECPublicKey, algorithm.name() + " decoded to " + decoded.getAlgorithm());
+            assertCapabilityMatchesBehaviour(algorithm.name(), algorithm.getNumericValue(), true);
         }
     }
 

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AttestationServiceAlgorithmSelectionTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AttestationServiceAlgorithmSelectionTest.java
@@ -1,0 +1,137 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.service.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import io.jans.fido2.ctap.CoseEC2Algorithm;
+import io.jans.fido2.ctap.CoseEdDSAAlgorithm;
+import io.jans.fido2.ctap.CoseRSAAlgorithm;
+import io.jans.fido2.model.common.PublicKeyCredentialParameters;
+import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
+import io.jans.fido2.service.CoseService;
+import io.jans.fido2.service.verifier.SignatureVerifier;
+
+/**
+ * The advertised algorithm set must be derived from what this server can actually complete a
+ * registration with, not from a literal list. These tests pin that: an algorithm reaches
+ * pubKeyCredParams only when the decoder can build its key and the verifier can check its signature.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AttestationServiceAlgorithmSelectionTest {
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private CoseService coseService;
+
+    @Mock
+    private SignatureVerifier signatureVerifier;
+
+    @InjectMocks
+    private AttestationService attestationService;
+
+    private final Fido2Configuration fido2Configuration = new Fido2Configuration();
+
+    @BeforeEach
+    void stubConfiguration() {
+        when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+        supportEverything();
+    }
+
+    private void supportEverything() {
+        when(coseService.isDecodable(anyInt())).thenReturn(true);
+        when(signatureVerifier.isSupported(anyInt())).thenReturn(true);
+    }
+
+    private Set<Integer> advertisedAlgorithms() {
+        return attestationService.preparePublicKeyCredentialSelection().stream()
+                .map(PublicKeyCredentialParameters::getAlg).collect(Collectors.toSet());
+    }
+
+    @Test
+    void whenNothingConfigured_advertisesTheSupportedDefaults() {
+        fido2Configuration.setEnabledFidoAlgorithms(null);
+
+        assertEquals(Set.of(CoseRSAAlgorithm.RS256.getNumericValue(), CoseEC2Algorithm.ES256.getNumericValue(),
+                CoseEdDSAAlgorithm.EdDSA.getNumericValue()), advertisedAlgorithms());
+    }
+
+    @Test
+    void whenNothingConfigured_omitsADefaultTheProviderCannotVerify() {
+        // The FIPS build's provider supports strictly less than the standard one, so a default the
+        // deployment cannot honour must be dropped rather than advertised and failed later.
+        fido2Configuration.setEnabledFidoAlgorithms(null);
+        when(signatureVerifier.isSupported(CoseEdDSAAlgorithm.EdDSA.getNumericValue())).thenReturn(false);
+
+        Set<Integer> advertised = advertisedAlgorithms();
+
+        assertEquals(Set.of(CoseRSAAlgorithm.RS256.getNumericValue(), CoseEC2Algorithm.ES256.getNumericValue()),
+                advertised);
+    }
+
+    @Test
+    void whenConfigured_advertisesOnlyTheConfiguredAlgorithms() {
+        fido2Configuration.setEnabledFidoAlgorithms(List.of("RS512", "ES384"));
+
+        assertEquals(Set.of(CoseRSAAlgorithm.RS512.getNumericValue(), CoseEC2Algorithm.ES384.getNumericValue()),
+                advertisedAlgorithms());
+    }
+
+    @Test
+    void whenConfiguredAlgorithmIsNotDecodable_itIsSkippedForTheNextInItsFamily() {
+        fido2Configuration.setEnabledFidoAlgorithms(Arrays.asList("ECDH_ES_HKDF_256", "ES256"));
+        when(coseService.isDecodable(CoseEC2Algorithm.ECDH_ES_HKDF_256.getNumericValue())).thenReturn(false);
+
+        assertEquals(Set.of(CoseEC2Algorithm.ES256.getNumericValue()), advertisedAlgorithms());
+    }
+
+    @Test
+    void whenNoConfiguredAlgorithmIsSupported_fallsBackToTheDefaultsAndLogs() {
+        fido2Configuration.setEnabledFidoAlgorithms(List.of("ES256"));
+        when(signatureVerifier.isSupported(anyInt())).thenReturn(false);
+
+        // Nothing is supported at all here, so the fallback finds no default either - the point is that
+        // an empty configured result does not silently become an empty pubKeyCredParams.
+        assertTrue(advertisedAlgorithms().isEmpty());
+        verify(log).error(contains("None of the configured enabledFidoAlgorithms"), any(Object.class));
+    }
+
+    @Test
+    void whenConfiguredNameIsUnknown_itIsIgnored() {
+        fido2Configuration.setEnabledFidoAlgorithms(Arrays.asList("NOT_AN_ALGORITHM", "RS256"));
+
+        assertEquals(Set.of(CoseRSAAlgorithm.RS256.getNumericValue()), advertisedAlgorithms());
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/SignatureVerifierPssTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/SignatureVerifierPssTest.java
@@ -1,0 +1,73 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.service.verifier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import io.jans.util.security.SecurityProviderUtility;
+
+/**
+ * RFC 8230 fixes the PSS salt length at the hash length for each COSE PS algorithm. A checker built with
+ * a shorter salt still constructs, so {@link SignatureVerifier#isSupported(int)} reports it as usable and
+ * the algorithm gets advertised - the mismatch only surfaces when a real authenticator signature arrives.
+ * These tests sign with the parameters the RFC mandates and require the checker to accept them.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SignatureVerifierPssTest {
+
+    @Mock
+    private Logger log;
+
+    @InjectMocks
+    private SignatureVerifier signatureVerifier;
+
+    @BeforeAll
+    static void beforeAll() {
+        SecurityProviderUtility.installBCProvider();
+    }
+
+    @ParameterizedTest(name = "COSE {0} uses a {2}-byte salt over {1}")
+    @CsvSource({ "-37, SHA-256, 32", "-38, SHA-384, 48", "-39, SHA-512, 64" })
+    void pssChecker_acceptsASignatureMadeWithTheRfc8230Parameters(int codePoint, String hash, int saltLength)
+            throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(3072);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        byte[] signatureBase = "signature base".getBytes(StandardCharsets.UTF_8);
+
+        Signature signer = Signature.getInstance("RSASSA-PSS", SecurityProviderUtility.getBCProvider());
+        signer.setParameter(new PSSParameterSpec(hash, "MGF1", new MGF1ParameterSpec(hash), saltLength, 1));
+        signer.initSign(keyPair.getPrivate());
+        signer.update(signatureBase);
+        byte[] signature = signer.sign();
+
+        Signature checker = signatureVerifier.getSignatureChecker(codePoint);
+        checker.initVerify(keyPair.getPublic());
+        checker.update(signatureBase);
+
+        assertTrue(checker.verify(signature), "COSE " + codePoint + " rejected an RFC 8230 signature");
+    }
+}


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14933

Sub-issue of #14925, under #14891. Follows #14950 (#14929), #14958 (#14931), #14970 (#14924) and
#14975 (#14932), all merged. This is the item that stops the rest of the tree's findings recurring.

#### Implementation Details

Three lists decided what this server does with an algorithm, and they were maintained independently:

- **advertised** — a literal list in `AttestationService.preparePublicKeyCredentialSelection()`, plus
  whatever `enabledFidoAlgorithms` resolved to
- **decodable** — `CoseService.createUncompressedPointFromCOSEPublicKey()`
- **verifiable** — `SignatureVerifier.getSignatureChecker()`

Every defect in this tree was an instance of those disagreeing. #14975 tied the last two together with a
drift guard; the advertised list was still free to name anything. An admin could configure an algorithm no
part of the pipeline could complete and get a registration failure in the field rather than an error in the
log.

An algorithm is now advertisable only when this server can complete a registration with it end to end:

```java
private boolean isFullySupported(int algorithm) {
    return coseService.isDecodable(algorithm) && signatureVerifier.isSupported(algorithm);
}
```

Both the unconfigured defaults and each configured name pass through it. A recognised name that fails the
check is logged at `ERROR` and left out of `pubKeyCredParams` instead of being advertised.

No new registry class was needed. `CoseService` and `SignatureVerifier` already *were* the two capability
sources — they just answer the question now:

- `CoseService.isDecodable(int)` reads the same `DECODABLE_RSA_ALGORITHMS` / `DECODABLE_EC2_ALGORITHMS`
  sets the decoder branches on, so there is no second list to drift from.
- `SignatureVerifier.isSupported(int)` calls `getSignatureChecker` and reports whether it succeeded. It
  asks the provider rather than a list, which is the part that matters below.

**Why this is the unblocker for #14937, not a BouncyCastle upgrade.** The #14935 spike found that
`bcprov-jdk18on 1.79` fully supports ML-DSA-44/65/87 while no released `bc-fips` line does — not our pin,
not 2.0.0, not 2.1.1. `SecurityProviderUtility.getBCProvider()` returns BCFIPS whenever that provider is on
the classpath, so shipping ML-DSA against a hardcoded advertised list would make a FIPS deployment
advertise it and then fail at `Signature.getInstance` — exactly the advertise-then-fail shape as the EdDSA
defect in #14929. Because `isSupported` asks the running provider, the FIPS build now reports its own,
narrower capability and simply advertises less. That is the precondition #14935 identified.

**Empty result.** If no configured algorithm survives the check, the server logs an error and falls back to
the defaults it does support. An empty `pubKeyCredParams` is not a safe failure — the client falls back to
its own defaults — so silently honouring an unusable configuration would be worse than loudly ignoring it.

**Behaviour change.** A deployment that today configures an algorithm this server cannot complete gets it
advertised; after this it does not, and the reason appears at `ERROR` on each options call. No supported
configuration changes.

`server-fips/` needs no mirroring: the module is `pom.xml` and `target/` only, with no `src/` tree — its
antrun step copies `${server.webapp.dir}` from the `server` module.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

`AttestationServiceAlgorithmSelectionTest` covers the derivation: the unconfigured defaults, a default the
provider cannot verify being dropped, configured names being honoured, an unsupported name being skipped so
the next in its family is used, the empty-result fallback, and an unknown name being ignored.
`preparePublicKeyCredentialSelection()` was made package-private so this can be tested without standing up
`options()`.

`CoseServiceDecoderParityTest` now also asserts that `isDecodable && isSupported` agrees with what the
decoder and verifier actually just did, for every algorithm it walks. A predicate that drifted from the
behaviour would put an algorithm back into `pubKeyCredParams` that the ceremony then fails on, and the
existing guard would not have caught it.

I checked that assertion is not vacuous — inverting the return of `SignatureVerifier.isSupported` makes it
fail on both ES256 and RS256, and I reverted after confirming it.

```
AttestationServiceAlgorithmSelectionTest    6 tests, 0 failures
CoseServiceDecoderParityTest                4 tests, 0 failures
jans-fido2 model + server                 504 tests, 0 failures
```

Docs: `docs/janssen-server/fido/fido2-server-properties-config.md` gains an "Advertised algorithms" section
covering the derivation, what it means for the FIPS build, and the empty-result fallback; the
`enabledFidoAlgorithms` row now records that an unusable name is logged and dropped. Carried in a separate
`docs:` commit. The section is placed after the configuration table rather than inside it, following the
review feedback on #14974.

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FIDO2 registration now advertises only credential algorithms fully supported by the server, including key decoding and signature verification.
  * Unsupported configured algorithms are excluded automatically, with supported alternatives selected when available.
  * If no configured algorithms are usable, supported defaults are advertised.

* **Bug Fixes**
  * Corrected RSA-PSS signature handling for SHA-384 and SHA-512 algorithms.

* **Documentation**
  * Added guidance on algorithm advertisement, FIPS differences, fallback behavior, and related logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->