### PR TITLE
fix(cloud-native): inconsistent env naming used for modifying jans-config-api configuration

### DIFF
--- a/charts/janssen-all-in-one/templates/configmap.yaml
+++ b/charts/janssen-all-in-one/templates/configmap.yaml
@@ -79,7 +79,6 @@ data:
   CN_CACHE_TYPE: {{ .Values.configmap.cnCacheType | quote }}
   CN_DOCUMENT_STORE_TYPE: {{ .Values.cnDocumentStoreType | quote }}
   DOMAIN: {{ .Values.fqdn | quote }}
-  CN_AUTH_SERVER_BACKEND: {{ cat ( index .Values "auth-server" "authServerServiceName" ) ":8080" | quote | nospace }}
   CN_AUTH_APP_LOGGERS: {{ index .Values "auth-server" "appLoggers"
   | toJson
   | replace "authLogTarget" "auth_log_target"

--- a/charts/janssen/charts/config/templates/configmaps.yaml
+++ b/charts/janssen/charts/config/templates/configmaps.yaml
@@ -79,7 +79,6 @@ data:
   CN_CACHE_TYPE: {{ .Values.configmap.cnCacheType | quote }}
   CN_DOCUMENT_STORE_TYPE: {{ .Values.global.cnDocumentStoreType | quote }}
   DOMAIN: {{ .Values.global.fqdn | quote }}
-  CN_AUTH_SERVER_BACKEND: {{ cat ( index .Values "global" "auth-server" "authServerServiceName" ) ":8080" | quote | nospace }}
   CN_AUTH_APP_LOGGERS: {{ index .Values "global" "auth-server" "appLoggers"
   | toJson
   | replace "authLogTarget" "auth_log_target"

--- a/docker-jans-config-api/README.md
+++ b/docker-jans-config-api/README.md
@@ -53,7 +53,7 @@ The following environment variables are supported by the container:
 - `CN_HYBRID_MAPPING`: Specify data mapping for each persistence (default to `"{}"`). Note this environment only takes effect when `CN_PERSISTENCE_TYPE` is set to `hybrid`. See [hybrid mapping](#hybrid-mapping) section for details.
 - `CN_CONFIG_API_JAVA_OPTIONS`: Java options passed to entrypoint, i.e. `-Xmx1024m` (default to empty-string).
 - `CN_CONFIG_API_LOG_LEVEL`: Log level for config api. Options include `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`.  and `ALL`. This defaults to `INFO`
-- `CN_AUTH_SERVER_URL`: Base URL of Janssen Auth server, i.e. `auth-server:8080` (default to empty string).
+- `CN_AUTH_BASE_URL`: Base URL of Janssen Auth server, i.e. `http://auth-server:8080` (default to empty string).
 - `GOOGLE_APPLICATION_CREDENTIALS`: Optional JSON file (contains Google credentials) that can be injected into container for authentication. Refer to https://cloud.google.com/docs/authentication/provide-credentials-adc#how-to for supported credentials.
 - `GOOGLE_PROJECT_ID`: ID of Google project.
 - `CN_GOOGLE_SECRET_VERSION_ID`: Janssen secret version ID in Google Secret Manager. Defaults to `latest`, which is recommended.

--- a/docker-jans-config-api/README.md
+++ b/docker-jans-config-api/README.md
@@ -53,7 +53,7 @@ The following environment variables are supported by the container:
 - `CN_HYBRID_MAPPING`: Specify data mapping for each persistence (default to `"{}"`). Note this environment only takes effect when `CN_PERSISTENCE_TYPE` is set to `hybrid`. See [hybrid mapping](#hybrid-mapping) section for details.
 - `CN_CONFIG_API_JAVA_OPTIONS`: Java options passed to entrypoint, i.e. `-Xmx1024m` (default to empty-string).
 - `CN_CONFIG_API_LOG_LEVEL`: Log level for config api. Options include `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`.  and `ALL`. This defaults to `INFO`
-- `CN_AUTH_BASE_URL`: Base URL of Janssen Auth server, i.e. `http://auth-server:8080` (default to empty string).
+- `CN_AUTH_BASE_URL`: Base URL of Janssen Auth server, i.e. `http://auth-server:8080` (default to empty string, previously called `CN_AUTH_SERVER_URL`).
 - `GOOGLE_APPLICATION_CREDENTIALS`: Optional JSON file (contains Google credentials) that can be injected into container for authentication. Refer to https://cloud.google.com/docs/authentication/provide-credentials-adc#how-to for supported credentials.
 - `GOOGLE_PROJECT_ID`: ID of Google project.
 - `CN_GOOGLE_SECRET_VERSION_ID`: Janssen secret version ID in Google Secret Manager. Defaults to `latest`, which is recommended.

--- a/docker-jans-config-api/README.md
+++ b/docker-jans-config-api/README.md
@@ -53,7 +53,7 @@ The following environment variables are supported by the container:
 - `CN_HYBRID_MAPPING`: Specify data mapping for each persistence (default to `"{}"`). Note this environment only takes effect when `CN_PERSISTENCE_TYPE` is set to `hybrid`. See [hybrid mapping](#hybrid-mapping) section for details.
 - `CN_CONFIG_API_JAVA_OPTIONS`: Java options passed to entrypoint, i.e. `-Xmx1024m` (default to empty-string).
 - `CN_CONFIG_API_LOG_LEVEL`: Log level for config api. Options include `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`.  and `ALL`. This defaults to `INFO`
-- `CN_AUTH_BASE_URL`: Base URL of Janssen Auth server, i.e. `http://auth-server:8080` (default to empty string, previously called `CN_AUTH_SERVER_URL`).
+- `CN_AUTH_BASE_URL`: Base URL of Janssen Auth server, i.e. `http://auth-server:8080` (default to empty string). `CN_AUTH_SERVER_URL` remains supported as a deprecated fallback.
 - `GOOGLE_APPLICATION_CREDENTIALS`: Optional JSON file (contains Google credentials) that can be injected into container for authentication. Refer to https://cloud.google.com/docs/authentication/provide-credentials-adc#how-to for supported credentials.
 - `GOOGLE_PROJECT_ID`: ID of Google project.
 - `CN_GOOGLE_SECRET_VERSION_ID`: Janssen secret version ID in Google Secret Manager. Defaults to `latest`, which is recommended.

--- a/docker-jans-config-api/scripts/bootstrap.py
+++ b/docker-jans-config-api/scripts/bootstrap.py
@@ -302,7 +302,8 @@ class PersistenceSetup:
             "endpointInjectionEnabled": "true",
             "configOauthEnabled": str(os.environ.get("CN_CONFIG_API_OAUTH_ENABLED") or True).lower(),
         }
-        ctx.update(self.url_modifier.get_injected_urls())
+        injected_urls = self.url_modifier.get_injected_urls()
+        ctx.update(injected_urls)
 
         # Client
         ctx["jca_client_id"] = self.manager.config.get("jca_client_id")

--- a/docker-jans-config-api/scripts/bootstrap.py
+++ b/docker-jans-config-api/scripts/bootstrap.py
@@ -12,7 +12,6 @@ from ldif import LDIFWriter
 from jans.pycloudlib import get_manager
 from jans.pycloudlib import wait_for_persistence
 from jans.pycloudlib.persistence.hybrid import render_hybrid_properties
-from jans.pycloudlib.persistence.sql import doc_id_from_dn
 from jans.pycloudlib.persistence.sql import SqlClient
 from jans.pycloudlib.persistence.sql import render_sql_properties
 from jans.pycloudlib.persistence.sql import override_simple_json_property
@@ -35,6 +34,7 @@ from utils import get_config_api_scope_mapping
 from utils import get_ads_project_base64
 from utils import AUI_AGAMA_PW_ARCHIVE
 from utils import AUI_AGAMA_PW_DEPLOYMENT_ID
+from utils import URLModifier
 
 logging.config.dictConfig(LOGGING_CONFIG)
 logger = logging.getLogger("jans-config-api")
@@ -282,40 +282,7 @@ class PersistenceSetup:
         self.client = client_cls(manager)
 
         self.plugins = plugins or []
-
-    def get_auth_config(self):
-        dn = "ou=jans-auth,ou=configuration,o=jans"
-        entry = self.client.get("jansAppConf", doc_id_from_dn(dn))
-        return json.loads(entry["jansConfDyn"])
-
-    def transform_url(self, url):
-        auth_server_url = os.environ.get("CN_AUTH_SERVER_URL", "")
-
-        if not auth_server_url:
-            return url
-
-        parse_result = urlparse(url)
-        if parse_result.path.startswith("/.well-known"):
-            path = f"/jans-auth{parse_result.path}"
-        else:
-            path = parse_result.path
-        return f"http://{auth_server_url}{path}"
-
-    def get_injected_urls(self):
-        auth_config = self.get_auth_config()
-
-        urls = (
-            "issuer",
-            "openIdConfigurationEndpoint",
-            "introspectionEndpoint",
-            "tokenEndpoint",
-            "tokenRevocationEndpoint",
-        )
-
-        return {
-            url: self.transform_url(auth_config[url])
-            for url in urls
-        }
+        self.url_modifier = URLModifier(self.client)
 
     @cached_property
     def ctx(self) -> dict[str, _t.Any]:
@@ -335,7 +302,7 @@ class PersistenceSetup:
             "endpointInjectionEnabled": "true",
             "configOauthEnabled": str(os.environ.get("CN_CONFIG_API_OAUTH_ENABLED") or True).lower(),
         }
-        ctx.update(self.get_injected_urls())
+        ctx.update(self.url_modifier.get_injected_urls())
 
         # Client
         ctx["jca_client_id"] = self.manager.config.get("jca_client_id")

--- a/docker-jans-config-api/scripts/upgrade.py
+++ b/docker-jans-config-api/scripts/upgrade.py
@@ -17,6 +17,7 @@ from utils import AUI_AGAMA_PW_ARCHIVE
 from utils import AUI_AGAMA_PW_DEPLOYMENT_ID
 from utils import get_ads_project_base64
 from utils import get_ads_project_md5sum
+from utils import URLModifier
 
 logging.config.dictConfig(LOGGING_CONFIG)
 logger = logging.getLogger("jans-config-api")
@@ -287,6 +288,21 @@ class Upgrade:
             entry.attrs["jansConfDyn"] = json.loads(entry.attrs["jansConfDyn"])
 
         conf, should_update = _transform_api_dynamic_config(entry.attrs["jansConfDyn"])
+
+        injected_urls = URLModifier(self.backend.client).get_injected_urls()
+
+        # config-api to auth URL mapping
+        url_mapping = {
+            "authIssuerUrl": "issuer",
+            "authOpenidConfigurationUrl": "openIdConfigurationEndpoint",
+            "authOpenidIntrospectionUrl": "introspectionEndpoint",
+            "authOpenidTokenUrl": "tokenEndpoint",
+        }
+
+        for config_api_attr, auth_attr in url_mapping.items():
+            if auth_attr in injected_urls and conf[config_api_attr] != injected_urls[auth_attr]:
+                conf[config_api_attr] = injected_urls[auth_attr]
+                should_update = True
 
         if should_update:
             entry.attrs["jansConfDyn"] = json.dumps(conf)

--- a/docker-jans-config-api/scripts/upgrade.py
+++ b/docker-jans-config-api/scripts/upgrade.py
@@ -300,7 +300,9 @@ class Upgrade:
         }
 
         for config_api_attr, auth_attr in url_mapping.items():
-            if auth_attr in injected_urls and conf[config_api_attr] != injected_urls[auth_attr]:
+            if any([config_api_attr not in conf, auth_attr not in injected_urls]):
+                continue
+            if conf[config_api_attr] != injected_urls[auth_attr]:
                 conf[config_api_attr] = injected_urls[auth_attr]
                 should_update = True
 

--- a/docker-jans-config-api/scripts/upgrade.py
+++ b/docker-jans-config-api/scripts/upgrade.py
@@ -300,9 +300,9 @@ class Upgrade:
         }
 
         for config_api_attr, auth_attr in url_mapping.items():
-            if any([config_api_attr not in conf, auth_attr not in injected_urls]):
+            if auth_attr not in injected_urls:
                 continue
-            if conf[config_api_attr] != injected_urls[auth_attr]:
+            if conf.get(config_api_attr) != injected_urls[auth_attr]:
                 conf[config_api_attr] = injected_urls[auth_attr]
                 should_update = True
 

--- a/docker-jans-config-api/scripts/utils.py
+++ b/docker-jans-config-api/scripts/utils.py
@@ -49,37 +49,33 @@ AUI_AGAMA_PW_DEPLOYMENT_ID = "ab7aec3d-43f5-3c3f-81de-93a24dfd3f84"
 AUI_AGAMA_PW_ARCHIVE = "/usr/share/java/admin-ui-plugin-agama-pw.gama"
 
 
-def transform_url(url):
-    auth_base_url = os.environ.get("CN_AUTH_BASE_URL") or os.environ.get("CN_AUTH_SERVER_URL") or ""
-
-    if not auth_base_url:
-        return url
-
-    logger.info("Found base URL override for endpoints from CN_AUTH_BASE_URL or CN_AUTH_SERVER_URL (deprecated) environment variable; value=%s", auth_base_url)
-
-    # handle bare URL (without scheme)
-    if not any([
-        auth_base_url.startswith("http://"),
-        auth_base_url.startswith("https://"),
-    ]):
-        auth_base_url = f"http://{auth_base_url}"
-
-    parse_result = urlparse(url)
-    if parse_result.path.startswith("/.well-known"):
-        path = f"/jans-auth{parse_result.path}"
-    else:
-        path = parse_result.path
-    return f"{auth_base_url}{path}"
-
-
 class URLModifier:
     def __init__(self, sql_client):
         self.client = sql_client
+
+        self.base_url = os.environ.get("CN_AUTH_BASE_URL") or os.environ.get("CN_AUTH_SERVER_URL") or ""
+
+        if self.base_url:
+            logger.info("Found base URL override for endpoints from CN_AUTH_BASE_URL or CN_AUTH_SERVER_URL (deprecated) environment variable; value=%s", self.base_url)
+            # handle bare URL (without scheme)
+            if not any([self.base_url.startswith("http://"), self.base_url.startswith("https://")]):
+                self.base_url = f"http://{self.base_url}"
 
     def get_auth_config(self):
         dn = "ou=jans-auth,ou=configuration,o=jans"
         entry = self.client.get("jansAppConf", doc_id_from_dn(dn))
         return json.loads(entry["jansConfDyn"])
+
+    def transform_url(self, url):
+        if not self.base_url:
+            return url
+
+        parse_result = urlparse(url)
+        if parse_result.path.startswith("/.well-known"):
+            path = f"/jans-auth{parse_result.path}"
+        else:
+            path = parse_result.path
+        return f"{self.base_url}{path}"
 
     def get_injected_urls(self):
         auth_config = self.get_auth_config()
@@ -88,10 +84,9 @@ class URLModifier:
             "openIdConfigurationEndpoint",
             "introspectionEndpoint",
             "tokenEndpoint",
-            "tokenRevocationEndpoint",
         )
 
         return {
-            url: transform_url(auth_config[url])
+            url: self.transform_url(auth_config[url])
             for url in urls
         }

--- a/docker-jans-config-api/scripts/utils.py
+++ b/docker-jans-config-api/scripts/utils.py
@@ -45,7 +45,7 @@ AUI_AGAMA_PW_ARCHIVE = "/usr/share/java/admin-ui-plugin-agama-pw.gama"
 
 
 def transform_url(url):
-    auth_base_url = os.environ.get("CN_AUTH_BASE_URL", "")
+    auth_base_url = os.environ.get("CN_AUTH_BASE_URL") or os.environ.get("CN_AUTH_SERVER_URL") or ""
 
     if not auth_base_url:
         return url

--- a/docker-jans-config-api/scripts/utils.py
+++ b/docker-jans-config-api/scripts/utils.py
@@ -1,6 +1,9 @@
 import json
+import os
 from hashlib import md5
+from urllib.parse import urlparse
 
+from jans.pycloudlib.persistence.sql import doc_id_from_dn
 from jans.pycloudlib.utils import exec_cmd
 
 
@@ -39,3 +42,49 @@ def get_ads_project_md5sum(path):
 
 AUI_AGAMA_PW_DEPLOYMENT_ID = "ab7aec3d-43f5-3c3f-81de-93a24dfd3f84"
 AUI_AGAMA_PW_ARCHIVE = "/usr/share/java/admin-ui-plugin-agama-pw.gama"
+
+
+def transform_url(url):
+    auth_base_url = os.environ.get("CN_AUTH_BASE_URL", "")
+
+    if not auth_base_url:
+        return url
+
+    parse_result = urlparse(url)
+    if parse_result.path.startswith("/.well-known"):
+        path = f"/jans-auth{parse_result.path}"
+    else:
+        path = parse_result.path
+
+    # handle bare URL (without scheme)
+    if not any([
+        auth_base_url.startswith("http://"),
+        auth_base_url.startswith("https://"),
+    ]):
+        auth_base_url = f"http://{auth_base_url}"
+    return f"{auth_base_url}{path}"
+
+
+class URLModifier:
+    def __init__(self, sql_client):
+        self.client = sql_client
+
+    def get_auth_config(self):
+        dn = "ou=jans-auth,ou=configuration,o=jans"
+        entry = self.client.get("jansAppConf", doc_id_from_dn(dn))
+        return json.loads(entry["jansConfDyn"])
+
+    def get_injected_urls(self):
+        auth_config = self.get_auth_config()
+        urls = (
+            "issuer",
+            "openIdConfigurationEndpoint",
+            "introspectionEndpoint",
+            "tokenEndpoint",
+            "tokenRevocationEndpoint",
+        )
+
+        return {
+            url: transform_url(auth_config[url])
+            for url in urls
+        }

--- a/docker-jans-config-api/scripts/utils.py
+++ b/docker-jans-config-api/scripts/utils.py
@@ -1,10 +1,15 @@
 import json
+import logging.config
 import os
 from hashlib import md5
 from urllib.parse import urlparse
 
 from jans.pycloudlib.persistence.sql import doc_id_from_dn
 from jans.pycloudlib.utils import exec_cmd
+
+from settings import LOGGING_CONFIG
+logging.config.dictConfig(LOGGING_CONFIG)
+logger = logging.getLogger("jans-config-api")
 
 
 def get_config_api_scope_mapping(path="/app/templates/jans-config-api/config-api-rs-protect.json"):
@@ -50,11 +55,7 @@ def transform_url(url):
     if not auth_base_url:
         return url
 
-    parse_result = urlparse(url)
-    if parse_result.path.startswith("/.well-known"):
-        path = f"/jans-auth{parse_result.path}"
-    else:
-        path = parse_result.path
+    logger.info("Found base URL override for endpoints from CN_AUTH_BASE_URL or CN_AUTH_SERVER_URL (deprecated) environment variable; value=%s", auth_base_url)
 
     # handle bare URL (without scheme)
     if not any([
@@ -62,6 +63,12 @@ def transform_url(url):
         auth_base_url.startswith("https://"),
     ]):
         auth_base_url = f"http://{auth_base_url}"
+
+    parse_result = urlparse(url)
+    if parse_result.path.startswith("/.well-known"):
+        path = f"/jans-auth{parse_result.path}"
+    else:
+        path = parse_result.path
     return f"{auth_base_url}{path}"
 
 


### PR DESCRIPTION
### Prepare

- [x] Read [PR guidelines](https://github.com/JanssenProject/jans/blob/main/docs/CONTRIBUTING.md#prs)
- [x] Read [license information](https://github.com/JanssenProject/jans/blob/main/LICENSE)

-------------------

### Description

#### Target issue
  <!-- Link or describe the issue this PR is fixing -->
  
  <!-- If issue shouldn't be closed after merging this PR, then we recommend adding a task in original target issue and create a separate issue from this task which can be closed when this PR gets merged. Mention this new issue created from task as target issue below. For more on how to create task issues visit https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists -->
  
closes #15060 

#### Implementation Details
  <!-- If the fix is an involved one then communicate high level analysis and implementation approach -->

-------------------
### Test and Document the changes
- [x] Static code analysis has been run locally and issues have been fixed
- [ ] Relevant unit and integration tests have been added/updated
- [x] Relevant documentation has been updated if any (i.e. user guides, installation and configuration guides, technical design docs etc)



Please check the below before submitting your PR. The PR will not be merged if there are no commits that start with `docs:` to indicate documentation changes or if the below checklist is not selected.
- [x] **I confirm that there is no impact on the docs due to the code changes in this PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication endpoint URLs are automatically synchronized in dynamic configuration.
  * Authentication URLs support a configurable base URL, scheme normalization, and standard discovery paths.
  * The previous `CN_AUTH_SERVER_URL` setting remains supported as a deprecated fallback.

* **Documentation**
  * Updated configuration guidance to use `CN_AUTH_BASE_URL`, including the full URL scheme.

* **Chores**
  * Removed the obsolete `CN_AUTH_SERVER_BACKEND` configuration entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->