### PR TITLE
feat(jans-auth-server): in role_based_scopes_update_token script, add user-INUM in access_token

### DIFF
--- a/docs/script-catalog/introspection/introspection-role-based-scope/introspection_role_based_scope.py
+++ b/docs/script-catalog/introspection/introspection-role-based-scope/introspection_role_based_scope.py
@@ -1,10 +1,9 @@
 # oxAuth is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
-# Copyright (c) 2021, Gluu
+# Copyright (c) 2018, Janssen
 #
-# Author: Yuriy Movchan, Arnab Dutta, Mustafa Baser
+# Author: Yuriy Zabrovarnyy, Arnab Dutta, Mustafa Baser
 #
 #
-
 from io.jans.as.model.jwt import Jwt
 from io.jans.service.cdi.util import CdiUtil
 from io.jans.as.model.crypto import AuthCryptoProvider
@@ -15,52 +14,40 @@ from io.jans.as.model.config.adminui import AdminConf
 from io.jans.as.common.model.session import SessionId
 from org.json import JSONObject
 from java.lang import String
-from java.util import HashSet
-from io.jans.model.custom.script.type.token import UpdateTokenType
-from jakarta.ws.rs import BadRequestException
 
-class UpdateToken(UpdateTokenType):
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+
+class Introspection(IntrospectionType):
     def __init__(self, currentTimeMillis):
         self.currentTimeMillis = currentTimeMillis
 
     def init(self, customScript, configurationAttributes):
-        print "Update token script. Initializing ..."
-        print "Update token script. Initialized successfully"
+        print "Introspection script. Initializing ..."
+        print "Introspection script. Initialized successfully"
 
         return True
 
     def destroy(self, configurationAttributes):
-        print "Update token script. Destroying ..."
-        print "Update token script. Destroyed successfully"
+        print "Introspection script. Destroying ..."
+        print "Introspection script. Destroyed successfully"
         return True
 
     def getApiVersion(self):
         return 11
 
-    # Returns boolean, true - indicates that script applied changes
-    # This method is called after adding headers and claims. Hence script can override them
+    # Returns boolean, true - apply introspection method, false - ignore it.
+    # This method is called after introspection response is ready. This method can modify introspection response.
     # Note :
-    # jsonWebResponse - is io.jans.as.model.token.JsonWebResponse, you can use any method to manipulate JWT
-    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
-    def modifyIdToken(self, jsonWebResponse, context):
-        return True
-
-    # Returns boolean, true - indicates that script applied changes. If false is returned token will not be created.
-    # refreshToken is reference of io.jans.as.server.model.common.RefreshToken (note authorization grant can be taken as context.getGrant())
-    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
-    def modifyRefreshToken(self, refreshToken, context):
-        return True
-
-    # Returns boolean, true - indicates that script applied changes. If false is returned token will not be created.
-    # accessToken is reference of io.jans.as.server.model.common.AccessToken (note authorization grant can be taken as context.getGrant())
-    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
-    def modifyAccessToken(self, accessToken, context):
-        print "Inside modifyAccessToken method of update token script ...."
+    # responseAsJsonObject - is org.codehaus.jettison.json.JSONObject, you can use any method to manipulate json
+    # context is reference of io.jans.as.service.external.context.ExternalIntrospectionContext (in https://github.com/JanssenFederation/oxauth project, )
+    def modifyResponse(self, responseAsJsonObject, context):
+        print "Inside modifyResponse method of introspection script ...."
+        scopes = []
         try:
-            if context.getGrant().getAuthorizationGrantType().toString() != 'client_credentials':
-                return True
-            scopes = HashSet()
-            userInum = None
             # Getting user-info-jwt
             ujwt = context.getHttpRequest().getParameter("ujwt")
             if not ujwt:
@@ -73,9 +60,9 @@ class UpdateToken(UpdateTokenType):
 
                 for ele in permissions:
                     if ele.getDefaultPermissionInToken() is not None and ele.getDefaultPermissionInToken():
-                        scopes.add(ele.getPermission())
+                        scopes.append(ele.getPermission())
 
-                context.overwriteAccessTokenScopes(accessToken, scopes)
+                responseAsJsonObject.accumulate("scope", scopes)
                 return True
 
             # Parse jwt
@@ -86,17 +73,12 @@ class UpdateToken(UpdateTokenType):
             jwks = JSONObject(jwksObj)
 
             # Validate JWT
