### PR TITLE
feat(jans-fido2): validate topOrigin against a configurable cross-origin policy

### DIFF
--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -59,15 +59,25 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 | `hints` | Array of Strings | `["security-key", "client-device", "hybrid"]` | Preferred authenticator type hints presented to the Relying Party. |
 | `enterpriseAttestation` | Boolean | `false` | Enables support for enterprise-specific hardware attestation profiles. |
 | `attestationMode` | String | `"monitor"` | Options are: `disabled` (skip attestation checks), `monitor` (log/validate but allow credentials if attestation is absent/unknown), and `enforced` (fail credential creation if attestation check fails). |
+| `allowedTopOrigins` | Array of Strings | `[]` | Full origins permitted to frame a cross-origin ceremony, each written as scheme, host and optional port (for example `https://portal.example.com`). Empty — the default — denies every framed ceremony. See [Cross-origin ceremonies](#cross-origin-ceremonies). |
 
 ### Cross-origin ceremonies
 
-Registration and authentication ceremonies performed inside a cross-origin iframe are rejected. As WebAuthn
-Level 3 requires, the server reads the `crossOrigin` member of `CollectedClientData`: an absent member is
-treated as `false`, a value of `true` fails the request with `cross_origin_not_allowed`, and both a
-non-boolean value and an explicit `null` fail with `invalid_request`.
+As WebAuthn Level 3 requires, the server reads the `crossOrigin` member of `CollectedClientData`. An absent
+member is treated as `false`; both a non-boolean value and an explicit `null` fail with `invalid_request`.
 
-There is no configuration to permit a framed ceremony against a chosen set of framing origins yet, so a
-deployment that embeds the ceremony in a cross-origin iframe will stop working after this change.
+When `crossOrigin` is `true`, the ceremony is allowed only if its `topOrigin` — the origin of the page that
+framed it — appears in `allowedTopOrigins`. The request fails with `cross_origin_not_allowed` when:
+
+- `allowedTopOrigins` is empty, which is the default and denies every framed ceremony
+- `topOrigin` is absent, `null`, not a string, or blank
+- `topOrigin` is not listed
+
+Entries are compared against the whole origin, ignoring case and surrounding whitespace. A different scheme
+or port is a different origin, so `https://portal.example.com` does not permit `http://portal.example.com`.
+
+`allowedTopOrigins` is deliberately separate from the `origins` under `rp`. Those say which origin may
+*serve* a ceremony; this says which origin may *frame* one. Reusing the former would silently widen the
+framing policy of every existing deployment.
 
 

--- a/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/model/conf/Fido2Configuration.java
@@ -64,6 +64,8 @@ public class Fido2Configuration {
 	private boolean enterpriseAttestation = false;
 	@DocProperty(description = "String value indicating whether MDS validation should be omitted during attestation", defaultValue = "monitor")
 	private String attestationMode = "monitor";
+	@DocProperty(description = "Full origins (scheme, host and optional port) permitted to frame a cross-origin ceremony; empty denies every framed ceremony")
+	private List<String> allowedTopOrigins = new ArrayList<>();
 
 	public boolean isRecordAbandonedAssertions() {
 		return recordAbandonedAssertions;
@@ -135,6 +137,14 @@ public class Fido2Configuration {
 
 	public void setRequestedParties(List<RequestedParty> requestedParties) {
 		this.requestedParties = requestedParties;
+	}
+
+	public List<String> getAllowedTopOrigins() {
+		return allowedTopOrigins;
+	}
+
+	public void setAllowedTopOrigins(List<String> allowedTopOrigins) {
+		this.allowedTopOrigins = allowedTopOrigins;
 	}
 
 	public List<String> getHints() {
@@ -232,7 +242,7 @@ public class Fido2Configuration {
 				+ userAutoEnrollment + ", unfinishedRequestExpiration=" + unfinishedRequestExpiration
 				+ ", authenticationHistoryExpiration=" + authenticationHistoryExpiration + ", serverMetadataFolder="
 				+ serverMetadataFolder + ", enabledFidoAlgorithms=" + enabledFidoAlgorithms + ", requestedParties="
-				+ requestedParties + ", metadataServers=" + metadataServers + ", disableMetadataService="
+				+ requestedParties + ", metadataServers=" + metadataServers + ", allowedTopOrigins=" + allowedTopOrigins + ", disableMetadataService="
 				+ disableMetadataService + ", mdsDownloadStartupRetries=" + mdsDownloadStartupRetries
 				+ ", mdsDownloadStartupRetryInterval=" + mdsDownloadStartupRetryInterval + ", hints=" + hints
 				+ ", enterpriseAttestation=" + enterpriseAttestation + ", attestationMode=" + attestationMode + "]";

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/CommonVerifiers.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/CommonVerifiers.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -32,6 +33,7 @@ import io.jans.fido2.model.attestation.AttestationOptions;
 import io.jans.fido2.model.attestation.AttestationResult;
 import io.jans.fido2.model.auth.AuthData;
 import io.jans.fido2.model.auth.CredAndCounterData;
+import io.jans.fido2.model.conf.AppConfiguration;
 import io.jans.fido2.model.conf.RequestedParty;
 import io.jans.fido2.model.error.CommonErrorResponseType;
 import io.jans.fido2.model.error.ErrorResponseFactory;
@@ -72,8 +74,12 @@ public class CommonVerifiers {
     @Inject
     private ErrorResponseFactory errorResponseFactory;
 
+    @Inject
+    private AppConfiguration appConfiguration;
+
     private static final String CHALLENGE = "challenge";
     private static final String CROSS_ORIGIN = "crossOrigin";
+    private static final String TOP_ORIGIN = "topOrigin";
     private static final String INVALID_FIELD = "Invalid field ";
 
     public void verifyRpIdHash(AuthData authData, String domain) {
@@ -382,10 +388,41 @@ public class CommonVerifiers {
         }
 
         if (crossOriginNode.booleanValue()) {
-            log.error("Cross-origin ceremony rejected: crossOrigin is true");
+            verifyTopOrigin(clientJsonNode);
+        }
+    }
+
+    /**
+     * WebAuthn Level 3 expects the RP to take topOrigin into account once crossOrigin is true. The framing
+     * origin is a different question from which origin served the ceremony, so it has its own allow-list
+     * rather than reusing the RP origins - reusing those would silently widen the framing policy of every
+     * existing deployment. The list defaults to empty, which denies every framed ceremony.
+     */
+    private void verifyTopOrigin(JsonNode clientJsonNode) {
+        List<String> allowedTopOrigins = appConfiguration.getFido2Configuration().getAllowedTopOrigins();
+        if ((allowedTopOrigins == null) || allowedTopOrigins.isEmpty()) {
+            log.error("Cross-origin ceremony rejected: crossOrigin is true and no allowedTopOrigins are configured");
             throw errorResponseFactory.badRequestException(CommonErrorResponseType.CROSS_ORIGIN_NOT_ALLOWED,
                     "Cross-origin ceremony is not allowed");
         }
+
+        JsonNode topOriginNode = clientJsonNode.get(TOP_ORIGIN);
+        if ((topOriginNode == null) || !topOriginNode.isTextual() || StringUtils.isBlank(topOriginNode.asText())) {
+            log.error("Cross-origin ceremony rejected: crossOrigin is true but topOrigin is missing or not a string");
+            throw errorResponseFactory.badRequestException(CommonErrorResponseType.CROSS_ORIGIN_NOT_ALLOWED,
+                    "Cross-origin ceremony is missing a usable topOrigin");
+        }
+
+        String topOrigin = topOriginNode.asText().trim();
+        boolean allowed = allowedTopOrigins.stream().filter(Objects::nonNull)
+                .anyMatch(allowedTopOrigin -> allowedTopOrigin.trim().equalsIgnoreCase(topOrigin));
+        if (!allowed) {
+            log.error("Cross-origin ceremony rejected: topOrigin {} is not listed in allowedTopOrigins", topOrigin);
+            throw errorResponseFactory.badRequestException(CommonErrorResponseType.CROSS_ORIGIN_NOT_ALLOWED,
+                    "Cross-origin ceremony is not allowed from this topOrigin");
+        }
+
+        log.debug("Cross-origin ceremony accepted from topOrigin {}", topOrigin);
     }
 
     public JsonNode verifyClientRaw(JsonNode responseNode) {

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/CommonVerifiersTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/verifier/CommonVerifiersTest.java
@@ -14,6 +14,7 @@ import io.jans.fido2.model.assertion.AssertionResult;
 import io.jans.fido2.model.attestation.AttestationOptions;
 import io.jans.fido2.model.auth.AuthData;
 import io.jans.fido2.model.conf.AppConfiguration;
+import io.jans.fido2.model.conf.Fido2Configuration;
 import io.jans.fido2.model.conf.RequestedParty;
 import io.jans.fido2.model.error.CommonErrorResponseType;
 import io.jans.fido2.model.error.ErrorResponseFactory;
@@ -76,9 +77,21 @@ class CommonVerifiersTest {
     @Mock
     private ErrorResponseFactory errorResponseFactory;
 
+    private final Fido2Configuration fido2Configuration = new Fido2Configuration();
+
     @BeforeEach
     void enableDebugLogging() {
         lenient().when(log.isDebugEnabled()).thenReturn(true);
+        lenient().when(appConfiguration.getFido2Configuration()).thenReturn(fido2Configuration);
+    }
+
+    private WebApplicationException stubCrossOriginRejection() {
+        WebApplicationException rejection = new WebApplicationException(
+                Response.status(400).entity("cross origin").build());
+        when(errorResponseFactory.badRequestException(eq(CommonErrorResponseType.CROSS_ORIGIN_NOT_ALLOWED), any()))
+                .thenReturn(rejection);
+
+        return rejection;
     }
 
     @Test
@@ -894,10 +907,81 @@ class CommonVerifiersTest {
     }
 
     @Test
-    void verifyClientJSON_whenCrossOriginTrue_rejected() throws IOException {
+    void verifyClientJSON_whenCrossOriginTrueAndNoTopOriginsConfigured_rejected() throws IOException {
+        // The allow-list defaults to empty, so upgrading keeps the blanket rejection this replaced.
         String encoded = stubClientDataJson(validClientDataNode().put("crossOrigin", true));
-        when(errorResponseFactory.badRequestException(eq(CommonErrorResponseType.CROSS_ORIGIN_NOT_ALLOWED), any()))
-                .thenReturn(new WebApplicationException(Response.status(400).entity("cross origin").build()));
+        stubCrossOriginRejection();
+
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> commonVerifiers.verifyClientJSON(encoded));
+
+        assertEquals(400, ex.getResponse().getStatus());
+    }
+
+    @Test
+    void verifyClientJSON_whenTopOriginIsAllowed_valid() throws IOException {
+        fido2Configuration.setAllowedTopOrigins(List.of("https://portal.example.com"));
+        String encoded = stubClientDataJson(
+                validClientDataNode().put("crossOrigin", true).put("topOrigin", "https://portal.example.com"));
+
+        assertNotNull(commonVerifiers.verifyClientJSON(encoded));
+    }
+
+    @Test
+    void verifyClientJSON_whenTopOriginDiffersOnlyInCaseOrSpacing_valid() throws IOException {
+        fido2Configuration.setAllowedTopOrigins(List.of("  https://Portal.Example.com  "));
+        String encoded = stubClientDataJson(
+                validClientDataNode().put("crossOrigin", true).put("topOrigin", "https://portal.example.com"));
+
+        assertNotNull(commonVerifiers.verifyClientJSON(encoded));
+    }
+
+    @Test
+    void verifyClientJSON_whenTopOriginIsNotListed_rejected() throws IOException {
+        fido2Configuration.setAllowedTopOrigins(List.of("https://portal.example.com"));
+        String encoded = stubClientDataJson(
+                validClientDataNode().put("crossOrigin", true).put("topOrigin", "https://evil.example.com"));
+        stubCrossOriginRejection();
+
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> commonVerifiers.verifyClientJSON(encoded));
+
+        assertEquals(400, ex.getResponse().getStatus());
+    }
+
+    /**
+     * A different scheme is a different origin, so an allow-list entry must not be matched by host alone.
+     */
+    @Test
+    void verifyClientJSON_whenTopOriginSchemeDiffers_rejected() throws IOException {
+        fido2Configuration.setAllowedTopOrigins(List.of("https://portal.example.com"));
+        String encoded = stubClientDataJson(
+                validClientDataNode().put("crossOrigin", true).put("topOrigin", "http://portal.example.com"));
+        stubCrossOriginRejection();
+
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> commonVerifiers.verifyClientJSON(encoded));
+
+        assertEquals(400, ex.getResponse().getStatus());
+    }
+
+    @Test
+    void verifyClientJSON_whenTopOriginIsAbsent_rejected() throws IOException {
+        fido2Configuration.setAllowedTopOrigins(List.of("https://portal.example.com"));
+        String encoded = stubClientDataJson(validClientDataNode().put("crossOrigin", true));
+        stubCrossOriginRejection();
+
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> commonVerifiers.verifyClientJSON(encoded));
+
+        assertEquals(400, ex.getResponse().getStatus());
+    }
+
+    @Test
+    void verifyClientJSON_whenTopOriginIsNotAString_rejected() throws IOException {
+        fido2Configuration.setAllowedTopOrigins(List.of("https://portal.example.com"));
+        String encoded = stubClientDataJson(validClientDataNode().put("crossOrigin", true).put("topOrigin", 7));
+        stubCrossOriginRejection();
 
         WebApplicationException ex = assertThrows(WebApplicationException.class,
                 () -> commonVerifiers.verifyClientJSON(encoded));


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14940

Sub-issue of #14938. Depends on #14939, delivered by #14974 and merged — this is the follow-up that PR
explicitly deferred to.

#### Implementation Details

#14974 made the server read `crossOrigin` and reject every framed ceremony. That is the safe default but not
the end state: `topOrigin` is what makes the cross-origin case *safe* rather than merely *blocked*. WebAuthn
Level 3 expects the RP to take `topOrigin` into account once `crossOrigin` is `true`, and until now a
deployment that legitimately needs a framed passkey ceremony had no option at all.

`CommonVerifiers.verifyCrossOrigin` now delegates to `verifyTopOrigin` when `crossOrigin` is `true` instead
of rejecting unconditionally. The ceremony is rejected with `cross_origin_not_allowed`, each case carrying
its own log line, when:

- `allowedTopOrigins` is empty — the default
- `topOrigin` is absent, `null`, not a string, or blank
- `topOrigin` is not listed

Everything else about the member is unchanged: an absent `crossOrigin` still means `false`, and a
non-boolean or explicitly `null` `crossOrigin` still fails as `invalid_request`. One guard continues to cover
both ceremonies, since `verifyClientJSON` serves attestation and assertion alike.

**No behaviour change on upgrade.** `allowedTopOrigins` defaults to empty, and empty means deny, so a
deployment that upgrades without configuring anything keeps exactly the blanket rejection #14974 introduced.
Framed ceremonies become possible only once an administrator opts in by naming the framing origins.

**A separate list, not the `rp` origins.** This is the alternative #14940 raises and rejects, and the
rejection is right. The `origins` under `rp` say which origin may *serve* a ceremony; `allowedTopOrigins`
says which may *frame* one. Reusing the former would silently widen the framing policy of every existing
deployment the moment this merged — precisely the kind of quiet widening the cross-origin work exists to
prevent.

**A flat property rather than per-`RequestedParty`.** Worth a reviewer's opinion. #14940's wording ("the
RP's configured origin policy") can be read either way. `verifyClientJSON` parses client data and has no RP
context, so scoping the list per RP would mean threading the resolved RP through both ceremonies — a much
larger change than the policy itself. If per-RP scoping is wanted, the structure to hang it on already
exists and it is a clean follow-up.

**Matching.** Comparison is against the whole origin, ignoring case and surrounding whitespace. It is
deliberately *not* host-only like `verifyRpDomain`: a different scheme or port is a different origin, so
`https://portal.example.com` must not be satisfied by `http://portal.example.com`.

`server-fips/` needs no mirroring: the module is `pom.xml` and `target/` only, with no `src/` tree — its
antrun step copies `${server.webapp.dir}` from the `server` module.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

Six cases added to `CommonVerifiersTest`: an allowed `topOrigin`; one differing only in case and surrounding
whitespace; one not on the list; one differing only in scheme; `topOrigin` absent while the list is
configured; and `topOrigin` present but not a string.

One existing test is renamed rather than changed. `verifyClientJSON_whenCrossOriginTrue_rejected` asserted
that `crossOrigin = true` is rejected, which is now true only because no origins are configured — it becomes
`verifyClientJSON_whenCrossOriginTrueAndNoTopOriginsConfigured_rejected`, same assertion, accurate name, and
it is what pins the no-behaviour-change-on-upgrade claim above.

I checked the allow-list comparison is load-bearing rather than incidentally satisfied — short-circuiting it
to always allow fails exactly the unlisted and scheme-mismatch cases and nothing else, and I reverted after
confirming.

```
CommonVerifiersTest         74 tests, 0 failures
jans-fido2 model + server  504 tests, 0 failures
```

`FetchMdsProviderServiceTest` errors on my machine because it makes live calls to `mds3.fido.tools` and local
DNS is down; it is excluded from that count and is unrelated to this change.

Docs: `docs/janssen-server/fido/fido2-server-properties-config.md` gains an `allowedTopOrigins` row, and the
"Cross-origin ceremonies" section is rewritten — it previously stated that no such configuration existed,
which this change makes false. The new text lists each rejection case, the matching rules, and why the
property is separate from `rp.origins`. Carried in a separate `docs:` commit.

`jans-linux-setup/jans_setup/templates/jans-fido2/dynamic-conf.json` is deliberately untouched: it is already
a partial mirror of `Fido2Configuration` (around ten of its properties), and the empty default is the one a
fresh install should have. Happy to add it explicitly if reviewers prefer the installer to surface the knob.

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cross-origin FIDO2 ceremonies can now be permitted using a configurable list of allowed top-level origins.
  * Origins are validated against the configured allow-list, including scheme and formatting requirements.

* **Bug Fixes**
  * Cross-origin ceremonies now return a clear rejection when the top origin is missing, invalid, or not allow-listed.

* **Documentation**
  * Updated FIDO2 configuration guidance to describe allowed top origins and distinguish them from relying-party origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->