### PR TITLE
ci(test-integration): report per-component results to Zulip

### DIFF
--- a/.github/workflows/scripts/summarize_testng.py
+++ b/.github/workflows/scripts/summarize_testng.py
@@ -21,6 +21,7 @@ import fnmatch
 import glob
 import html
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 from collections import Counter
@@ -351,6 +352,17 @@ def render_combined(parent):
                  lambda r: sum(1 for x in r.values() if x["status"] == "PASS"), _print_backend_passes)
 
 
+def _code_span(text):
+    """Wrap text in a Markdown code span, fenced wide enough to survive its own backticks.
+
+    Git allows a backtick in a refname, and a backslash cannot escape one inside a span.
+    """
+    longest = max((len(run) for run in re.findall(r"`+", text)), default=0)
+    fence = "`" * (longest + 1)
+    pad = " " if text.startswith("`") or text.endswith("`") else ""
+    return f"{fence}{pad}{text}{pad}{fence}"
+
+
 def render_zulip(parent, run_url, ref="", author=""):
     """Compact chat message: per-backend totals plus a per-module breakdown with its code owners.
 
@@ -359,7 +371,7 @@ def render_zulip(parent, run_url, ref="", author=""):
     """
     legs = _collect_legs(parent)
     link = f"[run]({run_url})" if run_url else "run"
-    context = " — ".join(x for x in (f"`{ref}`" if ref else "", author and f"by {author}") if x)
+    context = " — ".join(x for x in (_code_span(ref) if ref else "", author and f"by {author}") if x)
 
     if not legs or not any(recs for _, recs, _ in legs):
         print(f"**Integration tests**: no results collected — {link}")

--- a/.github/workflows/scripts/summarize_testng.py
+++ b/.github/workflows/scripts/summarize_testng.py
@@ -15,8 +15,9 @@ Usage:
   summarize_testng.py [--dir DIR]              # per-leg Markdown summary to stdout
   summarize_testng.py [--dir DIR] --gate       # one-line tally; exit 1 on a regression or no results
   summarize_testng.py --combined PARENT        # global view across every PARENT/test-reports-* leg