-            if userInfoJwt.getHeader().getSignatureAlgorithm().getAlgorithm() == None:
-                print "Error: Unsigned JWT not allowed. The User-Info JWT is not valid"
-                raise BadRequestException("Unsigned JWT not allowed. The User-Info JWT is not valid")
             authCryptoProvider = AuthCryptoProvider()
             validJwt = authCryptoProvider.verifySignature(userInfoJwt.getSigningInput(), userInfoJwt.getEncodedSignature(), userInfoJwt.getHeader().getKeyId(), jwks, None, userInfoJwt.getHeader().getSignatureAlgorithm())
 
             if validJwt == True:
                 # Get claims from parsed JWT
                 jwtClaims = userInfoJwt.getClaims()
-                # Get User-INUM from user-claims
-                userInum = jwtClaims.getClaim("inum")
                 jansAdminUIRole = list(jwtClaims.getClaim("jansAdminUIRole"))
                 # fetch role-scope mapping from database
                 try:
@@ -104,15 +86,13 @@ class UpdateToken(UpdateTokenType):
                     adminConf = AdminConf()
                     adminUIConfig = entryManager.find(adminConf.getClass(), "ou=admin-ui,ou=configuration,o=jans")
                     roleScopeMapping = adminUIConfig.getDynamic().getRolePermissionMapping()
-                    if userInum is not None:
-                        print "The `userInum` claim is present."
-                        context.getClaims().setClaim("userInum", userInum)
+
                     for ele in roleScopeMapping:
                         if ele.getRole() in jansAdminUIRole:
                             for scope in ele.getPermissions():
                                 if not scope in scopes:
-                                    scopes.add(scope)
-
+                                    scopes.append(scope)
+             
                     permissionTag = context.getHttpRequest().getParameter("permission_tag")
                     permissions = adminUIConfig.getDynamic().getPermissions()
 
@@ -122,37 +102,18 @@ class UpdateToken(UpdateTokenType):
                         scopesWithMatchingTags = self.filterScopesMatchingWithTags(permissionTagArr, permissions)
                         scopes = self.createScopeListMatchingWithTags(scopesWithMatchingTags, scopes)
 
+
                 except Exception as e:
                     print "Error:  Failed to fetch/parse Admin UI roleScopeMapping from DB"
                     print e
 
                 print "Following scopes will be added in api token: {}".format(scopes)
-            else:
-                print "Error:  The User-Info JWT is not valid"
-                raise BadRequestException("The User-Info JWT is not valid")
 
-            context.overwriteAccessTokenScopes(accessToken, scopes)
-
-        except BadRequestException:
-            print "Handling BadRequestException"
-            return False
+            responseAsJsonObject.accumulate("scope", scopes)
         except Exception as e:
                 print "Exception occured. Unable to resolve role/scope mapping."
                 print e
-                return False
         return True
-
-    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
-    def getRefreshTokenLifetimeInSeconds(self, context):
-        return 0
-
-    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
-    def getIdTokenLifetimeInSeconds(self, context):
-        return 0
-
-    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
-    def getAccessTokenLifetimeInSeconds(self, context):
-        return 0
 
     def filterScopesMatchingWithTags(self, permissionTag, permissions):
         scopesWithMatchingTags = []

--- a/docs/script-catalog/introspection/introspection-role-based-scope/introspection_role_based_scope.py
+++ b/docs/script-catalog/introspection/introspection-role-based-scope/introspection_role_based_scope.py
@@ -1,9 +1,10 @@
 # oxAuth is available under the MIT License (2008). See http://opensource.org/licenses/MIT for full text.
-# Copyright (c) 2018, Janssen
+# Copyright (c) 2021, Gluu
 #
-# Author: Yuriy Zabrovarnyy, Arnab Dutta, Mustafa Baser
+# Author: Yuriy Movchan, Arnab Dutta, Mustafa Baser
 #
 #
+
 from io.jans.as.model.jwt import Jwt
 from io.jans.service.cdi.util import CdiUtil
 from io.jans.as.model.crypto import AuthCryptoProvider
@@ -14,40 +15,52 @@ from io.jans.as.model.config.adminui import AdminConf
 from io.jans.as.common.model.session import SessionId
 from org.json import JSONObject
 from java.lang import String
