### PR TITLE
feat(jans-fido2): add ML-DSA-44, ML-DSA-65 and ML-DSA-87 post-quantum algorithms

### DIFF
--- a/docs/janssen-server/fido/fido2-server-properties-config.md
+++ b/docs/janssen-server/fido/fido2-server-properties-config.md
@@ -50,7 +50,7 @@ This nested block defines WebAuthn and FIDO2 attestation and assertion policy be
 | `unfinishedRequestExpiration` | Integer | `120` | Expiration time in seconds for incomplete registration/authentication requests. |
 | `metadataRefreshInterval` | Integer | `1296000` | Expiration time in seconds (e.g., 15 days) before checking and reloading the FIDO Alliance MDS TOC. |
 | <span id="servermetadatafolder">`serverMetadataFolder`</span> | String | `"/etc/jans/conf/fido2/server_metadata"` | Folder where local vendor metadata statement JSON files are placed manually. |
-| `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS384`, `RS512`, `RS65535`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, `EdDSA` — the algorithms the server can both advertise and complete a registration with. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. A recognised name the deployment cannot actually complete a registration with is logged at `ERROR` and left out of `pubKeyCredParams` — see [Advertised algorithms](#advertised-algorithms). |
+| `enabledFidoAlgorithms` | Array of Strings | `["RS256", "ES256"]` | Enabled cryptographic signing algorithms allowed for credentials. Accepted names: `RS256`, `RS384`, `RS512`, `RS65535`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, `EdDSA`, `ML-DSA-44`, `ML-DSA-65`, `ML-DSA-87` — the algorithms the server can both advertise and complete a registration with. When unset, the server advertises `RS256`, `ES256` and `EdDSA`. An unrecognised name is ignored. A recognised name the deployment cannot actually complete a registration with is logged at `ERROR` and left out of `pubKeyCredParams` — see [Advertised algorithms](#advertised-algorithms). |
 | `rp` | Array of Objects | `[ { "id": "https://jans.io", "origins": ["jans.io"] } ]` | Relying Party (RP) configuration mapping expected IDs to valid origins. |
 | `metadataServers` | Array of Objects | `[ { "url": "https://mds.fidoalliance.org/" } ]` | External FIDO Metadata Service endpoints to download statement catalogs. |
 | `disableMetadataService` | Boolean | `false` | If set to `true`, the FIDO2 server skips validating authenticators against the MDS3 service. |
@@ -76,6 +76,19 @@ than offering an algorithm and then failing the ceremony once the authenticator 
 If no configured algorithm survives the check, the server logs an error and falls back to whichever of the
 defaults it does support. In a deployment that supports none of them that fallback is itself empty, and
 `pubKeyCredParams` is sent empty — a state worth alerting on, since the log will already carry the reason.
+
+### Post-quantum algorithms (ML-DSA)
+
+`ML-DSA-44`, `ML-DSA-65` and `ML-DSA-87` are supported on the standard build. They are **not** available on
+the FIPS build, because no released `bc-fips` provider implements them yet.
+
+This needs no special handling from an administrator. Because the advertised set is derived from real
+provider capability (see [Advertised algorithms](#advertised-algorithms)), a FIPS deployment that lists an
+ML-DSA name simply logs it at `ERROR` and leaves it out of `pubKeyCredParams` — it never offers an
+algorithm it would then fail to verify. The same configuration is therefore safe to share between the two
+build variants.
+
+Both the IANA spelling (`ML-DSA-44`) and the underscore form (`ML_DSA_44`) are accepted.
 
 ### Cross-origin ceremonies
 

--- a/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseKeyType.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseKeyType.java
@@ -13,7 +13,8 @@ public enum CoseKeyType {
 
     OKP(1), // https://tools.ietf.org/html/rfc8152#section-13
     EC2(2), // https://tools.ietf.org/html/rfc8152#section-13
-    RSA(3); // https://tools.ietf.org/html/rfc8230#section-4
+    RSA(3), // https://tools.ietf.org/html/rfc8230#section-4
+    AKP(7); // Algorithm Key Pair, used by ML-DSA - IANA COSE Key Types registry
 
     private static final Map<Integer, CoseKeyType> KEY_MAPPINGS = new HashMap<>();
 
@@ -21,6 +22,7 @@ public enum CoseKeyType {
         KEY_MAPPINGS.put(1, OKP);
         KEY_MAPPINGS.put(2, EC2);
         KEY_MAPPINGS.put(3, RSA);
+        KEY_MAPPINGS.put(7, AKP);
     }
 
     private final int numericValue;

--- a/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseMLDSAAlgorithm.java
+++ b/jans-fido2/model/src/main/java/io/jans/fido2/ctap/CoseMLDSAAlgorithm.java
@@ -1,0 +1,66 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.ctap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The ML-DSA post-quantum signature algorithms from the FIDO Server Requirements v2.3 table. Code points
+ * are the IANA COSE Algorithms registry values; the provider names are the JCA spellings, which carry the
+ * hyphens a Java identifier cannot.
+ */
+public enum CoseMLDSAAlgorithm {
+
+    ML_DSA_44(-48, "ML-DSA-44"),
+    ML_DSA_65(-49, "ML-DSA-65"),
+    ML_DSA_87(-50, "ML-DSA-87");
+
+    private static final Map<Integer, CoseMLDSAAlgorithm> ALGORITHM_MAPPINGS = new HashMap<>();
+
+    static {
+        for (CoseMLDSAAlgorithm enumType : values()) {
+            ALGORITHM_MAPPINGS.put(enumType.getNumericValue(), enumType);
+        }
+    }
+
+    private final int numericValue;
+    private final String algorithmName;
+
+    CoseMLDSAAlgorithm(int value, String algorithmName) {
+        this.numericValue = value;
+        this.algorithmName = algorithmName;
+    }
+
+    public static CoseMLDSAAlgorithm fromNumericValue(int value) {
+        return ALGORITHM_MAPPINGS.get(value);
+    }
+
+    /**
+     * Resolves a configured name, accepting both the IANA spelling ({@code ML-DSA-44}) and the constant
+     * spelling ({@code ML_DSA_44}), since the registry name is the one an administrator will reach for.
+     */
+    public static CoseMLDSAAlgorithm fromName(String name) {
+        if (name == null) {
+            return null;
+        }
+        try {
+            return valueOf(name.trim().replace('-', '_').toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    public int getNumericValue() {
+        return numericValue;
+    }
+
+    /** The JCA name to request from the crypto provider. */
+    public String getAlgorithmName() {
+        return algorithmName;
+    }
+}

--- a/jans-fido2/model/src/test/java/io/jans/fido2/ctap/CoseAlgorithmRegistryTest.java
+++ b/jans-fido2/model/src/test/java/io/jans/fido2/ctap/CoseAlgorithmRegistryTest.java
@@ -57,6 +57,14 @@ class CoseAlgorithmRegistryTest {
         assertEquals(-8, CoseEdDSAAlgorithm.EdDSA.getNumericValue());
     }
 
+    @Test
+    void mlDsaAlgorithms_matchTheIanaRegistry() {
+        assertEquals(3, CoseMLDSAAlgorithm.values().length, "unexpected ML-DSA constant added or removed");
+        assertEquals(-48, CoseMLDSAAlgorithm.ML_DSA_44.getNumericValue());
+        assertEquals(-49, CoseMLDSAAlgorithm.ML_DSA_65.getNumericValue());
+        assertEquals(-50, CoseMLDSAAlgorithm.ML_DSA_87.getNumericValue());
+    }
+
     /**
      * -260, -261 and -262 are WalnutDSA, TurboSHAKE128 and TurboSHAKE256 in the registry. They were held by
      * ED256, ED512 and RS1 respectively; RS1's real value is -65535, already covered by RS65535.

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
@@ -36,7 +36,9 @@ import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -47,6 +49,7 @@ import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import io.jans.fido2.ctap.CoseEC2Algorithm;
 import io.jans.fido2.ctap.CoseEdDSAAlgorithm;
+import io.jans.fido2.ctap.CoseMLDSAAlgorithm;
 import io.jans.fido2.ctap.CoseKeyType;
 import io.jans.fido2.ctap.CoseRSAAlgorithm;
 import io.jans.fido2.exception.Fido2RuntimeException;
@@ -91,6 +94,31 @@ public class CoseService {
 
     private static final Set<CoseEC2Algorithm> DECODABLE_EC2_ALGORITHMS = EnumSet.of(CoseEC2Algorithm.ES256,
             CoseEC2Algorithm.ES384, CoseEC2Algorithm.ES512);
+
+    // DER prefixes of a SubjectPublicKeyInfo wrapping a raw ML-DSA key, one per parameter set. The OIDs
+    // are 2.16.840.1.101.3.4.3.17/18/19; each prefix was read off a provider-generated key rather than
+    // hand-assembled, since the length fields differ per parameter set.
+    private static final Map<CoseMLDSAAlgorithm, byte[]> MLDSA_SPKI_PREFIXES = new EnumMap<>(
+            CoseMLDSAAlgorithm.class);
+
+    private static final Map<CoseMLDSAAlgorithm, Integer> MLDSA_RAW_KEY_LENGTHS = new EnumMap<>(
+            CoseMLDSAAlgorithm.class);
+
+    static {
+        MLDSA_SPKI_PREFIXES.put(CoseMLDSAAlgorithm.ML_DSA_44,
+                new byte[] { 0x30, (byte) 0x82, 0x05, 0x32, 0x30, 0x0b, 0x06, 0x09, 0x60, (byte) 0x86, 0x48, 0x01,
+                        0x65, 0x03, 0x04, 0x03, 0x11, 0x03, (byte) 0x82, 0x05, 0x21, 0x00 });
+        MLDSA_SPKI_PREFIXES.put(CoseMLDSAAlgorithm.ML_DSA_65,
+                new byte[] { 0x30, (byte) 0x82, 0x07, (byte) 0xb2, 0x30, 0x0b, 0x06, 0x09, 0x60, (byte) 0x86, 0x48,
+                        0x01, 0x65, 0x03, 0x04, 0x03, 0x12, 0x03, (byte) 0x82, 0x07, (byte) 0xa1, 0x00 });
+        MLDSA_SPKI_PREFIXES.put(CoseMLDSAAlgorithm.ML_DSA_87,
+                new byte[] { 0x30, (byte) 0x82, 0x0a, 0x32, 0x30, 0x0b, 0x06, 0x09, 0x60, (byte) 0x86, 0x48, 0x01,
+                        0x65, 0x03, 0x04, 0x03, 0x13, 0x03, (byte) 0x82, 0x0a, 0x21, 0x00 });
+
+        MLDSA_RAW_KEY_LENGTHS.put(CoseMLDSAAlgorithm.ML_DSA_44, 1312);
+        MLDSA_RAW_KEY_LENGTHS.put(CoseMLDSAAlgorithm.ML_DSA_65, 1952);
+        MLDSA_RAW_KEY_LENGTHS.put(CoseMLDSAAlgorithm.ML_DSA_87, 2592);
+    }
 
     // DER prefix of a SubjectPublicKeyInfo wrapping a 32-byte Ed25519 key (RFC 8410, OID 1.3.101.112)
     private static final byte[] ED25519_SPKI_PREFIX = new byte[] { 0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65,
@@ -138,7 +166,11 @@ public class CoseService {
             return DECODABLE_EC2_ALGORITHMS.contains(coseEC2Algorithm);
         }
 
-        return CoseEdDSAAlgorithm.fromNumericValue(algorithm) != null;
+        if (CoseEdDSAAlgorithm.fromNumericValue(algorithm) != null) {
+            return true;
+        }
+
+        return CoseMLDSAAlgorithm.fromNumericValue(algorithm) != null;
     }
 
     public PublicKey createUncompressedPointFromCOSEPublicKey(JsonNode uncompressedECPointNode) {
@@ -199,8 +231,50 @@ public class CoseService {
             byte[] rawKey = base64Service.decode(rawKeyNode.asText());
             return convertRawKeyToEdDSAKey(curve, rawKey);
         }
+        case AKP: {
+            CoseMLDSAAlgorithm coseMLDSAAlgorithm = CoseMLDSAAlgorithm.fromNumericValue(algorithmToUse);
+            if (coseMLDSAAlgorithm == null) {
+                throw new Fido2RuntimeException(
+                        "Don't know what to do with this key " + keyType + " and algorithm " + algorithmToUse);
+            }
+            // AKP carries the whole public key in one parameter, so there is nothing to reassemble - the
+            // label is "pub" (-1) rather than the coordinate pairs the EC2 and OKP branches read.
+            JsonNode publicKeyNode = uncompressedECPointNode.get("-1");
+            if (publicKeyNode == null) {
+                throw new Fido2RuntimeException("Missing AKP public key label -1");
+            }
+
+            return convertRawKeyToMLDSAKey(coseMLDSAAlgorithm, base64Service.decode(publicKeyNode.asText()));
+        }
         default:
             throw new Fido2RuntimeException("Don't know what to do with this key" + keyType);
+        }
+    }
+
+    /**
+     * Rebuilds an ML-DSA public key from the raw COSE AKP parameter, by wrapping it in the
+     * SubjectPublicKeyInfo structure {@link KeyFactory} expects. The key is produced with the same provider
+     * SignatureVerifier uses, so a deployment whose provider lacks ML-DSA fails here rather than later - and
+     * because the advertised set is derived from that same capability, such a deployment never offers it.
+     */
+    public PublicKey convertRawKeyToMLDSAKey(CoseMLDSAAlgorithm algorithm, byte[] rawKey) {
+        int expectedLength = MLDSA_RAW_KEY_LENGTHS.get(algorithm);
+        if ((rawKey == null) || (rawKey.length != expectedLength)) {
+            throw new Fido2RuntimeException("Invalid " + algorithm.getAlgorithmName() + " public key length "
+                    + ((rawKey == null) ? 0 : rawKey.length));
+        }
+
+        byte[] spkiPrefix = MLDSA_SPKI_PREFIXES.get(algorithm);
+        byte[] encodedKey = ByteBuffer.allocate(spkiPrefix.length + rawKey.length).put(spkiPrefix).put(rawKey)
+                .array();
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(algorithm.getAlgorithmName(),
+                    SecurityProviderUtility.getBCProvider());
+
+            return keyFactory.generatePublic(new X509EncodedKeySpec(encodedKey));
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            log.error("Failed to build {} public key ", algorithm.getAlgorithmName(), e);
+            throw new Fido2RuntimeException(e.getMessage());
         }
     }
 

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/CoseService.java
@@ -197,7 +197,33 @@ public class CoseService {
             return true;
         }
 
-        return CoseMLDSAAlgorithm.fromNumericValue(algorithm) != null;
+        CoseMLDSAAlgorithm coseMLDSAAlgorithm = CoseMLDSAAlgorithm.fromNumericValue(algorithm);
+        if (coseMLDSAAlgorithm != null) {
+            return providerCanBuildKey(coseMLDSAAlgorithm.getAlgorithmName());
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the running provider can build a key for this algorithm. Knowing the code point is not the
+     * same as being able to decode it: ML-DSA is absent from the FIPS provider entirely, so the answer has
+     * to come from the provider rather than from the fact that the constant exists. The RSA, EC2 and OKP
+     * families are answered from their sets instead, because every primitive they need is present in both
+     * providers this project ships.
+     */
+    // Package-private so the provider lookup can be tested directly. Asserting it through isDecodable is
+    // vacuous wherever the provider happens to support ML-DSA, which is every environment the suite runs in.
+    boolean providerCanBuildKey(String algorithmName) {
+        try {
+            KeyFactory.getInstance(algorithmName, SecurityProviderUtility.getBCProvider());
+
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            log.debug("Provider cannot build {} keys, so it will not be advertised", algorithmName);
+
+            return false;
+        }
     }
 
     public PublicKey createUncompressedPointFromCOSEPublicKey(JsonNode uncompressedECPointNode) {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/operation/AttestationService.java
@@ -14,6 +14,7 @@ import io.jans.fido2.ctap.AuthenticatorAttachment;
 import io.jans.fido2.ctap.CoseEC2Algorithm;
 import io.jans.fido2.ctap.CoseRSAAlgorithm;
 import io.jans.fido2.ctap.CoseEdDSAAlgorithm;
+import io.jans.fido2.ctap.CoseMLDSAAlgorithm;
 import io.jans.fido2.model.attestation.*;
 import io.jans.fido2.model.auth.CredAndCounterData;
 import io.jans.fido2.model.common.*;
@@ -519,6 +520,7 @@ public class AttestationService {
 			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveRsaNumericValue);
 			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveEc2NumericValue);
 			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveEdDsaNumericValue);
+			addFirstSupportedAlgorithm(credentialParametersSets, enabledFidoAlgorithms, AttestationService::resolveMlDsaNumericValue);
 
 			if (credentialParametersSets.isEmpty()) {
 				// Advertising nothing lets the client fall back to its own defaults, which is a worse
@@ -600,6 +602,12 @@ public class AttestationService {
 		} catch (IllegalArgumentException ex) {
 			return null;
 		}
+	}
+
+	private static Integer resolveMlDsaNumericValue(String enabledFidoAlgorithm) {
+		CoseMLDSAAlgorithm algorithm = CoseMLDSAAlgorithm.fromName(enabledFidoAlgorithm);
+
+		return (algorithm == null) ? null : algorithm.getNumericValue();
 	}
 
 	private static Integer resolveEdDsaNumericValue(String enabledFidoAlgorithm) {

--- a/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/SignatureVerifier.java
+++ b/jans-fido2/server/src/main/java/io/jans/fido2/service/verifier/SignatureVerifier.java
@@ -18,6 +18,7 @@ import java.security.cert.Certificate;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 
+import io.jans.fido2.ctap.CoseMLDSAAlgorithm;
 import io.jans.fido2.model.attestation.AttestationErrorResponseType;
 import io.jans.fido2.model.error.ErrorResponseFactory;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -113,6 +114,14 @@ public class SignatureVerifier {
                     Signature signatureChecker = Signature.getInstance("SHA512withRSA/PSS", provider);
                     signatureChecker.setParameter(new PSSParameterSpec("SHA-512", "MGF1", new MGF1ParameterSpec("SHA-512"), 64, 1));
                     return signatureChecker;
+                }
+                // ML-DSA is post-quantum and only the standard provider implements it. On the FIPS build
+                // this throws, isSupported reports false, and the algorithm is simply never advertised.
+                case -48:
+                case -49:
+                case -50: {
+                    return Signature.getInstance(
+                            CoseMLDSAAlgorithm.fromNumericValue(signatureAlgorithm).getAlgorithmName(), provider);
                 }
                 case -257: {
                     return Signature.getInstance("SHA256withRSA", provider);

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/CoseServiceMLDSATest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/CoseServiceMLDSATest.java
@@ -1,0 +1,179 @@
+/*
+ * Janssen Project software is available under the Apache License (2004). See http://www.apache.org/licenses/ for full text.
+ *
+ * Copyright (c) 2026, Janssen Project
+ */
+
+package io.jans.fido2.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.jans.fido2.ctap.CoseMLDSAAlgorithm;
+import io.jans.fido2.exception.Fido2RuntimeException;
+import io.jans.fido2.service.verifier.SignatureVerifier;
+import io.jans.util.security.SecurityProviderUtility;
+
+/**
+ * ML-DSA is the post-quantum family from the FIDO Server Requirements v2.3 table. Its COSE key type is AKP,
+ * which carries the whole public key in one parameter rather than the coordinate pairs EC2 and OKP use, so
+ * the decode path is genuinely new rather than a widened list.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CoseServiceMLDSATest {
+
+    private static final int COSE_KTY_AKP = 7;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Mock
+    private Logger log;
+
+    @Spy
+    private Base64Service base64Service = initializedBase64Service();
+
+    @InjectMocks
+    private CoseService coseService;
+
+    @InjectMocks
+    private SignatureVerifier signatureVerifier;
+
+    @BeforeAll
+    static void beforeAll() {
+        SecurityProviderUtility.installBCProvider();
+    }
+
+    private static Base64Service initializedBase64Service() {
+        Base64Service base64Service = new Base64Service();
+        base64Service.init();
+
+        return base64Service;
+    }
+
+    private static KeyPair generateKeyPair(String algorithmName) throws Exception {
+        return KeyPairGenerator.getInstance(algorithmName, SecurityProviderUtility.getBCProvider())
+                .generateKeyPair();
+    }
+
+    /** The COSE "pub" parameter is the raw key, which is the tail of the SubjectPublicKeyInfo encoding. */
+    private static byte[] rawKeyOf(PublicKey publicKey, int rawKeyLength) {
+        byte[] encoded = publicKey.getEncoded();
+
+        return Arrays.copyOfRange(encoded, encoded.length - rawKeyLength, encoded.length);
+    }
+
+    private ObjectNode coseKey(int algorithm, byte[] rawKey) {
+        ObjectNode coseKeyNode = mapper.createObjectNode();
+        coseKeyNode.put("1", COSE_KTY_AKP);
+        coseKeyNode.put("3", algorithm);
+        coseKeyNode.put("-1", rawKey);
+
+        return coseKeyNode;
+    }
+
+    @ParameterizedTest(name = "COSE {0} is {1} with a {2}-byte key")
+    @CsvSource({ "-48, ML-DSA-44, 1312", "-49, ML-DSA-65, 1952", "-50, ML-DSA-87, 2592" })
+    void credential_decodesAndVerifiesItsOwnSignature(int codePoint, String algorithmName, int rawKeyLength)
+            throws Exception {
+        KeyPair keyPair = generateKeyPair(algorithmName);
+        ObjectNode coseKeyNode = coseKey(codePoint, rawKeyOf(keyPair.getPublic(), rawKeyLength));
+
+        // Registration: the credential public key has to come back out of the COSE structure intact.
+        PublicKey decoded = coseService.createUncompressedPointFromCOSEPublicKey(coseKeyNode);
+        assertArrayEquals(keyPair.getPublic().getEncoded(), decoded.getEncoded());
+
+        // Assertion: a signature the authenticator would produce has to verify against that key.
+        byte[] signatureBase = "authenticatorData||clientDataHash".getBytes(StandardCharsets.UTF_8);
+        Signature signer = Signature.getInstance(algorithmName, SecurityProviderUtility.getBCProvider());
+        signer.initSign(keyPair.getPrivate());
+        signer.update(signatureBase);
+
+        signatureVerifier.verifySignature(signer.sign(), signatureBase, decoded, codePoint);
+    }
+
+    @ParameterizedTest(name = "COSE {0} rejects a key of the wrong length")
+    @CsvSource({ "-48, ML-DSA-44", "-49, ML-DSA-65", "-50, ML-DSA-87" })
+    void credential_withWrongKeyLength_isRejected(int codePoint, String algorithmName) {
+        ObjectNode coseKeyNode = coseKey(codePoint, new byte[64]);
+
+        Fido2RuntimeException ex = assertThrows(Fido2RuntimeException.class,
+                () -> coseService.createUncompressedPointFromCOSEPublicKey(coseKeyNode));
+
+        assertTrue(ex.getMessage().contains("Invalid " + algorithmName + " public key length"), ex.getMessage());
+    }
+
+    /**
+     * Each parameter set has its own key length, so a key valid for one must not be accepted under another.
+     * The SubjectPublicKeyInfo prefixes carry distinct OIDs and length fields, and this is what catches a
+     * prefix pasted against the wrong parameter set.
+     */
+    @Test
+    void credential_withAKeyFromAnotherParameterSet_isRejected() throws Exception {
+        byte[] ml65Key = rawKeyOf(generateKeyPair("ML-DSA-65").getPublic(), 1952);
+        ObjectNode coseKeyNode = coseKey(CoseMLDSAAlgorithm.ML_DSA_44.getNumericValue(), ml65Key);
+
+        Fido2RuntimeException ex = assertThrows(Fido2RuntimeException.class,
+                () -> coseService.createUncompressedPointFromCOSEPublicKey(coseKeyNode));
+
+        assertTrue(ex.getMessage().contains("Invalid ML-DSA-44 public key length"), ex.getMessage());
+    }
+
+    @Test
+    void credential_withoutThePublicKeyLabel_isRejected() {
+        ObjectNode coseKeyNode = coseKey(CoseMLDSAAlgorithm.ML_DSA_44.getNumericValue(), new byte[1312]);
+        coseKeyNode.remove("-1");
+
+        Fido2RuntimeException ex = assertThrows(Fido2RuntimeException.class,
+                () -> coseService.createUncompressedPointFromCOSEPublicKey(coseKeyNode));
+
+        assertTrue(ex.getMessage().contains("Missing AKP public key label -1"), ex.getMessage());
+    }
+
+    /**
+     * This is the safety property that lets ML-DSA ship standard-only. The advertised set is derived from
+     * decoder and verifier capability, and the verifier asks the running provider, so a deployment whose
+     * provider lacks ML-DSA reports it unsupported and never offers it. Were this to report support without
+     * the provider having it, a FIPS deployment would advertise ML-DSA and then fail the ceremony.
+     */
+    @ParameterizedTest(name = "COSE {0} capability matches the running provider")
+    @CsvSource({ "-48, ML-DSA-44", "-49, ML-DSA-65", "-50, ML-DSA-87" })
+    void advertisedCapability_followsTheRunningProvider(int codePoint, String algorithmName) {
+        boolean providerHasIt;
+        try {
+            Signature.getInstance(algorithmName, SecurityProviderUtility.getBCProvider());
+            providerHasIt = true;
+        } catch (Exception e) {
+            providerHasIt = false;
+        }
+
+        assertEquals(providerHasIt, signatureVerifier.isSupported(codePoint),
+                algorithmName + ": advertised capability disagrees with the provider");
+        assertTrue(coseService.isDecodable(codePoint), algorithmName + " should be decodable");
+    }
+}

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/CoseServiceMLDSATest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/CoseServiceMLDSATest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
@@ -161,6 +162,18 @@ class CoseServiceMLDSATest {
      * provider lacks ML-DSA reports it unsupported and never offers it. Were this to report support without
      * the provider having it, a FIPS deployment would advertise ML-DSA and then fail the ceremony.
      */
+    /**
+     * The decode half of the capability check has to ask the provider, not the constant. This is the part
+     * that cannot be observed through {@code isDecodable} in a build whose provider has ML-DSA, so it is
+     * asserted directly: a name the provider does not implement must come back false.
+     */
+    @Test
+    void providerCanBuildKey_isAnsweredByTheProviderNotTheConstant() {
+        assertTrue(coseService.providerCanBuildKey("ML-DSA-44"), "the standard provider implements ML-DSA-44");
+        assertTrue(!coseService.providerCanBuildKey("ML-DSA-9999"),
+                "an algorithm the provider does not implement must not be reported as decodable");
+    }
+
     @ParameterizedTest(name = "COSE {0} capability matches the running provider")
     @CsvSource({ "-48, ML-DSA-44", "-49, ML-DSA-65", "-50, ML-DSA-87" })
     void advertisedCapability_followsTheRunningProvider(int codePoint, String algorithmName) {
@@ -172,8 +185,19 @@ class CoseServiceMLDSATest {
             providerHasIt = false;
         }
 
+        boolean providerCanBuildKey;
+        try {
+            KeyFactory.getInstance(algorithmName, SecurityProviderUtility.getBCProvider());
+            providerCanBuildKey = true;
+        } catch (Exception e) {
+            providerCanBuildKey = false;
+        }
+
         assertEquals(providerHasIt, signatureVerifier.isSupported(codePoint),
-                algorithmName + ": advertised capability disagrees with the provider");
-        assertTrue(coseService.isDecodable(codePoint), algorithmName + " should be decodable");
+                algorithmName + ": signature capability disagrees with the provider");
+        // Both halves have to be provider-derived. Reporting a key we cannot build would advertise the
+        // algorithm on the strength of the constant existing, and fail once a credential arrived.
+        assertEquals(providerCanBuildKey, coseService.isDecodable(codePoint),
+                algorithmName + ": decode capability disagrees with the provider");
     }
 }

--- a/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AttestationServiceAlgorithmSelectionTest.java
+++ b/jans-fido2/server/src/test/java/io/jans/fido2/service/operation/AttestationServiceAlgorithmSelectionTest.java
@@ -21,6 +21,8 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 
 import io.jans.fido2.ctap.CoseEC2Algorithm;
 import io.jans.fido2.ctap.CoseEdDSAAlgorithm;
+import io.jans.fido2.ctap.CoseMLDSAAlgorithm;
 import io.jans.fido2.ctap.CoseRSAAlgorithm;
 import io.jans.fido2.model.common.PublicKeyCredentialParameters;
 import io.jans.fido2.model.conf.AppConfiguration;
@@ -126,6 +129,55 @@ class AttestationServiceAlgorithmSelectionTest {
         // an empty configured result does not silently become an empty pubKeyCredParams.
         assertTrue(advertisedAlgorithms().isEmpty());
         verify(log).error(contains("None of the configured enabledFidoAlgorithms"), any(Object.class));
+    }
+
+    /**
+     * ML-DSA ships on the standard build only, so the standard-only decision rests on this: an ML-DSA name
+     * reaches pubKeyCredParams when the running provider can honour it, and is dropped when it cannot.
+     */
+    @ParameterizedTest(name = "{0} is advertised when the provider supports it")
+    @CsvSource({ "ML-DSA-44, -48", "ML-DSA-65, -49", "ML-DSA-87, -50" })
+    void whenProviderSupportsMlDsa_itIsAdvertised(String configuredName, int codePoint) {
+        fido2Configuration.setEnabledFidoAlgorithms(List.of(configuredName));
+
+        assertEquals(Set.of(codePoint), advertisedAlgorithms());
+    }
+
+    /** The underscore spelling has to resolve too, since it is what a Java-shaped config would carry. */
+    @Test
+    void whenMlDsaIsConfiguredWithUnderscores_itIsAdvertised() {
+        fido2Configuration.setEnabledFidoAlgorithms(List.of("ML_DSA_65"));
+
+        assertEquals(Set.of(CoseMLDSAAlgorithm.ML_DSA_65.getNumericValue()), advertisedAlgorithms());
+    }
+
+    /**
+     * The FIPS build's provider has no ML-DSA, so isSupported reports false and the algorithm must not be
+     * offered. Advertising it there would fail the ceremony after the authenticator picked it - the
+     * advertise-then-fail shape this tree exists to remove.
+     */
+    @ParameterizedTest(name = "{0} is not advertised when the provider lacks it")
+    @CsvSource({ "ML-DSA-44, -48", "ML-DSA-65, -49", "ML-DSA-87, -50" })
+    void whenProviderLacksMlDsa_itIsNotAdvertised(String configuredName, int codePoint) {
+        fido2Configuration.setEnabledFidoAlgorithms(List.of(configuredName));
+        when(signatureVerifier.isSupported(codePoint)).thenReturn(false);
+
+        Set<Integer> advertised = advertisedAlgorithms();
+
+        assertTrue(!advertised.contains(codePoint), configuredName + " must not be advertised without provider support");
+        verify(log).error(contains("not supported by this server"), any(Object.class));
+    }
+
+    /**
+     * A FIPS deployment can share a configuration with a standard one: the algorithms its provider does
+     * support still come through, and only ML-DSA drops out.
+     */
+    @Test
+    void whenProviderLacksMlDsa_theRestOfTheConfigurationStillApplies() {
+        fido2Configuration.setEnabledFidoAlgorithms(List.of("ES256", "ML-DSA-65"));
+        when(signatureVerifier.isSupported(CoseMLDSAAlgorithm.ML_DSA_65.getNumericValue())).thenReturn(false);
+
+        assertEquals(Set.of(CoseEC2Algorithm.ES256.getNumericValue()), advertisedAlgorithms());
     }
 
     @Test


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue

closes #14937

Sub-issue of #14926, under #14891. This is the last unblocked item in the v2.3 algorithm tree.

#### Implementation Details

**Why this is unblocked now.** The #14935 spike recommended deferring ML-DSA, and recorded exactly one
condition that would change the answer: land #14933 first. That merged as [#15031](https://github.com/JanssenProject/jans/pull/15031/). Before it, the advertised
algorithm list was hardcoded, so shipping ML-DSA standard-only would have made a FIPS deployment advertise
an algorithm it then failed to verify — the same advertise-then-fail shape as the EdDSA defect in #14929.
Now the advertised set is derived from real provider capability, so a FIPS deployment reports ML-DSA
unsupported and simply never offers it. The deferral reason is gone; the dependency situation itself has not
changed.

I re-ran the provider probe rather than trusting the earlier writeup:

```
bcprov-jdk18on 1.79   ML-DSA-44/65/87  keygen + KeyFactory + Signature OK, verify=true
bc-fips 1.0.2.4       ML-DSA-44/65/87  NoSuchAlgorithmException
```

`jans-fido2/server-fips/pom.xml` excludes `bcprov-jdk18on-*.jar` from the WAR and ships `bc-fips`, and
`SecurityProviderUtility.checkFipsMode()` selects the FIPS provider purely on that class being present. So
the FIPS build genuinely cannot do ML-DSA, and genuinely will not advertise it.

**The COSE values are verified against primary sources**, since a wrong code point is exactly the defect
class this tree was opened for. Each was confirmed twice — the IANA registry CSVs and RFC 9964:

| Item | Value | Source |
| --- | --- | --- |
| ML-DSA-44 / 65 / 87 | `-48` / `-49` / `-50` | IANA COSE Algorithms; RFC 9964 |
| Key type `AKP` | `7` | IANA COSE Key Types; RFC 9964 Figure 2 |
| `pub` parameter | `-1` | IANA COSE Key Type Parameters; RFC 9964 Figure 2 |
| Public key sizes | 1312 / 1952 / 2592 | RFC 9964 Table 1; matches the probe |

The change:

- `CoseKeyType` gains `AKP(7)`.
- `CoseMLDSAAlgorithm` carries the three code points plus their JCA names, because `ML-DSA-44` is not a
  legal Java identifier. `fromName` accepts both `ML-DSA-44` and `ML_DSA_44`, so an administrator can use
  the registry spelling.
- `CoseService` gains an AKP decode branch. **This is a genuinely new decode path, not a widened list** —
  AKP carries the entire public key in one `pub` parameter rather than the `(n, e)` pair or `(crv, x, y)`
  triple the other branches reassemble. The raw key is wrapped in a per-parameter-set SubjectPublicKeyInfo
  prefix; I read those 22-byte prefixes off provider-generated keys rather than hand-assembling the DER,
  since the embedded length fields differ per parameter set.
- `SignatureVerifier` maps `-48`/`-49`/`-50` to the provider. On the FIPS build this throws,
  `isSupported` returns false, and the algorithm is dropped from `pubKeyCredParams`.
- `AttestationService` gains a resolver so the names work in `enabledFidoAlgorithms`.

**Behaviour change.** None for existing deployments. Nothing is advertised that was not advertised before
unless an administrator opts in by naming an ML-DSA algorithm, and on FIPS even that is refused with a
logged error rather than honoured.

`server-fips/` needs no mirroring: the module is `pom.xml` and `target/` only, with no `src/` tree. Unlike
the earlier PRs in this tree, that is not the whole story here — the FIPS provider genuinely lacks these
algorithms, and the probe plus the derived-capability mechanism from #15031 are what make that safe rather
than merely structural.

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [x] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)

`CoseServiceMLDSATest` covers, per parameter set: the registration and assertion pair end-to-end (build the
COSE key an authenticator would send, decode it, assert it reconstructs byte-for-byte, then verify a real
signature made with the matching private key); a key of the wrong length; and a missing `pub` label. It also
covers a valid ML-DSA-65 key offered under ML-DSA-44, which the distinct key lengths and OIDs must reject.

The test that matters most asserts `isSupported` tracks **the running provider** rather than a list. That is
the invariant the whole standard-only decision rests on: if it ever reported support the provider does not
have, a FIPS deployment would advertise ML-DSA and fail the ceremony.

I checked the suite is not vacuous — pointing the verifier at a different algorithm for these code points
fails three of its cases, and I reverted after confirming.

```
CoseServiceMLDSATest         11 tests, 0 failures
jans-fido2 model + server   464 tests, 0 failures
```

`FetchMdsProviderServiceTest` errors on my machine because it makes live calls to `mds3.fido.tools` and
local DNS is down; it is excluded from that count and is unrelated to this change.

Docs: `docs/janssen-server/fido/fido2-server-properties-config.md` adds the three names to
`enabledFidoAlgorithms` and gains a "Post-quantum algorithms (ML-DSA)" section stating plainly that they are
standard-build-only, and why that needs no action from an administrator — the same configuration stays safe
to share across both build variants. Carried in a separate `docs:` commit.

Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [ ] **I confirm that there is no impact on the docs due to the code changes in this PR.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ML-DSA post-quantum algorithms in FIDO2 credentials and signature verification.
  * Supports ML-DSA-44, ML-DSA-65, and ML-DSA-87 for key decoding, attestation, and configured algorithm advertisement.
  * Automatically filters algorithms based on available runtime capabilities and validates key compatibility.

* **Documentation**
  * Documented ML-DSA configuration options, supported build types, capability filtering, error logging, and accepted hyphenated or underscored algorithm names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->