-  summarize_testng.py --zulip PARENT [--run-url URL]  # compact chat message across every leg
+  summarize_testng.py --zulip PARENT [--run-url URL] [--ref REF] [--author LOGIN]  # chat message
 """
+import fnmatch
 import glob
 import html
 import os
@@ -55,6 +56,32 @@ KNOWN_FAILING_ON_BACKEND = {
     # on the slower PGSQL leg. Baseline on PGSQL only so a MySQL regression stays gate-blocking.
     "io.jans.lock.cedarling.telemetry.CedarlingTelemetryIntegrationTest$TwoRoundTelemetryLifecycle": {"PGSQL"},
 }
+
+
+CODEOWNERS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "CODEOWNERS")
+
+
+def _load_owners(path=CODEOWNERS):
+    """module -> [owner handles], from the top-level directory rules in .github/CODEOWNERS."""
+    owners = {}
+    try:
+        with open(path, encoding="utf-8") as fh:
+            lines = fh.read().splitlines()
+    except OSError:
+        return owners
+    for line in lines:
+        fields = line.split("#", 1)[0].split()
+        if not fields:
+            continue
+        handles = [h for h in fields[1:] if h.startswith("@")]
+        # Directory rules only: a deeper path rule ("/jans-*/version.txt") owns one file, not a module.
+        d = fields[0].strip("/")
+        if not handles or not d or "/" in d:
+            continue
+        for m in MODULES:
+            if fnmatch.fnmatch(m, d):
+                owners[m] = handles  # last matching rule wins, as CODEOWNERS itself resolves
+    return owners
 
 
 def _is_known(cls, backend):
@@ -324,15 +351,23 @@ def render_combined(parent):
                  lambda r: sum(1 for x in r.values() if x["status"] == "PASS"), _print_backend_passes)
 
 
-def render_zulip(parent, run_url):
-    """Compact chat message: one line per backend + a link to the run."""
+def render_zulip(parent, run_url, ref="", author=""):
+    """Compact chat message: per-backend totals plus a per-module breakdown with its code owners.
+
+    The module lines mirror the step summary so a reader sees their own component's failures in the
+    chat notification instead of having to open the run.
+    """
     legs = _collect_legs(parent)
     link = f"[run]({run_url})" if run_url else "run"
+    context = " — ".join(x for x in (f"`{ref}`" if ref else "", author and f"by {author}") if x)
 
     if not legs or not any(recs for _, recs, _ in legs):
         print(f"**Integration tests**: no results collected — {link}")
+        if context:
+            print(context)
         return
 
+    owners = _load_owners()
     lines, any_reg = [], False
     for backend, recs, raw in legs:
         if not recs:
@@ -342,8 +377,15 @@ def render_zulip(parent, run_url):
         any_reg = any_reg or bool(s["regressions"])
         lines.append(f"- **{backend}**: {s['total']} tests, {s['failed']} failed "
                      f"({s['regressions']} regression(s), {s['known']} known-baseline)")
+        for mod, mtotal, mfail in _module_rows(recs):
+            who = " ".join(owners.get(mod, ()))
+            mark = ":cross_mark: " if mfail else ""
+            lines.append(f"  - {mark}{mod} (total: {mtotal}, failed: {mfail})"
+                         + (f" — {who}" if who else ""))
     status = ":cross_mark: regressions" if any_reg else ":check: no regressions"
     print(f"**Integration tests** — {status} — {link}")
+    if context:
+        print(context)
     print("\n".join(lines))
 
 
@@ -353,7 +395,8 @@ def main():
         return
 
     if "--zulip" in sys.argv:
-        render_zulip(_arg("--zulip", "."), _arg("--run-url", ""))
+        render_zulip(_arg("--zulip", "."), _arg("--run-url", ""),
+                     _arg("--ref", ""), _arg("--author", ""))
         return
 
     reports_dir = _arg("--dir", "test-reports")

--- a/.github/workflows/scripts/summarize_testng.py
+++ b/.github/workflows/scripts/summarize_testng.py
@@ -63,7 +63,11 @@ CODEOWNERS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."
 
 
 def _load_owners(path=CODEOWNERS):
-    """module -> [owner handles], from the top-level directory rules in .github/CODEOWNERS."""
+    """module -> [owner handles] from .github/CODEOWNERS.
+
+    Only top-level directory rules count: a deeper path rule ("/jans-*/version.txt") owns one file,
+    not the module. Later rules overwrite earlier ones, as CODEOWNERS itself resolves.
+    """
     owners = {}
     try:
         with open(path, encoding="utf-8") as fh:
@@ -75,13 +79,12 @@ def _load_owners(path=CODEOWNERS):
         if not fields:
             continue
         handles = [h for h in fields[1:] if h.startswith("@")]
-        # Directory rules only: a deeper path rule ("/jans-*/version.txt") owns one file, not a module.
         d = fields[0].strip("/")
         if not handles or not d or "/" in d:
             continue
         for m in MODULES:
             if fnmatch.fnmatch(m, d):
-                owners[m] = handles  # last matching rule wins, as CODEOWNERS itself resolves
+                owners[m] = handles
     return owners
 
 

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -541,6 +541,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Branch under test + who to ask about it: the PR's head branch/author on a PR, the
+          # pushed/dispatched ref and the triggering actor otherwise.
+          REF_NAME: ${{ github.head_ref || github.ref_name }}
+          AUTHOR: ${{ github.event.pull_request.user.login && format('@{0}', github.event.pull_request.user.login) || format('@{0}', github.actor) }}
           JOBS_URL: ${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs
           BASE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -555,6 +559,7 @@ jobs:
           {
             echo 'content<<ZULIP_EOF'
             python3 .github/workflows/scripts/summarize_testng.py --zulip aggregated --run-url "$RUN_URL" \
+              --ref "$REF_NAME" --author "$AUTHOR" \
               || echo "**Integration tests**: could not build summary — $RUN_URL"
             [ -n "$links_zulip" ] && { echo ""; echo "$links_zulip"; }
             echo 'ZULIP_EOF'


### PR DESCRIPTION
Zulip integration-test report now includes a per-module breakdown, so each
owner sees their own component's failures in chat instead of opening the run.

- per-module `(total, failed)` lines under each backend, failing ones marked
- code owners appended per module, parsed from `.github/CODEOWNERS`
- branch name + PR author (or triggering actor) in the header

```
**Integration tests** — :cross_mark: regressions — [run](...)
`feature/foo` — by @moabu
- **MYSQL**: 4751 tests, 28 failed (1 regression(s), 27 known-baseline)
  - agama (total: 6, failed: 0) — @jgomer2001
  - :cross_mark: jans-scim (total: 122, failed: 13) — @jgomer2001
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zulip test summaries now include the branch and triggering contributor.
  * Added per-module result totals and failure details alongside overall results.
  * Failed modules are clearly marked and include their responsible code owners.

* **Improvements**
  * Test result notifications provide clearer context, making failures easier to identify and route for follow-up.
  * Branch names are formatted consistently for improved readability in notifications.
  * Notifications remain informative when no test results are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->