+from java.util import HashSet
+from io.jans.model.custom.script.type.token import UpdateTokenType
+from jakarta.ws.rs import BadRequestException
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
-
-class Introspection(IntrospectionType):
+class UpdateToken(UpdateTokenType):
     def __init__(self, currentTimeMillis):
         self.currentTimeMillis = currentTimeMillis
 
     def init(self, customScript, configurationAttributes):
-        print "Introspection script. Initializing ..."
-        print "Introspection script. Initialized successfully"
+        print "Update token script. Initializing ..."
+        print "Update token script. Initialized successfully"
 
         return True
 
     def destroy(self, configurationAttributes):
-        print "Introspection script. Destroying ..."
-        print "Introspection script. Destroyed successfully"
+        print "Update token script. Destroying ..."
+        print "Update token script. Destroyed successfully"
         return True
 
     def getApiVersion(self):
         return 11
 
-    # Returns boolean, true - apply introspection method, false - ignore it.
-    # This method is called after introspection response is ready. This method can modify introspection response.
+    # Returns boolean, true - indicates that script applied changes
+    # This method is called after adding headers and claims. Hence script can override them
     # Note :
-    # responseAsJsonObject - is org.codehaus.jettison.json.JSONObject, you can use any method to manipulate json
-    # context is reference of io.jans.as.service.external.context.ExternalIntrospectionContext (in https://github.com/JanssenFederation/oxauth project, )
-    def modifyResponse(self, responseAsJsonObject, context):
-        print "Inside modifyResponse method of introspection script ...."
-        scopes = []
+    # jsonWebResponse - is io.jans.as.model.token.JsonWebResponse, you can use any method to manipulate JWT
+    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
+    def modifyIdToken(self, jsonWebResponse, context):
+        return True
+
+    # Returns boolean, true - indicates that script applied changes. If false is returned token will not be created.
+    # refreshToken is reference of io.jans.as.server.model.common.RefreshToken (note authorization grant can be taken as context.getGrant())
+    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
+    def modifyRefreshToken(self, refreshToken, context):
+        return True
+
+    # Returns boolean, true - indicates that script applied changes. If false is returned token will not be created.
+    # accessToken is reference of io.jans.as.server.model.common.AccessToken (note authorization grant can be taken as context.getGrant())
+    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
+    def modifyAccessToken(self, accessToken, context):
+        print "Inside modifyAccessToken method of update token script ...."
         try:
+            if context.getGrant().getAuthorizationGrantType().toString() != 'client_credentials':
+                return True
+            scopes = HashSet()
+            userInum = None
             # Getting user-info-jwt
             ujwt = context.getHttpRequest().getParameter("ujwt")
             if not ujwt:
@@ -60,9 +73,9 @@ class Introspection(IntrospectionType):
 
                 for ele in permissions:
                     if ele.getDefaultPermissionInToken() is not None and ele.getDefaultPermissionInToken():
-                        scopes.append(ele.getPermission())
+                        scopes.add(ele.getPermission())
 
-                responseAsJsonObject.accumulate("scope", scopes)
+                context.overwriteAccessTokenScopes(accessToken, scopes)
                 return True
 
             # Parse jwt
@@ -73,12 +86,17 @@ class Introspection(IntrospectionType):
             jwks = JSONObject(jwksObj)
 
             # Validate JWT
+            if userInfoJwt.getHeader().getSignatureAlgorithm().getAlgorithm() == None:
+                print "Error: Unsigned JWT not allowed. The User-Info JWT is not valid"
+                raise BadRequestException("Unsigned JWT not allowed. The User-Info JWT is not valid")
             authCryptoProvider = AuthCryptoProvider()
             validJwt = authCryptoProvider.verifySignature(userInfoJwt.getSigningInput(), userInfoJwt.getEncodedSignature(), userInfoJwt.getHeader().getKeyId(), jwks, None, userInfoJwt.getHeader().getSignatureAlgorithm())
 
             if validJwt == True:
                 # Get claims from parsed JWT
                 jwtClaims = userInfoJwt.getClaims()
+                # Get User-INUM from user-claims
+                userInum = jwtClaims.getClaim("inum")
                 jansAdminUIRole = list(jwtClaims.getClaim("jansAdminUIRole"))
                 # fetch role-scope mapping from database
                 try:
