### PR TITLE
feat(orm): disable ssl cert check in tests

### DIFF
--- a/jans-linux-setup/jans_setup/templates/test/jans-orm/conf/jans-sql.properties.mako
+++ b/jans-linux-setup/jans_setup/templates/test/jans-orm/conf/jans-sql.properties.mako
@@ -6,7 +6,8 @@ db.schema.name=${rdbm_schema}
 connection.uri=jdbc:postgresql://${rdbm_host}:${rdbm_port}/${rdbm_db}
 connection.driver-property.ssl=${rdbm_enable_ssl}
 connection.driver-property.sslmode=${rdbm_sslmode}
-connection.driver-property.sslfactory=${rdbm_sslfactory}
+connection.driver-property.sslfactory=org.postgresql.ssl.NonValidatingFactory
+#connection.driver-property.sslfactory=${rdbm_sslfactory}
 
 # Prefix connection.driver-property.key=value will be coverterd to key=value JDBC driver properties
 #connection.driver-property.driverProperty=driverPropertyValu


### PR DESCRIPTION
### Prepare

- [ ] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [ ] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
#15058
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #15058

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [ ] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [ ] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**

Closes #15057, 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - PostgreSQL connections now use a non-validating SSL factory by default.
  - The configurable SSL factory option remains available as a commented setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->