@@ -86,13 +104,15 @@ class Introspection(IntrospectionType):
                     adminConf = AdminConf()
                     adminUIConfig = entryManager.find(adminConf.getClass(), "ou=admin-ui,ou=configuration,o=jans")
                     roleScopeMapping = adminUIConfig.getDynamic().getRolePermissionMapping()
-
+                    if userInum is not None:
+                        print "The `userInum` claim is present."
+                        context.getClaims().setClaim("userInum", userInum)
                     for ele in roleScopeMapping:
                         if ele.getRole() in jansAdminUIRole:
                             for scope in ele.getPermissions():
                                 if not scope in scopes:
-                                    scopes.append(scope)
-             
+                                    scopes.add(scope)
+
                     permissionTag = context.getHttpRequest().getParameter("permission_tag")
                     permissions = adminUIConfig.getDynamic().getPermissions()
 
@@ -102,18 +122,37 @@ class Introspection(IntrospectionType):
                         scopesWithMatchingTags = self.filterScopesMatchingWithTags(permissionTagArr, permissions)
                         scopes = self.createScopeListMatchingWithTags(scopesWithMatchingTags, scopes)
 
-
                 except Exception as e:
                     print "Error:  Failed to fetch/parse Admin UI roleScopeMapping from DB"
                     print e
 
                 print "Following scopes will be added in api token: {}".format(scopes)
+            else:
+                print "Error:  The User-Info JWT is not valid"
+                raise BadRequestException("The User-Info JWT is not valid")
 
-            responseAsJsonObject.accumulate("scope", scopes)
+            context.overwriteAccessTokenScopes(accessToken, scopes)
+
+        except BadRequestException:
+            print "Handling BadRequestException"
+            return False
         except Exception as e:
                 print "Exception occured. Unable to resolve role/scope mapping."
                 print e
+                return False
         return True
+
+    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
+    def getRefreshTokenLifetimeInSeconds(self, context):
+        return 0
+
+    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
+    def getIdTokenLifetimeInSeconds(self, context):
+        return 0
+
+    # context is reference of io.jans.as.server.service.external.context.ExternalUpdateTokenContext (in https://github.com/JanssenProject/jans-auth-server project, )
+    def getAccessTokenLifetimeInSeconds(self, context):
+        return 0
 
     def filterScopesMatchingWithTags(self, permissionTag, permissions):
         scopesWithMatchingTags = []

--- a/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
+++ b/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
@@ -97,7 +97,7 @@ class UpdateToken(UpdateTokenType):
                 jwtClaims = userInfoJwt.getClaims()
                 # Get User-INUM from user-claims
                 userInum = jwtClaims.getClaim("inum")
-                if userInum is not None:
+                if userInum is None:
                     raise BadRequestException("The User-Info JWT does not contain the required (user) inum claim")
                 context.getClaims().setClaim("userInum", userInum)
                 jansAdminUIRole = list(jwtClaims.getClaim("jansAdminUIRole"))

--- a/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
+++ b/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
@@ -15,7 +15,7 @@ from io.jans.as.model.config.adminui import AdminConf
 from io.jans.as.common.model.session import SessionId
 from org.json import JSONObject
 from java.lang import String
-from com.google.common.collect import Sets
+from java.util import HashSet
 from io.jans.model.custom.script.type.token import UpdateTokenType
 from jakarta.ws.rs import BadRequestException
 
@@ -59,7 +59,8 @@ class UpdateToken(UpdateTokenType):
         try:
             if context.getGrant().getAuthorizationGrantType().toString() != 'client_credentials':
                 return True
-            scopes = Sets.newHashSet()
+            scopes = HashSet()
+            userInum = None
             # Getting user-info-jwt
             ujwt = context.getHttpRequest().getParameter("ujwt")
             if not ujwt:
@@ -94,6 +95,8 @@ class UpdateToken(UpdateTokenType):
             if validJwt == True:
                 # Get claims from parsed JWT
                 jwtClaims = userInfoJwt.getClaims()
+                # Get User-INUM from user-claims
+                userInum = jwtClaims.getClaim("inum")
                 jansAdminUIRole = list(jwtClaims.getClaim("jansAdminUIRole"))
                 # fetch role-scope mapping from database
                 try:
@@ -101,7 +104,9 @@ class UpdateToken(UpdateTokenType):
                     adminConf = AdminConf()
                     adminUIConfig = entryManager.find(adminConf.getClass(), "ou=admin-ui,ou=configuration,o=jans")
                     roleScopeMapping = adminUIConfig.getDynamic().getRolePermissionMapping()
-
+                    if userInum is not None:
+                        print "The `userInum` claim is present."
+                        context.getClaims().setClaim("userInum", userInum)
                     for ele in roleScopeMapping:
                         if ele.getRole() in jansAdminUIRole:
                             for scope in ele.getPermissions():
@@ -117,7 +122,6 @@ class UpdateToken(UpdateTokenType):
                         scopesWithMatchingTags = self.filterScopesMatchingWithTags(permissionTagArr, permissions)
                         scopes = self.createScopeListMatchingWithTags(scopesWithMatchingTags, scopes)
 
-
                 except Exception as e:
                     print "Error:  Failed to fetch/parse Admin UI roleScopeMapping from DB"
                     print e
@@ -128,6 +132,7 @@ class UpdateToken(UpdateTokenType):
                 raise BadRequestException("The User-Info JWT is not valid")
 
             context.overwriteAccessTokenScopes(accessToken, scopes)
+
         except BadRequestException:
             print "Handling BadRequestException"
             return False

--- a/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
+++ b/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
@@ -98,8 +98,8 @@ class UpdateToken(UpdateTokenType):
                 # Get User-INUM from user-claims
                 userInum = jwtClaims.getClaim("inum")
                 if userInum is not None:
-                    print "The `userInum` claim is present."
-                    context.getClaims().setClaim("userInum", userInum)
+                    raise BadRequestException("The User-Info JWT does not contain the required (user) inum claim")
+                context.getClaims().setClaim("userInum", userInum)
                 jansAdminUIRole = list(jwtClaims.getClaim("jansAdminUIRole"))
                 # fetch role-scope mapping from database
                 try:

--- a/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
+++ b/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
@@ -97,6 +97,9 @@ class UpdateToken(UpdateTokenType):
                 jwtClaims = userInfoJwt.getClaims()
                 # Get User-INUM from user-claims
                 userInum = jwtClaims.getClaim("inum")
+                if userInum is not None:
+                    print "The `userInum` claim is present."
+                    context.getClaims().setClaim("userInum", userInum)
                 jansAdminUIRole = list(jwtClaims.getClaim("jansAdminUIRole"))
                 # fetch role-scope mapping from database
                 try:
@@ -104,9 +107,6 @@ class UpdateToken(UpdateTokenType):
                     adminConf = AdminConf()
                     adminUIConfig = entryManager.find(adminConf.getClass(), "ou=admin-ui,ou=configuration,o=jans")
                     roleScopeMapping = adminUIConfig.getDynamic().getRolePermissionMapping()
-                    if userInum is not None:
-                        print "The `userInum` claim is present."
-                        context.getClaims().setClaim("userInum", userInum)
                     for ele in roleScopeMapping:
                         if ele.getRole() in jansAdminUIRole:
                             for scope in ele.getPermissions():

--- a/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
+++ b/docs/script-catalog/introspection/role-based-scopes-update-token/role_based_scopes_update_token.py
@@ -95,6 +95,22 @@ class UpdateToken(UpdateTokenType):
             if validJwt == True:
                 # Get claims from parsed JWT
                 jwtClaims = userInfoJwt.getClaims()
+                # Check the if the user info jwt has expired
+                exp = jwtClaims.getClaim("exp")
+                if exp is None:
+                    raise BadRequestException("The User-Info JWT does not contain the required exp claim")
+                try:
+                    currentTimeSeconds = self.currentTimeMillis / 1000
+                    if currentTimeSeconds >= long(exp):
+                        raise BadRequestException("The User-Info JWT has expired")
+                except BadRequestException:
+                    print "Error: The User-Info JWT has expired"
+                    raise
+                except Exception as e:
+                    print "Error: Unable to validate the exp claim"
+                    print e
+                    raise BadRequestException("Invalid exp claim in the User-Info JWT")
+
                 # Get User-INUM from user-claims
                 userInum = jwtClaims.getClaim("inum")
                 if userInum is None:


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #15035

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Update-token introspection now validates user-info tokens for signature, audience, expiration, and required user identifiers.
  - Requests with missing role claims are rejected.
  - Valid user identifiers are retained in the token context, enabling role- and tag-based scope processing.
  - Requests without a user-info token continue to receive default scopes.
  - Access-token scopes are updated based on resolved roles and tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->